### PR TITLE
docs: English-only docs and payment reconciliation compliance

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -1,18 +1,19 @@
 ---
-description: NeNe Clear 全作業共通の正本と安全方針
+description: NeNe Clear project rules and canonical docs
 alwaysApply: true
 ---
 
 # Project Rules
 
-- 正本は `README.md`、`AGENTS.md`、`docs/CONTRIBUTING.md`、`docs/inheritance-from-nene2.md`、`docs/development/`、`docs/workflow.md`。
-- AI/エージェントは作業前に `AGENTS.md` と関連 docs を確認する。
-- フレームワーク挙動は NENE2 upstream（`vendor/hideyukimori/nene2/docs/`）を参照する。製品ルールはこのリポジトリの docs を優先する。
-- **sibling 製品に統合しない。** 依存方向は `NeNe Clear → upstream API` のみ（ADR 0002）。
-- 秘密情報、トークン、パスワード、ローカル `.env`、生成物をコミットしない。
-- 変更は依頼範囲と Issue の目的に留め、無関係な整形やリファクタを混ぜない。
-- NeNe Clear はセルフホスト OSS の見積・請求・入金管理 — 適格請求書対応、Admin UI、PDF。
-- **会計・税務コンプライアンスは拘束ルール（非交渉）。** 請求・税・採番・PDF・保存の変更は `docs/explanation/accounting-compliance.md` 順守必須。逸脱は ADR ＋ 税理士確認なしに禁止。専門家がレビューしても逸脱ゼロを満たす。
-- 金額は **integer cents**（float 禁止）。実装は疎結合、型安全、OpenAPI/MCP 境界を優先（NENE2 継承）。
-- **命名規則は絶対順守・タイポ厳禁。** 全識別子は用語レジストリ `docs/explanation/terminology.md`（唯一の真実）と完全一致。スペルゆれ・未登録語はマージ禁止、追加/改名は同一 PR でレジストリ更新。
-- Cursor ルールと docs が食い違う場合は docs を先に更新し、このルールは短く保つ。
+- Canonical docs: `README.md`, `AGENTS.md`, `docs/CONTRIBUTING.md`, `docs/inheritance-from-nene2.md`, `docs/development/`, `docs/workflow.md`.
+- Read `AGENTS.md` and relevant docs before editing.
+- Framework behavior: NENE2 upstream (`vendor/hideyukimori/nene2/docs/`). Product rules: this repo.
+- **Do not merge into sibling products.** Dependency direction: `NeNe Clear → upstream API` only (ADR 0002).
+- Never commit secrets, tokens, passwords, local `.env`, or generated artifacts.
+- Keep changes scoped to the Issue; no unrelated formatting or refactors.
+- NeNe Clear: self-hosted OSS quote, invoice, payment, reconciliation, dunning — qualified invoice compliant.
+- **Accounting/tax compliance is binding.** Changes to billing, tax, numbering, PDF, retention, bank import, reconciliation, or dunning MUST follow `docs/explanation/accounting-compliance.md` and `docs/explanation/payment-reconciliation-dunning-compliance.md`. Deviations require ADR + licensed professional sign-off.
+- **Money: integer cents only** (no floats). Typed boundaries, OpenAPI/MCP (NENE2 inheritance).
+- **Naming:** all identifiers MUST match `docs/explanation/terminology.md`. No typos or unregistered terms.
+- **Repository docs: English only** (ADR 0008). Admin UI locales: ja + en (ADR 0005).
+- If Cursor rules conflict with docs, update docs first; keep rules concise.

--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -1,14 +1,14 @@
 ---
-description: Issue ベース開発と branch / PR / merge 運用
+description: Issue-driven workflow and PR merge policy
 alwaysApply: true
 ---
 
 # Issue Driven Workflow
 
-- コード、ドキュメント、設定変更は **必ず GitHub Issue ベース**。Issue 作成前に編集しない。
-- 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
-- **`main` へ直接 commit / push しない。** ブランチ名は `type/issue-number-summary`。
-- 標準完了フロー: commit → push → PR 作成（`Closes #番号` + セルフレビューチェックリスト名）→ CI 確認 → **merge** → ローカル `main` 同期。
-- コミットは Conventional Commits（`docs/development/commit-conventions.md`）。description/body は日本語、type/scope は英語。**subject に `(#issue)` を含める。**
-- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合はその指示を優先する。
-- 正本: `docs/workflow.md`、`docs/development/commit-conventions.md`（NENE2 継承）。
+- All code, documentation, and configuration changes **require a GitHub Issue** first.
+- Before starting: read `docs/roadmap.md`, `docs/milestones/`, `docs/todo/current.md`, and related Issues/PRs.
+- **Never commit or push directly to `main`.** Branch name: `type/issue-number-summary`.
+- Standard completion: commit → push → PR (`Closes #number` + self-review checklist) → CI → **merge** → sync local `main`.
+- Commits: Conventional Commits per `docs/development/commit-conventions.md` — **English** description/body, `(#issue)` in subject.
+- If the user limits scope (investigation only, no commit, PR only), follow that instruction.
+- Canonical: `docs/workflow.md`, `docs/development/commit-conventions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,13 @@ Entry point for AI agents working on **NeNe Clear** (private repo `nene-clear`).
 - **Philosophy:** `docs/explanation/philosophy.md`
 - **Product vision:** `docs/explanation/product-vision.md`
 - **Expansion roadmap (1–5):** `docs/explanation/expansion-roadmap.md`
+- **Reconciliation & dunning (binding):** `docs/explanation/payment-reconciliation-dunning-compliance.md`
+- **Accounting compliance (binding):** `docs/explanation/accounting-compliance.md`
 - **Requirements:** `docs/explanation/requirements.md`
 - **Terminology (binding):** `docs/explanation/terminology.md`
-- **Compliance (binding):** `docs/explanation/accounting-compliance.md`
 - **Current work:** `docs/todo/current.md`
 - **Roadmap:** `docs/roadmap.md`
+- **Language policy:** ADR 0008 — English-only repository docs
 
 ## Operating Rules
 
@@ -20,6 +22,7 @@ Entry point for AI agents working on **NeNe Clear** (private repo `nene-clear`).
 - Do **not** edit `nene-invoice` for Clear product work — this repo is canonical
 - Strategy changes → update `publication-strategy` first, then product docs here
 - Namespace: `NeneClear\`; money: integer cents
+- Compliance deviations require ADR + licensed tax/accounting professional sign-off
 
 ## Framework
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,30 +3,38 @@
 Private canonical repo for **NeNe Clear**. Strategy SSOT:
 [publication-strategy `docs/products/nene-clear.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-clear.md).
 
-## 一言
+## One-liner
 
-見積→請求→入金→**消込**まで。日本 SMB・自前ホスト・適格請求書・MCP 対応。
+Quote → invoice → payment → **reconciliation**. Japan SMB · self-hosted · qualified invoice · MCP-ready.
 
-## 絶対禁止
+## Hard rules
 
-- `nene-invoice` への製品変更（実験 repo は触らない）
-- `main` 直 commit
-- Issue なしの変更
+- Do **not** edit `nene-invoice` for Clear product work
+- No direct commits to `main`
+- No changes without a GitHub Issue
+- Repository docs are **English only** (ADR 0008)
 
-## 拡張ロードマップ（順序固定）
+## Expansion order (fixed)
 
-1. 入金消込・督促
-2. 発注・納品
-3. 契約更新
-4. 小規模サブスク
-5. 経費最小版
+1. Payment reconciliation & dunning
+2. Purchase order & delivery note
+3. Contract renewal
+4. Small-scale subscription billing
+5. Minimal expense reimbursement
 
-詳細: `docs/explanation/expansion-roadmap.md`
+Details: `docs/explanation/expansion-roadmap.md`
 
-## 正本
+## Compliance docs (binding)
 
-| 目的 | パス |
+| Topic | Path |
 | --- | --- |
-| 哲学 | `docs/explanation/philosophy.md` |
+| Invoice & tax | `docs/explanation/accounting-compliance.md` |
+| Reconciliation & dunning | `docs/explanation/payment-reconciliation-dunning-compliance.md` |
+
+## Canonical paths
+
+| Purpose | Path |
+| --- | --- |
+| Philosophy | `docs/explanation/philosophy.md` |
 | TODO | `docs/todo/current.md` |
-| 命名 | `docs/development/naming-conventions.md` |
+| Naming | `docs/development/naming-conventions.md` |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Clear billing from quote to cash — self-hosted for Japan SMB.**
 
