### PR TITLE
docs: Governance and product foundation initialization

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -1,0 +1,18 @@
+---
+description: NeNe Clear 全作業共通の正本と安全方針
+alwaysApply: true
+---
+
+# Project Rules
+
+- 正本は `README.md`、`AGENTS.md`、`docs/CONTRIBUTING.md`、`docs/inheritance-from-nene2.md`、`docs/development/`、`docs/workflow.md`。
+- AI/エージェントは作業前に `AGENTS.md` と関連 docs を確認する。
+- フレームワーク挙動は NENE2 upstream（`vendor/hideyukimori/nene2/docs/`）を参照する。製品ルールはこのリポジトリの docs を優先する。
+- **sibling 製品に統合しない。** 依存方向は `NeNe Clear → upstream API` のみ（ADR 0002）。
+- 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
+- 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
+- NeNe Clear はセルフホスト OSS の見積・請求・入金管理 — 適格請求書対応、Admin UI、PDF。
+- **会計・税務コンプライアンスは拘束ルール（非交渉）。** 請求・税・採番・PDF・保存の変更は `docs/explanation/accounting-compliance.md` 順守必須。逸脱は ADR ＋ 税理士確認なしに禁止。専門家がレビューしても逸脱ゼロを満たす。
+- 金額は **integer cents**（float 禁止）。実装は疎結合、型安全、OpenAPI/MCP 境界を優先（NENE2 継承）。
+- **命名規則は絶対順守・タイポ厳禁。** 全識別子は用語レジストリ `docs/explanation/terminology.md`（唯一の真実）と完全一致。スペルゆれ・未登録語はマージ禁止、追加/改名は同一 PR でレジストリ更新。
+- Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。