-**NeNe Clear** (*見積から入金まで、明快に。*) is a billing platform on [NENE2](https://github.com/hideyukiMORI/NENE2): quotes, **qualified invoice** (適格請求書) PDFs, payment tracking, reconciliation, and dunning — on shared hosting or Docker.
+**NeNe Clear** is a billing platform on [NENE2](https://github.com/hideyukiMORI/NENE2): quotes, qualified invoice PDFs, payment tracking, bank reconciliation, and dunning — on shared hosting or Docker.
 
 > **Repository:** private until Phase 3 launch-ready. Portfolio strategy: [publication-strategy `docs/products/nene-clear.md`](https://github.com/hideyukiMORI/publication-strategy/blob/main/docs/products/nene-clear.md).
 
@@ -15,6 +15,7 @@
 - **Japan invoice compliance** — registration number, tax rates, qualified invoice PDF
 - **Self-hosted OSS** — MIT; Tier A shared hosting or Tier B Docker/VPS
 - **Quote-to-cash** — estimate → invoice → collect → **clear**
+- **Professional-grade reconciliation** — bank import, human-confirmed matching, audit trail
 - **AI-readable** — OpenAPI + MCP; human confirms, AI proposes
 - **Sibling to NeNe ecosystem** — HTTP integration with Records / Concierge / Corpus
 
@@ -25,6 +26,8 @@
 | **Philosophy** | [`docs/explanation/philosophy.md`](./docs/explanation/philosophy.md) |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
 | **Expansion roadmap (1–5)** | [`docs/explanation/expansion-roadmap.md`](./docs/explanation/expansion-roadmap.md) |
+| **Reconciliation & dunning (binding)** | [`docs/explanation/payment-reconciliation-dunning-compliance.md`](./docs/explanation/payment-reconciliation-dunning-compliance.md) |
+| **Accounting compliance (binding)** | [`docs/explanation/accounting-compliance.md`](./docs/explanation/accounting-compliance.md) |
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |
 | **Agents** | [`AGENTS.md`](./AGENTS.md) |
 | **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) |

--- a/docs/adr/0005-bilingual-ja-en-scope.md
+++ b/docs/adr/0005-bilingual-ja-en-scope.md
@@ -45,11 +45,10 @@ NeNe Clear localizes to **Japanese (primary) and English (secondary) only**.
   (適格請求書) PDF renders its legally required fields in Japanese because it is
   a legal document under Japanese law. English applies to the operator's working
   UI chrome, navigation, and guides — not to the statutory invoice content.
-- **Development docs are unaffected.** Source-of-truth docs, OpenAPI text, and
-  API error metadata remain **English** per the existing language policy
-  (`docs/inheritance-from-nene2.md`); Issues, PRs, commits, and `.cursor/rules/`
-  continue to allow Japanese. This ADR governs **product localization**, not the
-  repository's documentation language.
+- **Development docs are English.** Source-of-truth docs, OpenAPI text, API error
+  metadata, Issues, PRs, and commits are **English** per
+  [ADR 0008](../adr/0008-english-only-repository-documentation.md). This ADR
+  governs **product UI localization**, not repository documentation language.
 
 ## Consequences
 

--- a/docs/adr/0008-english-only-repository-documentation.md
+++ b/docs/adr/0008-english-only-repository-documentation.md
@@ -1,0 +1,61 @@
+# ADR 0008: English-Only Repository Documentation
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear serves Japan-registered businesses subject to Japanese tax and
+invoice law. Operators may use a Japanese or English **admin UI** (ADR 0005),
+but **engineering documentation** is read by contributors, AI agents, and
+international reviewers — including accounting advisors evaluating compliance
+design.
+
+Mixed Japanese/English repository docs created drift: statutory labels duplicated
+in kanji inside English sections, maintainer-only Japanese blocks, and
+Japanese commit/cursor rules inconsistent with product docs aimed at
+professional review.
+
+## Decision
+
+All **repository documentation** is **English only**:
+
+- `README.md`, `AGENTS.md`, `CLAUDE.md`
+- Everything under `docs/` (explanation, ADR, review, development, integrations)
+- `.cursor/rules/` summaries
+- OpenAPI descriptions and Problem Details metadata (when added)
+- GitHub Issue titles and bodies, PR titles and bodies, and commit message
+  descriptions for this repository
+
+**Exceptions (not repository docs):**
+
+- **Qualified invoice PDF** statutory field text — Japanese as required by law
+  (ADR 0005)
+- **Admin UI locale catalogs** — Japanese (primary) and English (secondary)
+  (ADR 0005)
+- **Operator-facing install guides** shipped with the product — ja + en per ADR 0005
+- **Japanese law names** may appear once in parentheses where needed for advisor
+  traceability (e.g. "Act on Electronic Books and Records Preservation
+  (電子帳簿保存法)")
+
+## Consequences
+
+**Benefits**
+
+- Single language for compliance review by 税理士 / 公認会計士 reading design docs
+- AI agents and international contributors have one canonical prose language
+- Aligns with NENE2 public API / OpenAPI English policy
+
+**Costs**
+
+- Japanese-speaking maintainers write commits and Issues in English
+- Supersedes Japanese commit body rule in prior `commit-conventions.md`
+
+## Related
+
+- ADR 0005: Admin UI ja/en only
+- `docs/inheritance-from-nene2.md` — language policy row updated
+- Issue: `#3`
+- Supersedes: informal "Japanese allowed in commits/rules" wording
+- Superseded by: none

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -26,6 +26,7 @@ docs/adr/
 ├── 0007-product-identity-nene-clear.md
 ├── 0006-multi-tenancy-and-roles.md
 ├── 0007-product-identity-nene-clear.md
+├── 0008-english-only-repository-documentation.md
 └── NNNN-short-title.md
 ```
 

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -1,6 +1,6 @@
 # Commit Message Conventions
 
-NeNe Clear uses Conventional Commits, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md) and sibling NeNe products.
+NeNe Clear uses Conventional Commits, inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md) with English descriptions per [ADR 0008](../adr/0008-english-only-repository-documentation.md).
 
 ## Format
 
@@ -15,17 +15,17 @@ NeNe Clear uses Conventional Commits, inherited from [NENE2](https://github.com/
 ## Language
 
 - Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in **English**.
-- Write the **description and body in Japanese**.
+- Write the **description and body in English**.
 - Include the related GitHub Issue number in the **subject** for all work.
 
 Example:
 
 ```text
-docs(governance): Issue 駆動ワークフローを NENE2 正本に整合する (#1)
+docs(governance): align issue-driven workflow with NENE2 upstream (#1)
 ```
 
 ```text
-feat(invoice): 適格請求書 PDF 生成 UseCase を追加する (#12)
+feat(invoice): add qualified invoice PDF generation UseCase (#12)
 ```
 
 ## Issue number

--- a/docs/explanation/accounting-compliance.md
+++ b/docs/explanation/accounting-compliance.md
@@ -21,11 +21,12 @@ See also: [`requirements.md`](./requirements.md), [`domain-model.md`](./domain-m
    precedence over every other product goal.
 2. **No silent deviation.** Any departure from the rules in this document — even
    temporary — requires an **ADR** and **explicit review sign-off by a tax/
-   accounting professional (税理士)** recorded in that ADR. Code may not merge a
-   deviation without it.
+   accounting professional (licensed tax accountant / 税理士)** recorded in that ADR.
+   Code may not merge a deviation without it.
 3. **Engineering is not the legal authority.** This document is engineering's
    binding interpretation of the rules. When a requirement is unclear, **stop
-   and consult a 税理士** — do not guess. Record the resolved interpretation here.
+   and consult a licensed tax accountant (税理士)** — do not guess. Record the
+   resolved interpretation here.
 4. **Single source of truth for figures.** Every monetary and tax figure is
    computed once in the UseCase layer. The PDF, API, and stored copy render the
    exact same values; no layer recalculates independently.
@@ -39,9 +40,9 @@ comply with*; it is not legal advice.
 
 | Area | Rule set |
 | --- | --- |
-| Consumption tax | 消費税法（標準税率 10% / 軽減税率 8%） |
-| Qualified invoice | 適格請求書等保存方式（インボイス制度） |
-| Stored records | 電子帳簿保存法（電子取引データ・写しの保存） |
+| Consumption tax | Consumption Tax Act (standard 10% / reduced 8%) |
+| Qualified invoice | Qualified Invoice System (適格請求書等保存方式) |
+| Stored records | Act on Electronic Books and Records Preservation |
 
 When any of these change (rate changes, new statutory fields, retention rule
 changes), treat it as a compliance defect until the product is updated, and open
@@ -49,27 +50,28 @@ a P0 Issue.
 
 ---
 
-## 2. Qualified invoice (適格請求書) — mandatory content
+## 2. Qualified invoice — mandatory content
 
 When `is_qualified_invoice = true`, the system **MUST** enforce and render **all**
-of the following. Missing any required field **MUST** block issuance.
+fields required under the Qualified Invoice System. Missing any required field
+**MUST** block issuance. PDF rendering uses **Japanese statutory labels** on
+the document; this section describes the data rules in English.
 
-### Issuer (供給者)
-- Legal name (氏名又は名称)
-- Address (住所又は所在地)
-- **Registration number** (登録番号), format `T` + 13 digits — see §4
-- Transaction / issue date (取引年月日・交付年月日)
+### Issuer (supplier)
+- Legal name or trade name
+- Address
+- **Registration number**, format `T` + 13 digits — see §4
+- Transaction date and issue date
 
-### Buyer (交付を受ける者)
-- Name (氏名又は名称)
+### Buyer (recipient)
+- Name
 - Address when applicable
 
 ### Transaction details
-- Description per line (取引内容); reduced-rate items (軽減税率対象) **MUST** be
-  clearly marked
-- **Taxable amount per tax rate** (税率ごとに区分して合計した対価の額)
-- **Consumption tax amount per tax rate** (税率ごとの消費税額)
-- Total billed amount (請求金額)
+- Description per line; reduced-rate (8%) items **MUST** be clearly marked
+- **Taxable amount per tax rate** (aggregated per rate category)
+- **Consumption tax amount per tax rate**
+- Total billed amount
 
 These figures are statutory. They are not cosmetic PDF fields — they are
 validated in the UseCase before any document is issued or rendered.
@@ -85,8 +87,8 @@ validated in the UseCase before any document is issued or rendered.
   [ADR 0004](../adr/0004-tax-rounding-per-rate.md). Per-line rounding is
   **prohibited** because it can round more than once per rate within one
   document.
-- The per-rate consumption tax figure produced here is exactly the
-  税率ごとの消費税額 the qualified invoice must display.
+- The per-rate consumption tax figure produced here is exactly the amount the
+  qualified invoice must display per rate category.
 
 ---
 
@@ -105,8 +107,8 @@ validated in the UseCase before any document is issued or rendered.
 
 - **Issued documents are immutable.** Once an invoice is `issued`, its line
   items, tax figures, totals, dates, and number **MUST NOT** be edited or
-  deleted. Corrections are made by issuing a **credit note / 修正適格請求書**
-  (Phase 4+), never by mutating or removing the original.
+  deleted. Corrections are made by issuing a **credit note / corrected qualified
+  invoice** (Phase 4+), never by mutating or removing the original.
 - **Sequential numbering with no compliance-breaking gaps.** Quote and invoice
   numbers are assigned in sequence per organization and year. The system **MUST
   NOT** silently reuse, back-fill, or delete numbers in a way that hides a
@@ -116,7 +118,7 @@ validated in the UseCase before any document is issued or rendered.
 
 ---
 
-## 6. Retention of issued copies (写しの保存)
+## 6. Retention of issued copies
 
 - The system **MUST** retain a copy of every **issued** qualified invoice (and
   the figures used to produce it).
@@ -147,10 +149,33 @@ validated in the UseCase before any document is issued or rendered.
 
 ---
 
-## 9. How this rule applies to every change
+## 9. Payment reconciliation and dunning (Expansion #1)
+
+From Expansion #1 onward, bank import, payment matching, and dunning are
+**binding compliance surfaces**. All rules in
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+apply with the same force as sections 1–8 above.
+
+Summary (non-exhaustive — the linked document is authoritative):
+
+- **`paid_at` MUST reflect bank value date** when reconciled from import.
+- **Partial payments, overpayments, and transfer-fee mismatches** MUST follow
+  documented allocation rules; no silent write-offs.
+- **Imported bank lines and match history** MUST be immutable, retained, and
+  searchable per the Act on Electronic Books and Records Preservation.
+- **Dunning** is operator-controlled professional reminder only; default
+  templates MUST NOT threaten legal action or auto-compute statutory interest
+  claims on outstanding balance.
+- **Human confirmation** MUST finalize reconciliation unless a future ADR
+  defines a narrow auto-match exception with professional sign-off.
+
+---
+
+## 10. How this rule applies to every change
 
 Any change that touches quotes, invoices, payments, tax calculation, document
-numbering, PDF rendering, or retention **MUST**:
+numbering, PDF rendering, retention, bank import, reconciliation, or dunning
+**MUST**:
 
 1. Be reviewed against this document and [`../review/compliance.md`](../review/compliance.md).
 2. State compliance impact in the PR.

--- a/docs/explanation/expansion-roadmap.md
+++ b/docs/explanation/expansion-roadmap.md
@@ -12,7 +12,7 @@ See also: [`roadmap.md`](../roadmap.md) (Phase 0–4), [`requirements.md`](./req
 
 **Do not start Expansion #1 until:**
 
-- Phase 1: `invoices`, `payments`, invoice status (`issued` / `partially_paid` / `paid`), overdue computation ✅
+- Phase 1: `invoices`, `payments`, invoice status (`issued` / `partially_paid` / `paid`), overdue computation
 - Phase 2 (minimum): admin can list unpaid/overdue invoices and record a payment manually
 
 Expansion features assume the **quote-to-cash core** exists. Building reconciliation on top of a half-finished invoice API creates rework.
@@ -21,62 +21,73 @@ Expansion features assume the **quote-to-cash core** exists. Building reconcilia
 
 ## Approved sequence
 
-| # | Theme (JA) | Theme (EN) | One line |
-| --- | --- | --- | --- |
-| **1** | 入金消込・督促管理 | Payment reconciliation & dunning | Match bank deposits to invoices; remind clients on overdue |
-| **2** | 発注書・納品書管理 | Purchase order & delivery note | Outbound PO to suppliers; delivery notes linked to quotes/invoices |
-| **3** | 契約期限・更新管理 | Contract term & renewal | Track contract end dates; renewal quotes and alerts |
-| **4** | 小規模サブスク請求管理 | Small-scale subscription billing | Recurring invoices for fixed monthly/yearly amounts |
-| **5** | 経費申請の最小版 | Minimal expense reimbursement | Employee expense requests with approval — not full accounting |
+| # | Theme | One line |
+| --- | --- | --- |
+| **1** | Payment reconciliation & dunning | Match bank deposits to invoices; professional overdue reminders |
+| **2** | Purchase order & delivery note | Outbound PO to suppliers; delivery notes linked to quotes/invoices |
+| **3** | Contract term & renewal | Track contract end dates; renewal quotes and alerts |
+| **4** | Small-scale subscription billing | Recurring invoices for fixed monthly/yearly amounts |
+| **5** | Minimal expense reimbursement | Employee expense requests with approval — not full accounting |
 
 Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR + roadmap update.
 
 ---
 
-## Expansion #1 — Payment reconciliation & dunning（入金消込・督促管理）
+## Expansion #1 — Payment reconciliation & dunning
+
+**Binding compliance:** [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
 
 ### Why first
 
 - Directly completes **quote-to-cash** after invoicing — highest daily-use value for office managers
 - Extends existing `payment` and `invoice.overdue` domain — no new document type required
-- Differentiates from “PDF invoice generator” tools; matches pain of Excel + bank CSV today
+- Differentiates from "PDF invoice generator" tools; matches pain of Excel + bank CSV today
 - Shared hosting friendly: CSV import first; no bank API required for MVP
 
 ### In scope (MVP)
 
 | Area | Capability |
 | --- | --- |
-| **Bank import** | Upload bank CSV (major Japanese bank formats documented one at a time); parse into `bank_transaction` rows |
-| **Reconciliation** | Match transaction → invoice by rules: exact amount, client name fuzzy match, transfer reference; manual match UI/API |
-| **Partial / overpay** | Support partial match; remainder stays unmatched or credit balance (document in ADR) |
-| **Dunning** | Overdue invoice list; dunning email templates (ja); manual send + optional scheduled reminder (cron/CLI) |
-| **Audit** | Log who matched what and when; log dunning sends |
+| **Bank import** | Upload bank CSV (major Japanese bank formats documented one at a time); parse into `bank_transaction` rows with import batch provenance |
+| **Reconciliation** | Match transaction → invoice by rules: exact amount, client name fuzzy match, transfer reference; **human-confirmed** match UI/API |
+| **Partial / overpay / fees** | Partial match; overpayment → `client_credit`; transfer-fee mismatch per compliance doc §2.4 — no silent write-off |
+| **Dunning** | Overdue invoice list; dunning email templates (Japanese primary); manual send + optional scheduled reminder with minimum interval |
+| **Audit** | Log who matched what and when; log dunning sends; immutable bank import lines |
+| **Export** | CSV for accounting software: invoice, paid_at, amounts, match ids |
 
 ### Out of scope (Expansion #1)
 
 - Automatic bank API / Moneytree / freee bank sync
 - Payment gateway capture (Stripe, PayPay) — Phase 4 optional
 - General ledger / journal entries
-- Multi-invoice single transfer split logic beyond simple “allocate amount across invoices” (Phase 1.5 if needed)
+- Statutory interest auto-accrual on outstanding balance
+- Debt collection agency workflows
 
 ### Planned entities (register in `terminology.md` before code)
 
 | Concept | Working name | Notes |
 | --- | --- | --- |
+| Import batch | `bank_import_batch` | File hash, actor, timestamp |
 | Imported bank line | `bank_transaction` | Raw import row; unmatched until reconciled |
 | Match link | `payment_reconciliation` | Links `bank_transaction` → `payment` or creates `payment` |
+| Client credit | `client_credit` | Overpayment balance |
 | Dunning run | `dunning_notice` | invoice_id, sent_at, template_id, channel (email) |
 
 ### Suggested delivery phases
 
-1. **E1-a** — `bank_transaction` import + list unmatched
-2. **E1-b** — Manual match → create/update `payment`, update invoice status
-3. **E1-c** — Rule-based match suggestions (amount + date window)
-4. **E1-d** — Dunning templates + send + history
+1. **E1-a** — `bank_import_batch` + `bank_transaction` import + list unmatched
+2. **E1-b** — Manual match → create/update `payment`, update invoice status, audit log
+3. **E1-c** — Rule-based match suggestions (amount + date window); still human confirm
+4. **E1-d** — Dunning templates + send + history + minimum interval guard
+
+### Professional sign-off gate
+
+Before E1-d ships to production operators, obtain advisor review per
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md) §7.
 
 ---
 
-## Expansion #2 — Purchase order & delivery note（発注書・納品書管理）
+## Expansion #2 — Purchase order & delivery note
 
 ### Why second
 
@@ -97,7 +108,7 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 
 ---
 
-## Expansion #3 — Contract term & renewal（契約期限・更新管理）
+## Expansion #3 — Contract term & renewal
 
 ### Why third
 
@@ -108,7 +119,7 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 
 - **Contract** entity: client_id, title, start_at, end_at, auto_renew flag, renewal_notice_days
 - Dashboard: contracts expiring in 30/60/90 days
-- One-click “renewal quote” from expiring contract
+- One-click "renewal quote" from expiring contract
 
 ### Out of scope
 
@@ -117,12 +128,12 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 
 ---
 
-## Expansion #4 — Small-scale subscription billing（小規模サブスク請求管理）
+## Expansion #4 — Small-scale subscription billing
 
 ### Why fourth
 
 - Depends on stable invoice + payment + preferably reconciliation (#1)
-- “10 monthly retainers” not “Stripe Billing scale”
+- "10 monthly retainers" not "Stripe Billing scale"
 
 ### In scope (MVP)
 
@@ -137,7 +148,7 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 
 ---
 
-## Expansion #5 — Minimal expense reimbursement（経費申請の最小版）
+## Expansion #5 — Minimal expense reimbursement
 
 ### Why last
 
@@ -173,7 +184,8 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 2. Open a GitHub Issue: `feat: Expansion #N — <short name>`.
 3. Register new terms in `terminology.md` + `glossary.md` in the same PR.
 4. Add ADR if architecture choice is non-obvious (e.g. bank CSV format strategy, dunning scheduler on Tier A).
-5. Update this file only if **order or scope** changes — with maintainer approval.
+5. For Expansion #1+, review [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md).
+6. Update this file only if **order or scope** changes — with maintainer approval.
 
 ---
 
@@ -181,4 +193,4 @@ Implement **in numeric order** unless an Issue explicitly reprioritizes with ADR
 
 **Next implementation target after Phase 1–2 core:** **Expansion #1 — Payment reconciliation & dunning.**
 
-Last updated: 2026-05-29 (Issue #27)
+Last updated: 2026-05-29

--- a/docs/explanation/payment-reconciliation-dunning-compliance.md
+++ b/docs/explanation/payment-reconciliation-dunning-compliance.md
@@ -1,0 +1,325 @@
+# Payment Reconciliation & Dunning — Binding Compliance Rules
+
+**Status: binding (non-negotiable) for Expansion #1 and all payment-matching /
+dunning features.** This document is the source of truth for how NeNe Clear
+implements **payment reconciliation** and **dunning** in a
+way that accounting and tax professionals can review without finding silent
+deviations from documented practice.
+
+This is **not legal advice**. It is engineering's binding interpretation of
+obligations that apply when a Japan-registered business uses NeNe Clear to
+match bank deposits to issued invoices and to send payment reminders. Where
+interpretation is unclear, **stop and consult a licensed tax accountant
+(税理士) or certified public accountant (公認会計士)** — record the resolution in
+an ADR and update this document.
+
+See also: [`accounting-compliance.md`](./accounting-compliance.md),
+[`expansion-roadmap.md`](./expansion-roadmap.md) (Expansion #1),
+[`philosophy.md`](./philosophy.md) (human confirms, AI proposes),
+[`../review/compliance.md`](../review/compliance.md).
+
+---
+
+## 0. Scope — what NeNe Clear is and is not
+
+### In scope
+
+NeNe Clear maintains a **billing subledger**:
+
+- Issued invoices and their outstanding balances
+- Payment records tied to invoices
+- Imported bank deposit lines and reconciliation links between deposits and payments
+- Operator-controlled dunning notices with full send history
+
+This supports **accounts receivable (売掛金) clearance at the document level** —
+the operator and their advisor can see which invoice was paid, when, and from
+which bank line.
+
+### Out of scope (by design)
+
+| Capability | Where it belongs |
+| --- | --- |
+| General ledger / journal entries (仕訳) | Accounting software (freee, Money Forward, Yayoi, etc.) |
+| Revenue recognition policy for corporation tax | Operator + tax advisor |
+| Consumption tax filing (申告) | Operator + tax advisor |
+| Statutory interest calculation as legal claim | Operator judgment; optional template text only |
+| Debt collection agency services | Not this product |
+| Credit scoring or third-party collections | Not this product |
+
+NeNe Clear **exports** reconciliation and payment data (CSV) for import into
+accounting software. It does **not** replace double-entry bookkeeping.
+
+---
+
+## 1. Statutory and professional basis
+
+NeNe Clear targets compliance with the following **as they apply to billing
+records, bank evidence, and payment reminders**. This table states *what we
+design for*; it is not legal advice.
+
+| Area | Relevant rules (Japan) | NeNe Clear role |
+| --- | --- | --- |
+| Bookkeeping & evidence | Corporation Tax Act bookkeeping duty; Civil Code performance of obligations | Preserve tamper-evident payment and match history |
+| Consumption tax | Consumption Tax Act — taxable period and qualified invoice rules | Payment date recorded accurately; invoice figures unchanged after issue |
+| Electronic records | Act on Electronic Books and Records Preservation (電子帳簿保存法) | Retain imported bank data and reconciliation audit trail with searchability |
+| Personal data | Act on the Protection of Personal Information (個人情報保護法) | Dunning uses client contact data only as operator instructs; log sends |
+| Late payment | Civil Code; Interest Rate Act (法定利率) | Reminders state facts; no automated legal threats or coercive language |
+| Fair business practice | Act against Unjustifiable Premiums and Misleading Representations (B2B context: professional tone) | Templates reviewed; operator controls send |
+
+When rules change, open a **P0 Issue** and update this document before shipping
+affected features.
+
+---
+
+## 2. Payment reconciliation — accounting rules
+
+### 2.1 Definitions
+
+| Term | Meaning in NeNe Clear |
+| --- | --- |
+| **Bank transaction** | One imported credit line on the company's bank account |
+| **Payment** | Business record that an invoice received funds |
+| **Reconciliation** | Confirmed link between one bank transaction (or portion) and one or more payments |
+| **Outstanding balance** | `invoice.total_cents − sum(allocated payment amounts)` for that invoice |
+
+### 2.2 Payment date (`paid_at`) — MUST
+
+- **`paid_at` MUST reflect the date the deposit was credited** on the bank
+  statement (入金日 / 取引日 on the import file), not the date the operator
+  clicked "match" unless they explicitly override with documented reason.
+- If import date and bank value date differ, **bank value date wins** unless an
+  ADR documents a per-bank-format exception.
+- Manual payment entry (without bank import) is allowed in Phase 1–2 core; from
+  Expansion #1 onward, **reconciled payments SHOULD prefer bank-sourced dates**.
+
+### 2.3 Partial payment — MUST
+
+- Multiple payments MAY apply to one invoice.
+- After each allocation, invoice status MUST be:
+  - `partially_paid` when `0 < outstanding < total`
+  - `paid` when `outstanding = 0`
+- Allocated amounts MUST NOT exceed invoice outstanding without triggering
+  **overpayment handling** (§2.5).
+- Sum of allocations across invoices for one bank transaction MUST equal the
+  transaction amount (or documented remainder per §2.5).
+
+### 2.4 Transfer fee mismatch — MUST document
+
+When the client pays net of bank transfer fee (振込手数料):
+
+- The bank credit amount may be **less than** invoice total.
+- Matching MUST NOT silently write off the difference.
+- Operator MUST choose one of:
+  1. **Partial payment** — allocate bank amount only; remainder stays outstanding
+  2. **Fee absorption** — allocate full invoice amount with explicit fee
+     write-off reason (audit log); requires `admin` capability
+  3. **Separate fee expense** — record in accounting software; NeNe Clear
+     records payment at bank amount only
+
+Default: **(1) partial payment**. Options (2) and (3) MUST leave an audit entry.
+
+### 2.5 Overpayment — MUST
+
+When bank credit **exceeds** invoice outstanding:
+
+- System MUST NOT discard the excess.
+- Excess MUST be recorded as **client credit balance** (`client_credit` or
+  equivalent — register in `terminology.md` before code).
+- Operator MAY apply credit to a future invoice via explicit allocation — never
+  automatic without confirmation.
+
+### 2.6 Multi-invoice single deposit — MUST
+
+One bank transaction MAY allocate to multiple invoices (一括入金の按分):
+
+- Allocation rows MUST sum to transaction amount.
+- Each row MUST reference `invoice_id` and `amount_cents`.
+- Confirmation is **one human action** per transaction batch, not silent auto-split.
+
+### 2.7 Reversal and correction — MUST
+
+- **Unmatch / reverse reconciliation:** creates a **reversal record**; does
+  NOT hard-delete payment or bank transaction history.
+- Invoice status MUST be recomputed from remaining valid payments.
+- Reason code and operator identity MUST be stored.
+
+### 2.8 Human confirmation — MUST
+
+Automatic match suggestions (rules or AI) MUST NOT finalize reconciliation
+without **explicit operator confirmation** unless a future ADR defines a
+narrow, low-risk auto-match subset (e.g. exact amount + exact invoice number in
+transfer reference) with professional sign-off.
+
+See [`philosophy.md`](./philosophy.md) §2.2.
+
+---
+
+## 3. Bank import — electronic records rules
+
+Under the Act on Electronic Books and Records Preservation, imported bank data
+used as evidence MUST be handled as **electronic transaction data** (電子取引データ).
+
+### 3.1 Import integrity — MUST
+
+| Requirement | Rule |
+| --- | --- |
+| Immutability | After import, `bank_transaction` amount, date, and counterparty text MUST NOT be edited in place |
+| Correction | Erroneous imports are voided via reversal import batch, not silent edit |
+| Provenance | Store `import_batch_id`, source filename, file hash (SHA-256), `imported_at`, `imported_by` |
+| Account scope | Each batch tied to one company bank account registered in `company_settings` |
+| Duplicate detection | Same file hash or duplicate line key MUST warn or block re-import |
+
+### 3.2 Retention — MUST
+
+- Imported bank lines and reconciliation links follow **§6 of
+  [`accounting-compliance.md`](./accounting-compliance.md)** — minimum **7 years**,
+  up to **10 years** where applicable; no auto-purge.
+- Searchability: list/filter by date, amount, match status, client, invoice number.
+
+### 3.3 Timestamps and audit — MUST
+
+- System clock used for `imported_at` MUST be documented in operator guide.
+- All match/unmatch actions logged per §8 of `accounting-compliance.md`.
+
+---
+
+## 4. Dunning (督促管理) — legal and operational rules
+
+Dunning in NeNe Clear means **professional payment reminders** for overdue or
+unpaid issued invoices. It is **not** debt collection, legal enforcement, or
+credit reporting.
+
+### 4.1 Eligibility — MUST
+
+Dunning MAY be sent only when:
+
+- Invoice status is `issued`, `partially_paid`, or `overdue`
+- Invoice is not voided
+- Outstanding balance > 0
+- Client has a deliverable email address (or operator chooses another logged channel)
+
+Dunning MUST NOT target `draft` invoices.
+
+### 4.2 Operator control — MUST
+
+| Rule | Detail |
+| --- | --- |
+| Send authority | `admin` or `member` with explicit capability (`send_dunning`) |
+| Trigger | Manual send per invoice OR scheduled job with org-level opt-in |
+| No silent spam | Scheduled dunning MUST respect minimum interval (default **7 days** since last notice for same invoice) |
+| Template change | Template version stored on each send record |
+
+### 4.3 Template content — MUST include
+
+- Issuer legal name and contact
+- Invoice number, issue date, due date
+- **Outstanding amount** (current, not original total if partially paid)
+- Payment instructions (bank name, branch, account type, account number from `company_settings`)
+- Professional closing; no abusive or threatening language
+
+### 4.4 Template content — MUST NOT include (unless operator custom template + advisor review)
+
+- False claims of legal action ("we will sue immediately")
+- Misrepresentation of statutory penalties
+- **Automatic statutory interest calculation presented as a legal demand** —
+  optional informational text MAY reference contract terms; default templates
+  MUST NOT compute compound interest without ADR + advisor sign-off
+- Third-party collection agency impersonation
+
+### 4.5 Statutory interest (法定利率) — advisory note
+
+B2B monetary debts may carry statutory interest under the Interest Rate Act
+(current statutory rate: confirm with advisor at time of implementation). NeNe
+Clear:
+
+- MAY offer an **optional** template placeholder for contractually agreed or
+  statutory interest — **disabled by default**
+- MUST NOT auto-add interest to `outstanding` balance in the billing subledger
+  without ADR and professional sign-off
+- Operator remains responsible for correctness of any interest claim
+
+### 4.6 Personal information — MUST
+
+- Client email and name in dunning are personal data; operator is **data controller**
+- Send history is retained for audit (who, when, to whom, template version)
+- Logs MUST NOT include unrelated client data in the same export row
+
+### 4.7 Channel — Phase E1-d
+
+- Primary channel: **email** via operator SMTP
+- Each send creates immutable `dunning_notice` row
+- Future channels (postal log-only) require ADR
+
+---
+
+## 5. Relationship to consumption tax accounting
+
+NeNe Clear does **not** determine whether the operator uses **invoice basis**
+(請求書ベース) or **payment basis** (支払ベース) for consumption tax.
+
+The system MUST:
+
+- Keep **issued invoice tax figures immutable** after issue
+- Record **payment dates** accurately for advisor export
+- Export CSV columns: invoice number, issue date, paid_at, amount_cents, tax breakdown (from invoice), match id
+
+Tax advisor uses export to prepare returns; NeNe Clear does not file.
+
+---
+
+## 6. Audit trail — MUST (Expansion #1)
+
+In addition to [`accounting-compliance.md`](./accounting-compliance.md) §8:
+
+| Event | Minimum audit fields |
+| --- | --- |
+| Bank import batch | batch id, file hash, row count, actor, timestamp |
+| Match confirmed | bank_transaction id(s), payment id(s), invoice id(s), amounts, actor, timestamp |
+| Match reversed | reversal id, prior match id, reason, actor, timestamp |
+| Dunning sent | invoice id, outstanding at send, recipient, template version, actor, timestamp |
+| Client credit created | client id, amount, source transaction, actor, timestamp |
+
+Audit records follow the same no-silent-mutation rule as issued invoices.
+
+---
+
+## 7. Professional review checklist
+
+Before Expansion #1 ships, a licensed **税理士 or 公認会計士** SHOULD sign off on:
+
+1. Payment date sourcing from bank import
+2. Partial / overpayment / fee mismatch flows
+3. Immutability and retention of bank + match records
+4. Default dunning template wording (Japanese primary)
+5. Confirmation that subledger export columns meet their journal import workflow
+
+Record sign-off in the Expansion #1 milestone Issue or ADR.
+
+---
+
+## 8. How this rule applies to every change
+
+Any change touching bank import, matching, payment allocation, client credit,
+dunning templates, or send scheduling **MUST**:
+
+1. Be reviewed against this document and [`../review/compliance.md`](../review/compliance.md).
+2. State compliance impact in the PR.
+3. If it deviates from any rule here, carry an ADR with professional sign-off.
+
+If unsure whether a change has compliance impact, **assume it does**.
+
+---
+
+## Related entities (register before code)
+
+| Concept | Working table name |
+| --- | --- |
+| Imported bank line | `bank_transaction` |
+| Import batch | `bank_import_batch` |
+| Match link | `payment_reconciliation` |
+| Client overpayment credit | `client_credit` |
+| Dunning send | `dunning_notice` |
+
+See [`terminology.md`](./terminology.md) for canonical spellings before implementation.
+
+Last updated: 2026-05-29

--- a/docs/explanation/philosophy.md
+++ b/docs/explanation/philosophy.md
@@ -2,13 +2,10 @@
 
 **NeNe Clear** (*Clear billing from quote to cash.*)
 
-This document records **ideals** (理想), **philosophy** (理念・哲学), and
-**non‑negotiable beliefs** for the product. It complements
-[`product-vision.md`](./product-vision.md) (scope and personas) and
-[`expansion-roadmap.md`](./expansion-roadmap.md) (feature sequence).
-
-Canonical language: **English**. Maintainer intent in Japanese appears in
-§8 where it aids nuance; public API and OpenAPI remain English.
+This document records **ideals**, **philosophy**, and **non‑negotiable beliefs**
+for the product. It complements [`product-vision.md`](./product-vision.md) (scope
+and personas) and [`expansion-roadmap.md`](./expansion-roadmap.md) (feature
+sequence).
 
 Product name: [ADR 0007](../adr/0007-product-identity-nene-clear.md).
 
@@ -37,13 +34,14 @@ punishment for being small.
 
 ### 1.3 Compliance is structure, not paperwork
 
-適格請求書 and tax rules are not PDF decoration. They are **validation rules**
-in the API — the same rules whether a human clicks "Issue" or an agent calls
-`createInvoice` via MCP.
+Qualified invoice and consumption tax rules are not PDF decoration. They are
+**validation rules** in the API — the same rules whether a human clicks
+"Issue" or an agent calls `createInvoice` via MCP.
 
 **Ideal:** A tax reviewer finds **zero deviations** from documented compliance
-([`accounting-compliance.md`](./accounting-compliance.md)); any change requires
-ADR and professional sign-off.
+([`accounting-compliance.md`](./accounting-compliance.md),
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md));
+any change requires ADR and professional sign-off.
 
 ### 1.4 AI everywhere — but responsibility stays in the system
 
@@ -94,7 +92,8 @@ Especially for **payment reconciliation** (Expansion #1):
 - A human **confirms** → audit log → `payment` + invoice status update.
 
 Automatic clearing without confirmation is a liability, not a feature, until
-explicitly ADR'd for a defined low-risk subset.
+explicitly ADR'd for a defined low-risk subset. See
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md).
 
 ### 2.3 Same contract for GUI and MCP
 
@@ -113,7 +112,8 @@ NeNe Records, Corpus, and Concierge remain upstream/downstream **via HTTP only**
 
 Admin UI: **Japanese + English** (ADR 0005). Statutory invoice content:
 **Japanese**. The product serves non-Japanese founders running Japan-registered
-entities — compliance is fixed; UI language is flexible.
+entities — compliance is fixed; UI language is flexible. Repository docs are
+**English only** (ADR 0008).
 
 ---
 
@@ -136,7 +136,7 @@ If most answers are no, reconsider or split the work.
 
 | We are not | Why |
 | --- | --- |
-| A general ledger | freee / MF territory; we export CSV instead |
+| A general ledger | freee / Money Forward territory; we export CSV instead |
 | A bank | We import CSV; we do not hold deposits |
 | A payment gateway (Phase 1–3 core) | Manual record first; PSP optional later |
 | A WordPress plugin | Sibling app on same origin is fine |
@@ -149,9 +149,9 @@ If most answers are no, reconsider or split the work.
 
 | Reading | Meaning |
 | --- | --- |
-| **Clear (verb)** | 消込 — reconcile bank lines to invoices |
-| **Clear (adjective)** | 明快 — transparent status: draft, issued, overdue, paid |
-| **Clear (verb)** | クリア — remove Excel chaos; one system of record |
+| **Clear (verb)** | Reconcile bank lines to invoices |
+| **Clear (adjective)** | Transparent status: draft, issued, overdue, paid |
+| **Clear (verb)** | Remove Excel chaos; one system of record |
 
 One word, three readings — same as Records / Corpus / Concierge in the NeNe
 family.
@@ -174,33 +174,39 @@ Back office (same server or VPS)
 
 ---
 
-## 7. Document map
+## 7. Maintainer intent
+
+> **Free quote-to-cash from Excel and memory.**
+>
+> Qualified invoices are API-enforced rules, not PDF cosmetics. Data stays on
+> hosting the operator already pays for — no extra SaaS bill. In the AI era,
+> humans confirm, AI proposes, and the audit trail remains — all three at once
+> for a self-hosted back-office OSS.
+>
+> The name **Clear** means both **reconciliation** and **clarity**. We will not
+> shrink to "invoice PDF generator only."
+
+---
+
+## 8. Document map
 
 | Question | Read |
 | --- | --- |
 | Why does the product exist? | This file + `product-vision.md` |
 | What do we build in v1? | `requirements.md` |
 | What comes after MVP? | `expansion-roadmap.md` |
+| Reconciliation & dunning rules? | `payment-reconciliation-dunning-compliance.md` |
 | What is the product called? | ADR 0007 — **NeNe Clear** |
 | What are exact spellings? | `terminology.md` |
-
----
-
-## 8. Maintainer intent (理念 — 日本語)
-
-> **見積から入金までを、Excel と記憶から解放する。**
->
-> 適格請求書は「PDF の体裁」ではなく、API が守るルール。データは自分のレンタルサーバーに置き、SaaS 月額を増やさない。AI 時代だからこそ、人間が確定し、AI が提案し、記録が残る — その三つを同時に満たすバックオフィス OSS。
->
-> 名前 **Clear** は「消込」と「明快」の両方。請求書 PDF だけのツールにはならない。
 
 ---
 
 ## Related
 
 - ADR 0007: Product identity
+- ADR 0008: English-only repository docs
 - [`product-vision.md`](./product-vision.md)
 - [`expansion-roadmap.md`](./expansion-roadmap.md)
 - [`accounting-compliance.md`](./accounting-compliance.md)
 
-Last updated: 2026-05-29 (Issue #31)
+Last updated: 2026-05-29

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -7,7 +7,7 @@ NeNe Clear is a self-hosted quote and invoice platform built on [NENE2](https://
 
 ## Origin
 
-Every Japan SMB must issue **qualified invoices** (適格請求書) under the invoice system (インボイス制度). SaaS accounting tools (freee, Money Forward, Yayoi) solve this well but charge recurring fees and hold financial data on vendor infrastructure. Many micro-businesses on **shared hosting** already run their website on the same server — they want billing documents without another monthly subscription.
+Every Japan SMB must issue **qualified invoices** under the Qualified Invoice System. SaaS accounting tools (freee, Money Forward, Yayoi) solve this well but charge recurring fees and hold financial data on vendor infrastructure. Many micro-businesses on **shared hosting** already run their website on the same server — they want billing documents without another monthly subscription.
 
 NeNe Clear offers an alternative: **run quote and invoice management on infrastructure you control**, with source code you can audit, and optional integration with sibling NeNe products for catalog and lead capture.
 
@@ -19,8 +19,8 @@ Operators and AI agents can:
 
 - register company issuer profile (name, address, invoice registration number, bank details)
 - manage **clients** (buyers) with billing addresses
-- create **quotes** (見積書) with line items and tax breakdown
-- convert accepted quotes to **invoices** (請求書) with one action
+- create **quotes** with line items and tax breakdown
+- convert accepted quotes to **invoices** with one action
 - issue **qualified invoice** PDFs that meet Japan invoice system requirements
 - record **payments** and see overdue / unpaid status at a glance
 - optionally import product names from [NeNe Records](https://github.com/hideyukiMORI/nene-records) or create draft clients from [NeNe Concierge](https://github.com/hideyukiMORI/nene-concierge) leads
@@ -44,9 +44,9 @@ Docker Compose for local development and production. Same API and admin UI as Ti
 
 A growing segment: founders and staff who are not native Japanese speakers but
 run a company registered in Japan. They are bound by the same Japanese invoice
-and tax rules, but operate the admin UI more comfortably in English. NeNe
-Invoice serves them with an **English admin UI**, while statutory documents
-remain Japanese — see [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
+and tax rules, but operate the admin UI more comfortably in English. NeNe Clear
+serves them with an **English admin UI**, while statutory documents remain
+Japanese — see [ADR 0005](../adr/0005-bilingual-ja-en-scope.md).
 
 **Multi-tenant hosting operators**
 
@@ -71,13 +71,14 @@ The same pattern applies to **small manufacturers**, **creative agencies**, **eq
 
 NeNe Clear optimizes for **quote-to-cash for B2B SMB**:
 
-1. Operator registers **issuer profile** (自社情報 + インボイス登録番号).
-2. Operator adds **clients** (取引先).
-3. Operator creates a **quote** with line items (品名, 数量, 単価, 税率).
-4. Client accepts → operator converts quote to **invoice** (請求書).
+1. Operator registers **issuer profile** (legal name, address, invoice registration number).
+2. Operator adds **clients** (buyers).
+3. Operator creates a **quote** with line items (description, quantity, unit price, tax rate).
+4. Client accepts → operator converts quote to **invoice**.
 5. System generates **qualified invoice PDF** with required fields.
 6. Operator sends PDF by email or download link.
 7. Client pays → operator records **payment** → invoice marked paid.
+8. (Expansion #1) Operator imports bank CSV → confirms match → outstanding cleared with audit trail.
 
 **Not the primary story:** full double-entry bookkeeping, payroll, expense reimbursement, inventory, or POS. Those belong to other products or Phase 4+ integrations.
 
@@ -154,7 +155,7 @@ See also [`requirements.md`](./requirements.md#explicit-non-goals).
 - **Not** inventory management or POS (NeNe Shop is a separate future product)
 - **Not** a WordPress plugin (coexist on same domain is fine)
 - **Not** embedded inside NeNe Records or other sibling repos
-- **Not** e-invoice (電子インボイス) PEPPOL network transmission in Phase 1–3 — PDF + email first
+- **Not** structured e-invoice (PEPPOL) network transmission in Phase 1–3 — PDF + email first
 - **Not** payment gateway integration in Phase 1 — manual payment recording first; Stripe/PayPay in Phase 4+
 - **Not** multilingual beyond Japanese and English — UI locales bound to ja/en by [ADR 0005](../adr/0005-bilingual-ja-en-scope.md)
 

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -37,10 +37,10 @@ All tenant-scoped entities below carry **`organization_id`** (ADR 0006).
 | --- | --- | --- |
 | **organization** | Tenant | name, slug (unique), plan, is_active, custom_domain (optional), external_id (optional) |
 | **user** | Operator account | email (unique), password_hash, role (superadmin/admin/member/viewer), organization_id (NULL for superadmin), status (active/invited) |
-| **company_settings** | Issuer (自社) profile — **per organization** | organization_id, legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
-| **client** | Buyer (取引先) | name, contact_name, email, billing_address, **registration_number** (optional for B2B qualified invoice) |
-| **quote** | Estimate (見積書) | client_id, quote_number, issued_at, valid_until, status, subtotal_cents, tax_cents, total_cents, notes |
-| **invoice** | Bill (請求書) | client_id, quote_id (optional), invoice_number, issued_at, due_at, status, subtotal_cents, tax_cents, total_cents, **is_qualified_invoice** |
+| **company_settings** | Issuer profile — **per organization** | organization_id, legal_name, address, phone, email, **registration_number**, bank_name, bank_branch, account_type, account_number, logo_url (optional) |
+| **client** | Buyer / customer | name, contact_name, email, billing_address, **registration_number** (optional for B2B qualified invoice) |
+| **quote** | Estimate / quotation | client_id, quote_number, issued_at, valid_until, status, subtotal_cents, tax_cents, total_cents, notes |
+| **invoice** | Bill / invoice | client_id, quote_id (optional), invoice_number, issued_at, due_at, status, subtotal_cents, tax_cents, total_cents, **is_qualified_invoice** |
 | **line_item** | Row on quote or invoice | parent_type (quote/invoice), parent_id, description, quantity, unit_price_cents, tax_rate_bps, sort_order |
 | **payment** | Payment record | invoice_id, paid_at, amount_cents, method (bank_transfer/cash/other), notes |
 
@@ -48,7 +48,7 @@ All money: **integer cents**. Tax rate: **basis points** (1000 = 10.00%).
 
 ---
 
-## 3. Japan qualified invoice (適格請求書) — required fields
+## 3. Japan qualified invoice — required fields
 
 > **Binding compliance.** The rules in this section are governed by
 > [`accounting-compliance.md`](./accounting-compliance.md) (non-negotiable). A
@@ -59,22 +59,22 @@ When `is_qualified_invoice = true`, the system must enforce and render:
 
 ### Issuer (supplier)
 
-- [ ] Legal name (氏名又は名称)
-- [ ] Address (住所又は所在地)
-- [ ] **Registration number** (登録番号) — format `T` + 13 digits
-- [ ] Issue date (請求書の交付年月日)
+- [ ] Legal name or trade name
+- [ ] Address
+- [ ] **Registration number** — format `T` + 13 digits
+- [ ] Issue date
 
 ### Buyer (optional on simplified invoices, required for full B2B)
 
-- [ ] Name (氏名又は名称)
-- [ ] Address (住所又は所在地) — when provided
+- [ ] Name
+- [ ] Address — when provided
 
 ### Transaction details
 
-- [ ] Line items: description (取引内容), tax rate per line or document
-- [ ] Taxable amount per rate category (税率ごとの対価の額)
-- [ ] Consumption tax per rate category (税率ごとの消費税額)
-- [ ] Total billing amount (請求金額)
+- [ ] Line items: description, tax rate per line or document
+- [ ] Taxable amount per rate category
+- [ ] Consumption tax per rate category
+- [ ] Total billing amount
 
 ### Validation rules (API layer)
 
@@ -179,13 +179,13 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 | Item | Reason |
 | --- | --- |
 | General ledger / journal entries | Different product category; export to accounting SaaS instead |
-| Payroll / 給与 | Out of scope |
-| Expense receipts / 経費精算 | Out of scope |
+| Payroll | Out of scope |
+| Expense receipts (full reimbursement) | Out of scope until Expansion #5 |
 | Inventory / stock | NeNe Shop territory |
-| PEPPOL / 電子インボイス network | Phase 4+ research; PDF first |
+| PEPPOL / structured e-invoice network | Phase 4+ research; PDF first |
 | Multi-currency | JPY only for Phase 1–3 |
 | Multilingual UI beyond ja/en | Domain locked to Japanese rules; UI bound to Japanese + English (ADR 0005) |
-| Consumption tax filing (申告) | Operator exports data; no tax return generation |
+| Consumption tax filing | Operator exports data; no tax return generation |
 
 ---
 
@@ -200,9 +200,27 @@ Quote numbers and invoice numbers: auto-increment per organization with configur
 
 ---
 
+## 10. Expansion #1 — payment reconciliation & dunning (requirements summary)
+
+Full binding rules: [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md).
+
+| Requirement | Phase |
+| --- | --- |
+| Bank CSV import with batch provenance (hash, actor, timestamp) | E1-a |
+| `bank_transaction` list unmatched / matched | E1-a |
+| Human-confirmed match → `payment` + `payment_reconciliation` | E1-b |
+| Partial payment, overpayment → `client_credit`, transfer-fee rules | E1-b |
+| Match reversal with audit (no hard delete) | E1-b |
+| Rule-based match suggestions (non-final until confirmed) | E1-c |
+| Dunning templates (Japanese primary), send log, minimum interval | E1-d |
+| CSV export for accounting import | E1-d |
+
+---
+
 ## Related
 
 - **Compliance (binding):** [`accounting-compliance.md`](./accounting-compliance.md)
+- **Reconciliation & dunning (binding):** [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
 - Domain model: [`domain-model.md`](./domain-model.md)
 - Naming: [`../development/naming-conventions.md`](../development/naming-conventions.md)
 - Roadmap: [`../roadmap.md`](../roadmap.md)

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -53,7 +53,7 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + billing additions |
 | Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
 | Monetary values | Integer **cents** in DB and JSON; no floats |
-| Language policy | English for public docs, OpenAPI, API error metadata; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
+| Language policy | **English** for all repository docs, Issues, PRs, commits, OpenAPI, API errors (ADR 0008); admin UI **ja + en** only (ADR 0005) |
 | Review checklists | `docs/review/` — task-specific lists for this product |
 
 ## NeNe Clear–specific (not inherited)
@@ -61,7 +61,8 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 Record these in ADRs or product docs when they stabilize:
 
 - Client / quote / invoice / payment domain model
-- Japan qualified invoice (適格請求書) field validation rules
+- Japan qualified invoice field validation rules
+- Payment reconciliation and dunning compliance rules
 - PDF generation strategy (server-side, no client-side tax calculation)
 - Admin frontend vs public document download boundaries
 - MCP tool catalog for billing operations

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -1,17 +1,22 @@
 # Accounting & Tax Compliance Self-Review
 
 **Binding.** Use for **any** change touching quotes, invoices, payments, tax
-calculation, document numbering, PDF rendering, or record retention. If unsure
-whether a change has compliance impact, assume it does and run this list.
+calculation, document numbering, PDF rendering, record retention, bank import,
+payment reconciliation, or dunning. If unsure whether a change has compliance
+impact, assume it does and run this list.
 
-Source of truth: [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+Source of truth:
+
+- [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md)
+- [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md)
+
 Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
 
-## Checklist
+## Checklist — invoices & tax
 
-- [ ] Change reviewed against `docs/explanation/accounting-compliance.md`; compliance impact stated in the PR.
+- [ ] Change reviewed against binding compliance docs; compliance impact stated in the PR.
 - [ ] Qualified invoice required fields enforced before issuance (issuer name/address/`T`+13 registration number/date, per-rate taxable amount, per-rate consumption tax, total, buyer name).
-- [ ] Reduced-rate (軽減税率 8%) items clearly marked.
+- [ ] Reduced-rate (8%) items clearly marked.
 - [ ] Consumption tax rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
 - [ ] Allowed tax rates only (10% / 8%); any rate change carries an ADR.
 - [ ] Registration number treated as **syntax-only** validation; no UI/doc implies it proves existence/validity.
@@ -23,3 +28,18 @@ Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
 - [ ] Monetary/tax figures computed once in the UseCase; PDF/API/stored copy do not recalculate independently.
 - [ ] Audit trail recorded for issuance and payment (Phase 2+).
 - [ ] Any deviation from the binding rules carries an ADR with tax/accounting professional sign-off.
+
+## Checklist — reconciliation & dunning (Expansion #1+)
+
+- [ ] `paid_at` uses bank value date when matched from import (unless documented override).
+- [ ] Partial payments update `partially_paid` / `paid` correctly; no over-allocation without overpayment flow.
+- [ ] Transfer-fee mismatch handled per compliance doc §2.4 — no silent write-off.
+- [ ] Overpayment creates `client_credit`; excess not discarded.
+- [ ] Multi-invoice allocation sums to bank transaction amount.
+- [ ] Match reversal creates audit record; no hard delete of payment/bank history.
+- [ ] Human confirmation required before match is final (unless ADR exception).
+- [ ] Bank import batch stores file hash, actor, timestamp; imported lines immutable.
+- [ ] Dunning only for issued/partially_paid/overdue with outstanding > 0.
+- [ ] Dunning send logged; minimum interval enforced for scheduled sends.
+- [ ] Default dunning templates: no threats, no auto statutory interest on balance.
+- [ ] CSV export columns suitable for advisor handoff (document in PR if changed).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ Operators can self-host a billing platform that:
 
 - manages clients and company issuer profile
 - creates quotes and converts them to invoices
-- issues Japan qualified invoice (適格請求書) compliant PDFs
+- issues Japan qualified invoice compliant PDFs
 - tracks payment status and overdue items
 - runs on **Tier A** shared hosting or **Tier B** Docker/VPS
 - optionally integrates with NeNe Records and NeNe Concierge via HTTP
@@ -73,11 +73,13 @@ Goal: connect to sibling products.
 
 After Phase 1–3 core billing is stable, implement in this order:
 
-1. **Payment reconciliation & dunning** — 入金消込・督促管理
-2. **Purchase order & delivery note** — 発注書・納品書管理
-3. **Contract term & renewal** — 契約期限・更新管理
-4. **Small-scale subscription billing** — 小規模サブスク請求管理
-5. **Minimal expense reimbursement** — 経費申請の最小版
+1. **Payment reconciliation & dunning**
+2. **Purchase order & delivery note**
+3. **Contract term & renewal**
+4. **Small-scale subscription billing**
+5. **Minimal expense reimbursement**
+
+Compliance for #1: [`docs/explanation/payment-reconciliation-dunning-compliance.md`](./explanation/payment-reconciliation-dunning-compliance.md).
 
 Full scope, prerequisites, and MVP boundaries: [`docs/explanation/expansion-roadmap.md`](./explanation/expansion-roadmap.md).
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,7 +4,7 @@ Last updated: 2026-05-29
 
 ## Status
 
-**Phase 0 — Governance & product docs:** initialized (Issue #1).
+**Phase 0 — Governance & product docs:** Issue #1 merged; Issue #3 English docs + reconciliation compliance.
 
 **Runtime:** not started. Next: NENE2 scaffold (Issue #4+).
 
@@ -20,11 +20,13 @@ Last updated: 2026-05-29
 
 See [`docs/explanation/expansion-roadmap.md`](./explanation/expansion-roadmap.md):
 
-1. Payment reconciliation & dunning — 入金消込・督促
-2. PO & delivery note — 発注・納品
-3. Contract renewal — 契約期限・更新
-4. Small subscription billing — 小規模サブスク
-5. Minimal expense reimbursement — 経費最小版
+1. Payment reconciliation & dunning
+2. Purchase order & delivery note
+3. Contract term & renewal
+4. Small-scale subscription billing
+5. Minimal expense reimbursement
+
+**Expansion #1 compliance SSOT:** [`payment-reconciliation-dunning-compliance.md`](./explanation/payment-reconciliation-dunning-compliance.md)
 
 ## Next steps
 
@@ -32,9 +34,11 @@ See [`docs/explanation/expansion-roadmap.md`](./explanation/expansion-roadmap.md
 2. Phase 1 — core billing API (multi-tenant, clients, quotes, invoices, payments)
 3. Phase 2 — admin UI + PDF
 4. Phase 3 — Tier A installer → **then consider public**
+5. Expansion #1 — after Phase 1–2 core; advisor sign-off before E1-d production
 
 ## Handoff
 
 - Namespace: `NeneClear\`
 - Problem Details: `https://nene-clear.dev/problems/`
+- Repository docs: English only (ADR 0008)
 - Private until launch — no Packagist until public


### PR DESCRIPTION
## Summary

- **ADR 0008:** All repository documentation, Issues, PRs, and commits are English-only; admin UI remains ja + en (ADR 0005).
- **New binding doc:** `docs/explanation/payment-reconciliation-dunning-compliance.md` — statutory basis, payment date rules, partial/overpayment/fee handling, electronic records retention, dunning legal boundaries, audit trail, professional sign-off gate.
- **Updated:** `accounting-compliance.md` §9–10, `expansion-roadmap.md` Expansion #1, `requirements.md` §10, `review/compliance.md` reconciliation checklist, README/AGENTS/CLAUDE/cursor rules, commit conventions.

## Test plan

- [x] Grep: no standalone Japanese prose blocks (law names in parentheses only per ADR 0008)
- [x] Cross-links between compliance docs resolve
- [x] Expansion #1 references binding compliance doc

Self-review: docs-policy, compliance

Closes #3

Made with [Cursor](https://cursor.com)