--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -1,0 +1,14 @@
+---
+description: Issue ベース開発と branch / PR / merge 運用
+alwaysApply: true
+---
+
+# Issue Driven Workflow
+
+- コード、ドキュメント、設定変更は **必ず GitHub Issue ベース**。Issue 作成前に編集しない。
+- 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
+- **`main` へ直接 commit / push しない。** ブランチ名は `type/issue-number-summary`。
+- 標準完了フロー: commit → push → PR 作成（`Closes #番号` + セルフレビューチェックリスト名）→ CI 確認 → **merge** → ローカル `main` 同期。
+- コミットは Conventional Commits（`docs/development/commit-conventions.md`）。description/body は日本語、type/scope は英語。**subject に `(#issue)` を含める。**
+- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合はその指示を優先する。
+- 正本: `docs/workflow.md`、`docs/development/commit-conventions.md`（NENE2 継承）。

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+/vendor/
+/node_modules/
+/.env
+/.env.local
+/.env.*.local
+/.phpunit.result.cache
+/.phpunit.cache/
+/.phpstan.cache/
+/.php-cs-fixer.cache
+/var/
+/public_html/assets/
+/public_html/admin/*
+!/public_html/admin/.htaccess
+/storage/
+/build/
+/frontend/node_modules/
+/frontend/apps/*/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent / AI Guide
+
+Entry point for AI agents working on **NeNe Clear** (private repo `nene-clear`).
+
+## Read First
+
+- **Portfolio strategy (external):** [publication-strategy `docs/products/nene-clear.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-clear.md)
+- **Philosophy:** `docs/explanation/philosophy.md`
+- **Product vision:** `docs/explanation/product-vision.md`
+- **Expansion roadmap (1–5):** `docs/explanation/expansion-roadmap.md`
+- **Requirements:** `docs/explanation/requirements.md`
+- **Terminology (binding):** `docs/explanation/terminology.md`
+- **Compliance (binding):** `docs/explanation/accounting-compliance.md`
+- **Current work:** `docs/todo/current.md`
+- **Roadmap:** `docs/roadmap.md`
+
+## Operating Rules
+
+- Issue-driven; no direct commits to `main`
+- Do **not** edit `nene-invoice` for Clear product work — this repo is canonical
+- Strategy changes → update `publication-strategy` first, then product docs here
+- Namespace: `NeneClear\`; money: integer cents
+
+## Framework
+
+[NENE2](https://github.com/hideyukiMORI/NENE2) via Composer when runtime lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md — NeNe Clear
+
+Private canonical repo for **NeNe Clear**. Strategy SSOT:
+[publication-strategy `docs/products/nene-clear.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-clear.md).
+
+## 一言
+
+見積→請求→入金→**消込**まで。日本 SMB・自前ホスト・適格請求書・MCP 対応。
+
+## 絶対禁止
+
+- `nene-invoice` への製品変更（実験 repo は触らない）
+- `main` 直 commit
+- Issue なしの変更
+
+## 拡張ロードマップ（順序固定）
+
+1. 入金消込・督促
+2. 発注・納品
+3. 契約更新
+4. 小規模サブスク
+5. 経費最小版
+
+詳細: `docs/explanation/expansion-roadmap.md`
+
+## 正本
+
+| 目的 | パス |
+| --- | --- |
+| 哲学 | `docs/explanation/philosophy.md` |
+| TODO | `docs/todo/current.md` |
+| 命名 | `docs/development/naming-conventions.md` |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hideyukiMORI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# NeNe Clear
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
+[![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
+[![Private](https://img.shields.io/badge/status-private-red)]()
+
+**Clear billing from quote to cash — self-hosted for Japan SMB.**
+
+**NeNe Clear** (*見積から入金まで、明快に。*) is a billing platform on [NENE2](https://github.com/hideyukiMORI/NENE2): quotes, **qualified invoice** (適格請求書) PDFs, payment tracking, reconciliation, and dunning — on shared hosting or Docker.
+
+> **Repository:** private until Phase 3 launch-ready. Portfolio strategy: [publication-strategy `docs/products/nene-clear.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-clear.md).
+
+## Goals
+
+- **Japan invoice compliance** — registration number, tax rates, qualified invoice PDF
+- **Self-hosted OSS** — MIT; Tier A shared hosting or Tier B Docker/VPS
+- **Quote-to-cash** — estimate → invoice → collect → **clear**
+- **AI-readable** — OpenAPI + MCP; human confirms, AI proposes
+- **Sibling to NeNe ecosystem** — HTTP integration with Records / Concierge / Corpus
+
+## Documentation
+
+| Topic | Document |
+| --- | --- |
+| **Philosophy** | [`docs/explanation/philosophy.md`](./docs/explanation/philosophy.md) |
+| **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
+| **Expansion roadmap (1–5)** | [`docs/explanation/expansion-roadmap.md`](./docs/explanation/expansion-roadmap.md) |
+| **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
+| **Agents** | [`AGENTS.md`](./AGENTS.md) |
+| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) |
+
+## Status
+
+**Phase 0** — governance and product design. Runtime scaffold follows Issues #4+.
+
+## Ecosystem
+
+```
+NENE2 (framework)
+  ├── NeNe Records   (CMS)
+  ├── NeNe Corpus    (knowledge chat)
+  ├── NeNe Concierge (scenario chat)
+  └── NeNe Clear     (billing — this repo)
+```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+NeNe Clear is built through small, Issue-driven changes. This document is the shared entry point for humans and AI agents.
+
+## Required Reading
+
+| Topic | Document |
+| --- | --- |
+| NENE2 inheritance map | `docs/inheritance-from-nene2.md` |
+| Sibling product boundaries | `docs/integrations/sibling-products.md` |
+| Workflow | `docs/workflow.md` |
+| Coding standards | `docs/development/coding-standards.md` |
+| Naming conventions | `docs/development/naming-conventions.md` |
+| Glossary | `docs/explanation/glossary.md` |
+| Backend standards (PHP/API) | `docs/development/backend-standards.md` |
+| Commit messages | `docs/development/commit-conventions.md` |
+| AI tools | `docs/integrations/ai-tools.md` |
+| Agent entry point | `AGENTS.md` |
+| Roadmap | `docs/roadmap.md` |
+| Current work | `docs/todo/current.md` |
+
+## Collaboration Policy
+
+Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md):
+
+1. Create or reuse a GitHub Issue **before** editing.
+2. Branch from `main` as `type/issue-number-summary`.
+3. Implement, verify (`composer check` when applicable), commit with `(#issue)`.
+4. Push, open PR with `Closes #number`, merge after checks — **do not push directly to `main`**.
+
+- Use one branch and one PR per focused work unit.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Explain intent, impact, verification, and remaining risk in PRs.
+- Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
+
+## Secrets
+
+Do not commit passwords, tokens, private URLs, production credentials, or local `.env` files. Commit only non-secret examples such as `.env.example` when needed.
+
+Sensitive keys for this product include:
+
+- Admin JWT secrets
+- Upstream API bearer tokens (NeNe Records, NeNe Concierge)
+- SMTP credentials for invoice email delivery
+
+## Engineering Theme
+
+NeNe Clear should stay readable, secure, and self-hostable:
+
+- strict, typed, explicit boundaries (inherited from NENE2)
+- decoupled use cases and infrastructure
+- OpenAPI contracts before client assumptions
+- Japan invoice compliance fields validated at API layer
+- MCP access only through documented HTTP boundaries
+- **never** merge into or embed inside NeNe Records (ADR 0002)
+
+## Upstream Framework
+
+Runtime HTTP, middleware, and DI patterns come from [NENE2](https://github.com/hideyukiMORI/NENE2). When framework behavior is unclear, read NENE2 docs under `vendor/hideyukimori/nene2/docs/` after `composer install`.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR 0000: Title
+
+## Status
+
+proposed
+
+## Context
+
+Describe the problem, constraints, and trade-offs that make this decision necessary.
+
+## Decision
+
+Describe the decision in clear, direct language.
+
+## Consequences
+
+Describe the expected benefits, costs, and follow-up work.
+
+## Related
+
+- Issue: `#000`
+- PR: `#000`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0001-inherit-nene2-governance.md
+++ b/docs/adr/0001-inherit-nene2-governance.md
@@ -1,0 +1,51 @@
+# ADR 0001: Inherit NENE2 Governance and Workflow
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear is a consumer application built on [NENE2](https://github.com/hideyukiMORI/NENE2). The maintainer wants the same strict engineering discipline as NENE2 and sibling NeNe products (Records, Corpus, Concierge) — Issue-driven workflow, Conventional Commits, self-review checklists, and AI-readable documentation — without copying the entire NENE2 documentation tree.
+
+Alternatives considered:
+
+1. **Link-only** — rejected; product-specific rules (billing, invoice compliance, sibling boundaries) would be unclear.
+2. **Full copy** — rejected; upstream drift would be hard to track.
+3. **Hybrid inheritance** (chosen): local source-of-truth for workflow and product rules; reference NENE2 upstream for framework runtime behavior.
+
+## Decision
+
+Adopt NENE2 governance patterns locally:
+
+- Issue-driven development with `type/issue-number-summary` branches
+- Conventional Commits (English type/scope, Japanese description/body, Issue number in subject)
+- Self-review checklists under `docs/review/`
+- ADR policy under `docs/development/adr.md`
+- AI agent entry via `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/`
+- Inheritance map in `docs/inheritance-from-nene2.md`
+
+Framework HTTP, middleware, validation, and MCP behavior remain defined by NENE2 unless this repository records an explicit deviation in a later ADR.
+
+## Consequences
+
+**Benefits**
+
+- Contributors and AI agents have a single local entry point.
+- Product rules (billing model, invoice fields, upstream boundaries) stay separate from framework rules.
+- NENE2 upstream improvements remain consumable via Composer.
+
+**Costs**
+
+- Two documentation layers must stay mentally in sync when NENE2 workflow policy changes materially.
+
+**Follow-up**
+
+- Scaffold runtime and CI (Phase 0+).
+- Add billing and compliance ADRs as domains stabilize.
+
+## Related
+
+- NENE2 workflow: https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md
+- NeNe Records ADR 0001 (precedent): https://github.com/hideyukiMORI/nene-records/blob/main/docs/adr/0001-inherit-nene2-governance.md
+- Inheritance map: `docs/inheritance-from-nene2.md`

--- a/docs/adr/0002-separate-from-sibling-products.md
+++ b/docs/adr/0002-separate-from-sibling-products.md
@@ -1,0 +1,67 @@
+# ADR 0002: Separate Product from Sibling NeNe Applications
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear is a quote and invoice platform. Sibling products in the NeNe ecosystem each own a distinct domain:
+
+- **NeNe Records** — CMS and typed entity platform
+- **NeNe Corpus** — knowledge chat with citations
+- **NeNe Concierge** — scenario-driven conversion chat
+
+NeNe Clear may consume sibling HTTP APIs (product catalog from Records, leads from Concierge) but must not embed billing logic into those repositories or share their databases.
+
+Alternatives considered:
+
+1. **Billing module inside NeNe Records** — rejected; mixes CMS and financial failure domains; Concierge already plans HTTP integration to separate Shop/Booking products.
+2. **Shared database** — rejected; couples schemas and bypasses API contracts.
+3. **Independent product with HTTP clients** (chosen): NeNe Clear calls sibling APIs only.
+
+## Decision
+
+NeNe Clear is a **separate repository and deployable unit**:
+
+- Dependency direction: `NeNe Clear → sibling API`. Never `Sibling → NeNe Clear` code inclusion.
+- No shared PHP codebase beyond Composer dependency on NENE2.
+- No invoice routes, PDF generation, or payment logic in sibling repos.
+- Siblings expose documented HTTP APIs; NeNe Clear implements `Upstream/` HTTP clients when integration is needed.
+- MCP tools map to NeNe Clear OpenAPI operations only — not direct access to sibling databases.
+
+```
+Admin UI / MCP
+    ↓
+NeNe Clear API (clients, quotes, invoices, payments)
+    ↓
+NeNe Clear database (owned here)
+    ↓ optional HTTP
+NeNe Records / NeNe Concierge / external APIs
+```
+
+Billing-owned data (clients, quotes, invoices, payments, PDF artifacts metadata) lives in **NeNe Clear database only**.
+
+## Consequences
+
+**Benefits**
+
+- Sibling products remain stable when billing services change.
+- Clear OSS story: four products, one framework, HTTP integration.
+- Security boundaries: CMS admin JWT ≠ billing admin JWT.
+
+**Costs**
+
+- Multiple repos to maintain; cross-repo API contracts must stay documented.
+- Some duplication of admin UI patterns (acceptable; different domains).
+
+**Follow-up**
+
+- Document upstream client env vars in `docs/integrations/sibling-products.md`.
+- Add contract tests when Records product catalog API is consumed.
+
+## Related
+
+- Product vision: `docs/explanation/product-vision.md`
+- Sibling integration policy: `docs/integrations/sibling-products.md`
+- NeNe Concierge glossary (Shop/Booking precedent): https://github.com/hideyukiMORI/nene-concierge/blob/main/docs/explanation/glossary.md

--- a/docs/adr/0004-tax-rounding-per-rate.md
+++ b/docs/adr/0004-tax-rounding-per-rate.md
@@ -1,0 +1,88 @@
+# ADR 0004: Consumption Tax Rounding Once Per Rate Per Document
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear calculates consumption tax for quotes and invoices. The early
+domain model draft (`docs/explanation/domain-model.md`) rounded tax **per line
+item** and then summed the rounded line amounts into the document tax total.
+
+Under the Japan qualified invoice system (適格請求書等保存方式), consumption tax
+rounding is constrained: for **one qualified invoice**, the tax amount may be
+rounded **once per tax rate** (税率ごとに1回). Rounding each line item and then
+summing is **not** permitted, because it can round more than once per rate
+within a single document and produce a tax total that does not match the
+rate-grouped statutory figure.
+
+The rounding direction itself (round half-up / floor / ceil) is the issuer's
+choice, but it must be applied at the rate-group level, not per line, and stay
+consistent across a document.
+
+Alternatives considered:
+
+1. **Round per line item, then sum** — rejected; rounds more than once per rate
+   and is non-compliant with the qualified invoice rule.
+2. **No rounding until the grand total** — rejected; the qualified invoice
+   requires the consumption tax **per tax rate category** (税率ごとの消費税額)
+   to be a displayed, rounded figure, so rounding must happen at the rate group.
+3. **Round once per tax rate per document** (chosen) — compliant and matches the
+   rate-category figures the PDF must render.
+
+## Decision
+
+Compute consumption tax by grouping line items by `tax_rate_bps`, summing the
+taxable amount per rate, and rounding **once per rate** to integer minimum
+currency units. Do not round individual line item tax amounts.
+
+```
+# Group line items by tax_rate_bps:
+for each rate group:
+    taxable_amount_cents[rate] = sum(quantity * unit_price_cents) in that group
+    tax_cents[rate]            = round(taxable_amount_cents[rate] * rate / 10000)   # ROUND ONCE here
+
+subtotal_cents = sum(taxable_amount_cents[rate] for all rates)
+tax_cents      = sum(tax_cents[rate] for all rates)
+total_cents    = subtotal_cents + tax_cents
+```
+
+- Rounding direction: **half-up** to integer minimum currency units, applied per
+  rate group. A future ADR may make the direction configurable per issuer if a
+  real operator requires floor/ceil; until then half-up is the single rule.
+- This calculation is the **single source of truth** in the UseCase layer. The
+  PDF and API responses both render these exact values; neither recalculates.
+- `tax_rate_bps` is in basis points (1000 = 10%, 800 = 8% reduced). See
+  `docs/explanation/glossary.md`.
+
+## Consequences
+
+**Benefits**
+
+- Compliant with the qualified invoice "round once per tax rate per document"
+  rule.
+- The per-rate `tax_cents[rate]` figures are exactly the
+  税率ごとの消費税額 the qualified invoice PDF must display.
+- API and PDF totals are guaranteed equal — one calculation, no per-line drift.
+
+**Costs**
+
+- Line items no longer carry an independently rounded tax amount; any per-line
+  tax shown in the UI is illustrative and must be labeled as such, not summed.
+- Changing the rounding direction later is an issuer-visible behavior change and
+  needs its own ADR.
+
+**Follow-up**
+
+- Implement in the `Quote` / `Invoice` tax calculation UseCase (Phase 1) with
+  unit tests covering mixed 10% / 8% documents and half-up boundary cases.
+
+## Related
+
+- Domain model: `docs/explanation/domain-model.md`
+- Requirements (qualified invoice fields): `docs/explanation/requirements.md`
+- Backend standards (money and tax): `docs/development/backend-standards.md`
+- Issue: `#9`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0005-bilingual-ja-en-scope.md
+++ b/docs/adr/0005-bilingual-ja-en-scope.md
@@ -1,0 +1,84 @@
+# ADR 0005: Bind Product Localization to Japanese and English Only
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear is built around the Japan invoice system (適格請求書, consumption
+tax rates, per-rate rounding — see ADR 0004). The domain rules are
+Japan-specific and cannot be localized away.
+
+The operator base is shifting: more non-Japanese people now run businesses
+**inside Japan**. They operate under Japanese accounting and tax rules but are
+more comfortable driving the admin UI in English. So an English operator UI adds
+real value.
+
+Going further to arbitrary multilingual support (e.g. zh, ko, fr, es) does not.
+A non-Japanese-accounting locale serves no real operator, because every operator
+— regardless of native language — is subject to the same Japanese statutory
+rules. Each added UI locale increases translation surface, review burden, and
+the risk of mistranslating tax/legal terms, without serving the actual audience.
+
+Alternatives considered:
+
+1. **Japanese only** — rejected; excludes the growing non-Japanese operator
+   segment running businesses in Japan.
+2. **Full i18n / community-driven multilingual** — rejected; large maintenance
+   and translation-accuracy surface for locales that match no real operator
+   profile, since the domain is locked to Japanese rules.
+3. **Japanese + English only** (chosen) — covers the actual operator base at a
+   bounded, maintainable translation surface.
+
+## Decision
+
+NeNe Clear localizes to **Japanese (primary) and English (secondary) only**.
+
+- **In scope:** admin UI strings, operator-facing guides, and operator-visible
+  labels in **ja and en**. Japanese is the default; English is a first-class
+  alternate.
+- **Out of scope:** any additional UI locale. Pull requests adding other locales
+  are declined unless a future ADR supersedes this decision. This is a
+  deliberate product non-goal, not a missing feature.
+- **Statutory document content stays Japanese.** The qualified invoice
+  (適格請求書) PDF renders its legally required fields in Japanese because it is
+  a legal document under Japanese law. English applies to the operator's working
+  UI chrome, navigation, and guides — not to the statutory invoice content.
+- **Development docs are unaffected.** Source-of-truth docs, OpenAPI text, and
+  API error metadata remain **English** per the existing language policy
+  (`docs/inheritance-from-nene2.md`); Issues, PRs, commits, and `.cursor/rules/`
+  continue to allow Japanese. This ADR governs **product localization**, not the
+  repository's documentation language.
+
+## Consequences
+
+**Benefits**
+
+- Serves the real operator base — Japanese SMB plus non-Japanese operators doing
+  business in Japan — without over-investing.
+- Bounded, maintainable translation surface; lower risk of mistranslated tax or
+  legal terminology.
+- Clear contributor expectation: locale additions beyond ja/en are out of scope.
+
+**Costs**
+
+- Explicitly turns away community multilingual contributions.
+- Frontend must carry a real ja/en locale catalog from Phase 2, not a
+  Japanese-only string set.
+
+**Follow-up**
+
+- Phase 2 admin UI ships ja + en locale catalogs (`docs/development/frontend-standards.md`).
+- If a concrete operator need for another locale ever appears, supersede this
+  ADR rather than quietly adding locales.
+
+## Related
+
+- Product vision: `docs/explanation/product-vision.md`
+- Requirements: `docs/explanation/requirements.md`
+- Frontend standards: `docs/development/frontend-standards.md`
+- Documentation language policy: `docs/inheritance-from-nene2.md`
+- Issue: `#11`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0006-multi-tenancy-and-roles.md
+++ b/docs/adr/0006-multi-tenancy-and-roles.md
@@ -1,0 +1,117 @@
+# ADR 0006: Adopt Multi-Tenancy and Role Hierarchy as Foundational
+
+## Status
+
+accepted
+
+## Context
+
+The early product docs assumed Phase 1 was single-tenant, with multi-tenancy
+deferred ("`company_settings` singleton per organization (Phase 1 single-tenant;
+multi-tenant adds `organization_id`)"). In practice the product must support, from
+the foundation:
+
+- agencies and hosting operators running **one install for multiple client
+  organizations**, and
+- a **role hierarchy** where a platform operator manages organizations and an
+  organization administrator manages that organization's users.
+
+Sibling product [NeNe Records](https://github.com/hideyukiMORI/nene-records)
+already implements exactly this on NENE2 (per-request organization resolution,
+`Role`/`Capability` enums, `CapabilityMiddleware`, `organization_id` on
+tenant-scoped tables). Retrofitting tenancy later would touch every table,
+repository, and route — far more costly than building tenant-aware from day one.
+
+Alternatives considered:
+
+1. **Single-tenant first, retrofit later** — rejected; a later `organization_id`
+   migration across all billing tables plus auth rework is high-risk and
+   re-opens compliance-sensitive code (issued documents, numbering).
+2. **Separate install per tenant only** — rejected; does not serve agencies and
+   duplicates operations; the data model should still be tenant-aware.
+3. **Multi-tenant foundation, mirroring NeNe Records** (chosen) — tenant-aware
+   schema and middleware from the start; a single install may still run as one
+   organization via the `single` resolution mode.
+
+## Decision
+
+NeNe Clear is **multi-tenant from the foundation**, adopting the NeNe Records
+architecture.
+
+### Tenancy
+
+- Every tenant-scoped table carries **`organization_id`** (`company_settings`,
+  `clients`, `quotes`, `invoices`, `line_items`, `payments`,
+  `document_sequences`, `users`).
+- The **organization** (`organizations` table) is the tenant. Each organization
+  is an independent **issuer** of qualified invoices, with its own
+  `company_settings` (legal name, address, **registration number**, bank info).
+- Per-request **organization resolution** runs in middleware before authorization
+  (mirroring `OrgResolverMiddleware`). Supported modes: **`single`** (default —
+  one organization per install), `path` (`/{org-slug}/…`), `subdomain`, and
+  `custom_domain`. The resolved organization id is held in a request-scoped holder
+  and **every repository query is org-scoped**.
+- Document numbering sequences are **per organization and year** (already in
+  `domain-model.md`); tenancy makes the scope explicit.
+
+### Roles and capabilities
+
+A `Role` enum and a `Capability` enum, resolved per route by a capability
+resolver and enforced by `CapabilityMiddleware` (mirroring NeNe Records):
+
+| Role | Scope | Capabilities |
+| --- | --- | --- |
+| **`superadmin`** | Cross-tenant (platform operator) | All, **including `manage_organizations`**. `organization_id` may be `NULL`. |
+| **`admin`** | Single organization | All **except** `manage_organizations` — manages the org's **users**, **company settings** (issuer profile), and billing. |
+| **`member`** | Single organization | Billing operator — create/edit/send quotes & invoices, record payments (`manage_billing`, `view_billing`). **Cannot** manage users or settings. |
+| **`viewer`** | Single organization | Read-only (`view_billing`). Optional; Phase 3+. |
+
+Capabilities (billing-specific; the set differs from NeNe Records' content
+capabilities): `manage_organizations`, `manage_users`, `manage_company_settings`,
+`manage_billing`, `view_billing`.
+
+- **Superadmin manages organizations** (`/admin/organizations` — create, list,
+  delete tenants).
+- **Admin manages users** within the organization (`/admin/users`).
+- Role and capability string values are registered in
+  [`../explanation/terminology.md`](../explanation/terminology.md) (binding).
+
+### Compliance interaction
+
+- Each organization's issuer registration number and issued documents are scoped
+  to that organization; cross-tenant reads are prohibited. This does not relax any
+  rule in [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) —
+  immutability, numbering, and retention apply **per organization**.
+
+## Consequences
+
+**Benefits**
+
+- Serves agencies/hosting operators and single SMBs from one codebase; `single`
+  mode keeps the simple case simple.
+- Avoids a high-risk tenancy retrofit across compliance-sensitive billing tables.
+- Consistent with the NeNe ecosystem; patterns and reviews transfer.
+
+**Costs**
+
+- Every repository query must be org-scoped — a standing review item
+  (`docs/review/database.md`, `docs/review/middleware-security.md`).
+- Auth, org resolution, and RBAC are part of the runtime foundation (Issue #4),
+  enlarging it beyond a bare health endpoint.
+
+**Follow-up**
+
+- **PR-B (Issue #4 expanded):** runtime foundation — org resolution + JWT auth +
+  RBAC wiring + `GET /health`.
+- **PR-C+:** organization CRUD (superadmin) and user CRUD (admin).
+
+## Related
+
+- Reference implementation: NeNe Records `src/Organization/`, `src/Auth/` (Role, Capability, CapabilityResolver, CapabilityMiddleware), `src/Organization/Resolution/`
+- Requirements: `docs/explanation/requirements.md`
+- Domain model: `docs/explanation/domain-model.md`
+- Terminology registry: `docs/explanation/terminology.md`
+- Compliance: `docs/explanation/accounting-compliance.md`
+- Issue: `#17`
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0007-product-identity-nene-clear.md
+++ b/docs/adr/0007-product-identity-nene-clear.md
@@ -1,0 +1,35 @@
+# ADR 0007: Product Identity — NeNe Clear
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear is the fourth **application-layer** product in the NeNe portfolio
+(beside Records, Corpus, Concierge). The public working repo `nene-invoice` was
+used for early experiments; **this repository (`nene-clear`) is the canonical
+product** (private until launch). Strategy lives in
+[publication-strategy decision 0004](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/decisions/0004-nene-clear-product-strategy.md).
+
+## Decision
+
+- **Product name:** NeNe Clear
+- **Tagline (EN):** Clear billing from quote to cash.
+- **Tagline (JA):** 見積から入金まで、明快に。
+- **Repository:** `hideyukiMORI/nene-clear` (private until public launch)
+- **PHP namespace:** `NeneClear\`
+- **Problem Details base:** `https://nene-clear.dev/problems/`
+
+*"Clear"* reads as payment **clearing** (消込), **clarity** of status, and
+removing Excel chaos.
+
+## Consequences
+
+- All docs and code use **NeNe Clear** in prose and `NeneClear\` in PHP.
+- `nene-invoice` is not updated for product strategy; do not merge strategy docs there.
+
+## Related
+
+- Philosophy: `docs/explanation/philosophy.md`
+- Issue: #1

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -1,0 +1,51 @@
+# ADR Policy
+
+NeNe Clear uses lightweight Architecture Decision Records, inherited from [NENE2 ADR policy](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/adr.md).
+
+## When to write an ADR
+
+Write an ADR when a decision affects:
+
+- quote, invoice, payment architecture, or public API contracts
+- Japan invoice compliance strategy or PDF generation approach
+- dependency or framework integration choices
+- authentication, authorization, or MCP safety boundaries
+- dual deployment (Tier A shared hosting vs Tier B Docker)
+- release, versioning, or compatibility policy
+- long-term maintenance cost
+
+Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/current.md`.
+
+## Directory and naming
+
+```text
+docs/adr/
+├── 0000-template.md
+├── 0001-inherit-nene2-governance.md
+├── 0002-separate-from-sibling-products.md
+├── 0007-product-identity-nene-clear.md
+├── 0006-multi-tenancy-and-roles.md
+├── 0007-product-identity-nene-clear.md
+└── NNNN-short-title.md
+```
+
+Use a stable four-digit sequence. Do not renumber after publication.
+
+## Status values
+
+- `proposed`
+- `accepted`
+- `deprecated`
+- `superseded`
+
+Supersede old ADRs instead of silently rewriting history.
+
+## Template
+
+Use `docs/adr/0000-template.md`.
+
+## Relationship to NENE2 ADRs
+
+- NENE2 ADRs describe **framework** decisions.
+- NeNe Clear ADRs describe **product** decisions.
+- When consuming NENE2, prefer upstream ADRs for framework behavior; record local deviations here.

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -1,0 +1,125 @@
+# Backend Standards
+
+NeNe Clear backend policy for PHP API code. Adapted from [NeNe Records](https://github.com/hideyukiMORI/nene-records) and [NeNe Corpus](https://github.com/hideyukiMORI/nene-corpus) backend standards for a **billing OSS** on NENE2.
+
+**Framework baseline:** NENE2 `docs/development/` — deviate only via local ADR.
+
+**Naming and terms:** [`naming-conventions.md`](./naming-conventions.md), [`glossary.md`](../explanation/glossary.md).
+
+---
+
+## 1. Project shape
+
+NeNe Clear is a **NENE2 consumer project**:
+
+```
+vendor/hideyukimori/nene2/   ← framework (do not edit)
+src/                         ← product code (NeneClear\)
+tests/                       ← mirrors src/
+docs/openapi/openapi.yaml    ← public contract
+public_html/index.php        ← front controller
+```
+
+Namespace: `NeneClear\`
+
+---
+
+## 2. Module layout (domain-grouped)
+
+Organize by **domain**, not technical layer:
+
+```
+src/
+  ApplicationServiceProvider.php
+  Http/
+  Organization/     # tenants + per-request resolution (Organization/Resolution/)
+  Auth/             # JWT login, Role / Capability, capability middleware
+  User/             # operator accounts within an organization
+  Company/          # issuer profile, tax registration, bank info (per organization)
+  Client/           # customer master
+  Quote/            # estimates
+  Invoice/          # issued invoices, qualified invoice fields
+  LineItem/         # shared line item logic (quote + invoice)
+  Payment/          # payment records, status
+  Pdf/              # server-side PDF generation
+  Upstream/         # optional HTTP clients (Records, Concierge)
+```
+
+Every tenant-scoped table and query carries `organization_id` (ADR 0006). Only
+superadmin operates cross-tenant.
+
+**Zero-tolerance placement:** handlers live in their domain folder (`Invoice/CreateInvoiceHandler.php`), not `src/Handlers/`.
+
+---
+
+## 3. Layering rules
+
+```
+Handler → UseCase → RepositoryInterface → PdoRepository
+```
+
+| Layer | May | Must not |
+| --- | --- | --- |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response | SQL, business rules, direct PDF library calls |
+| **UseCase** | Business rules, tax calculation, orchestration | `$_SERVER`, PDO, raw HTTP |
+| **Repository** | SQL / persistence | HTTP, PDF generation |
+| **Pdf adapter** | Render PDF from DTO | Domain invariants, SQL |
+
+Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
+
+---
+
+## 4. HTTP & OpenAPI
+
+- Every public route appears in `docs/openapi/openapi.yaml` with `operationId`.
+- Success and Problem Details error shapes documented.
+- RFC 9457 Problem Details for errors; base URL `https://nene-clear.dev/problems/`.
+- Admin routes require JWT Bearer auth (Phase 1+).
+
+---
+
+## 5. Money and tax
+
+> **Compliance is binding (non-negotiable).** All billing, tax, numbering, PDF,
+> and retention behavior **MUST** comply with
+> [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+> Where compliance conflicts with convenience, compliance wins. Deviations
+> require an ADR with tax-professional sign-off. Run
+> [`../review/compliance.md`](../review/compliance.md) for any change in this area.
+
+- Store all amounts as **integer cents** (`subtotal_cents`, `tax_cents`, `total_cents`). Float / DECIMAL for money is prohibited.
+- Tax rates: store as basis points or documented enum — never float percentages in persisted data.
+- Consumption tax is rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
+- Japan qualified invoice fields validated in UseCase layer before PDF generation; missing required fields block issuance.
+- Issued documents are immutable; corrections via credit note, not edit/delete. No hard delete of billing records.
+- PDF totals must match API-calculated cents — single source of truth in UseCase.
+
+---
+
+## 6. Database
+
+- Phinx migrations under `database/migrations/`.
+- Schema snapshots under `database/schema/`.
+- Soft delete: `is_deleted`, `deleted_at` unless ADR says otherwise.
+- Multi-tenant: `organization_id` on tenant-scoped tables when tenancy lands (ADR TBD).
+
+---
+
+## 7. Testing
+
+- UseCase tests: no DB — inject repository fakes or in-memory implementations.
+- Repository tests: SQLite in-memory PDO.
+- HTTP tests: contract tests against OpenAPI shapes.
+- PDF tests: assert byte output or snapshot hash — do not visually review in CI.
+
+---
+
+## 8. Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Self-review: [`docs/review/backend-api.md`](../review/backend-api.md), [`docs/review/database.md`](../review/database.md), [`docs/review/compliance.md`](../review/compliance.md).

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,61 @@
+# Coding Standards
+
+NeNe Clear coding standards split by surface. **Full policies live in the dedicated documents below** — this file is the index.
+
+| Surface | Source of truth |
+| --- | --- |
+| **PHP / API / database** | [`backend-standards.md`](./backend-standards.md) |
+| **Naming (code, API, DB, tests)** | [`naming-conventions.md`](./naming-conventions.md) |
+| **Canonical term/identifier spellings** | [`../explanation/terminology.md`](../explanation/terminology.md) |
+| **Product term meanings (glossary)** | [`../explanation/glossary.md`](../explanation/glossary.md) |
+| **React / TypeScript admin** | [`frontend-standards.md`](./frontend-standards.md) (Phase 2+) |
+| **NENE2 inheritance map** | [`../inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
+
+**Framework baseline:** [NENE2 coding standards](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/coding-standards.md) — NeNe Clear deviates only where local docs or ADRs say so.
+
+---
+
+## Shared rules (all surfaces)
+
+- **Naming conventions are absolute (non-negotiable).** Violations and typos block merge — see [`naming-conventions.md`](./naming-conventions.md).
+- **Terminology has one source of truth:** [`../explanation/terminology.md`](../explanation/terminology.md). Every identifier must match it exactly; adding/renaming a term updates the registry in the same PR.
+- **Zero typos in identifiers.** Spelling variants of registered terms are defects, not style preferences.
+- GitHub Issue-driven work; focused PRs; no direct commits to `main`
+- **Strict typing** at boundaries — PHP readonly DTOs; TypeScript strict mode (when frontend exists)
+- **OpenAPI** is the public API contract; MCP maps to the same HTTP operations
+- Application Problem Details `type`: `https://nene-clear.dev/problems/{problem-name}`
+- **Monetary values:** integer cents everywhere — no floats in DB or JSON
+- **Placement violations block merge** — see backend standards
+- Public docs, OpenAPI text, and API error metadata: **English**
+- Issues, PRs, commits, `.cursor/rules/`: **Japanese allowed**
+- **Never integrate billing into sibling products** — ADR 0002
+
+---
+
+## Backend (summary)
+
+Full policy: **`docs/development/backend-standards.md`**. Naming: **`docs/development/naming-conventions.md`**.
+
+- NENE2 consumer — framework in `vendor/`, product in `src/`
+- Domain-grouped modules — not layer folders
+- Handler → UseCase → RepositoryInterface → PdoRepository
+- No PDO/SQL outside `Pdo*Repository`; no business logic in handlers
+- Phinx migrations + `database/schema/` snapshots
+- PHPUnit: in-memory use cases, SQLite repositories, OpenAPI contract tests
+- `composer check` before merge
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+When `frontend/` exists:
+
+```bash
+npm run check --prefix frontend
+```

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,0 +1,61 @@
+# Commit Message Conventions
+
+NeNe Clear uses Conventional Commits, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md) and sibling NeNe products.
+
+## Format
+
+```text
+<type>(<optional scope>): <description> (#<issue>)
+
+[optional body]
+
+[optional footer]
+```
+
+## Language
+
+- Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in **English**.
+- Write the **description and body in Japanese**.
+- Include the related GitHub Issue number in the **subject** for all work.
+
+Example:
+
+```text
+docs(governance): Issue 駆動ワークフローを NENE2 正本に整合する (#1)
+```
+
+```text
+feat(invoice): 適格請求書 PDF 生成 UseCase を追加する (#12)
+```
+
+## Issue number
+
+| Situation | Rule |
+| --- | --- |
+| Normal work | Subject **must** include `(#issue)` |
+| Docs-only follow-up on same Issue | Reuse the same Issue number |
+
+If you start editing without an Issue, **stop and create one first** — see `docs/workflow.md`.
+
+## Common Types
+
+| Type | Use |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change without feature or bug fix |
+| `test` | Test additions or changes |
+| `build` | Dependency or build setup |
+| `ci` | CI configuration |
+| `chore` | Maintenance |
+
+## Body
+
+Use the body when the reason is not obvious from the subject. Explain why the change exists, what trade-off was chosen, and whether follow-up work remains.
+
+## Breaking Changes
+
+Use `!` or a `BREAKING CHANGE:` footer when public API, configuration, CLI, or documented behavior changes incompatibly.
+
+Public API changes must also update OpenAPI and, when applicable, `docs/mcp/tools.json`.

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -1,0 +1,18 @@
+# Frontend Standards
+
+**Status:** Phase 2 — not implemented yet.
+
+NeNe Clear admin UI will follow sibling product conventions:
+
+- React + TypeScript + Vite
+- Strict mode enabled
+- API client maps **snake_case** JSON without renaming fields
+- UI strings in locale catalogs — **ja (primary) + en (secondary) only**; no
+  hardcoded strings, no other locales (ADR 0005)
+- Statutory invoice content rendered in Japanese regardless of UI locale (legal
+  document); en applies to UI chrome and operator guides
+- No admin JWT in public document download pages
+
+When `frontend/` lands, expand this document with component layout, test strategy, and build output paths (`public_html/admin/`).
+
+Until then, mark frontend checklist items as `N/A` in PRs.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -1,0 +1,237 @@
+# Naming Conventions
+
+Authoritative naming rules for NeNe Clear code, API contracts, database objects, tests, and English documentation.
+
+> **Absolute adherence — non-negotiable.** These rules are **MUST**, not
+> suggestions. A name that violates a rule here, or a typo / spelling variant of
+> a registered term, is a defect and **blocks merge**. There is no "close
+> enough." When in doubt, match the registry exactly.
+>
+> The concrete canonical spelling of every term and identifier lives in the
+> **single source of truth**: [`../explanation/terminology.md`](../explanation/terminology.md).
+> This document defines the *patterns*; the registry defines the *exact strings*.
+> Introducing or renaming any identifier **MUST** update the registry in the same PR.
+
+**Terminology registry (canonical spellings):** [`docs/explanation/terminology.md`](../explanation/terminology.md)
+**Glossary (product term meanings):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
+
+**Framework baseline:** NENE2 [`domain-layer.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/domain-layer.md) and [`database-migrations.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/database-migrations.md). This document is the NeNe Clear override and extension list.
+
+---
+
+## 1. PHP
+
+### Files and namespaces
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Namespace root | `NeneClear\` | `NeneClear\Invoice\CreateInvoiceHandler` |
+| Domain folder | PascalCase singular domain name | `src/Client/`, `src/Invoice/` |
+| File name | Match the primary class | `CreateInvoiceHandler.php` |
+| One public class per file | Required | — |
+
+### Classes and interfaces
+
+| Role | Pattern | Example |
+| --- | --- | --- |
+| HTTP handler | `{Verb}{Noun}Handler` | `CreateInvoiceHandler`, `ListClientsHandler` |
+| Use case interface | `{Verb}{Noun}UseCaseInterface` | `CreateInvoiceUseCaseInterface` |
+| Use case impl | `{Verb}{Noun}UseCase` | `CreateInvoiceUseCase` |
+| Use case method | Always `execute` | `execute(CreateInvoiceInput $input): CreateInvoiceOutput` |
+| Input DTO | `{Verb}{Noun}Input` | `CreateInvoiceInput` |
+| Output DTO | `{Verb}{Noun}Output` | `CreateInvoiceOutput` |
+| Domain entity | Singular noun, no suffix | `Client`, `Quote`, `Invoice`, `Payment` |
+| Repository interface | `{Entity}RepositoryInterface` | `InvoiceRepositoryInterface` |
+| PDO repository | `Pdo{Entity}Repository` | `PdoInvoiceRepository` |
+| PDF adapter | `{Purpose}PdfGenerator` in `Pdf/` | `InvoicePdfGenerator` |
+| Domain exception | `{Entity}{Reason}Exception` | `InvoiceNotFoundException` |
+| Service provider | `{Purpose}ServiceProvider` | `RuntimeServiceProvider` |
+
+All application classes: `final` and `readonly` where applicable. Every PHP file: `declare(strict_types=1);`.
+
+### Modules (`src/`)
+
+Use only domain-grouped top-level folders. Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
+
+Planned domains (Phase 1+): `Organization/`, `Auth/`, `User/`, `Client/`, `Quote/`, `Invoice/`, `Payment/`, `Company/`, `LineItem/`, `Pdf/`, `Http/`.
+
+### Methods and properties
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Methods | camelCase | `findById`, `markAsPaid` |
+| Properties | camelCase | `$clientId`, `$invoiceRepository` |
+| Constants | UPPER_SNAKE_CASE | `MAX_LINE_ITEMS` |
+
+Repository methods use **domain verbs**: `findById`, `save`, `delete` — not `selectById`, `insertRow`.
+
+---
+
+## 2. HTTP routes and OpenAPI
+
+### URL paths
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Path segments | lowercase **kebab-case** | `/admin/clients`, `/admin/invoices` |
+| Collection paths | plural noun | `/admin/quotes`, `/admin/payments` |
+| Single resource | `{id}` path param | `/admin/invoices/{id}` |
+| Public download | noun path | `/documents/invoices/{token}/pdf` |
+| Path param name | lowercase singular | `id`, `clientId` |
+
+Admin mutating routes live under `/admin/…`.
+
+### operationId
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Case | camelCase | `getHealth`, `createInvoice` |
+| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listClients`, `getInvoiceById` |
+| Stability | Never rename after release; deprecate instead | — |
+
+Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mcp/tools.json` `operationId`.
+
+### OpenAPI schema names
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Response schema | `{Resource}Response` | `InvoiceResponse` |
+| List response | `{Resource}ListResponse` | `ClientListResponse` |
+| Create request | `Create{Resource}Request` | `CreateQuoteRequest` |
+| Tag names | PascalCase singular group | `System`, `Admin`, `Client`, `Invoice` |
+
+Public OpenAPI summaries, descriptions, and examples: **English only**.
+
+---
+
+## 3. JSON (request and response bodies)
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Property names | **snake_case** | `client_id`, `issued_at`, `tax_rate` |
+| Money amounts | integer **cents** | `subtotal_cents`, `tax_cents`, `total_cents` |
+| Booleans | `is_` / `has_` prefix | `is_paid`, `is_qualified_invoice` |
+| Timestamps | `_at` suffix, ISO 8601 string | `issued_at`, `due_at`, `paid_at` |
+| Foreign keys | `{entity}_id` | `client_id`, `quote_id` |
+| List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
+
+Do not mix camelCase in public JSON. Do not use floats for money.
+
+---
+
+## 4. Problem Details and validation errors
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Base URL | `https://nene-clear.dev/problems/` | — |
+| Type slug | kebab-case | `validation-failed`, `invoice-not-found` |
+| Validation `errors[].field` | snake_case path | `body.registration_number` |
+| Validation `errors[].code` | snake_case | `required`, `invalid_invoice_number` |
+
+Problem Details `title` and `detail`: English.
+
+---
+
+## 5. Database
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Table names | snake_case, **plural** | `clients`, `quotes`, `invoices`, `line_items`, `payments` |
+| Column names | snake_case | `client_id`, `total_cents`, `issued_at` |
+| Money columns | `*_cents` suffix, integer | `subtotal_cents`, `tax_cents` |
+| Primary key | `id` | BIGINT auto-increment |
+| Foreign key column | `{singular_entity}_id` | `quote_id`, `invoice_id` |
+| Index names | `idx_{table}_{columns}` | `idx_invoices_client_id` |
+| Unique constraints | `uniq_{table}_{columns}` | `uniq_invoices_number` |
+
+SQL lives only in `Pdo*Repository` classes.
+
+### Migrations
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260529120000_create_invoices_table.php` |
+| Snapshot file | `database/schema/{table}.sql` | `database/schema/invoices.sql` |
+
+---
+
+## 6. Environment variables
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Names | UPPER_SNAKE_CASE | `DB_HOST`, `NENE_CLEAR_PORT` |
+| Prefix | Product-specific compose overrides | `NENE_CLEAR_` |
+| Secrets | Never commit; document in `.env.example` only | — |
+
+---
+
+## 7. Tests
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Test class | `{ClassUnderTest}Test` | `CreateInvoiceUseCaseTest` |
+| Test method | `test_{behavior}_when_{condition}` | `test_rejects_missing_registration_number_when_qualified_invoice` |
+| Test namespace | Mirror `src/` under `tests/` | `tests/Invoice/CreateInvoiceUseCaseTest.php` |
+
+---
+
+## 8. MCP tools
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Tool `name` | Same as OpenAPI `operationId` | `listInvoices` |
+| Tool `title` | Short English Title Case | `List Invoices` |
+| `safety` | `read` or `write` | Prefer `read` until auth review passes |
+
+Catalog: `docs/mcp/tools.json`. Validate with `composer mcp`.
+
+---
+
+## 9. Frontend (Phase 2+)
+
+| Item | Rule |
+| --- | --- |
+| Components | PascalCase file and export |
+| Hooks | camelCase with `use` prefix |
+| API client | Maps snake_case JSON; do not rename API fields in transit |
+| Admin SPA | React + TypeScript strict mode |
+
+Full frontend standards: **`docs/development/frontend-standards.md`** (Phase 2).
+
+---
+
+## 10. Documentation and commits
+
+| Surface | Language | Naming |
+| --- | --- | --- |
+| Public docs, OpenAPI, API errors | English | Use glossary canonical terms |
+| Issues, PRs, commit bodies | Japanese allowed | Prefer glossary English term on first mention |
+| Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
+| ADR file | `NNNN-kebab-title.md` | `0002-separate-from-sibling-products.md` |
+
+When adding or renaming any identifier, update [`terminology.md`](../explanation/terminology.md) in the same PR; if it is a product concept, also update [`glossary.md`](../explanation/glossary.md).
+
+---
+
+## 11. Prohibited patterns
+
+- **Typos or spelling variants of any term registered in `terminology.md`** (e.g. `tax_registration_number` for `registration_number`, `sub_total_cents` for `subtotal_cents`) — blocks merge
+- **Unregistered identifiers** — using an entity, status, field, slug, or `operationId` not present in `terminology.md` without adding it in the same PR
+- Layer-first folders (`src/Handlers/`, `src/Repositories/`)
+- SQL outside `Pdo*Repository`
+- camelCase in public JSON property names
+- Float or DECIMAL for money in SQLite tests or API JSON
+- Renaming shipped `operationId` values
+- Embedding billing logic in NeNe Records or other sibling repos
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Review checklists: [`docs/review/`](../review/).

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -1,0 +1,39 @@
+# Self-Review Checklist Policy
+
+NeNe Clear uses self-review checklists before push or PR, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/self-review.md).
+
+## How to use
+
+1. Identify the work type.
+2. Open the matching checklist in `docs/review/`.
+3. Review every applicable item.
+4. Run the narrowest useful verification.
+5. Mention the checklist in the PR body.
+
+Example:
+
+```text
+Self-review: backend-api, openapi-contract
+```
+
+If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist items to pass review.
+
+## Checklist files
+
+| File | Use for |
+| --- | --- |
+| `compliance.md` | **Binding.** Any change touching quotes, invoices, payments, tax, numbering, PDF, or retention |
+| `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
+| `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
+| `database.md` | Migrations, repositories, soft delete |
+| `middleware-security.md` | Auth, CORS, logging, rate limits |
+| `docs-policy.md` | Workflow, ADRs, roadmap, Cursor rules |
+| `frontend.md` | **Phase 2 — not in repo yet.** Admin React/TypeScript |
+
+Do **not** use `frontend.md` until Phase 2 creates `frontend/`. Until then, skip that checklist or mark `N/A`.
+
+## AI agents
+
+Pick relevant checklists before finalizing changes. Do not claim an item passed if it was not checked.
+
+If no checklist matches, use `docs/workflow.md`, `docs/development/coding-standards.md`, and `docs/inheritance-from-nene2.md` directly.

--- a/docs/explanation/accounting-compliance.md
+++ b/docs/explanation/accounting-compliance.md
@@ -1,0 +1,161 @@
+# Accounting & Tax Compliance — Binding Rules
+
+**Status: binding (non-negotiable).** This document is the source of truth for
+NeNe Clear's adherence to Japanese accounting, consumption tax, and qualified
+invoice law. A finance or accounting professional reviewing the system must be
+able to find **zero deviations** from the rules below.
+
+These are not guidelines. They are **MUST** requirements. Where a rule here
+conflicts with UX, performance, implementation convenience, or any other
+concern, **compliance wins** — every time, without exception.
+
+See also: [`requirements.md`](./requirements.md), [`domain-model.md`](./domain-model.md),
+[ADR 0004](../adr/0004-tax-rounding-per-rate.md), self-review checklist
+[`../review/compliance.md`](../review/compliance.md).
+
+---
+
+## 0. Governing principle
+
+1. **Compliance is non-negotiable.** Correct adherence to the law takes
+   precedence over every other product goal.
+2. **No silent deviation.** Any departure from the rules in this document — even
+   temporary — requires an **ADR** and **explicit review sign-off by a tax/
+   accounting professional (税理士)** recorded in that ADR. Code may not merge a
+   deviation without it.
+3. **Engineering is not the legal authority.** This document is engineering's
+   binding interpretation of the rules. When a requirement is unclear, **stop
+   and consult a 税理士** — do not guess. Record the resolved interpretation here.
+4. **Single source of truth for figures.** Every monetary and tax figure is
+   computed once in the UseCase layer. The PDF, API, and stored copy render the
+   exact same values; no layer recalculates independently.
+
+---
+
+## 1. Statutory basis
+
+NeNe Clear targets the following Japanese rules. This list states *what we
+comply with*; it is not legal advice.
+
+| Area | Rule set |
+| --- | --- |
+| Consumption tax | 消費税法（標準税率 10% / 軽減税率 8%） |
+| Qualified invoice | 適格請求書等保存方式（インボイス制度） |
+| Stored records | 電子帳簿保存法（電子取引データ・写しの保存） |
+
+When any of these change (rate changes, new statutory fields, retention rule
+changes), treat it as a compliance defect until the product is updated, and open
+a P0 Issue.
+
+---
+
+## 2. Qualified invoice (適格請求書) — mandatory content
+
+When `is_qualified_invoice = true`, the system **MUST** enforce and render **all**
+of the following. Missing any required field **MUST** block issuance.
+
+### Issuer (供給者)
+- Legal name (氏名又は名称)
+- Address (住所又は所在地)
+- **Registration number** (登録番号), format `T` + 13 digits — see §4
+- Transaction / issue date (取引年月日・交付年月日)
+
+### Buyer (交付を受ける者)
+- Name (氏名又は名称)
+- Address when applicable
+
+### Transaction details
+- Description per line (取引内容); reduced-rate items (軽減税率対象) **MUST** be
+  clearly marked
+- **Taxable amount per tax rate** (税率ごとに区分して合計した対価の額)
+- **Consumption tax amount per tax rate** (税率ごとの消費税額)
+- Total billed amount (請求金額)
+
+These figures are statutory. They are not cosmetic PDF fields — they are
+validated in the UseCase before any document is issued or rendered.
+
+---
+
+## 3. Consumption tax calculation
+
+- Allowed rates: **10% (1000 bps)** and **8% reduced (800 bps)**. Adding or
+  changing a rate is a compliance change → requires an ADR.
+- **Rounding: once per tax rate per document**, never per line item.
+  Direction: half-up. This is binding — see
+  [ADR 0004](../adr/0004-tax-rounding-per-rate.md). Per-line rounding is
+  **prohibited** because it can round more than once per rate within one
+  document.
+- The per-rate consumption tax figure produced here is exactly the
+  税率ごとの消費税額 the qualified invoice must display.
+
+---
+
+## 4. Registration number
+
+- Format check: `^T[0-9]{13}$`. This is **syntax only** — it does **not** prove
+  the number exists or is registered, and the system does **not** perform a
+  check-digit or registry lookup. UI and docs **MUST NOT** present a format pass
+  as proof of validity.
+- An invoice **MUST NOT** be markable as qualified while the issuer registration
+  number is empty.
+
+---
+
+## 5. Document integrity, numbering, and immutability
+
+- **Issued documents are immutable.** Once an invoice is `issued`, its line
+  items, tax figures, totals, dates, and number **MUST NOT** be edited or
+  deleted. Corrections are made by issuing a **credit note / 修正適格請求書**
+  (Phase 4+), never by mutating or removing the original.
+- **Sequential numbering with no compliance-breaking gaps.** Quote and invoice
+  numbers are assigned in sequence per organization and year. The system **MUST
+  NOT** silently reuse, back-fill, or delete numbers in a way that hides a
+  voided document. A voided document is recorded as voided, not erased.
+- **No hard delete of billing records.** Quotes, invoices, payments, and issued
+  PDFs use soft delete / void semantics; financial history is preserved.
+
+---
+
+## 6. Retention of issued copies (写しの保存)
+
+- The system **MUST** retain a copy of every **issued** qualified invoice (and
+  the figures used to produce it).
+- Retained copies are **tamper-evident**: a stored issued document **MUST NOT**
+  be silently mutated. Reissuing produces a new versioned record, not an
+  in-place overwrite.
+- Statutory retention is **7 years** (and may extend to **10 years** in certain
+  loss-carryforward situations). The product **MUST NOT** auto-purge issued
+  billing records before the statutory period. Operators are warned before any
+  destructive retention action.
+
+---
+
+## 7. Money representation
+
+- All amounts are stored and transmitted as **integer minimum currency units**
+  (`*_cents`; for JPY, ¥1 = 1 unit). **Float and DECIMAL for money are
+  prohibited** in DB, API JSON, and tests.
+- Phase 1–3 currency is **JPY only**.
+
+---
+
+## 8. Audit trail
+
+- Invoice **issuance** and **payment recording** are auditable events
+  (who / when / what), from Phase 2.
+- Audit records follow the same no-silent-mutation rule as §6.
+
+---
+
+## 9. How this rule applies to every change
+
+Any change that touches quotes, invoices, payments, tax calculation, document
+numbering, PDF rendering, or retention **MUST**:
+
+1. Be reviewed against this document and [`../review/compliance.md`](../review/compliance.md).
+2. State compliance impact in the PR.
+3. If it deviates from any rule here, carry an ADR with professional sign-off
+   (§0.2). No exceptions.
+
+If you are unsure whether a change has compliance impact, **assume it does** and
+run the checklist.

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -1,0 +1,180 @@
+# Domain Model
+
+NeNe Clear domain overview — entities, relationships, and state machines. Implementation follows Handler → UseCase → Repository layering.
+
+See also: [`requirements.md`](./requirements.md), [`glossary.md`](./glossary.md).
+
+---
+
+## Entity relationship (MVP)
+
+```mermaid
+erDiagram
+    organization ||--o{ user : "has"
+    organization ||--|| company_settings : "issuer profile"
+    organization ||--o{ client : "owns"
+    organization ||--o{ quote : "owns"
+    organization ||--o{ invoice : "owns"
+    organization ||--o{ payment : "owns"
+    client ||--o{ quote : "buyer"
+    client ||--o{ invoice : "buyer"
+    quote ||--o| invoice : "converts_to"
+    quote ||--|{ line_item : "has"
+    invoice ||--|{ line_item : "has"
+    invoice ||--o{ payment : "receives"
+```
+
+- **organization**: the tenant (ADR 0006). Every tenant-scoped table carries `organization_id`. Default resolution mode `single`; agencies use path/subdomain/custom_domain.
+- **user**: operator account with a `role` (superadmin/admin/member/viewer). superadmin is cross-tenant (`organization_id` NULL); all others belong to one organization.
+- **company_settings**: one issuer profile **per organization** (each org issues its own qualified invoices under its own registration number).
+- **line_item**: polymorphic parent — `parent_type` + `parent_id` (`quote` or `invoice`).
+- **payment**: always linked to one invoice; partial payments sum to `amount_cents` on invoice.
+
+---
+
+## Quote state machine
+
+```
+                    ┌──────────┐
+                    │  draft   │
+                    └────┬─────┘
+                         │ finalize / send
+                         ▼
+                    ┌──────────┐
+         ┌──────────│   sent   │──────────┐
+         │          └────┬─────┘          │
+         │ reject        │ accept         │ valid_until passed
+         ▼               ▼                ▼
+    ┌──────────┐   ┌──────────┐     ┌──────────┐
+    │ rejected │   │ accepted │     │ expired  │
+    └──────────┘   └────┬─────┘     └──────────┘
+                        │ convert_to_invoice
+                        ▼
+                   (creates invoice)
+```
+
+**Rules:**
+
+- Only `draft` quotes are freely editable.
+- `sent` quotes: line items locked; status transitions only.
+- Only `accepted` quotes may convert to invoice (UseCase validates).
+
+---
+
+## Invoice state machine
+
+```
+                    ┌──────────┐
+                    │  draft   │
+                    └────┬─────┘
+                         │ issue (generates number, locks fields)
+                         ▼
+                    ┌──────────┐
+         ┌──────────│  issued  │────────────────┐
+         │          └────┬─────┘                │
+         │               │ record payment       │ due_at < today
+         │               ▼                      ▼
+         │     ┌──────────────────┐        ┌──────────┐
+         │     │ partially_paid   │        │ overdue  │ (computed flag)
+         │     └────────┬─────────┘        └──────────┘
+         │              │ full payment
+         │              ▼
+         │         ┌──────────┐
+         └────────►│   paid   │
+                   └──────────┘
+```
+
+**Rules:**
+
+- `issued` invoices: line items and tax totals immutable (credit notes = Phase 4+).
+- `paid` when sum(payments.amount_cents) >= invoice.total_cents.
+- `overdue`: computed when status is `issued` or `partially_paid` and `due_at < now`.
+
+---
+
+## Tax calculation (UseCase)
+
+Single source of truth for API and PDF. Consumption tax is rounded **once per
+tax rate per document** — never per line item — to comply with the qualified
+invoice system. See [ADR 0004](../adr/0004-tax-rounding-per-rate.md).
+
+```
+For each line_item:
+  line_subtotal_cents = quantity * unit_price_cents   # not rounded for tax
+
+Group by tax_rate_bps:
+  taxable_amount_cents[rate] += line_subtotal_cents
+  tax_cents[rate] = round(taxable_amount_cents[rate] * rate / 10000)   # round ONCE per rate
+
+subtotal_cents = sum(taxable_amount_cents[rate])
+tax_cents = sum(tax_cents[rate])
+total_cents = subtotal_cents + tax_cents
+```
+
+Rounding: half-up to integer minimum currency units, applied per rate group, not
+per line. Any per-line tax shown in the UI is illustrative only and must not be
+summed into the document total. Rationale and rejected alternatives:
+[ADR 0004](../adr/0004-tax-rounding-per-rate.md).
+
+---
+
+## Document numbering
+
+| Document | Pattern | Example |
+| --- | --- | --- |
+| Quote | `{prefix}{year}-{seq:03d}` | `EST-2026-001` |
+| Invoice | `{prefix}{year}-{seq:03d}` | `INV-2026-001` |
+
+Sequences scoped per organization and year. Stored in `document_sequences` table (Phase 1).
+
+---
+
+## PDF generation boundary
+
+```
+UseCase (calculates totals, validates qualified fields)
+    ↓ InvoicePdfInput DTO
+Pdf/InvoicePdfGenerator (infrastructure — TCPDF or similar)
+    ↓ bytes
+Handler (Content-Type: application/pdf)
+```
+
+UseCase never calls PDF library directly. Handler never recalculates tax.
+
+---
+
+## Planned modules (`src/`)
+
+| Module | Responsibility |
+| --- | --- |
+| `Organization/` | Tenants + per-request resolution (`Organization/Resolution/`) — superadmin CRUD |
+| `Auth/` | JWT login, `Role` / `Capability`, capability middleware |
+| `User/` | Operator accounts within an organization — admin CRUD |
+| `Company/` | Issuer profile settings (per organization) |
+| `Client/` | Buyer master |
+| `Quote/` | Quote CRUD, status transitions |
+| `Invoice/` | Invoice CRUD, issue, convert from quote |
+| `LineItem/` | Shared line item attach/detach |
+| `Payment/` | Payment recording |
+| `Pdf/` | PDF rendering adapters |
+| `DocumentSequence/` | Auto-number generation (per organization) |
+| `Upstream/` | Optional Records / Concierge HTTP clients |
+
+---
+
+## Integration touchpoints (Phase 4+)
+
+| Event | Direction | Action |
+| --- | --- | --- |
+| Concierge lead captured | Concierge → Invoice | POST webhook creates `client` draft + optional `quote` draft |
+| Records product selected | Invoice → Records | GET catalog item → prefill line_item description and unit_price_cents |
+| Invoice issued | Invoice → external | Webhook or email (SMTP) — no sibling required |
+
+---
+
+## Related
+
+- Requirements: [`requirements.md`](./requirements.md)
+- Backend standards: [`../development/backend-standards.md`](../development/backend-standards.md)
+- ADR 0002: [`../adr/0002-separate-from-sibling-products.md`](../adr/0002-separate-from-sibling-products.md)
+- ADR 0004 (tax rounding): [`../adr/0004-tax-rounding-per-rate.md`](../adr/0004-tax-rounding-per-rate.md)

--- a/docs/explanation/expansion-roadmap.md
+++ b/docs/explanation/expansion-roadmap.md
@@ -1,0 +1,184 @@
+# Post-MVP Expansion Roadmap
+
+Maintainer-approved feature sequence **after** Phase 1–3 core billing (quote → invoice → manual payment recording → PDF/admin UI) is stable.
+
+This document is the source of truth for **what comes next** and **in what order**. Individual expansions get their own Issues, ADRs (when needed), and milestone entries — do not jump ahead without updating this file.
+
+See also: [`roadmap.md`](../roadmap.md) (Phase 0–4), [`requirements.md`](./requirements.md), [`product-vision.md`](./product-vision.md).
+
+---
+
+## Prerequisite
+
+**Do not start Expansion #1 until:**
+
+- Phase 1: `invoices`, `payments`, invoice status (`issued` / `partially_paid` / `paid`), overdue computation ✅
+- Phase 2 (minimum): admin can list unpaid/overdue invoices and record a payment manually
+
+Expansion features assume the **quote-to-cash core** exists. Building reconciliation on top of a half-finished invoice API creates rework.
+
+---
+
+## Approved sequence
+
+| # | Theme (JA) | Theme (EN) | One line |
+| --- | --- | --- | --- |
+| **1** | 入金消込・督促管理 | Payment reconciliation & dunning | Match bank deposits to invoices; remind clients on overdue |
+| **2** | 発注書・納品書管理 | Purchase order & delivery note | Outbound PO to suppliers; delivery notes linked to quotes/invoices |
+| **3** | 契約期限・更新管理 | Contract term & renewal | Track contract end dates; renewal quotes and alerts |
+| **4** | 小規模サブスク請求管理 | Small-scale subscription billing | Recurring invoices for fixed monthly/yearly amounts |
+| **5** | 経費申請の最小版 | Minimal expense reimbursement | Employee expense requests with approval — not full accounting |
+
+Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR + roadmap update.
+
+---
+
+## Expansion #1 — Payment reconciliation & dunning（入金消込・督促管理）
+
+### Why first
+
+- Directly completes **quote-to-cash** after invoicing — highest daily-use value for office managers
+- Extends existing `payment` and `invoice.overdue` domain — no new document type required
+- Differentiates from “PDF invoice generator” tools; matches pain of Excel + bank CSV today
+- Shared hosting friendly: CSV import first; no bank API required for MVP
+
+### In scope (MVP)
+
+| Area | Capability |
+| --- | --- |
+| **Bank import** | Upload bank CSV (major Japanese bank formats documented one at a time); parse into `bank_transaction` rows |
+| **Reconciliation** | Match transaction → invoice by rules: exact amount, client name fuzzy match, transfer reference; manual match UI/API |
+| **Partial / overpay** | Support partial match; remainder stays unmatched or credit balance (document in ADR) |
+| **Dunning** | Overdue invoice list; dunning email templates (ja); manual send + optional scheduled reminder (cron/CLI) |
+| **Audit** | Log who matched what and when; log dunning sends |
+
+### Out of scope (Expansion #1)
+
+- Automatic bank API / Moneytree / freee bank sync
+- Payment gateway capture (Stripe, PayPay) — Phase 4 optional
+- General ledger / journal entries
+- Multi-invoice single transfer split logic beyond simple “allocate amount across invoices” (Phase 1.5 if needed)
+
+### Planned entities (register in `terminology.md` before code)
+
+| Concept | Working name | Notes |
+| --- | --- | --- |
+| Imported bank line | `bank_transaction` | Raw import row; unmatched until reconciled |
+| Match link | `payment_reconciliation` | Links `bank_transaction` → `payment` or creates `payment` |
+| Dunning run | `dunning_notice` | invoice_id, sent_at, template_id, channel (email) |
+
+### Suggested delivery phases
+
+1. **E1-a** — `bank_transaction` import + list unmatched
+2. **E1-b** — Manual match → create/update `payment`, update invoice status
+3. **E1-c** — Rule-based match suggestions (amount + date window)
+4. **E1-d** — Dunning templates + send + history
+
+---
+
+## Expansion #2 — Purchase order & delivery note（発注書・納品書管理）
+
+### Why second
+
+- Extends document chain **before** billing: PO → delivery → invoice
+- Natural for B2B SMB (wholesale, manufacturing) already in product persona
+- Reuses line-item and PDF patterns from quotes/invoices
+
+### In scope (MVP)
+
+- **Purchase order** (`purchase_order`) to suppliers — separate from client-facing quote
+- **Delivery note** (`delivery_note`) — links to quote or invoice; PDF; optional client signature flag (manual)
+- Status: draft → sent → accepted / cancelled
+
+### Out of scope
+
+- Inventory / stock levels (NeNe Shop territory)
+- EDI / B2B platform integration
+
+---
+
+## Expansion #3 — Contract term & renewal（契約期限・更新管理）
+
+### Why third
+
+- Builds on **client** master + **quote** renewal workflow
+- Recurring revenue ops without full subscription engine (that's #4)
+
+### In scope (MVP)
+
+- **Contract** entity: client_id, title, start_at, end_at, auto_renew flag, renewal_notice_days
+- Dashboard: contracts expiring in 30/60/90 days
+- One-click “renewal quote” from expiring contract
+
+### Out of scope
+
+- Legal contract CLM (DocuSign, CloudSign)
+- Automatic contract PDF storage (optional link URL only)
+
+---
+
+## Expansion #4 — Small-scale subscription billing（小規模サブスク請求管理）
+
+### Why fourth
+
+- Depends on stable invoice + payment + preferably reconciliation (#1)
+- “10 monthly retainers” not “Stripe Billing scale”
+
+### In scope (MVP)
+
+- **Subscription** plan: client, amount_cents, interval (monthly/yearly), next_invoice_at
+- Cron/CLI generates draft invoice on schedule; operator approves or auto-issue (config)
+- Pause / cancel subscription
+
+### Out of scope
+
+- Proration, metered usage, multi-plan upgrades
+- Card-on-file / direct debit (link to external PSP in Phase 4+)
+
+---
+
+## Expansion #5 — Minimal expense reimbursement（経費申請の最小版）
+
+### Why last
+
+- Different actor (employee vs client); approval workflow adds RBAC surface
+- Explicitly **not** full accounting — stays minimal to avoid freee/MF overlap
+
+### In scope (MVP)
+
+- **Expense report**: submitter, date, amount_cents, category, receipt image upload, status (draft/submitted/approved/rejected)
+- Approver = `admin`; single-step approval
+- Export CSV for accounting software — no journal posting
+
+### Out of scope
+
+- Commute / per-diem rules, corporate card feed, payroll integration
+
+---
+
+## Relationship to Phase 4 (ecosystem)
+
+| Phase 4 item | Expansion touchpoint |
+| --- | --- |
+| NeNe Concierge lead → quote | Independent; can ship before Expansion #1 |
+| NeNe Records catalog import | Helps Expansion #2 line items |
+| MCP tools | Add per expansion (e.g. `listUnmatchedTransactions`, `sendDunningNotice`) |
+| CSV export | Expansion #5 depends on it |
+
+---
+
+## How to start an expansion
+
+1. Confirm prerequisite phase complete in `docs/todo/current.md`.
+2. Open a GitHub Issue: `feat: Expansion #N — <short name>`.
+3. Register new terms in `terminology.md` + `glossary.md` in the same PR.
+4. Add ADR if architecture choice is non-obvious (e.g. bank CSV format strategy, dunning scheduler on Tier A).
+5. Update this file only if **order or scope** changes — with maintainer approval.
+
+---
+
+## Current focus
+
+**Next implementation target after Phase 1–2 core:** **Expansion #1 — Payment reconciliation & dunning.**
+
+Last updated: 2026-05-29 (Issue #27)

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -1,0 +1,36 @@
+# Glossary
+
+Canonical English terms for NeNe Clear public docs, OpenAPI, and code comments.
+
+> This file defines the **meaning** of product concepts. The authoritative
+> **spelling** of every term and identifier (entities, fields, status values,
+> slugs) lives in the single source of truth
+> [`terminology.md`](./terminology.md) — spellings here MUST conform to it.
+
+| Term | Definition | Avoid |
+| --- | --- | --- |
+| **organization** | The tenant — an independent issuer with its own users, issuer profile, and billing data (ADR 0006) | "tenant" / "account" / "company" in code identifiers |
+| **superadmin** | Cross-tenant platform role; manages organizations (`manage_organizations`) | "root", "owner", "superuser" in code |
+| **admin** | Organization-scoped role; manages the org's users, issuer settings, and billing | "manager" |
+| **member** | Organization-scoped billing operator; creates/sends documents and records payments; no user/settings management | "user", "staff" in code identifiers |
+| **organization resolution** | Per-request selection of the tenant; modes `single` (default) / `path` / `subdomain` / `custom_domain` | "tenant detection" |
+| **quote** | An estimate (見積書) sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers |
+| **invoice** | A billing document (請求書) issued to a client | "bill" |
+| **qualified invoice** | Japan invoice system compliant document (適格請求書) with required issuer, tax, and registration fields | mixing Japanese in API field names |
+| **issuer** | The operator's company that issues quotes and invoices (自社) | "seller", "supplier" in code |
+| **client** | Customer / buyer (取引先) in the billing system | "customer" in code identifiers |
+| **line item** | A single row on a quote or invoice (品名, quantity, unit price, tax rate) | "row", "detail" |
+| **payment** | A recorded receipt against an invoice (入金) | "receipt" (PDF noun) |
+| **registration number** | Japan invoice registration number (インボイス登録番号), format `T` + 13 digits. API validation is **syntax only** — format, not existence or check digit | "T-number" without context; treating regex pass as proof of validity |
+| **cents** | Integer amount in the **smallest currency unit**. For JPY (the only Phase 1–3 currency) one "cent" is one 円, so `total_cents = 1000` means ¥1,000. The suffix is a fixed internal convention, not a sub-yen unit | float or DECIMAL money; reading `_cents` as 1/100 yen |
+| **tax rate bps** | Tax rate in basis points (1000 = 10.00%, 800 = 8.00%) | float percentages in DB |
+| **quote-to-cash** | Flow from estimate through invoice to payment | "order-to-cash" (ERP term) |
+| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server" in code |
+| **Tier B** | Docker / VPS deployment | "cloud tier" |
+| **handler** | HTTP entry point class | "controller" |
+| **use case** | Business logic class with `execute()` | "service" (UseCase sense) |
+| **sync PDF download** | Single HTTP response returning PDF bytes | "streaming PDF" |
+| **overdue** | Invoice past `due_at` with unpaid balance — computed status | stored status in Phase 1 (optional) |
+| **UI locale** | Admin UI / operator-facing language. Bound to **ja (primary) + en (secondary) only** — not multilingual (ADR 0005). Distinct from the English-only dev-docs language policy | adding locales beyond ja/en; conflating UI locale with statutory invoice language |
+
+When adding terms, update this table in the same PR.

--- a/docs/explanation/philosophy.md
+++ b/docs/explanation/philosophy.md
@@ -1,0 +1,206 @@
+# Philosophy — NeNe Clear
+
+**NeNe Clear** (*Clear billing from quote to cash.*)
+
+This document records **ideals** (理想), **philosophy** (理念・哲学), and
+**non‑negotiable beliefs** for the product. It complements
+[`product-vision.md`](./product-vision.md) (scope and personas) and
+[`expansion-roadmap.md`](./expansion-roadmap.md) (feature sequence).
+
+Canonical language: **English**. Maintainer intent in Japanese appears in
+§8 where it aids nuance; public API and OpenAPI remain English.
+
+Product name: [ADR 0007](../adr/0007-product-identity-nene-clear.md).
+
+---
+
+## 1. What we believe
+
+### 1.1 Every SMB deserves a clear money trail
+
+Small businesses do not fail because they lack features — they fail because
+**money movement is opaque**. Quotes live in email, invoices in Excel, payments
+in bank CSV, reminders in someone's memory.
+
+**Ideal:** One self-hosted place where *what was promised*, *what was billed*,
+*what arrived*, and *what is still owed* are **visible and auditable** — for
+the office manager **and** for any AI assistant the team already uses.
+
+### 1.2 Self-hosting is a feature, not nostalgia
+
+Japan SMB on shared hosting (FTP, MySQL, no Docker) is not "legacy." It is a
+**deliberate choice**: data stays on infrastructure the operator already pays for,
+beside WordPress or a static site, without another SaaS bill.
+
+**Ideal:** Tier A install feels as approachable as uploading a CMS — not as
+punishment for being small.
+
+### 1.3 Compliance is structure, not paperwork
+
+適格請求書 and tax rules are not PDF decoration. They are **validation rules**
+in the API — the same rules whether a human clicks "Issue" or an agent calls
+`createInvoice` via MCP.
+
+**Ideal:** A tax reviewer finds **zero deviations** from documented compliance
+([`accounting-compliance.md`](./accounting-compliance.md)); any change requires
+ADR and professional sign-off.
+
+### 1.4 AI everywhere — but responsibility stays in the system
+
+By the time this product reaches operators, many teams will use Claude, Codex, or
+similar tools daily. That does **not** replace the product. It changes **how**
+operators interact with it.
+
+**Ideal — dual surface:**
+
+| Actor | Surface | Responsibility |
+| --- | --- | --- |
+| **Human operator** | Admin UI | Confirms matches, sends dunning, owns decisions |
+| **AI assistant** | OpenAPI + MCP | Proposes matches, drafts quotes, lists overdue — **never silent writes without audit** |
+| **End client** | PDF / email | Receives documents; no account required |
+
+FTP install does not mean "no AI." It means **AI runs on the client side**
+(browser, desktop, MCP host) while **billing truth lives in MySQL** on the
+server.
+
+### 1.5 Small scope, long horizon
+
+We refuse to become freee. We **embrace** being the narrow, excellent layer:
+**quote → invoice → collect → clear** — then carefully add PO, contracts,
+subscriptions, and minimal expenses ([expansion roadmap](./expansion-roadmap.md)).
+
+**Ideal:** A wholesaler with eight staff gets 80% of their billing pain solved
+without learning double-entry accounting.
+
+---
+
+## 2. Philosophy (how we build)
+
+### 2.1 Clear over clever
+
+- Explicit layers (Handler → UseCase → Repository), not magic.
+- Integer cents, not floats. Registered terms, not synonyms
+  ([`terminology.md`](./terminology.md)).
+- OpenAPI before UI assumptions.
+
+If an agent or junior developer cannot find the rule in docs, the design failed.
+
+### 2.2 Human confirms, AI proposes
+
+Especially for **payment reconciliation** (Expansion #1):
+
+- Import and structure bank data in the system.
+- Rules and AI **suggest** matches.
+- A human **confirms** → audit log → `payment` + invoice status update.
+
+Automatic clearing without confirmation is a liability, not a feature, until
+explicitly ADR'd for a defined low-risk subset.
+
+### 2.3 Same contract for GUI and MCP
+
+Everything an operator can do in admin UI must be reachable via documented HTTP
+(and MCP where appropriate). No hidden SQL paths for agents.
+
+This mirrors NeNe Concierge's "GUI parity with API" principle — applied to
+**back-office billing**.
+
+### 2.4 Sibling products, separate repos
+
+NeNe Records, Corpus, and Concierge remain upstream/downstream **via HTTP only**
+(ADR 0002). Clear owns billing data; it never merges into CMS or chat repos.
+
+### 2.5 Bilingual operators, Japanese law
+
+Admin UI: **Japanese + English** (ADR 0005). Statutory invoice content:
+**Japanese**. The product serves non-Japanese founders running Japan-registered
+entities — compliance is fixed; UI language is flexible.
+
+---
+
+## 3. Ideals checklist (north star behaviors)
+
+When evaluating a feature or PR, ask:
+
+1. Does it make the **quote-to-cash loop clearer** for a non-engineer?
+2. Does it work on **Tier A** without Redis, without CLI, without Codex on the server?
+3. Does it leave an **audit trail** suitable for "who matched this deposit?"
+4. Can an **AI agent** perform the same action through OpenAPI/MCP?
+5. Does it stay **out of full accounting** territory unless the expansion roadmap says otherwise?
+6. Does it **register terms** before shipping identifiers?
+
+If most answers are no, reconsider or split the work.
+
+---
+
+## 4. What we refuse to become
+
+| We are not | Why |
+| --- | --- |
+| A general ledger | freee / MF territory; we export CSV instead |
+| A bank | We import CSV; we do not hold deposits |
+| A payment gateway (Phase 1–3 core) | Manual record first; PSP optional later |
+| A WordPress plugin | Sibling app on same origin is fine |
+| An AI chatbot | MCP proposes; UI and logs confirm |
+| A debt collection agency | Dunning is operator-controlled professional reminder |
+
+---
+
+## 5. Name — why *Clear*
+
+| Reading | Meaning |
+| --- | --- |
+| **Clear (verb)** | 消込 — reconcile bank lines to invoices |
+| **Clear (adjective)** | 明快 — transparent status: draft, issued, overdue, paid |
+| **Clear (verb)** | クリア — remove Excel chaos; one system of record |
+
+One word, three readings — same as Records / Corpus / Concierge in the NeNe
+family.
+
+---
+
+## 6. Relationship to the NeNe portfolio
+
+```
+Website (WordPress / static)
+    ├── NeNe Corpus      — visitor asks questions (public knowledge)
+    ├── NeNe Concierge   — visitor converts (scenario chat)
+    └── NeNe Records     — content & catalog (CMS)
+
+Back office (same server or VPS)
+    └── NeNe Clear       — quote, bill, collect, clear (this product)
+```
+
+**Front office** attracts and informs. **Clear** closes the commercial loop.
+
+---
+
+## 7. Document map
+
+| Question | Read |
+| --- | --- |
+| Why does the product exist? | This file + `product-vision.md` |
+| What do we build in v1? | `requirements.md` |
+| What comes after MVP? | `expansion-roadmap.md` |
+| What is the product called? | ADR 0007 — **NeNe Clear** |
+| What are exact spellings? | `terminology.md` |
+
+---
+
+## 8. Maintainer intent (理念 — 日本語)
+
+> **見積から入金までを、Excel と記憶から解放する。**
+>
+> 適格請求書は「PDF の体裁」ではなく、API が守るルール。データは自分のレンタルサーバーに置き、SaaS 月額を増やさない。AI 時代だからこそ、人間が確定し、AI が提案し、記録が残る — その三つを同時に満たすバックオフィス OSS。
+>
+> 名前 **Clear** は「消込」と「明快」の両方。請求書 PDF だけのツールにはならない。
+
+---
+
+## Related
+
+- ADR 0007: Product identity
+- [`product-vision.md`](./product-vision.md)
+- [`expansion-roadmap.md`](./expansion-roadmap.md)
+- [`accounting-compliance.md`](./accounting-compliance.md)
+
+Last updated: 2026-05-29 (Issue #31)

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -1,0 +1,174 @@
+# Product Vision
+
+> **Product name:** **NeNe Clear** — see [`philosophy.md`](./philosophy.md) and
+> [ADR 0007](../adr/0007-product-identity-nene-clear.md). Repository: `nene-clear` (private until launch).
+
+NeNe Clear is a self-hosted quote and invoice platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). This document records why the product exists, what it optimizes for, and how it relates to the NeNe ecosystem.
+
+## Origin
+
+Every Japan SMB must issue **qualified invoices** (適格請求書) under the invoice system (インボイス制度). SaaS accounting tools (freee, Money Forward, Yayoi) solve this well but charge recurring fees and hold financial data on vendor infrastructure. Many micro-businesses on **shared hosting** already run their website on the same server — they want billing documents without another monthly subscription.
+
+NeNe Clear offers an alternative: **run quote and invoice management on infrastructure you control**, with source code you can audit, and optional integration with sibling NeNe products for catalog and lead capture.
+
+The product showcases NENE2's strengths — OpenAPI-first APIs, Clean Architecture, MCP-ready ops boundaries, and field-trial-grade security — in a **back-office application** every SMB needs, not a demo endpoint.
+
+## North Star
+
+Operators and AI agents can:
+
+- register company issuer profile (name, address, invoice registration number, bank details)
+- manage **clients** (buyers) with billing addresses
+- create **quotes** (見積書) with line items and tax breakdown
+- convert accepted quotes to **invoices** (請求書) with one action
+- issue **qualified invoice** PDFs that meet Japan invoice system requirements
+- record **payments** and see overdue / unpaid status at a glance
+- optionally import product names from [NeNe Records](https://github.com/hideyukiMORI/nene-records) or create draft clients from [NeNe Concierge](https://github.com/hideyukiMORI/nene-concierge) leads
+- operate all of the above via admin UI, REST API, or MCP tools
+
+Operators keep financial document data on their stack. End clients receive PDF or email — they never need an account.
+
+NeNe Clear is **not** a PHP framework. It is a **product** that consumes NENE2.
+
+## Target Operators and Markets
+
+**Primary — Japan SMB on Tier A shared hosting**
+
+Companies with 1–20 staff who already pay for shared hosting (Xserver, Sakura, Lolipop, etc.) and find SaaS accounting monthly fees heavy. A general-affairs or accounting staff member — often not an engineer — manages invoices today in Excel or paper. After Phase 3, they should install via **web installer**, enter company registration number, create clients and invoices from admin UI — without Docker or CLI.
+
+**Secondary — Tier B developers and VPS operators**
+
+Docker Compose for local development and production. Same API and admin UI as Tier A.
+
+**Non-Japanese operators doing business in Japan**
+
+A growing segment: founders and staff who are not native Japanese speakers but
+run a company registered in Japan. They are bound by the same Japanese invoice
+and tax rules, but operate the admin UI more comfortably in English. NeNe
+Invoice serves them with an **English admin UI**, while statutory documents
+remain Japanese — see [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
+
+**Multi-tenant hosting operators**
+
+Agencies running one NeNe Clear instance for multiple client organizations.
+Multi-tenancy is **foundational, not deferred** — every tenant-scoped table
+carries `organization_id` and a per-request resolver selects the tenant
+([ADR 0006](../adr/0006-multi-tenancy-and-roles.md)). A single-SMB install simply
+runs in the default `single` resolution mode. A **superadmin** manages
+organizations; an organization **admin** manages that organization's users and
+issuer settings; **members** operate billing. Same pattern as NeNe Records /
+Concierge multi-tenancy.
+
+## Primary Persona
+
+A fictional but representative operator:
+
+> A **regional food ingredient wholesaler** with 8 employees runs its website on shared hosting. The **office manager** creates quotes in Excel, converts to PDF manually, and tracks payments in a spreadsheet. Since the invoice system started, they must include registration numbers and correct tax rates on every document. freee is ¥1,980/month — leadership prefers a **one-time setup on existing hosting** plus no recurring SaaS. After Phase 3, they install NeNe Clear beside their WordPress site, enter clients once, issue qualified invoice PDFs from admin UI, and email them — paying only for hosting they already have.
+
+The same pattern applies to **small manufacturers**, **creative agencies**, **equipment dealers**, and any B2B SMB that quotes before invoicing.
+
+## Primary Use Case
+
+NeNe Clear optimizes for **quote-to-cash for B2B SMB**:
+
+1. Operator registers **issuer profile** (自社情報 + インボイス登録番号).
+2. Operator adds **clients** (取引先).
+3. Operator creates a **quote** with line items (品名, 数量, 単価, 税率).
+4. Client accepts → operator converts quote to **invoice** (請求書).
+5. System generates **qualified invoice PDF** with required fields.
+6. Operator sends PDF by email or download link.
+7. Client pays → operator records **payment** → invoice marked paid.
+
+**Not the primary story:** full double-entry bookkeeping, payroll, expense reimbursement, inventory, or POS. Those belong to other products or Phase 4+ integrations.
+
+## Dual Deployment (planned — ADR 0003)
+
+Same codebase, two installation paths:
+
+| Tier | Path | Admin access |
+| --- | --- | --- |
+| **Tier A — shared hosting** | Release ZIP + web installer + MySQL | Browser admin SPA |
+| **Tier B — Docker / VPS** | `docker compose up` | Browser admin SPA |
+
+## Philosophy
+
+### 1. Quote-to-cash, not full accounting
+
+NeNe Clear owns the document flow from estimate to payment tracking. It does not replace a tax accountant or ERP. Export to CSV for accounting software is a Phase 2+ feature, not day-one scope.
+
+### 2. Japan invoice compliance as first-class data
+
+Qualified invoice fields are validated at the API layer — not optional PDF templates. Registration number format, tax rate (10% / 8%), reduced-rate flags, and issuer/buyer identification are domain rules in UseCases.
+
+### 3. Integer cents everywhere
+
+All amounts stored and transmitted as integer cents. No floats in database or JSON. PDF rendering uses the same cents values the API calculated.
+
+### 4. Self-hosted OSS first
+
+MIT license. Operators control data. SMTP for email delivery uses operator-provided credentials — no vendor mail relay required.
+
+### 5. MCP for operators, not for clients
+
+MCP tools map to admin API operations ("list overdue invoices", "create quote for client X"). Client-facing PDF download uses tokenized URLs — not MCP.
+
+### 6. Japanese and English only — not multilingual
+
+The product localizes to **Japanese (primary) and English (secondary) only**.
+More non-Japanese operators now run businesses inside Japan; they work under
+Japanese accounting rules but prefer an English admin UI, so English is
+first-class. Arbitrary multilingual support is a deliberate **non-goal**: the
+domain is locked to Japanese invoice/tax rules, so additional locales add
+translation and maintenance surface without serving any real operator. The
+qualified invoice PDF's statutory content stays Japanese (legal document); en
+applies to the operator UI and guides. See [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
+
+### 7. Separation from sibling products
+
+NeNe Records owns CMS content. NeNe Corpus owns knowledge chat. NeNe Concierge owns scenario chat. NeNe Clear owns billing documents. Integration is HTTP-only — ADR 0002.
+
+```
+NENE2 (framework)
+  ├── NeNe Records   (CMS · optional product catalog upstream)
+  ├── NeNe Corpus    (knowledge chat — no default link)
+  ├── NeNe Concierge (scenario chat · optional lead upstream)
+  └── NeNe Clear   (quote · invoice · payment — this repo)
+```
+
+## Comparison
+
+| Aspect | SaaS accounting (freee/MF) | Excel + manual PDF | NeNe Clear |
+| --- | --- | --- | --- |
+| License / cost | Monthly subscription | Free but error-prone | OSS + hosting you already pay |
+| Data location | Vendor cloud | Local files | Your server |
+| Qualified invoice | Built-in | Manual | Built-in, API-validated |
+| AI / MCP ops | Vendor lock-in | None | OpenAPI + MCP catalog |
+| Ecosystem link | None | None | Records / Concierge HTTP |
+
+## Non-goals
+
+See also [`requirements.md`](./requirements.md#explicit-non-goals).
+
+- **Not** full double-entry accounting or general ledger
+- **Not** payroll, expense reimbursement, or fixed-asset management
+- **Not** inventory management or POS (NeNe Shop is a separate future product)
+- **Not** a WordPress plugin (coexist on same domain is fine)
+- **Not** embedded inside NeNe Records or other sibling repos
+- **Not** e-invoice (電子インボイス) PEPPOL network transmission in Phase 1–3 — PDF + email first
+- **Not** payment gateway integration in Phase 1 — manual payment recording first; Stripe/PayPay in Phase 4+
+- **Not** multilingual beyond Japanese and English — UI locales bound to ja/en by [ADR 0005](../adr/0005-bilingual-ja-en-scope.md)
+
+## Success Criteria (Phase 3 complete)
+
+- Operator on Tier A shared hosting installs without SSH
+- Creates qualified invoice PDF with registration number in under 10 minutes after install
+- `composer check` and admin smoke tests green
+- OpenAPI documents all admin operations; MCP catalog validates
+
+## Related
+
+- Requirements: [`requirements.md`](./requirements.md)
+- Domain model: [`domain-model.md`](./domain-model.md)
+- Glossary: [`glossary.md`](./glossary.md)
+- Roadmap: [`../roadmap.md`](../roadmap.md)
+- Sibling boundaries: [`../integrations/sibling-products.md`](../integrations/sibling-products.md)

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -1,0 +1,208 @@
+# Requirements
+
+Functional and compliance requirements for NeNe Clear. MVP scope maps to **Phase 1–3** unless noted.
+
+See also: [`product-vision.md`](./product-vision.md), [`domain-model.md`](./domain-model.md).
+
+---
+
+## 1. Tenancy and user roles
+
+NeNe Clear is **multi-tenant from the foundation** — see
+[ADR 0006](../adr/0006-multi-tenancy-and-roles.md). The **organization** is the
+tenant; every tenant-scoped table carries `organization_id`. A single install may
+run as one organization via the default `single` resolution mode; agencies use
+`path` / `subdomain` / `custom_domain`.
+
+| Role | Scope | Capabilities | Phase |
+| --- | --- | --- | --- |
+| **superadmin** | Cross-tenant | Everything, incl. `manage_organizations` (create/list/delete tenants). `organization_id` may be `NULL` | 1 |
+| **admin** | One organization | Everything except `manage_organizations` — manages the org's **users**, **company settings** (issuer profile), and billing | 1 |
+| **member** | One organization | Billing operator: create/edit/send quotes & invoices, record payments (`manage_billing`, `view_billing`). Cannot manage users/settings | 1 |
+| **viewer** (optional) | One organization | Read-only documents and reports (`view_billing`) | 3+ |
+| **public client** | — | Download invoice PDF via time-limited token URL — no login | 2 |
+
+Authorization: a `Role` enum + `Capability` enum resolved per route and enforced
+by capability middleware. Role/capability string values are registered in
+[`../development/naming-conventions.md`](../development/naming-conventions.md) and
+[`terminology.md`](./terminology.md) (binding). Admin JWT for mutating routes.
+
+---
+
+## 2. Core entities (MVP)
+
+All tenant-scoped entities below carry **`organization_id`** (ADR 0006).
+
+| Entity | Purpose | Key fields |
+| --- | --- | --- |
+| **organization** | Tenant | name, slug (unique), plan, is_active, custom_domain (optional), external_id (optional) |
+| **user** | Operator account | email (unique), password_hash, role (superadmin/admin/member/viewer), organization_id (NULL for superadmin), status (active/invited) |
+| **company_settings** | Issuer (自社) profile — **per organization** | organization_id, legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
+| **client** | Buyer (取引先) | name, contact_name, email, billing_address, **registration_number** (optional for B2B qualified invoice) |
+| **quote** | Estimate (見積書) | client_id, quote_number, issued_at, valid_until, status, subtotal_cents, tax_cents, total_cents, notes |
+| **invoice** | Bill (請求書) | client_id, quote_id (optional), invoice_number, issued_at, due_at, status, subtotal_cents, tax_cents, total_cents, **is_qualified_invoice** |
+| **line_item** | Row on quote or invoice | parent_type (quote/invoice), parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order |
+| **payment** | Payment record | invoice_id, paid_at, amount_cents, method (bank_transfer/cash/other), notes |
+
+All money: **integer cents**. Tax rate: **basis points** (1000 = 10.00%).
+
+---
+
+## 3. Japan qualified invoice (適格請求書) — required fields
+
+> **Binding compliance.** The rules in this section are governed by
+> [`accounting-compliance.md`](./accounting-compliance.md) (non-negotiable). A
+> finance professional reviewing the system must find zero deviations. Any
+> departure requires an ADR with tax-professional sign-off.
+
+When `is_qualified_invoice = true`, the system must enforce and render:
+
+### Issuer (supplier)
+
+- [ ] Legal name (氏名又は名称)
+- [ ] Address (住所又は所在地)
+- [ ] **Registration number** (登録番号) — format `T` + 13 digits
+- [ ] Issue date (請求書の交付年月日)
+
+### Buyer (optional on simplified invoices, required for full B2B)
+
+- [ ] Name (氏名又は名称)
+- [ ] Address (住所又は所在地) — when provided
+
+### Transaction details
+
+- [ ] Line items: description (取引内容), tax rate per line or document
+- [ ] Taxable amount per rate category (税率ごとの対価の額)
+- [ ] Consumption tax per rate category (税率ごとの消費税額)
+- [ ] Total billing amount (請求金額)
+
+### Validation rules (API layer)
+
+- Registration number regex: `^T[0-9]{13}$` — **syntax check only**. This
+  validates format, not existence; the system does **not** verify the number
+  against the National Tax Agency registry or compute a check digit. Passing the
+  regex does not mean the number is registered or valid.
+- Tax rates allowed: 1000 (10%), 800 (8% reduced) — extensible via ADR
+- Invoice cannot be marked qualified if issuer registration_number is empty
+- Consumption tax is rounded **once per tax rate per document**, never per line
+  item — see [ADR 0004](../adr/0004-tax-rounding-per-rate.md)
+- PDF totals must match API-calculated cents (single source: UseCase)
+
+---
+
+## 4. Document lifecycle
+
+| From | Action | To | Phase |
+| --- | --- | --- | --- |
+| — | Create quote | quote `draft` | 1 |
+| draft | Send / finalize | quote `sent` | 1 |
+| sent | Accept | quote `accepted` | 1 |
+| sent | Reject / expire | quote `rejected` / `expired` | 1 |
+| accepted | Convert | invoice `draft` | 1 |
+| — | Create invoice directly | invoice `draft` | 1 |
+| draft | Issue | invoice `issued` | 1 |
+| issued | Record full payment | invoice `paid` | 1 |
+| issued | Partial payment | invoice `partially_paid` | 2 |
+| issued | Past due_at unpaid | invoice `overdue` (computed) | 1 |
+
+Quote numbers and invoice numbers: auto-increment per organization with configurable prefix (e.g. `EST-2026-001`, `INV-2026-001`).
+
+---
+
+## 5. MVP features by phase
+
+### Phase 1 — API only
+
+- [ ] Organization resolution middleware (default `single`; path/subdomain/custom_domain) + `organization_id` scoping on every query (ADR 0006)
+- [ ] Admin JWT auth + `Role`/`Capability` RBAC (capability middleware)
+- [ ] Organization CRUD — superadmin (`/admin/organizations`)
+- [ ] User CRUD — admin within organization (`/admin/users`)
+- [ ] Company settings CRUD (per organization)
+- [ ] Client CRUD + soft delete
+- [ ] Quote CRUD + line items + status transitions
+- [ ] Invoice CRUD + convert from quote + line items
+- [ ] Payment create + list by invoice
+- [ ] Qualified invoice field validation
+- [ ] OpenAPI 3.1 + PHPUnit + PHPStan 8
+
+### Phase 2 — Admin UI + PDF
+
+- [ ] React admin SPA (clients, quotes, invoices, payments, settings)
+- [ ] Admin UI locale catalogs: **ja (primary) + en (secondary)** — no other locales (ADR 0005)
+- [ ] Server-side qualified invoice PDF (Japanese layout)
+- [ ] Quote PDF (optional, simpler layout)
+- [ ] Email invoice PDF via SMTP
+- [ ] Public PDF download token URL
+- [ ] Dashboard: unpaid / overdue summary
+
+### Phase 3 — Tier A shared hosting
+
+- [ ] Web installer (MySQL credentials, admin user, company name)
+- [ ] Release ZIP build script
+- [ ] Operator guide (Japanese)
+- [ ] Same-origin admin on shared hosting
+
+### Phase 4 — Ecosystem + extensions
+
+- [ ] NeNe Records product import for line items
+- [ ] NeNe Concierge webhook → draft client / quote
+- [ ] MCP tool catalog (read + write with auth)
+- [ ] CSV export for accounting software
+- [ ] Payment gateway link (Stripe, etc.) — optional
+
+---
+
+## 6. API requirements
+
+- JSON API, OpenAPI 3.1 contract
+- RFC 9457 Problem Details for errors
+- snake_case JSON properties
+- Pagination: `limit`, `offset`, `items` envelope
+- Admin routes under `/admin/…`
+- `GET /health` unauthenticated
+
+---
+
+## 7. Security requirements
+
+- Admin JWT for mutating routes; `Capability` enforced per route (ADR 0006)
+- **Tenant isolation**: every query scoped by resolved `organization_id`; cross-tenant reads/writes prohibited. Only superadmin operates cross-tenant
+- PDF download tokens: random, time-limited, scoped to one invoice
+- No stack traces in production responses
+- Secrets in `.env` only — never committed
+- Audit log for invoice issue and payment record (Phase 2+)
+
+---
+
+## 8. Explicit non-goals
+
+| Item | Reason |
+| --- | --- |
+| General ledger / journal entries | Different product category; export to accounting SaaS instead |
+| Payroll / 給与 | Out of scope |
+| Expense receipts / 経費精算 | Out of scope |
+| Inventory / stock | NeNe Shop territory |
+| PEPPOL / 電子インボイス network | Phase 4+ research; PDF first |
+| Multi-currency | JPY only for Phase 1–3 |
+| Multilingual UI beyond ja/en | Domain locked to Japanese rules; UI bound to Japanese + English (ADR 0005) |
+| Consumption tax filing (申告) | Operator exports data; no tax return generation |
+
+---
+
+## 9. Acceptance tests (Phase 3 smoke)
+
+1. Install on clean MySQL via web installer.
+2. Enter company profile with valid `T` registration number.
+3. Create client + quote with 2 line items (10% and 8% tax).
+4. Convert to invoice, issue, download qualified invoice PDF.
+5. Record payment → invoice status `paid`.
+6. List overdue invoices returns empty after payment.
+
+---
+
+## Related
+
+- **Compliance (binding):** [`accounting-compliance.md`](./accounting-compliance.md)
+- Domain model: [`domain-model.md`](./domain-model.md)
+- Naming: [`../development/naming-conventions.md`](../development/naming-conventions.md)
+- Roadmap: [`../roadmap.md`](../roadmap.md)

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -1,0 +1,162 @@
+# Terminology Registry — Single Source of Truth
+
+**Status: binding.** This file is the **single source of truth** for the
+canonical spelling and form of every NeNe Clear term and identifier:
+entities, status values, JSON/DB field names, enums, Problem Details slugs, and
+`operationId` stems.
+
+If an identifier appears anywhere in the codebase, OpenAPI, database, tests, or
+docs, its spelling **MUST** match this registry **exactly** — same characters,
+same case, same separators. There is no "close enough."
+
+## Authority and absolute rules
+
+1. **Exact match is mandatory.** Any spelling variant or typo of a registered
+   term is a defect and **blocks merge** — there are no acceptable synonyms or
+   abbreviations outside this registry.
+2. **Register before you use.** Introducing a new term/identifier, or renaming
+   an existing one, **MUST** update this registry in the **same PR**. Code that
+   uses an unregistered term does not merge.
+3. **No renaming after release.** Shipped `operationId` values and public JSON
+   field names are stable; deprecate, do not rename (see `naming-conventions.md`).
+4. **Roles of the three docs — do not duplicate, cross-reference:**
+   - **`terminology.md`** (this file) — the authoritative **spelling/form** of every identifier.
+   - **`glossary.md`** — the **meaning** of product concepts. Its spellings MUST conform to this registry.
+   - **`naming-conventions.md`** — the **patterns/rules** that generate names. This registry is the concrete instantiation of those rules.
+
+See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](../development/naming-conventions.md).
+
+---
+
+## 0. Product identity (display names)
+
+| Concept | Canonical | Notes |
+| --- | --- | --- |
+| Public product name | **NeNe Clear** | ADR 0007 |
+| Repository slug | `nene-clear` | Private until public launch |
+| PHP namespace | `NeneClear\` | ADR 0007 |
+| Problem Details base | `https://nene-clear.dev/problems/` | Until branding domain Issue |
+
+---
+
+## 1. Domain entities
+
+| Concept | PHP class / domain folder | Table | Primary FK in JSON/DB |
+| --- | --- | --- | --- |
+| Tenant | `Organization` | `organizations` | `organization_id` |
+| Operator account | `User` | `users` | `user_id` |
+| Issuer profile | `Company` (folder); `CompanySettings` (entity) | `company_settings` | — (one per `organization_id`) |
+| Buyer | `Client` | `clients` | `client_id` |
+| Estimate | `Quote` | `quotes` | `quote_id` |
+| Bill | `Invoice` | `invoices` | `invoice_id` |
+| Document row | `LineItem` | `line_items` | `line_item_id` |
+| Receipt | `Payment` | `payments` | `payment_id` |
+| Number generator | `DocumentSequence` | `document_sequences` | — |
+
+Domain folders are **PascalCase singular**; tables are **snake_case plural**.
+
+---
+
+## 2. Status values (exact strings)
+
+Stored and transmitted **exactly** as written (lowercase snake_case).
+
+| Owner | Allowed values |
+| --- | --- |
+| `quote.status` | `draft`, `sent`, `accepted`, `rejected`, `expired` |
+| `invoice.status` | `draft`, `issued`, `partially_paid`, `paid` |
+| invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
+| `payment.method` | `bank_transfer`, `cash`, `other` |
+| `line_item.parent_type` | `quote`, `invoice` |
+| `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
+| `user.status` | `active`, `invited` |
+| Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
+| Org resolution mode | `single` (default), `path`, `subdomain`, `custom_domain` |
+
+Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering them here first.
+
+---
+
+## 3. Canonical field / column names (snake_case)
+
+| Term | Canonical | Never |
+| --- | --- | --- |
+| Tenant foreign key | `organization_id` | `org_id`, `tenant_id`, `organizationId` |
+| Organization slug | `slug` | `org_slug`, `code` |
+| User role | `role` (values in §2) | `user_role`, `permission` |
+| User credential | `password_hash` | `password`, `pass_hash` |
+| Invoice registration number | `registration_number` | `tax_registration_number`, `invoice_registration_number`, `t_number` |
+| Qualified-invoice flag | `is_qualified_invoice` | `qualified`, `is_qualified` |
+| Soft-delete flag / time | `is_deleted`, `deleted_at` | `deleted`, `is_del` |
+| Subtotal (pre-tax) | `subtotal_cents` | `sub_total_cents`, `subtotal` |
+| Tax amount | `tax_cents` | `tax`, `tax_amount` |
+| Total | `total_cents` | `amount_cents` (on documents), `grand_total` |
+| Unit price | `unit_price_cents` | `price_cents`, `unitprice_cents` |
+| Payment amount | `amount_cents` | `paid_cents`, `payment_cents` |
+| Tax rate | `tax_rate_bps` | `tax_rate`, `rate`, `tax_rate_percent` |
+| Foreign keys | `client_id`, `quote_id`, `invoice_id` | `clientId`, `client` |
+| Polymorphic parent | `parent_type`, `parent_id` | `parentType`, `owner_id` |
+| Numbers | `quote_number`, `invoice_number` | `number`, `quote_no` |
+| Timestamps | `issued_at`, `due_at`, `paid_at`, `valid_until`, `deleted_at` | `issue_date`, `due_date`, `paidAt` |
+| Issuer fields | `legal_name`, `bank_name`, `bank_branch`, `account_type`, `account_number`, `logo_url` | `company_name`, `branch`, `acct_no` |
+| Client fields | `contact_name`, `billing_address` | `contact`, `address` |
+| List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
+
+Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
+the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are
+`{singular_entity}_id`. See `naming-conventions.md` for the full pattern set.
+
+---
+
+## 4. Problem Details type slugs (kebab-case)
+
+Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
+
+| Slug | Use |
+| --- | --- |
+| `validation-failed` | Request body/field validation error |
+| `invoice-not-found` | Invoice id/token not found |
+| `quote-not-found` | Quote id not found |
+| `client-not-found` | Client id not found |
+| `organization-not-found` | Organization id/slug not found |
+| `user-not-found` | User id not found |
+| `invalid-credentials` | Login failed — wrong email or password |
+| `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
+| `insufficient-capability` | Authenticated but lacks required capability |
+| `organization-not-resolved` | Tenant could not be resolved for the request |
+| `invalid-state-transition` | Disallowed status change |
+| `qualified-invoice-incomplete` | Missing required qualified-invoice field |
+
+Add new slugs here before using them. Validation `errors[].field` uses
+snake_case paths (e.g. `body.registration_number`); `errors[].code` is
+snake_case (e.g. `required`, `invalid_invoice_number`).
+
+---
+
+## 5. operationId stems (camelCase)
+
+Shape `{verb}{Resource}` / `{verb}{Resource}ById`. Stable after release. Must
+match between OpenAPI, route registration, and `docs/mcp/tools.json`.
+
+| operationId | Resource |
+| --- | --- |
+| `getHealth` | System |
+| `login`, `getCurrentUser` | Auth |
+| `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
+| `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
+| `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
+| `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
+| `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
+| `listPayments`, `createPayment` | Payment |
+
+Extend this list (do not improvise) when adding operations.
+
+---
+
+## How to add or change a term
+
+1. Add/rename the entry **here** in the same PR as the code.
+2. Update `glossary.md` if it is a product concept; update `naming-conventions.md`
+   if it introduces a new pattern.
+3. Run the docs-policy and backend-api self-review checklists.
+4. Confirm no spelling variant of the term remains anywhere (grep before commit).

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -1,0 +1,90 @@
+# Inheritance from NENE2
+
+NeNe Clear inherits engineering governance from [NENE2](https://github.com/hideyukiMORI/NENE2). This document is the source of truth for what is inherited, what is adapted, and what is NeNe Clear–specific.
+
+## Relationship
+
+| Layer | Repository | Role |
+| --- | --- | --- |
+| Framework runtime | [NENE2](https://github.com/hideyukiMORI/NENE2) | HTTP runtime, DI, middleware, Problem Details, OpenAPI/MCP patterns |
+| Application platform | **NeNe Clear** (this repo) | Quote, invoice, payment, client, PDF, admin UI |
+| Sibling products | [nene-records](https://github.com/hideyukiMORI/nene-records), [nene-corpus](https://github.com/hideyukiMORI/nene-corpus), [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Optional upstream HTTP integrations |
+| Reference trials | [NENE2-FT](https://github.com/hideyukiMORI/NENE2-FT) | Patterns and friction notes from field trials |
+
+NeNe Clear is a **consumer project**, not a fork of NENE2. Framework code stays in NENE2; product code stays here.
+
+## Inherited by policy (same rules)
+
+These policies are adopted with the same intent as NENE2 and sibling NeNe products. Local copies live in this repository.
+
+| Topic | Local document |
+| --- | --- |
+| Issue-driven workflow | `docs/workflow.md` |
+| Conventional Commits | `docs/development/commit-conventions.md` |
+| Self-review before PR | `docs/development/self-review.md` |
+| ADR operation | `docs/development/adr.md` |
+| AI agent workflow | `docs/integrations/ai-tools.md`, `AGENTS.md` |
+| Cursor summaries | `.cursor/rules/` |
+
+## Inherited by reference (framework behavior)
+
+When implementing HTTP, middleware, validation, or error responses, follow NENE2 upstream docs unless NeNe Clear records an explicit deviation in an ADR.
+
+| Topic | NENE2 upstream |
+| --- | --- |
+| HTTP runtime (PSR-7/15/17) | `docs/development/http-runtime.md` |
+| Middleware order and security | `docs/development/middleware-security.md` |
+| Request validation layers | `docs/development/request-validation.md` |
+| Problem Details errors | `docs/development/api-error-responses.md` |
+| Authentication boundaries | `docs/development/authentication-boundary.md` |
+| OpenAPI conventions | `docs/integrations/openapi.md` |
+| MCP tool policy | `docs/integrations/mcp-tools.md`, `docs/explanation/why-mcp.md` |
+| Database adapter boundaries | `docs/development/database-migrations.md` |
+| Domain / use case layering | `docs/development/domain-layer.md` |
+
+Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs/` as the framework reference during development.
+
+## Adapted for NeNe Clear
+
+| Topic | NeNe Clear choice |
+| --- | --- |
+| Product goal | API-first quote and invoice platform (not general accounting) |
+| Public Problem Details base URL | `https://nene-clear.dev/problems/` |
+| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + billing additions |
+| Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
+| Monetary values | Integer **cents** in DB and JSON; no floats |
+| Language policy | English for public docs, OpenAPI, API error metadata; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
+| Review checklists | `docs/review/` — task-specific lists for this product |
+
+## NeNe Clear–specific (not inherited)
+
+Record these in ADRs or product docs when they stabilize:
+
+- Client / quote / invoice / payment domain model
+- Japan qualified invoice (適格請求書) field validation rules
+- PDF generation strategy (server-side, no client-side tax calculation)
+- Admin frontend vs public document download boundaries
+- MCP tool catalog for billing operations
+- Release versioning of the NeNe Clear product (`v0.x` until first stable API)
+
+## When upstream and local docs conflict
+
+1. Update the **local source-of-truth doc** in this repository first.
+2. If the conflict is about **framework behavior**, prefer NENE2 upstream unless an ADR documents a deliberate deviation.
+3. Keep `.cursor/rules/` as a short summary; do not duplicate full policy text there.
+
+## Verification commands (once runtime is scaffolded)
+
+NeNe Clear should expose the same quality gates as NENE2 consumer projects:
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+When `frontend/` exists:
+
+```bash
+npm run check --prefix frontend
+```

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -1,0 +1,39 @@
+# AI Tools Policy
+
+NeNe Clear inherits NENE2 AI integration principles with billing-specific boundaries.
+
+## Agent entry
+
+- `AGENTS.md` — read first
+- `CLAUDE.md` — quick rules
+- `.cursor/rules/` — Cursor summaries
+
+## MCP boundary
+
+- MCP tools map to **OpenAPI HTTP operations** only.
+- MCP is for **operators and development agents**, not public document download clients.
+- Do not add tools that read the database directly or execute shell commands without Issue + security review.
+- Write tools (create invoice, mark paid) require auth review before catalog publication.
+
+Validate catalog:
+
+```bash
+composer mcp
+```
+
+## Secrets in agent sessions
+
+Agents must not commit:
+
+- `.env` files
+- Admin JWT secrets
+- Production upstream URLs with embedded credentials
+- SMTP passwords
+
+## Cross-repo work
+
+- CMS or catalog API gaps → Issue in **nene-records**, not workarounds here.
+- Lead capture API gaps → Issue in **nene-concierge**.
+- Framework bugs → Issue in **NENE2**.
+
+See also: `docs/integrations/sibling-products.md`, ADR 0002.

--- a/docs/integrations/sibling-products.md
+++ b/docs/integrations/sibling-products.md
@@ -1,0 +1,44 @@
+# Sibling Product Integration
+
+NeNe Clear integrates with other NeNe ecosystem products **via HTTP only**. See ADR 0002.
+
+## Dependency direction
+
+```
+NeNe Clear  →  HTTP  →  NeNe Records / NeNe Concierge / NeNe Corpus (optional)
+```
+
+Never embed NeNe Clear code in sibling repositories. Never share databases.
+
+## Planned integrations
+
+| Sibling | Direction | Use case | Phase |
+| --- | --- | --- | --- |
+| **NeNe Records** | Invoice → Records (read) | Import product names and prices for line items | Phase 4+ |
+| **NeNe Concierge** | Concierge → Invoice (write via webhook/API) | Create draft client or quote from scenario lead capture | Phase 4+ |
+| **NeNe Corpus** | None required | No default integration | — |
+
+## Environment variables (planned)
+
+Document in `.env.example` when clients land:
+
+| Variable | Purpose |
+| --- | --- |
+| `NENE_RECORDS_API_BASE_URL` | Optional product catalog upstream |
+| `NENE_RECORDS_BEARER_TOKEN` | Read-only token for Records API |
+| `NENE_CONCIERGE_WEBHOOK_SECRET` | Verify inbound lead webhooks |
+
+## Implementation rules
+
+- HTTP clients live in `src/Upstream/`.
+- UseCases depend on interfaces, not concrete HTTP clients.
+- Upstream failures must degrade gracefully (local manual entry always available).
+- Contract tests when upstream OpenAPI is stable.
+
+## Reporting bugs
+
+| Symptom | Open Issue in |
+| --- | --- |
+| Missing Records catalog API | nene-records |
+| Concierge action node needs Invoice endpoint | nene-concierge (or here if Invoice API is the deliverable) |
+| NENE2 middleware / Problem Details | NENE2 |

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -1,0 +1,24 @@
+# Milestone: Governance and Foundation (2026-05)
+
+Goal: establish NeNe Clear engineering discipline and product design before billing features grow.
+
+**Status: complete (2026-05-29)**
+
+## Acceptance Criteria
+
+- [x] GitHub repository created (`hideyukiMORI/nene-clear`)
+- [x] `docs/inheritance-from-nene2.md` documents local vs upstream rules
+- [x] `docs/workflow.md` and commit conventions in place
+- [x] `AGENTS.md`, `CLAUDE.md`, `docs/CONTRIBUTING.md` exist
+- [x] `.cursor/rules/` summaries for always-on agent guidance
+- [x] `docs/review/` initial self-review checklists
+- [x] ADR 0001 and ADR 0002 accepted
+- [x] `docs/roadmap.md`, `docs/todo/current.md` initialized
+- [x] Product vision, requirements, domain model (Issue #3)
+- [x] `composer check` green on `main` (Issue #4 — runtime scaffold + `GET /health`)
+
+## Follow-up Milestone
+
+Phase 0+ — NENE2 runtime scaffold, health endpoint, OpenAPI stub, CI (Issues #4–#7).
+
+Then Phase 1 — Core billing API (clients, quotes, invoices, payments).

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,0 +1,19 @@
+# Backend API Self-Review
+
+Use for handlers, use cases, validation, routes, and HTTP behavior.
+
+Source policies: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`, `docs/inheritance-from-nene2.md`.
+
+## Checklist
+
+- [ ] Change has a linked GitHub Issue; commit subject includes `(#issue)`.
+- [ ] Handler stays thin: parse → DTO → UseCase → response.
+- [ ] Business rules live in UseCase, not Handler or Repository.
+- [ ] Money fields use integer cents — no floats.
+- [ ] Japan invoice validation rules enforced in UseCase before persistence/PDF.
+- [ ] All identifiers (fields, status values, `operationId`, slugs) match `docs/explanation/terminology.md` exactly — no typos, no unregistered terms.
+- [ ] New routes documented in OpenAPI with `operationId`.
+- [ ] Problem Details used for errors; no stack traces in responses.
+- [ ] Admin mutating routes require auth when applicable.
+- [ ] Tests cover happy path and at least one failure case.
+- [ ] `composer check` or narrowest equivalent run and noted in PR.

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -1,0 +1,25 @@
+# Accounting & Tax Compliance Self-Review
+
+**Binding.** Use for **any** change touching quotes, invoices, payments, tax
+calculation, document numbering, PDF rendering, or record retention. If unsure
+whether a change has compliance impact, assume it does and run this list.
+
+Source of truth: [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
+
+## Checklist
+
+- [ ] Change reviewed against `docs/explanation/accounting-compliance.md`; compliance impact stated in the PR.
+- [ ] Qualified invoice required fields enforced before issuance (issuer name/address/`T`+13 registration number/date, per-rate taxable amount, per-rate consumption tax, total, buyer name).
+- [ ] Reduced-rate (軽減税率 8%) items clearly marked.
+- [ ] Consumption tax rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
+- [ ] Allowed tax rates only (10% / 8%); any rate change carries an ADR.
+- [ ] Registration number treated as **syntax-only** validation; no UI/doc implies it proves existence/validity.
+- [ ] Issued documents are immutable; corrections via credit note, not edit/delete.
+- [ ] Document numbering sequential; no silent gap, reuse, or hard delete that hides a voided document.
+- [ ] No hard delete of billing records (soft delete / void only).
+- [ ] Issued copies retained and tamper-evident; no auto-purge before the statutory period (7y, up to 10y).
+- [ ] All money is integer minimum currency units; no float/DECIMAL in DB, JSON, or tests.
+- [ ] Monetary/tax figures computed once in the UseCase; PDF/API/stored copy do not recalculate independently.
+- [ ] Audit trail recorded for issuance and payment (Phase 2+).
+- [ ] Any deviation from the binding rules carries an ADR with tax/accounting professional sign-off.

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,0 +1,16 @@
+# Database Self-Review
+
+Use for migrations, repositories, and schema changes.
+
+Source policies: `docs/development/backend-standards.md`, `docs/development/naming-conventions.md`.
+
+## Checklist
+
+- [ ] Migration file name follows `YYYYMMDDHHMMSS_snake_description.php`.
+- [ ] Table names plural snake_case; money columns use `*_cents` integer.
+- [ ] Foreign keys named `{entity}_id`.
+- [ ] SQL only in `Pdo*Repository` classes.
+- [ ] Schema snapshot updated under `database/schema/` when applicable.
+- [ ] Soft delete columns consistent (`is_deleted`, `deleted_at`) unless ADR says otherwise.
+- [ ] Repository tests use SQLite in-memory PDO.
+- [ ] Rollback considered for destructive migrations.

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -1,0 +1,28 @@
+# Documentation and Policy Self-Review
+
+Use for policy docs, workflow docs, ADRs, roadmap updates, TODO updates, and Cursor rules.
+
+Source policies:
+
+- `docs/workflow.md`
+- `docs/development/adr.md`
+- `docs/inheritance-from-nene2.md`
+- `docs/explanation/glossary.md`
+- `docs/development/naming-conventions.md`
+- `docs/todo/current.md`
+- `docs/roadmap.md`
+
+## Checklist
+
+- [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
+- [ ] `docs/roadmap.md` or `docs/todo/current.md` updated when project state changed.
+- [ ] Major architecture decisions considered whether an ADR is needed.
+- [ ] NENE2 inheritance changes reflected in `docs/inheritance-from-nene2.md`.
+- [ ] Public source-of-truth docs and OpenAPI text remain English unless policy allows otherwise.
+- [ ] Cursor rules stay concise; full policy not duplicated in `.cursor/rules/`.
+- [ ] Issue and PR references included where useful.
+- [ ] Wording is concrete enough for humans and AI agents to follow.
+- [ ] English docs use canonical terms from `docs/explanation/glossary.md`.
+- [ ] All identifiers match `docs/explanation/terminology.md` exactly — no typos or spelling variants.
+- [ ] New or renamed terms/identifiers registered in `docs/explanation/terminology.md` in this PR (and glossary if a product concept).
+- [ ] `git diff --check` reviewed for whitespace errors.

--- a/docs/review/frontend.md
+++ b/docs/review/frontend.md
@@ -1,0 +1,15 @@
+# Frontend Self-Review
+
+**Status:** Phase 2 — not implemented yet.
+
+When `frontend/` exists, use this checklist for React/TypeScript admin UI changes.
+
+## Checklist (placeholder)
+
+- [ ] TypeScript strict mode passes.
+- [ ] API client uses snake_case fields without renaming.
+- [ ] UI strings in locale catalogs.
+- [ ] Admin JWT not stored in localStorage without documented threat model.
+- [ ] `npm run check --prefix frontend` passes.
+
+Until Phase 2, mark `N/A` in PRs.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -1,0 +1,15 @@
+# Middleware and Security Self-Review
+
+Use for auth, CORS, logging, rate limits, and security-sensitive changes.
+
+Source policies: NENE2 middleware docs, `docs/integrations/ai-tools.md`.
+
+## Checklist
+
+- [ ] Secrets not logged (JWT, SMTP password, upstream bearer tokens).
+- [ ] Admin JWT not exposed to public document download routes.
+- [ ] CORS config explicit — no `*` in production paths.
+- [ ] Auth middleware on admin mutating routes.
+- [ ] PDF download tokens time-limited or scoped when public.
+- [ ] No sensitive data in Problem Details `detail` for production.
+- [ ] MCP write tools reviewed for auth and audit requirements.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,0 +1,16 @@
+# OpenAPI Contract Self-Review
+
+Use for OpenAPI schema changes, examples, and contract tests.
+
+Source policies: `docs/development/naming-conventions.md`, NENE2 OpenAPI conventions.
+
+## Checklist
+
+- [ ] Every new route has `operationId` in camelCase — stable after release.
+- [ ] Request/response schemas use snake_case property names.
+- [ ] Money fields documented as integer cents with description.
+- [ ] Success and Problem Details responses documented.
+- [ ] Examples included for non-trivial endpoints.
+- [ ] `composer openapi` passes.
+- [ ] MCP catalog updated when ops-facing endpoints change (`composer mcp`).
+- [ ] Public text (summary, description) is English.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,88 @@
+# Roadmap
+
+NeNe Clear is a self-hosted quote and invoice OSS on NENE2 — Japan SMB billing without SaaS lock-in.
+
+## North Star
+
+Operators can self-host a billing platform that:
+
+- manages clients and company issuer profile
+- creates quotes and converts them to invoices
+- issues Japan qualified invoice (適格請求書) compliant PDFs
+- tracks payment status and overdue items
+- runs on **Tier A** shared hosting or **Tier B** Docker/VPS
+- optionally integrates with NeNe Records and NeNe Concierge via HTTP
+
+Full scope: [`docs/explanation/product-vision.md`](./explanation/product-vision.md), [`docs/explanation/requirements.md`](./explanation/requirements.md).
+
+## Phase 0: Governance and Foundation
+
+Goal: engineering discipline and product design before runtime code.
+
+- Governance docs, ADR 0001/0002, inheritance map ✅
+- Product vision, requirements, domain model ✅ (Issue #3)
+- Multi-tenancy + role hierarchy adopted as foundational ✅ ADR 0006 (Issue #17)
+- NENE2 consumer scaffold (tenant resolution + JWT auth + RBAC + `GET /health`), OpenAPI, CI 🔲 Issues #4–#7
+- ADR 0003 dual deployment 🔲 Issue #7
+
+Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
+
+**Status: product docs complete; runtime scaffold next.**
+
+## Phase 1: Core Billing API
+
+Goal: tenancy, auth, client master, quotes, invoices, payments — API and DB only.
+
+- `organizations`, `users`, `company_settings`, `clients`, `quotes`, `invoices`, `line_items`, `payments`, `document_sequences` — all tenant-scoped by `organization_id` (ADR 0006)
+- Organization resolution (default `single`) + JWT auth + `Role`/`Capability` RBAC
+- Organization CRUD (superadmin); user CRUD (admin)
+- Japan qualified invoice field validation in UseCases
+- Quote → invoice conversion
+- OpenAPI + PHPUnit + PHPStan 8
+
+See [`docs/explanation/requirements.md#phase-1--api-only`](./explanation/requirements.md#phase-1--api-only).
+
+## Phase 2: Admin UI + PDF
+
+Goal: operators manage billing without CLI.
+
+- React admin SPA — ja + en locale catalogs (ADR 0005; no other locales)
+- Server-side qualified invoice PDF (Japanese layout)
+- Email delivery via SMTP
+- Public PDF download token
+- Dashboard: unpaid / overdue
+
+## Phase 3: Tier A Shared Hosting
+
+Goal: Japan SMB install path.
+
+- Web installer + release ZIP
+- Operator guide (Japanese)
+- Same-origin admin on shared hosting
+
+## Phase 4: Ecosystem Integration
+
+Goal: connect to sibling products.
+
+- NeNe Records product catalog import
+- NeNe Concierge lead → draft client / quote webhook
+- MCP tool catalog
+- CSV export; optional payment gateway
+
+## Post-MVP expansions (maintainer sequence)
+
+After Phase 1–3 core billing is stable, implement in this order:
+
+1. **Payment reconciliation & dunning** — 入金消込・督促管理
+2. **Purchase order & delivery note** — 発注書・納品書管理
+3. **Contract term & renewal** — 契約期限・更新管理
+4. **Small-scale subscription billing** — 小規模サブスク請求管理
+5. **Minimal expense reimbursement** — 経費申請の最小版
+
+Full scope, prerequisites, and MVP boundaries: [`docs/explanation/expansion-roadmap.md`](./explanation/expansion-roadmap.md).
+
+**Current expansion focus:** #1 (after core invoice + payment lands).
+
+## Non-goals
+
+See [`docs/explanation/product-vision.md#non-goals`](./explanation/product-vision.md#non-goals).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,0 +1,40 @@
+# Current Work
+
+Last updated: 2026-05-29
+
+## Status
+
+**Phase 0 — Governance & product docs:** initialized (Issue #1).
+
+**Runtime:** not started. Next: NENE2 scaffold (Issue #4+).
+
+## Repository
+
+| Repo | Role |
+| --- | --- |
+| **`nene-clear`** (this) | Canonical private product |
+| **`nene-invoice`** | Public experiment — **do not use for strategy or new features** |
+| **`publication-strategy`** | Portfolio strategy + expansion order SSOT |
+
+## Post-MVP expansion (approved order)
+
+See [`docs/explanation/expansion-roadmap.md`](./explanation/expansion-roadmap.md):
+
+1. Payment reconciliation & dunning — 入金消込・督促
+2. PO & delivery note — 発注・納品
+3. Contract renewal — 契約期限・更新
+4. Small subscription billing — 小規模サブスク
+5. Minimal expense reimbursement — 経費最小版
+
+## Next steps
+
+1. Issue #4 — NENE2 runtime scaffold + `GET /health`
+2. Phase 1 — core billing API (multi-tenant, clients, quotes, invoices, payments)
+3. Phase 2 — admin UI + PDF
+4. Phase 3 — Tier A installer → **then consider public**
+
+## Handoff
+
+- Namespace: `NeneClear\`
+- Problem Details: `https://nene-clear.dev/problems/`
+- Private until launch — no Packagist until public

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,74 @@
+# Workflow
+
+NeNe Clear uses GitHub Issues for work tracking and local Markdown for project memory. This workflow inherits [NENE2 `docs/workflow.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md) with the substitutions below.
+
+See also: `docs/inheritance-from-nene2.md`.
+
+## Standard Flow
+
+1. Create or reuse a focused GitHub Issue.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+3. Create a branch from `main` named like `type/issue-number-summary`.
+4. Implement the smallest useful change.
+5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
+6. Review the relevant self-review checklist in `docs/review/`.
+7. Run the narrowest meaningful verification available.
+8. Commit with Conventional Commits and include the Issue number.
+9. Push the branch and create a PR linked to the Issue.
+10. Merge after review and checks.
+11. Return local `main` to the merged, clean state.
+
+## Branch Names
+
+Use Conventional Commit style as the prefix:
+
+- `docs/1-governance-foundation`
+- `feat/5-client-crud`
+- `fix/12-tax-rate-validation`
+- `test/8-invoice-pdf-generation`
+
+## PR Requirements
+
+Every PR should include:
+
+- purpose
+- change summary
+- verification results
+- self-review checklist used, when applicable
+- related Issue, preferably `Closes #number`
+- remaining risks or follow-up work
+
+Do not commit directly to `main`.
+
+## Local Project Memory
+
+- `docs/roadmap.md`: long-lived direction and phases
+- `docs/milestones/`: medium-sized goals and acceptance criteria
+- `docs/todo/current.md`: current task board and handoff notes
+- `docs/adr/`: major architecture decisions
+- `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
+
+Do not leave important decisions only in chat. If it changes how the project should be built, record it in `docs/`.
+
+Use ADRs for decisions that affect architecture, public contracts, dependency choices, or long-term maintenance. See `docs/development/adr.md`.
+
+Use self-review checklists before push or PR. See `docs/development/self-review.md`.
+
+## AI Agent Responsibilities
+
+AI agents should manage the normal lifecycle when asked to complete work:
+
+- create or reuse the Issue
+- create the Issue branch
+- read `AGENTS.md` and relevant docs before editing
+- edit only relevant files
+- review relevant self-review checklists
+- verify the change
+- commit, push, open PR, merge, and sync `main`
+- update local docs that describe project state
+
+If a user explicitly says investigation only, no commit, no PR, or another narrower scope, follow that instruction.
+
+## Initial Issues Backlog
+
+Phase 0 bootstrap Issues are tracked in `docs/todo/current.md`. After governance lands, use GitHub Issues for all work — no direct `main` commits.


### PR DESCRIPTION
## Summary

- Initialize NeNe Clear private repository with governance and product documentation (mirrors early `nene-invoice` bootstrap).
- Product identity: **NeNe Clear** (ADR 0007), namespace `NeneClear\`.
- Includes expansion roadmap items 1–5, philosophy, requirements, domain model, and sibling integration boundaries.
- No runtime code — Phase 0 docs only.

## Test plan

- [x] All markdown files present and consistent naming
- [x] No secrets in repo
- [x] ADR index lists 0007

Closes #1

Made with [Cursor](https://cursor.com)