### PR TITLE
docs: rewrite nene-invoice residue to Clear reconciliation & dunning domain (#7)

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -14,7 +14,7 @@ alwaysApply: true
 - NeNe Clear: self-hosted OSS **reconciliation & dunning** — not quote/invoice (ADR 0009).
 - **Do not add quote/invoice/PDF features** — `nene-invoice` owns 見積・請求・入金 (ADR 0009).
 - **Not upper compatible** with `nene-invoice`. Separate domain, separate DB.
-- **Accounting/tax compliance is binding.** Changes to billing, tax, numbering, PDF, retention, bank import, reconciliation, or dunning MUST follow `docs/explanation/accounting-compliance.md` and `docs/explanation/payment-reconciliation-dunning-compliance.md`. Deviations require ADR + licensed professional sign-off.
+- **Compliance is binding.** Changes to bank import, reconciliation, allocation, client credit, dunning, retention, or audit MUST follow `docs/explanation/payment-reconciliation-dunning-compliance.md` (authoritative) and `docs/explanation/accounting-compliance.md`. Deviations require ADR + licensed professional sign-off.
 - **Money: integer cents only** (no floats). Typed boundaries, OpenAPI/MCP (NENE2 inheritance).
 - **Naming:** all identifiers MUST match `docs/explanation/terminology.md`. No typos or unregistered terms.
 - **Repository docs: English only** (ADR 0008). Admin UI locales: ja + en (ADR 0005).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,8 +40,8 @@ Do not commit passwords, tokens, private URLs, production credentials, or local 
 Sensitive keys for this product include:
 
 - Admin JWT secrets
-- Upstream API bearer tokens (NeNe Records, NeNe Concierge)
-- SMTP credentials for invoice email delivery
+- Invoice upstream API bearer token (and optional NeNe Records / NeNe Concierge tokens)
+- SMTP credentials for dunning email delivery
 
 ## Engineering Theme
 
@@ -50,7 +50,7 @@ NeNe Clear should stay readable, secure, and self-hostable:
 - strict, typed, explicit boundaries (inherited from NENE2)
 - decoupled use cases and infrastructure
 - OpenAPI contracts before client assumptions
-- Japan invoice compliance fields validated at API layer
+- Reconciliation/dunning compliance enforced at the API layer; no quote/invoice/tax/PDF logic (ADR 0009)
 - MCP access only through documented HTTP boundaries
 - **never** merge into or embed inside NeNe Records (ADR 0002)
 

--- a/docs/adr/0001-inherit-nene2-governance.md
+++ b/docs/adr/0001-inherit-nene2-governance.md
@@ -10,7 +10,7 @@ NeNe Clear is a consumer application built on [NENE2](https://github.com/hideyuk
 
 Alternatives considered:
 
-1. **Link-only** — rejected; product-specific rules (billing, invoice compliance, sibling boundaries) would be unclear.
+1. **Link-only** — rejected; product-specific rules (reconciliation/dunning, compliance, sibling boundaries) would be unclear.
 2. **Full copy** — rejected; upstream drift would be hard to track.
 3. **Hybrid inheritance** (chosen): local source-of-truth for workflow and product rules; reference NENE2 upstream for framework runtime behavior.
 
@@ -19,7 +19,7 @@ Alternatives considered:
 Adopt NENE2 governance patterns locally:
 
 - Issue-driven development with `type/issue-number-summary` branches
-- Conventional Commits (English type/scope, Japanese description/body, Issue number in subject)
+- Conventional Commits (English type/scope and description/body per ADR 0008, Issue number in subject)
 - Self-review checklists under `docs/review/`
 - ADR policy under `docs/development/adr.md`
 - AI agent entry via `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/`
@@ -32,7 +32,7 @@ Framework HTTP, middleware, validation, and MCP behavior remain defined by NENE2
 **Benefits**
 
 - Contributors and AI agents have a single local entry point.
-- Product rules (billing model, invoice fields, upstream boundaries) stay separate from framework rules.
+- Product rules (reconciliation/dunning model, upstream boundaries) stay separate from framework rules.
 - NENE2 upstream improvements remain consumable via Composer.
 
 **Costs**
@@ -42,7 +42,7 @@ Framework HTTP, middleware, validation, and MCP behavior remain defined by NENE2
 **Follow-up**
 
 - Scaffold runtime and CI (Phase 0+).
-- Add billing and compliance ADRs as domains stabilize.
+- Add reconciliation/dunning and compliance ADRs as domains stabilize.
 
 ## Related
 

--- a/docs/adr/0002-separate-from-sibling-products.md
+++ b/docs/adr/0002-separate-from-sibling-products.md
@@ -58,7 +58,7 @@ in **NeNe Clear database only**. Invoice figures are **never** authoritative in 
 
 - Sibling products remain stable when billing services change.
 - Clear OSS story: four products, one framework, HTTP integration.
-- Security boundaries: CMS admin JWT ≠ billing admin JWT.
+- Security boundaries: CMS admin JWT ≠ Clear admin JWT.
 
 **Costs**
 

--- a/docs/adr/0004-tax-rounding-per-rate.md
+++ b/docs/adr/0004-tax-rounding-per-rate.md
@@ -2,87 +2,42 @@
 
 ## Status
 
-accepted
+superseded by [ADR 0009](./0009-separate-from-nene-invoice.md) — **relocated to
+`nene-invoice`**. Not applicable to NeNe Clear.
 
 ## Context
 
-NeNe Clear calculates consumption tax for quotes and invoices. The early
-domain model draft (`docs/explanation/domain-model.md`) rounded tax **per line
-item** and then summed the rounded line amounts into the document tax total.
+This ADR was written while NeNe Clear's bootstrap docs still described quote and
+invoice issuance. It specified that consumption tax for a qualified invoice must
+be rounded **once per tax rate per document** (税率ごとに1回), never per line
+item.
 
-Under the Japan qualified invoice system (適格請求書等保存方式), consumption tax
-rounding is constrained: for **one qualified invoice**, the tax amount may be
-rounded **once per tax rate** (税率ごとに1回). Rounding each line item and then
-summing is **not** permitted, because it can round more than once per rate
-within a single document and produce a tax total that does not match the
-rate-grouped statutory figure.
-
-The rounding direction itself (round half-up / floor / ceil) is the issuer's
-choice, but it must be applied at the rate-group level, not per line, and stay
-consistent across a document.
-
-Alternatives considered:
-
-1. **Round per line item, then sum** — rejected; rounds more than once per rate
-   and is non-compliant with the qualified invoice rule.
-2. **No rounding until the grand total** — rejected; the qualified invoice
-   requires the consumption tax **per tax rate category** (税率ごとの消費税額)
-   to be a displayed, rounded figure, so rounding must happen at the rate group.
-3. **Round once per tax rate per document** (chosen) — compliant and matches the
-   rate-category figures the PDF must render.
+[ADR 0009](./0009-separate-from-nene-invoice.md) split the domains: **quote,
+invoice, qualified-invoice content, and consumption-tax calculation belong to
+[`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice)**, not Clear.
+NeNe Clear performs **payment reconciliation and dunning only**; it never
+computes invoice tax or totals — it reads `total_cents` / `outstanding_cents`
+from the Invoice upstream and allocates known bank amounts against them.
 
 ## Decision
 
-Compute consumption tax by grouping line items by `tax_rate_bps`, summing the
-taxable amount per rate, and rounding **once per rate** to integer minimum
-currency units. Do not round individual line item tax amounts.
-
-```
-# Group line items by tax_rate_bps:
-for each rate group:
-    taxable_amount_cents[rate] = sum(quantity * unit_price_cents) in that group
-    tax_cents[rate]            = round(taxable_amount_cents[rate] * rate / 10000)   # ROUND ONCE here
-
-subtotal_cents = sum(taxable_amount_cents[rate] for all rates)
-tax_cents      = sum(tax_cents[rate] for all rates)
-total_cents    = subtotal_cents + tax_cents
-```
-
-- Rounding direction: **half-up** to integer minimum currency units, applied per
-  rate group. A future ADR may make the direction configurable per issuer if a
-  real operator requires floor/ceil; until then half-up is the single rule.
-- This calculation is the **single source of truth** in the UseCase layer. The
-  PDF and API responses both render these exact values; neither recalculates.
-- `tax_rate_bps` is in basis points (1000 = 10%, 800 = 8% reduced). See
-  `docs/explanation/glossary.md`.
+- The per-rate tax-rounding rule is **out of scope for NeNe Clear** and is no
+  longer binding in this repository.
+- The decision itself remains valid **for `nene-invoice`**, which owns tax
+  calculation. Maintain and evolve it there.
+- No tax-rounding logic may be implemented in NeNe Clear.
 
 ## Consequences
 
-**Benefits**
-
-- Compliant with the qualified invoice "round once per tax rate per document"
-  rule.
-- The per-rate `tax_cents[rate]` figures are exactly the
-  税率ごとの消費税額 the qualified invoice PDF must display.
-- API and PDF totals are guaranteed equal — one calculation, no per-line drift.
-
-**Costs**
-
-- Line items no longer carry an independently rounded tax amount; any per-line
-  tax shown in the UI is illustrative and must be labeled as such, not summed.
-- Changing the rounding direction later is an issuer-visible behavior change and
-  needs its own ADR.
-
-**Follow-up**
-
-- Implement in the `Quote` / `Invoice` tax calculation UseCase (Phase 1) with
-  unit tests covering mixed 10% / 8% documents and half-up boundary cases.
+- Clear's domain model, compliance, and code carry **no consumption-tax
+  calculation** (see [`../explanation/domain-model.md`](../explanation/domain-model.md)
+  "Allocation logic" and [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) §0.4).
+- This ADR number is retained as a historical record; the live rule lives in the
+  Invoice repository.
 
 ## Related
 
-- Domain model: `docs/explanation/domain-model.md`
-- Requirements (qualified invoice fields): `docs/explanation/requirements.md`
-- Backend standards (money and tax): `docs/development/backend-standards.md`
+- ADR 0009: Separate domain from nene-invoice
+- Accounting & records compliance (Clear scope): [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md)
 - Issue: `#9`
-- Supersedes: none
-- Superseded by: none
+- Superseded by: ADR 0009

--- a/docs/adr/0005-bilingual-ja-en-scope.md
+++ b/docs/adr/0005-bilingual-ja-en-scope.md
@@ -6,9 +6,11 @@ accepted
 
 ## Context
 
-NeNe Clear is built around the Japan invoice system (適格請求書, consumption
-tax rates, per-rate rounding — see ADR 0004). The domain rules are
-Japan-specific and cannot be localized away.
+NeNe Clear is built around Japanese reconciliation and dunning practice — bank
+deposit evidence under the Act on Electronic Books and Records Preservation
+(電子帳簿保存法), accounts-receivable clearance (消込), and professional
+overdue reminders (督促) bounded by the Civil Code and Interest Rate Act. These
+domain rules are Japan-specific and cannot be localized away.
 
 The operator base is shifting: more non-Japanese people now run businesses
 **inside Japan**. They operate under Japanese accounting and tax rules but are
@@ -19,7 +21,8 @@ Going further to arbitrary multilingual support (e.g. zh, ko, fr, es) does not.
 A non-Japanese-accounting locale serves no real operator, because every operator
 — regardless of native language — is subject to the same Japanese statutory
 rules. Each added UI locale increases translation surface, review burden, and
-the risk of mistranslating tax/legal terms, without serving the actual audience.
+the risk of mistranslating accounting/legal terms, without serving the actual
+audience.
 
 Alternatives considered:
 
@@ -41,10 +44,11 @@ NeNe Clear localizes to **Japanese (primary) and English (secondary) only**.
 - **Out of scope:** any additional UI locale. Pull requests adding other locales
   are declined unless a future ADR supersedes this decision. This is a
   deliberate product non-goal, not a missing feature.
-- **Statutory document content stays Japanese.** The qualified invoice
-  (適格請求書) PDF renders its legally required fields in Japanese because it is
-  a legal document under Japanese law. English applies to the operator's working
-  UI chrome, navigation, and guides — not to the statutory invoice content.
+- **Operator-facing legal/statutory text stays Japanese.** Dunning notice
+  content sent to Japanese clients, and any statutory labels surfaced from
+  upstream invoices, render in Japanese. English applies to the operator's
+  working UI chrome, navigation, and guides — not to outbound Japanese
+  correspondence.
 - **Development docs are English.** Source-of-truth docs, OpenAPI text, API error
   metadata, Issues, PRs, and commits are **English** per
   [ADR 0008](../adr/0008-english-only-repository-documentation.md). This ADR

--- a/docs/adr/0006-multi-tenancy-and-roles.md
+++ b/docs/adr/0006-multi-tenancy-and-roles.md
@@ -25,8 +25,8 @@ repository, and route — far more costly than building tenant-aware from day on
 Alternatives considered:
 
 1. **Single-tenant first, retrofit later** — rejected; a later `organization_id`
-   migration across all billing tables plus auth rework is high-risk and
-   re-opens compliance-sensitive code (issued documents, numbering).
+   migration across all reconciliation tables plus auth rework is high-risk and
+   re-opens compliance-sensitive code (bank import integrity, audit, retention).
 2. **Separate install per tenant only** — rejected; does not serve agencies and
    duplicates operations; the data model should still be tenant-aware.
 3. **Multi-tenant foundation, mirroring NeNe Records** (chosen) — tenant-aware
@@ -40,19 +40,24 @@ architecture.
 
 ### Tenancy
 
-- Every tenant-scoped table carries **`organization_id`** (`company_settings`,
-  `clients`, `quotes`, `invoices`, `line_items`, `payments`,
-  `document_sequences`, `users`).
+> The entity and capability examples below were corrected to NeNe Clear's
+> domain (reconciliation & dunning) per [ADR 0009](./0009-separate-from-nene-invoice.md).
+> The tenancy/role **decision** is unchanged.
+
+- Every tenant-scoped table carries **`organization_id`** (`clear_settings`,
+  `bank_import_batches`, `bank_transactions`, `payment_reconciliations`,
+  `client_credits`, `dunning_notices`, `audit_events`, `users`).
 - The **organization** (`organizations` table) is the tenant. Each organization
-  is an independent **issuer** of qualified invoices, with its own
-  `company_settings` (legal name, address, **registration number**, bank info).
+  is an independent **operator** running reconciliation and dunning, with its own
+  `clear_settings` (Invoice upstream API URL/token, registered bank accounts,
+  dunning defaults).
 - Per-request **organization resolution** runs in middleware before authorization
   (mirroring `OrgResolverMiddleware`). Supported modes: **`single`** (default —
   one organization per install), `path` (`/{org-slug}/…`), `subdomain`, and
   `custom_domain`. The resolved organization id is held in a request-scoped holder
   and **every repository query is org-scoped**.
-- Document numbering sequences are **per organization and year** (already in
-  `domain-model.md`); tenancy makes the scope explicit.
+- Clear issues **no** statutory document numbers (those belong to `nene-invoice`).
+  Import provenance is keyed per organization by `file_hash` + `bank_import_batch_id`.
 
 ### Roles and capabilities
 
@@ -62,13 +67,14 @@ resolver and enforced by `CapabilityMiddleware` (mirroring NeNe Records):
 | Role | Scope | Capabilities |
 | --- | --- | --- |
 | **`superadmin`** | Cross-tenant (platform operator) | All, **including `manage_organizations`**. `organization_id` may be `NULL`. |
-| **`admin`** | Single organization | All **except** `manage_organizations` — manages the org's **users**, **company settings** (issuer profile), and billing. |
-| **`member`** | Single organization | Billing operator — create/edit/send quotes & invoices, record payments (`manage_billing`, `view_billing`). **Cannot** manage users or settings. |
-| **`viewer`** | Single organization | Read-only (`view_billing`). Optional; Phase 3+. |
+| **`admin`** | Single organization | All **except** `manage_organizations` — manages the org's **users**, **Clear settings** (upstream config, bank accounts, dunning defaults), reconciliation, and dunning. |
+| **`member`** | Single organization | Reconciliation operator — import bank CSV, confirm/reverse matches (`manage_reconciliation`), send dunning when granted (`send_dunning`). **Cannot** manage users or settings. |
+| **`viewer`** | Single organization | Read-only (`view_reconciliation`) — matched/unmatched lists, dunning history. Optional; Phase 2+. |
 
-Capabilities (billing-specific; the set differs from NeNe Records' content
-capabilities): `manage_organizations`, `manage_users`, `manage_company_settings`,
-`manage_billing`, `view_billing`.
+Capabilities (reconciliation/dunning-specific; the set differs from NeNe
+Records' content capabilities): `manage_organizations`, `manage_users`,
+`manage_clear_settings`, `manage_reconciliation`, `view_reconciliation`,
+`send_dunning`.
 
 - **Superadmin manages organizations** (`/admin/organizations` — create, list,
   delete tenants).
@@ -78,10 +84,12 @@ capabilities): `manage_organizations`, `manage_users`, `manage_company_settings`
 
 ### Compliance interaction
 
-- Each organization's issuer registration number and issued documents are scoped
-  to that organization; cross-tenant reads are prohibited. This does not relax any
-  rule in [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) —
-  immutability, numbering, and retention apply **per organization**.
+- Each organization's bank transactions, reconciliation links, client credits,
+  and dunning history are scoped to that organization; cross-tenant reads are
+  prohibited. This does not relax any rule in
+  [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md)
+  or [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) —
+  immutability, retention, and audit apply **per organization**.
 
 ## Consequences
 

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -6,8 +6,8 @@ NeNe Clear uses lightweight Architecture Decision Records, inherited from [NENE2
 
 Write an ADR when a decision affects:
 
-- quote, invoice, payment architecture, or public API contracts
-- Japan invoice compliance strategy or PDF generation approach
+- bank import, reconciliation, client-credit, or dunning architecture, or public API contracts
+- reconciliation/dunning compliance strategy or the Invoice upstream API contract
 - dependency or framework integration choices
 - authentication, authorization, or MCP safety boundaries
 - dual deployment (Tier A shared hosting vs Tier B Docker)
@@ -23,7 +23,8 @@ docs/adr/
 ├── 0000-template.md
 ├── 0001-inherit-nene2-governance.md
 ├── 0002-separate-from-sibling-products.md
-├── 0007-product-identity-nene-clear.md
+├── 0004-tax-rounding-per-rate.md          # superseded — relocated to nene-invoice (ADR 0009)
+├── 0005-bilingual-ja-en-scope.md
 ├── 0006-multi-tenancy-and-roles.md
 ├── 0007-product-identity-nene-clear.md
 ├── 0008-english-only-repository-documentation.md

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -1,6 +1,6 @@
 # Backend Standards
 
-NeNe Clear backend policy for PHP API code. Adapted from [NeNe Records](https://github.com/hideyukiMORI/nene-records) and [NeNe Corpus](https://github.com/hideyukiMORI/nene-corpus) backend standards for a **billing OSS** on NENE2.
+NeNe Clear backend policy for PHP API code. Adapted from [NeNe Records](https://github.com/hideyukiMORI/nene-records) and [NeNe Corpus](https://github.com/hideyukiMORI/nene-corpus) backend standards for a **payment reconciliation & dunning OSS** on NENE2.
 
 **Framework baseline:** NENE2 `docs/development/` — deviate only via local ADR.
 
@@ -35,20 +35,19 @@ src/
   Organization/     # tenants + per-request resolution (Organization/Resolution/)
   Auth/             # JWT login, Role / Capability, capability middleware
   User/             # operator accounts within an organization
-  Company/          # issuer profile, tax registration, bank info (per organization)
-  Client/           # customer master
-  Quote/            # estimates
-  Invoice/          # issued invoices, qualified invoice fields
-  LineItem/         # shared line item logic (quote + invoice)
-  Payment/          # payment records, status
-  Pdf/              # server-side PDF generation
-  Upstream/         # optional HTTP clients (Records, Concierge)
+  Settings/         # ClearSettings — upstream URL/token, bank accounts, dunning defaults (per organization)
+  BankImport/       # CSV import, bank_import_batches, bank_transactions, duplicate detection
+  Reconciliation/   # match proposal, confirmation, allocation, reversal
+  ClientCredit/     # overpayment balances and application
+  Dunning/          # templates, send, send history
+  Upstream/         # Invoice API client (read invoices/clients, write payments); optional Records/Concierge
+  Audit/            # immutable audit events
 ```
 
 Every tenant-scoped table and query carries `organization_id` (ADR 0006). Only
 superadmin operates cross-tenant.
 
-**Zero-tolerance placement:** handlers live in their domain folder (`Invoice/CreateInvoiceHandler.php`), not `src/Handlers/`.
+**Zero-tolerance placement:** handlers live in their domain folder (`Reconciliation/ConfirmMatchHandler.php`), not `src/Handlers/`.
 
 ---
 
@@ -60,10 +59,10 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 
 | Layer | May | Must not |
 | --- | --- | --- |
-| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response | SQL, business rules, direct PDF library calls |
-| **UseCase** | Business rules, tax calculation, orchestration | `$_SERVER`, PDO, raw HTTP |
-| **Repository** | SQL / persistence | HTTP, PDF generation |
-| **Pdf adapter** | Render PDF from DTO | Domain invariants, SQL |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response | SQL, business rules, direct upstream HTTP calls |
+| **UseCase** | Business rules, allocation logic, dunning eligibility, orchestration | `$_SERVER`, PDO, raw HTTP |
+| **Repository** | SQL / persistence | HTTP, business rules |
+| **Upstream client** | HTTP calls to the Invoice API behind an interface | Domain invariants, SQL |
 
 Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
@@ -78,21 +77,21 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
 ---
 
-## 5. Money and tax
+## 5. Money and reconciliation
 
-> **Compliance is binding (non-negotiable).** All billing, tax, numbering, PDF,
-> and retention behavior **MUST** comply with
-> [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
+> **Compliance is binding (non-negotiable).** All bank import, reconciliation,
+> client-credit, dunning, retention, and audit behavior **MUST** comply with
+> [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md)
+> (authoritative) and [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md).
 > Where compliance conflicts with convenience, compliance wins. Deviations
 > require an ADR with tax-professional sign-off. Run
 > [`../review/compliance.md`](../review/compliance.md) for any change in this area.
 
-- Store all amounts as **integer cents** (`subtotal_cents`, `tax_cents`, `total_cents`). Float / DECIMAL for money is prohibited.
-- Tax rates: store as basis points or documented enum — never float percentages in persisted data.
-- Consumption tax is rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
-- Japan qualified invoice fields validated in UseCase layer before PDF generation; missing required fields block issuance.
-- Issued documents are immutable; corrections via credit note, not edit/delete. No hard delete of billing records.
-- PDF totals must match API-calculated cents — single source of truth in UseCase.
+- Store all amounts as **integer cents** (`amount_cents`, `remaining_cents`, `outstanding_at_send_cents`). Float / DECIMAL for money is prohibited.
+- **No quote/invoice/tax/PDF logic** (ADR 0009). Invoice totals and tax are read from the Invoice upstream; Clear allocates known bank amounts and never recomputes them.
+- Allocation math is computed once in the UseCase; API responses and stored rows render the same values.
+- Imported bank lines are immutable; corrections via reversal import batch, not in-place edit. No hard delete of bank/match/dunning history.
+- `paid_at` written upstream uses the bank value date (`value_date`), not the confirm date.
 
 ---
 
@@ -101,7 +100,7 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 - Phinx migrations under `database/migrations/`.
 - Schema snapshots under `database/schema/`.
 - Soft delete: `is_deleted`, `deleted_at` unless ADR says otherwise.
-- Multi-tenant: `organization_id` on tenant-scoped tables when tenancy lands (ADR TBD).
+- Multi-tenant from the foundation: `organization_id` on every tenant-scoped table (ADR 0006).
 
 ---
 
@@ -110,7 +109,8 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 - UseCase tests: no DB — inject repository fakes or in-memory implementations.
 - Repository tests: SQLite in-memory PDO.
 - HTTP tests: contract tests against OpenAPI shapes.
-- PDF tests: assert byte output or snapshot hash — do not visually review in CI.
+- Upstream client tests: fake the Invoice API behind the client interface; cover degraded mode (`upstream-invoice-unavailable`).
+- Reconciliation tests: cover partial payment, overpayment → client credit, transfer-fee mismatch, and reversal.
 
 ---
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -27,8 +27,8 @@ NeNe Clear coding standards split by surface. **Full policies live in the dedica
 - **Monetary values:** integer cents everywhere — no floats in DB or JSON
 - **Placement violations block merge** — see backend standards
 - Public docs, OpenAPI text, and API error metadata: **English**
-- Issues, PRs, commits, `.cursor/rules/`: **Japanese allowed**
-- **Never integrate billing into sibling products** — ADR 0002
+- Issues, PRs, commits, `.cursor/rules/`: **English only** (ADR 0008)
+- **Never integrate reconciliation/dunning into sibling products** — ADR 0002
 
 ---
 

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -25,7 +25,7 @@ docs(governance): align issue-driven workflow with NENE2 upstream (#1)
 ```
 
 ```text
-feat(invoice): add qualified invoice PDF generation UseCase (#12)
+feat(reconciliation): add bank CSV import and confirm-match UseCase (#12)
 ```
 
 ## Issue number

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -9,9 +9,10 @@ NeNe Clear admin UI will follow sibling product conventions:
 - API client maps **snake_case** JSON without renaming fields
 - UI strings in locale catalogs — **ja (primary) + en (secondary) only**; no
   hardcoded strings, no other locales (ADR 0005)
-- Statutory invoice content rendered in Japanese regardless of UI locale (legal
-  document); en applies to UI chrome and operator guides
-- No admin JWT in public document download pages
+- Outbound Japanese correspondence (dunning notices) and statutory labels from
+  upstream invoices render in Japanese regardless of UI locale; en applies to UI
+  chrome and operator guides
+- Admin JWT never exposed to unauthenticated pages
 
 When `frontend/` lands, expand this document with component layout, test strategy, and build output paths (`public_html/admin/`).
 

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -25,26 +25,26 @@ Authoritative naming rules for NeNe Clear code, API contracts, database objects,
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Namespace root | `NeneClear\` | `NeneClear\Invoice\CreateInvoiceHandler` |
-| Domain folder | PascalCase singular domain name | `src/Client/`, `src/Invoice/` |
-| File name | Match the primary class | `CreateInvoiceHandler.php` |
+| Namespace root | `NeneClear\` | `NeneClear\Reconciliation\ConfirmMatchHandler` |
+| Domain folder | PascalCase singular domain name | `src/Reconciliation/`, `src/Dunning/` |
+| File name | Match the primary class | `ConfirmMatchHandler.php` |
 | One public class per file | Required | — |
 
 ### Classes and interfaces
 
 | Role | Pattern | Example |
 | --- | --- | --- |
-| HTTP handler | `{Verb}{Noun}Handler` | `CreateInvoiceHandler`, `ListClientsHandler` |
-| Use case interface | `{Verb}{Noun}UseCaseInterface` | `CreateInvoiceUseCaseInterface` |
-| Use case impl | `{Verb}{Noun}UseCase` | `CreateInvoiceUseCase` |
-| Use case method | Always `execute` | `execute(CreateInvoiceInput $input): CreateInvoiceOutput` |
-| Input DTO | `{Verb}{Noun}Input` | `CreateInvoiceInput` |
-| Output DTO | `{Verb}{Noun}Output` | `CreateInvoiceOutput` |
-| Domain entity | Singular noun, no suffix | `Client`, `Quote`, `Invoice`, `Payment` |
-| Repository interface | `{Entity}RepositoryInterface` | `InvoiceRepositoryInterface` |
-| PDO repository | `Pdo{Entity}Repository` | `PdoInvoiceRepository` |
-| PDF adapter | `{Purpose}PdfGenerator` in `Pdf/` | `InvoicePdfGenerator` |
-| Domain exception | `{Entity}{Reason}Exception` | `InvoiceNotFoundException` |
+| HTTP handler | `{Verb}{Noun}Handler` | `ConfirmMatchHandler`, `ListBankTransactionsHandler` |
+| Use case interface | `{Verb}{Noun}UseCaseInterface` | `ConfirmMatchUseCaseInterface` |
+| Use case impl | `{Verb}{Noun}UseCase` | `ConfirmMatchUseCase` |
+| Use case method | Always `execute` | `execute(ConfirmMatchInput $input): ConfirmMatchOutput` |
+| Input DTO | `{Verb}{Noun}Input` | `ConfirmMatchInput` |
+| Output DTO | `{Verb}{Noun}Output` | `ConfirmMatchOutput` |
+| Domain entity | Singular noun, no suffix | `BankTransaction`, `PaymentReconciliation`, `DunningNotice` |
+| Repository interface | `{Entity}RepositoryInterface` | `BankTransactionRepositoryInterface` |
+| PDO repository | `Pdo{Entity}Repository` | `PdoBankTransactionRepository` |
+| Upstream client | `{Purpose}ClientInterface` + `Http{Purpose}Client` in `Upstream/` | `InvoiceUpstreamClientInterface`, `HttpInvoiceUpstreamClient` |
+| Domain exception | `{Entity}{Reason}Exception` | `BankTransactionNotFoundException` |
 | Service provider | `{Purpose}ServiceProvider` | `RuntimeServiceProvider` |
 
 All application classes: `final` and `readonly` where applicable. Every PHP file: `declare(strict_types=1);`.
@@ -53,15 +53,15 @@ All application classes: `final` and `readonly` where applicable. Every PHP file
 
 Use only domain-grouped top-level folders. Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
 
-Planned domains (Phase 1+): `Organization/`, `Auth/`, `User/`, `Client/`, `Quote/`, `Invoice/`, `Payment/`, `Company/`, `LineItem/`, `Pdf/`, `Http/`.
+Planned domains (Phase 1+): `Organization/`, `Auth/`, `User/`, `Settings/`, `BankImport/`, `Reconciliation/`, `ClientCredit/`, `Dunning/`, `Upstream/`, `Audit/`, `Http/`.
 
 ### Methods and properties
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Methods | camelCase | `findById`, `markAsPaid` |
-| Properties | camelCase | `$clientId`, `$invoiceRepository` |
-| Constants | UPPER_SNAKE_CASE | `MAX_LINE_ITEMS` |
+| Methods | camelCase | `findById`, `markAsMatched` |
+| Properties | camelCase | `$bankTransactionId`, `$reconciliationRepository` |
+| Constants | UPPER_SNAKE_CASE | `DEFAULT_DUNNING_INTERVAL_DAYS` |
 
 Repository methods use **domain verbs**: `findById`, `save`, `delete` — not `selectById`, `insertRow`.
 
@@ -73,11 +73,11 @@ Repository methods use **domain verbs**: `findById`, `save`, `delete` — not `s
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Path segments | lowercase **kebab-case** | `/admin/clients`, `/admin/invoices` |
-| Collection paths | plural noun | `/admin/quotes`, `/admin/payments` |
-| Single resource | `{id}` path param | `/admin/invoices/{id}` |
-| Public download | noun path | `/documents/invoices/{token}/pdf` |
-| Path param name | lowercase singular | `id`, `clientId` |
+| Path segments | lowercase **kebab-case** | `/admin/bank-transactions`, `/admin/reconciliations` |
+| Collection paths | plural noun | `/admin/bank-import-batches`, `/admin/dunning-notices` |
+| Single resource | `{id}` path param | `/admin/bank-transactions/{id}` |
+| Upstream read proxy | noun path | `/admin/upstream/invoices` |
+| Path param name | lowercase singular | `id`, `bankTransactionId` |
 
 Admin mutating routes live under `/admin/…`.
 
@@ -85,8 +85,8 @@ Admin mutating routes live under `/admin/…`.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Case | camelCase | `getHealth`, `createInvoice` |
-| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listClients`, `getInvoiceById` |
+| Case | camelCase | `getHealth`, `confirmMatch` |
+| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listBankTransactions`, `getReconciliationById` |
 | Stability | Never rename after release; deprecate instead | — |
 
 Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mcp/tools.json` `operationId`.
@@ -95,10 +95,10 @@ Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mc
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Response schema | `{Resource}Response` | `InvoiceResponse` |
-| List response | `{Resource}ListResponse` | `ClientListResponse` |
-| Create request | `Create{Resource}Request` | `CreateQuoteRequest` |
-| Tag names | PascalCase singular group | `System`, `Admin`, `Client`, `Invoice` |
+| Response schema | `{Resource}Response` | `BankTransactionResponse` |
+| List response | `{Resource}ListResponse` | `DunningNoticeListResponse` |
+| Create request | `Create{Resource}Request` | `ConfirmMatchRequest` |
+| Tag names | PascalCase singular group | `System`, `Admin`, `Reconciliation`, `Dunning` |
 
 Public OpenAPI summaries, descriptions, and examples: **English only**.
 
@@ -108,11 +108,12 @@ Public OpenAPI summaries, descriptions, and examples: **English only**.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Property names | **snake_case** | `client_id`, `issued_at`, `tax_rate` |
-| Money amounts | integer **cents** | `subtotal_cents`, `tax_cents`, `total_cents` |
-| Booleans | `is_` / `has_` prefix | `is_paid`, `is_qualified_invoice` |
-| Timestamps | `_at` suffix, ISO 8601 string | `issued_at`, `due_at`, `paid_at` |
-| Foreign keys | `{entity}_id` | `client_id`, `quote_id` |
+| Property names | **snake_case** | `bank_transaction_id`, `confirmed_at`, `counterparty_text` |
+| Money amounts | integer **cents** | `amount_cents`, `outstanding_at_send_cents`, `remaining_cents` |
+| Booleans | `is_` / `has_` prefix | `is_deleted`, `has_remainder` |
+| Timestamps | `_at` suffix, ISO 8601 string | `imported_at`, `confirmed_at`, `sent_at` |
+| Calendar dates | `_date` suffix (documented exception: `value_date`) | `value_date` |
+| Foreign keys | `{entity}_id` | `bank_transaction_id`, `invoice_id` (upstream) |
 | List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
 
 Do not mix camelCase in public JSON. Do not use floats for money.
@@ -124,9 +125,9 @@ Do not mix camelCase in public JSON. Do not use floats for money.
 | Item | Rule | Example |
 | --- | --- | --- |
 | Base URL | `https://nene-clear.dev/problems/` | — |
-| Type slug | kebab-case | `validation-failed`, `invoice-not-found` |
-| Validation `errors[].field` | snake_case path | `body.registration_number` |
-| Validation `errors[].code` | snake_case | `required`, `invalid_invoice_number` |
+| Type slug | kebab-case | `validation-failed`, `bank-transaction-not-found` |
+| Validation `errors[].field` | snake_case path | `body.value_date` |
+| Validation `errors[].code` | snake_case | `required`, `invalid_amount` |
 
 Problem Details `title` and `detail`: English.
 
@@ -136,13 +137,13 @@ Problem Details `title` and `detail`: English.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Table names | snake_case, **plural** | `clients`, `quotes`, `invoices`, `line_items`, `payments` |
-| Column names | snake_case | `client_id`, `total_cents`, `issued_at` |
-| Money columns | `*_cents` suffix, integer | `subtotal_cents`, `tax_cents` |
+| Table names | snake_case, **plural** | `bank_transactions`, `bank_import_batches`, `payment_reconciliations`, `dunning_notices` |
+| Column names | snake_case | `bank_transaction_id`, `amount_cents`, `confirmed_at` |
+| Money columns | `*_cents` suffix, integer | `amount_cents`, `remaining_cents` |
 | Primary key | `id` | BIGINT auto-increment |
-| Foreign key column | `{singular_entity}_id` | `quote_id`, `invoice_id` |
-| Index names | `idx_{table}_{columns}` | `idx_invoices_client_id` |
-| Unique constraints | `uniq_{table}_{columns}` | `uniq_invoices_number` |
+| Foreign key column | `{singular_entity}_id` | `bank_import_batch_id`, `invoice_id` (upstream) |
+| Index names | `idx_{table}_{columns}` | `idx_bank_transactions_status` |
+| Unique constraints | `uniq_{table}_{columns}` | `uniq_bank_import_batches_file_hash` |
 
 SQL lives only in `Pdo*Repository` classes.
 
@@ -150,8 +151,8 @@ SQL lives only in `Pdo*Repository` classes.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260529120000_create_invoices_table.php` |
-| Snapshot file | `database/schema/{table}.sql` | `database/schema/invoices.sql` |
+| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260529120000_create_bank_transactions_table.php` |
+| Snapshot file | `database/schema/{table}.sql` | `database/schema/bank_transactions.sql` |
 
 ---
 
@@ -169,9 +170,9 @@ SQL lives only in `Pdo*Repository` classes.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Test class | `{ClassUnderTest}Test` | `CreateInvoiceUseCaseTest` |
-| Test method | `test_{behavior}_when_{condition}` | `test_rejects_missing_registration_number_when_qualified_invoice` |
-| Test namespace | Mirror `src/` under `tests/` | `tests/Invoice/CreateInvoiceUseCaseTest.php` |
+| Test class | `{ClassUnderTest}Test` | `ConfirmMatchUseCaseTest` |
+| Test method | `test_{behavior}_when_{condition}` | `test_records_client_credit_when_allocation_exceeds_outstanding` |
+| Test namespace | Mirror `src/` under `tests/` | `tests/Reconciliation/ConfirmMatchUseCaseTest.php` |
 
 ---
 
@@ -179,8 +180,8 @@ SQL lives only in `Pdo*Repository` classes.
 
 | Item | Rule | Example |
 | --- | --- | --- |
-| Tool `name` | Same as OpenAPI `operationId` | `listInvoices` |
-| Tool `title` | Short English Title Case | `List Invoices` |
+| Tool `name` | Same as OpenAPI `operationId` | `listUnmatchedTransactions` |
+| Tool `title` | Short English Title Case | `List Unmatched Transactions` |
 | `safety` | `read` or `write` | Prefer `read` until auth review passes |
 
 Catalog: `docs/mcp/tools.json`. Validate with `composer mcp`.
@@ -205,7 +206,7 @@ Full frontend standards: **`docs/development/frontend-standards.md`** (Phase 2).
 | Surface | Language | Naming |
 | --- | --- | --- |
 | Public docs, OpenAPI, API errors | English | Use glossary canonical terms |
-| Issues, PRs, commit bodies | Japanese allowed | Prefer glossary English term on first mention |
+| Issues, PRs, commit bodies | English only ([ADR 0008](../adr/0008-english-only-repository-documentation.md)) | Use glossary English term on first mention |
 | Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
 | ADR file | `NNNN-kebab-title.md` | `0002-separate-from-sibling-products.md` |
 
@@ -215,14 +216,14 @@ When adding or renaming any identifier, update [`terminology.md`](../explanation
 
 ## 11. Prohibited patterns
 
-- **Typos or spelling variants of any term registered in `terminology.md`** (e.g. `tax_registration_number` for `registration_number`, `sub_total_cents` for `subtotal_cents`) — blocks merge
+- **Typos or spelling variants of any term registered in `terminology.md`** (e.g. `tenant_id` for `organization_id`, `deposit_cents` for `amount_cents`) — blocks merge
 - **Unregistered identifiers** — using an entity, status, field, slug, or `operationId` not present in `terminology.md` without adding it in the same PR
 - Layer-first folders (`src/Handlers/`, `src/Repositories/`)
 - SQL outside `Pdo*Repository`
 - camelCase in public JSON property names
 - Float or DECIMAL for money in SQLite tests or API JSON
 - Renaming shipped `operationId` values
-- Embedding billing logic in NeNe Records or other sibling repos
+- **Implementing quote/invoice/line-item/PDF/tax logic in Clear** — that domain belongs to `nene-invoice` (ADR 0009); Clear reads invoices via the upstream API only
 
 ---
 

--- a/docs/development/self-review.md
+++ b/docs/development/self-review.md
@@ -22,7 +22,7 @@ If an item is not applicable, mark it mentally as `N/A`. Do not delete checklist
 
 | File | Use for |
 | --- | --- |
-| `compliance.md` | **Binding.** Any change touching quotes, invoices, payments, tax, numbering, PDF, or retention |
+| `compliance.md` | **Binding.** Any change touching bank import, reconciliation, allocation, client credit, dunning, retention, or audit |
 | `backend-api.md` | Endpoints, handlers, validation, HTTP behavior |
 | `openapi-contract.md` | OpenAPI schemas, examples, contract tests |
 | `database.md` | Migrations, repositories, soft delete |

--- a/docs/explanation/accounting-compliance.md
+++ b/docs/explanation/accounting-compliance.md
@@ -1,21 +1,28 @@
-# Accounting & Tax Compliance — Binding Rules
+# Accounting & Records Compliance — Binding Rules
 
-> **Scope (ADR 0009):** NeNe Clear owns **reconciliation and dunning** only.
-> **Quote, invoice, and qualified invoice compliance belong in
-> [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice).** Sections 1–8
-> below are **bootstrap residue** retained for reference until moved to Invoice;
-> **§9–10 and [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
-> are authoritative for Clear.**
+> **Scope (ADR 0009):** NeNe Clear owns **payment reconciliation and dunning**.
+> Quote, invoice, qualified-invoice content, consumption-tax calculation, and
+> per-rate tax rounding belong to
+> [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice) — they are
+> **not** implemented or governed here. The previous §1–8 of this file (qualified
+> invoice fields, tax calculation, document numbering, PDF retention) were
+> bootstrap residue and have been removed; that compliance now lives in the
+> Invoice repository.
+>
+> **Authoritative for Clear:**
+> [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md).
+> This file holds only the **cross-cutting principles** (money representation,
+> electronic-records retention, audit trail) that the reconciliation/dunning
+> rules build on.
 
-**Status: binding (non-negotiable)** where applicable to Clear's domain.
+**Status: binding (non-negotiable)** within Clear's domain.
 
 These are not guidelines. They are **MUST** requirements. Where a rule here
 conflicts with UX, performance, implementation convenience, or any other
 concern, **compliance wins** — every time, without exception.
 
 See also: [`requirements.md`](./requirements.md), [`domain-model.md`](./domain-model.md),
-[ADR 0004](../adr/0004-tax-rounding-per-rate.md), self-review checklist
-[`../review/compliance.md`](../review/compliance.md).
+self-review checklist [`../review/compliance.md`](../review/compliance.md).
 
 ---
 
@@ -23,168 +30,107 @@ See also: [`requirements.md`](./requirements.md), [`domain-model.md`](./domain-m
 
 1. **Compliance is non-negotiable.** Correct adherence to the law takes
    precedence over every other product goal.
-2. **No silent deviation.** Any departure from the rules in this document — even
-   temporary — requires an **ADR** and **explicit review sign-off by a tax/
-   accounting professional (licensed tax accountant / 税理士)** recorded in that ADR.
-   Code may not merge a deviation without it.
+2. **No silent deviation.** Any departure from the rules in this document or in
+   [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+   — even temporary — requires an **ADR** and **explicit review sign-off by a
+   licensed tax accountant / 税理士** recorded in that ADR. Code may not merge a
+   deviation without it.
 3. **Engineering is not the legal authority.** This document is engineering's
    binding interpretation of the rules. When a requirement is unclear, **stop
    and consult a licensed tax accountant (税理士)** — do not guess. Record the
    resolved interpretation here.
-4. **Single source of truth for figures.** Every monetary and tax figure is
-   computed once in the UseCase layer. The PDF, API, and stored copy render the
-   exact same values; no layer recalculates independently.
+4. **Invoice figures are upstream truth.** Clear does **not** compute invoice
+   totals or consumption tax. It reads `total_cents` / `outstanding_cents` from
+   the Invoice upstream and computes only **allocations** of known bank amounts.
+   Allocation math is done once in the UseCase layer; API responses and stored
+   rows render the same values without recomputation.
 
 ---
 
-## 1. Statutory basis
+## 1. Statutory basis (Clear scope)
 
-NeNe Clear targets the following Japanese rules. This list states *what we
-comply with*; it is not legal advice.
+NeNe Clear targets the following Japanese rules **as they apply to bank
+evidence, reconciliation records, and payment reminders**. This list states
+*what we design for*; it is not legal advice.
 
-| Area | Rule set |
-| --- | --- |
-| Consumption tax | Consumption Tax Act (standard 10% / reduced 8%) |
-| Qualified invoice | Qualified Invoice System (適格請求書等保存方式) |
-| Stored records | Act on Electronic Books and Records Preservation |
+| Area | Rule set | Clear role |
+| --- | --- | --- |
+| Bookkeeping & evidence | Corporation Tax Act bookkeeping duty; Civil Code performance of obligations | Preserve tamper-evident bank, match, and dunning history |
+| Electronic records | Act on Electronic Books and Records Preservation (電子帳簿保存法) | Retain imported bank data and reconciliation audit trail with searchability |
+| Personal data | Act on the Protection of Personal Information (個人情報保護法) | Use client contact data for dunning only as the operator instructs; log sends |
+| Late payment | Civil Code; Interest Rate Act (法定利率) | Reminders state facts; no automated legal threats or coercive language |
 
-When any of these change (rate changes, new statutory fields, retention rule
-changes), treat it as a compliance defect until the product is updated, and open
-a P0 Issue.
-
----
-
-## 2. Qualified invoice — mandatory content
-
-When `is_qualified_invoice = true`, the system **MUST** enforce and render **all**
-fields required under the Qualified Invoice System. Missing any required field
-**MUST** block issuance. PDF rendering uses **Japanese statutory labels** on
-the document; this section describes the data rules in English.
-
-### Issuer (supplier)
-- Legal name or trade name
-- Address
-- **Registration number**, format `T` + 13 digits — see §4
-- Transaction date and issue date
-
-### Buyer (recipient)
-- Name
-- Address when applicable
-
-### Transaction details
-- Description per line; reduced-rate (8%) items **MUST** be clearly marked
-- **Taxable amount per tax rate** (aggregated per rate category)
-- **Consumption tax amount per tax rate**
-- Total billed amount
-
-These figures are statutory. They are not cosmetic PDF fields — they are
-validated in the UseCase before any document is issued or rendered.
+Consumption-tax filing, qualified-invoice content, and revenue recognition are
+**out of scope** (operator + tax advisor + `nene-invoice`). When any in-scope
+rule changes, treat it as a compliance defect until updated, and open a P0 Issue.
 
 ---
 
-## 3. Consumption tax calculation
-
-- Allowed rates: **10% (1000 bps)** and **8% reduced (800 bps)**. Adding or
-  changing a rate is a compliance change → requires an ADR.
-- **Rounding: once per tax rate per document**, never per line item.
-  Direction: half-up. This is binding — see
-  [ADR 0004](../adr/0004-tax-rounding-per-rate.md). Per-line rounding is
-  **prohibited** because it can round more than once per rate within one
-  document.
-- The per-rate consumption tax figure produced here is exactly the amount the
-  qualified invoice must display per rate category.
-
----
-
-## 4. Registration number
-
-- Format check: `^T[0-9]{13}$`. This is **syntax only** — it does **not** prove
-  the number exists or is registered, and the system does **not** perform a
-  check-digit or registry lookup. UI and docs **MUST NOT** present a format pass
-  as proof of validity.
-- An invoice **MUST NOT** be markable as qualified while the issuer registration
-  number is empty.
-
----
-
-## 5. Document integrity, numbering, and immutability
-
-- **Issued documents are immutable.** Once an invoice is `issued`, its line
-  items, tax figures, totals, dates, and number **MUST NOT** be edited or
-  deleted. Corrections are made by issuing a **credit note / corrected qualified
-  invoice** (Phase 4+), never by mutating or removing the original.
-- **Sequential numbering with no compliance-breaking gaps.** Quote and invoice
-  numbers are assigned in sequence per organization and year. The system **MUST
-  NOT** silently reuse, back-fill, or delete numbers in a way that hides a
-  voided document. A voided document is recorded as voided, not erased.
-- **No hard delete of billing records.** Quotes, invoices, payments, and issued
-  PDFs use soft delete / void semantics; financial history is preserved.
-
----
-
-## 6. Retention of issued copies
-
-- The system **MUST** retain a copy of every **issued** qualified invoice (and
-  the figures used to produce it).
-- Retained copies are **tamper-evident**: a stored issued document **MUST NOT**
-  be silently mutated. Reissuing produces a new versioned record, not an
-  in-place overwrite.
-- Statutory retention is **7 years** (and may extend to **10 years** in certain
-  loss-carryforward situations). The product **MUST NOT** auto-purge issued
-  billing records before the statutory period. Operators are warned before any
-  destructive retention action.
-
----
-
-## 7. Money representation
+## 2. Money representation
 
 - All amounts are stored and transmitted as **integer minimum currency units**
   (`*_cents`; for JPY, ¥1 = 1 unit). **Float and DECIMAL for money are
   prohibited** in DB, API JSON, and tests.
 - Phase 1–3 currency is **JPY only**.
+- Clear never alters upstream invoice figures; it records bank amounts,
+  allocations, client-credit balances, and the outstanding-at-send snapshot.
 
 ---
 
-## 8. Audit trail
+## 3. Retention of bank and reconciliation records
 
-- Invoice **issuance** and **payment recording** are auditable events
-  (who / when / what), from Phase 2.
-- Audit records follow the same no-silent-mutation rule as §6.
+- Imported bank lines, reconciliation links, client-credit history, and dunning
+  send records are retained for a **minimum of 7 years**, up to **10 years**
+  where applicable (e.g. loss-carryforward). The product **MUST NOT** auto-purge
+  these before the statutory period; operators are warned before any destructive
+  retention action.
+- Retained records are **tamper-evident**: a stored `bank_transaction`,
+  `payment_reconciliation`, or `dunning_notice` **MUST NOT** be silently mutated.
+  Corrections use reversal records / reversal import batches, never in-place edits
+  (see reconciliation compliance §2.7, §3.1).
+- **Searchability:** list/filter by date, amount, match status, client, and
+  invoice number.
 
 ---
 
-## 9. Payment reconciliation and dunning (core product)
+## 4. Audit trail
 
-Bank import, payment matching, and dunning are **NeNe Clear's core domain** —
-not a post-MVP expansion. All rules in
+Every state-changing action records an immutable `audit_event` (who / when /
+what). Minimum fields per event are defined in
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md) §6:
+
+| Event | Audited |
+| --- | --- |
+| Bank import batch | batch id, file hash, row count, actor, timestamp |
+| Match confirmed | bank transaction id(s), payment id(s), invoice id(s), amounts, actor, timestamp |
+| Match reversed | reversal id, prior match id, reason, actor, timestamp |
+| Dunning sent | invoice id, outstanding at send, recipient, template version, actor, timestamp |
+| Client credit created | client id, amount, source transaction, actor, timestamp |
+
+Audit records follow the same no-silent-mutation rule as §3.
+
+---
+
+## 5. Reconciliation & dunning (core domain)
+
+Bank import, payment matching, client credit, and dunning are NeNe Clear's
+**core domain**. The binding rules — payment date sourcing, partial/overpayment/
+transfer-fee handling, import integrity, dunning eligibility and template
+boundaries, human confirmation — live in
 [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
-apply with the same force as sections 1–8 above.
-
-Summary (non-exhaustive — the linked document is authoritative):
-
-- **`paid_at` MUST reflect bank value date** when reconciled from import.
-- **Partial payments, overpayments, and transfer-fee mismatches** MUST follow
-  documented allocation rules; no silent write-offs.
-- **Imported bank lines and match history** MUST be immutable, retained, and
-  searchable per the Act on Electronic Books and Records Preservation.
-- **Dunning** is operator-controlled professional reminder only; default
-  templates MUST NOT threaten legal action or auto-compute statutory interest
-  claims on outstanding balance.
-- **Human confirmation** MUST finalize reconciliation unless a future ADR
-  defines a narrow auto-match exception with professional sign-off.
+and apply with the same force as the principles above.
 
 ---
 
-## 10. How this rule applies to every change
+## 6. How this rule applies to every change
 
-Any change that touches quotes, invoices, payments, tax calculation, document
-numbering, PDF rendering, retention, bank import, reconciliation, or dunning
-**MUST**:
+Any change that touches bank import, reconciliation, payment allocation, client
+credit, dunning, retention, or audit **MUST**:
 
 1. Be reviewed against this document and [`../review/compliance.md`](../review/compliance.md).
 2. State compliance impact in the PR.
-3. If it deviates from any rule here, carry an ADR with professional sign-off
-   (§0.2). No exceptions.
+3. If it deviates from any rule here or in the reconciliation/dunning compliance
+   doc, carry an ADR with professional sign-off (§0.2). No exceptions.
 
 If you are unsure whether a change has compliance impact, **assume it does** and
 run the checklist.

--- a/docs/explanation/domain-model.md
+++ b/docs/explanation/domain-model.md
@@ -1,145 +1,214 @@
 # Domain Model
 
-NeNe Clear domain overview — entities, relationships, and state machines. Implementation follows Handler → UseCase → Repository layering.
+NeNe Clear domain overview — entities, relationships, and state machines for
+**payment reconciliation and dunning** ([ADR 0009](../adr/0009-separate-from-nene-invoice.md)).
+Implementation follows Handler → UseCase → Repository layering.
 
-See also: [`requirements.md`](./requirements.md), [`glossary.md`](./glossary.md).
+> **Scope:** Clear owns bank import, matching, client credit, and dunning.
+> Invoices, clients, and payments are **read from the NeNe Invoice upstream API**
+> and written back via that API after a confirmed match — never stored as a
+> source of truth here, never issued or tax-calculated here.
+
+See also: [`requirements.md`](./requirements.md), [`glossary.md`](./glossary.md),
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md),
+[`../integrations/sibling-products.md`](../integrations/sibling-products.md).
 
 ---
 
 ## Entity relationship (MVP)
 
+Solid entities are **owned by Clear**. The dashed `invoice` / `client` /
+`payment` nodes are **upstream read models** (owned by NeNe Invoice), referenced
+by id only.
+
 ```mermaid
 erDiagram
     organization ||--o{ user : "has"
-    organization ||--|| company_settings : "issuer profile"
-    organization ||--o{ client : "owns"
-    organization ||--o{ quote : "owns"
-    organization ||--o{ invoice : "owns"
-    organization ||--o{ payment : "owns"
-    client ||--o{ quote : "buyer"
-    client ||--o{ invoice : "buyer"
-    quote ||--o| invoice : "converts_to"
-    quote ||--|{ line_item : "has"
-    invoice ||--|{ line_item : "has"
-    invoice ||--o{ payment : "receives"
+    organization ||--|| clear_settings : "config (upstream URL, banks, dunning defaults)"
+    organization ||--o{ bank_import_batch : "owns"
+    organization ||--o{ bank_transaction : "owns"
+    organization ||--o{ payment_reconciliation : "owns"
+    organization ||--o{ client_credit : "owns"
+    organization ||--o{ dunning_notice : "owns"
+    organization ||--o{ audit_event : "owns"
+    bank_import_batch ||--|{ bank_transaction : "contains"
+    bank_transaction ||--o{ payment_reconciliation : "matched by"
+    payment_reconciliation ||--|{ reconciliation_allocation : "splits into"
+    reconciliation_allocation }o--|| invoice : "upstream (read)"
+    bank_transaction ||--o{ client_credit : "overpayment source"
+    client_credit }o--|| client : "upstream (read)"
+    dunning_notice }o--|| invoice : "upstream (read)"
 ```
 
 - **organization**: the tenant (ADR 0006). Every tenant-scoped table carries `organization_id`. Default resolution mode `single`; agencies use path/subdomain/custom_domain.
 - **user**: operator account with a `role` (superadmin/admin/member/viewer). superadmin is cross-tenant (`organization_id` NULL); all others belong to one organization.
-- **company_settings**: one issuer profile **per organization** (each org issues its own qualified invoices under its own registration number).
-- **line_item**: polymorphic parent — `parent_type` + `parent_id` (`quote` or `invoice`).
-- **payment**: always linked to one invoice; partial payments sum to `amount_cents` on invoice.
+- **clear_settings**: one row **per organization** — Invoice upstream API base URL and token, registered company bank accounts, and dunning defaults (template, minimum interval).
+- **bank_import_batch**: provenance of one CSV import (`file_hash`, `source_filename`, `row_count`, `imported_by`, `imported_at`).
+- **bank_transaction**: one imported deposit line; immutable after import; `unmatched` until reconciled.
+- **payment_reconciliation**: a confirmed match between one bank transaction and one or more upstream invoices; its **reconciliation_allocation** rows carry the per-invoice `amount_cents`.
+- **client_credit**: overpayment balance held for an upstream client and applied to future invoices by explicit operator action only.
+- **dunning_notice**: immutable send record per upstream invoice.
+- **invoice / client / payment**: **upstream** — read from NeNe Invoice; never an SSOT here (see [`terminology.md`](./terminology.md) §6).
 
 ---
 
-## Quote state machine
+## Bank transaction state machine
 
 ```
-                    ┌──────────┐
-                    │  draft   │
-                    └────┬─────┘
-                         │ finalize / send
-                         ▼
-                    ┌──────────┐
-         ┌──────────│   sent   │──────────┐
-         │          └────┬─────┘          │
-         │ reject        │ accept         │ valid_until passed
-         ▼               ▼                ▼
-    ┌──────────┐   ┌──────────┐     ┌──────────┐
-    │ rejected │   │ accepted │     │ expired  │
-    └──────────┘   └────┬─────┘     └──────────┘
-                        │ convert_to_invoice
-                        ▼
-                   (creates invoice)
+                    ┌─────────────┐
+        import      │  unmatched  │
+        ───────────►└──────┬──────┘
+                           │ confirm match (full)
+                           ▼
+                    ┌─────────────┐
+         ┌──────────│   matched   │◄─────────┐
+         │ reverse  └─────────────┘          │ confirm remaining
+         ▼                                   │
+   ┌───────────────────┐   confirm match     │
+   │ partially_matched │◄──(partial)─────────┘
+   └───────────────────┘
+                    (reversal import batch)
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │   voided    │  (erroneous import; never hard-deleted)
+                    └─────────────┘
 ```
 
 **Rules:**
 
-- Only `draft` quotes are freely editable.
-- `sent` quotes: line items locked; status transitions only.
-- Only `accepted` quotes may convert to invoice (UseCase validates).
+- Imported lines are **immutable** (amount, value date, counterparty text). Erroneous imports are corrected by a **reversal import batch**, never edited in place (compliance §3.1).
+- `unmatched` → `partially_matched` while `0 < allocated < amount_cents`; → `matched` when `allocated = amount_cents`.
+- A confirmed match can be **reversed**, recomputing the transaction back toward `unmatched` / `partially_matched` from remaining valid allocations.
+- `voided` only via a reversal import batch; the original row is preserved.
 
 ---
 
-## Invoice state machine
+## Reconciliation state machine
 
 ```
-                    ┌──────────┐
-                    │  draft   │
-                    └────┬─────┘
-                         │ issue (generates number, locks fields)
-                         ▼
-                    ┌──────────┐
-         ┌──────────│  issued  │────────────────┐
-         │          └────┬─────┘                │
-         │               │ record payment       │ due_at < today
-         │               ▼                      ▼
-         │     ┌──────────────────┐        ┌──────────┐
-         │     │ partially_paid   │        │ overdue  │ (computed flag)
-         │     └────────┬─────────┘        └──────────┘
-         │              │ full payment
-         │              ▼
-         │         ┌──────────┐
-         └────────►│   paid   │
-                   └──────────┘
+                    ┌─────────────┐
+   propose + human  │  confirmed  │
+   confirm ────────►└──────┬──────┘
+                           │ reverse (reason_code, actor)
+                           ▼
+                    ┌─────────────┐
+                    │  reversed   │  (reversal record; no hard delete)
+                    └─────────────┘
 ```
 
 **Rules:**
 
-- `issued` invoices: line items and tax totals immutable (credit notes = Phase 4+).
-- `paid` when sum(payments.amount_cents) >= invoice.total_cents.
-- `overdue`: computed when status is `issued` or `partially_paid` and `due_at < now`.
+- Automatic suggestions (rules or AI) **MUST NOT** finalize a match without explicit operator confirmation (compliance §2.8, [`philosophy.md`](./philosophy.md) §1.4).
+- Confirming a match calls the Invoice API to create/update the upstream payment, then stores the `payment_reconciliation` + `reconciliation_allocation` rows and an `audit_event`.
+- Reversal creates a reversal record, calls the Invoice API to restore outstanding, and recomputes affected bank transaction status. No payment or bank history is hard-deleted.
 
 ---
 
-## Tax calculation (UseCase)
+## Upstream invoice status (read-only, owned by NeNe Invoice)
 
-Single source of truth for API and PDF. Consumption tax is rounded **once per
-tax rate per document** — never per line item — to comply with the qualified
-invoice system. See [ADR 0004](../adr/0004-tax-rounding-per-rate.md).
+Clear does **not** own these transitions; it mirrors them read-only to drive
+matching UI and dunning eligibility.
 
 ```
-For each line_item:
-  line_subtotal_cents = quantity * unit_price_cents   # not rounded for tax
-
-Group by tax_rate_bps:
-  taxable_amount_cents[rate] += line_subtotal_cents
-  tax_cents[rate] = round(taxable_amount_cents[rate] * rate / 10000)   # round ONCE per rate
-
-subtotal_cents = sum(taxable_amount_cents[rate])
-tax_cents = sum(tax_cents[rate])
-total_cents = subtotal_cents + tax_cents
+issued ──► partially_paid ──► paid
+   │            │
+   └────────────┴──► overdue (computed when due_at < now and outstanding > 0)
 ```
 
-Rounding: half-up to integer minimum currency units, applied per rate group, not
-per line. Any per-line tax shown in the UI is illustrative only and must not be
-summed into the document total. Rationale and rejected alternatives:
-[ADR 0004](../adr/0004-tax-rounding-per-rate.md).
+Dunning is eligible only for `issued`, `partially_paid`, or `overdue` with
+outstanding > 0 (compliance §4.1).
 
 ---
 
-## Document numbering
+## Allocation logic (UseCase)
 
-| Document | Pattern | Example |
-| --- | --- | --- |
-| Quote | `{prefix}{year}-{seq:03d}` | `EST-2026-001` |
-| Invoice | `{prefix}{year}-{seq:03d}` | `INV-2026-001` |
+Single source of truth for matching a bank transaction to upstream invoices.
+Clear never calculates invoice tax or totals — it only **allocates a known
+deposit amount** against outstanding balances reported by Invoice.
 
-Sequences scoped per organization and year. Stored in `document_sequences` table (Phase 1).
+```
+Given one bank_transaction with amount_cents,
+and operator-chosen allocations [(invoice_id, amount_cents), ...]:
+
+sum(allocation.amount_cents) MUST equal bank_transaction.amount_cents
+    (or leave a documented remainder per the overpayment / fee rules)
+
+For each allocation:
+  outstanding = upstream invoice.outstanding_cents   # fetched from Invoice API
+  if allocation.amount_cents <= outstanding:
+      write payment to Invoice API (paid_at = bank_transaction.value_date)
+  elif allocation.amount_cents > outstanding:
+      allocate outstanding to the invoice;
+      record excess as client_credit (NEVER discard)        # compliance §2.5
+
+Transfer-fee mismatch (credit < invoice total): operator chooses
+  (1) partial payment [default], (2) fee absorption (admin + reason_code),
+  or (3) separate expense — each leaves an audit_event.     # compliance §2.4
+```
+
+`paid_at` uses the **bank value date** (`value_date`), not the confirm date
+(compliance §2.2). Each confirmed allocation produces an `audit_event`. See
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+for the binding rules.
 
 ---
 
-## PDF generation boundary
+## Dunning eligibility and send (UseCase)
 
 ```
-UseCase (calculates totals, validates qualified fields)
-    ↓ InvoicePdfInput DTO
-Pdf/InvoicePdfGenerator (infrastructure — TCPDF or similar)
-    ↓ bytes
-Handler (Content-Type: application/pdf)
+Eligible(invoice) :=
+    invoice.status in {issued, partially_paid, overdue}
+    AND invoice.outstanding_cents > 0
+    AND NOT invoice voided
+    AND client has a deliverable recipient_email
+    AND (now - last dunning_notice.sent_at for this invoice) >= minimum interval
+
+On send:
+  render template (invoice number, dates, outstanding_at_send_cents,
+                   bank instructions from clear_settings)
+  send via operator SMTP
+  write immutable dunning_notice (template_version, recipient_email, sent_by, sent_at)
+  write audit_event
 ```
 
-UseCase never calls PDF library directly. Handler never recalculates tax.
+Default minimum interval is **7 days** (compliance §4.2). Default templates MUST
+NOT threaten legal action or auto-compute statutory interest (compliance §4.4).
+
+---
+
+## Import batch identity
+
+Clear issues **no** statutory document numbers (those belong to NeNe Invoice).
+Import provenance is identified by:
+
+| Field | Purpose |
+| --- | --- |
+| `bank_import_batch_id` | Internal batch id |
+| `file_hash` (SHA-256) | Duplicate-import detection (`duplicate-bank-import`) |
+| `source_filename` | Operator traceability |
+| `imported_at` / `imported_by` | Audit |
+
+Duplicate file hash or duplicate line key MUST warn or block re-import
+(compliance §3.1).
+
+---
+
+## Upstream integration boundary
+
+```
+UseCase (matching, dunning eligibility)
+    ↓ depends on interface, not concrete HTTP client
+Upstream/Invoice/InvoiceUpstreamClientInterface
+    ↓ implemented by
+Upstream/Invoice/HttpInvoiceUpstreamClient (reads invoices/clients; writes payments)
+```
+
+UseCases depend on the upstream **interface**, never on a concrete HTTP client.
+If the Invoice API is unavailable, Clear enters **degraded mode**: import still
+works; match confirmation (which writes upstream) is blocked with an operator
+warning (`upstream-invoice-unavailable`). See
+[`../integrations/sibling-products.md`](../integrations/sibling-products.md).
 
 ---
 
@@ -150,31 +219,21 @@ UseCase never calls PDF library directly. Handler never recalculates tax.
 | `Organization/` | Tenants + per-request resolution (`Organization/Resolution/`) — superadmin CRUD |
 | `Auth/` | JWT login, `Role` / `Capability`, capability middleware |
 | `User/` | Operator accounts within an organization — admin CRUD |
-| `Company/` | Issuer profile settings (per organization) |
-| `Client/` | Buyer master |
-| `Quote/` | Quote CRUD, status transitions |
-| `Invoice/` | Invoice CRUD, issue, convert from quote |
-| `LineItem/` | Shared line item attach/detach |
-| `Payment/` | Payment recording |
-| `Pdf/` | PDF rendering adapters |
-| `DocumentSequence/` | Auto-number generation (per organization) |
-| `Upstream/` | Optional Records / Concierge HTTP clients |
-
----
-
-## Integration touchpoints (Phase 4+)
-
-| Event | Direction | Action |
-| --- | --- | --- |
-| Concierge lead captured | Concierge → Invoice | POST webhook creates `client` draft + optional `quote` draft |
-| Records product selected | Invoice → Records | GET catalog item → prefill line_item description and unit_price_cents |
-| Invoice issued | Invoice → external | Webhook or email (SMTP) — no sibling required |
+| `Settings/` | `ClearSettings` — upstream URL/token, bank accounts, dunning defaults (per organization) |
+| `BankImport/` | CSV import, `bank_import_batch`, `bank_transaction`, duplicate detection |
+| `Reconciliation/` | Match proposal, confirmation, allocation, reversal |
+| `ClientCredit/` | Overpayment balances and application |
+| `Dunning/` | Templates, send, send history |
+| `Upstream/Invoice/` | Invoice API client (read invoices/clients, write payments) |
+| `Audit/` | Immutable audit events |
+| `Http/` | Shared HTTP plumbing |
 
 ---
 
 ## Related
 
 - Requirements: [`requirements.md`](./requirements.md)
+- Reconciliation & dunning compliance (binding): [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
 - Backend standards: [`../development/backend-standards.md`](../development/backend-standards.md)
-- ADR 0002: [`../adr/0002-separate-from-sibling-products.md`](../adr/0002-separate-from-sibling-products.md)
-- ADR 0004 (tax rounding): [`../adr/0004-tax-rounding-per-rate.md`](../adr/0004-tax-rounding-per-rate.md)
+- ADR 0006 (tenancy & roles): [`../adr/0006-multi-tenancy-and-roles.md`](../adr/0006-multi-tenancy-and-roles.md)
+- ADR 0009 (domain split): [`../adr/0009-separate-from-nene-invoice.md`](../adr/0009-separate-from-nene-invoice.md)

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -6,31 +6,46 @@ Canonical English terms for NeNe Clear public docs, OpenAPI, and code comments.
 > **spelling** of every term and identifier (entities, fields, status values,
 > slugs) lives in the single source of truth
 > [`terminology.md`](./terminology.md) — spellings here MUST conform to it.
+>
+> **Domain (ADR 0009):** NeNe Clear covers **payment reconciliation and
+> dunning**. Quote, invoice, and qualified-invoice concepts belong to
+> [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice); they appear
+> here only as **upstream read models**.
 
 | Term | Definition | Avoid |
 | --- | --- | --- |
-| **organization** | The tenant — an independent issuer with its own users, issuer profile, and billing data (ADR 0006) | "tenant" / "account" / "company" in code identifiers |
+| **organization** | The tenant — an independent operator with its own users, Clear settings, and reconciliation data (ADR 0006) | "tenant" / "account" / "company" in code identifiers |
 | **superadmin** | Cross-tenant platform role; manages organizations (`manage_organizations`) | "root", "owner", "superuser" in code |
-| **admin** | Organization-scoped role; manages the org's users, issuer settings, and billing | "manager" |
-| **member** | Organization-scoped billing operator; creates/sends documents and records payments; no user/settings management | "user", "staff" in code identifiers |
+| **admin** | Organization-scoped role; manages users, Clear settings, reconciliation, and dunning | "manager" |
+| **member** | Organization-scoped operator; confirms/reverses matches and sends dunning when granted; no user/settings management | "user", "staff" in code identifiers |
+| **viewer** | Organization-scoped read-only role; sees matched/unmatched lists and dunning history | "guest" |
 | **organization resolution** | Per-request selection of the tenant; modes `single` (default) / `path` / `subdomain` / `custom_domain` | "tenant detection" |
-| **quote** | An estimate (見積書) sent to a client before work is confirmed; may convert to an invoice | "estimate" in code identifiers |
-| **invoice** | A billing document (請求書) issued to a client | "bill" |
-| **qualified invoice** | Japan invoice system compliant document (適格請求書) with required issuer, tax, and registration fields | mixing Japanese in API field names |
-| **issuer** | The operator's company that issues quotes and invoices (自社) | "seller", "supplier" in code |
-| **client** | Customer / buyer (取引先) in the billing system | "customer" in code identifiers |
-| **line item** | A single row on a quote or invoice (品名, quantity, unit price, tax rate) | "row", "detail" |
-| **payment** | A recorded receipt against an invoice (入金) | "receipt" (PDF noun) |
-| **registration number** | Japan invoice registration number (インボイス登録番号), format `T` + 13 digits. API validation is **syntax only** — format, not existence or check digit | "T-number" without context; treating regex pass as proof of validity |
-| **cents** | Integer amount in the **smallest currency unit**. For JPY (the only Phase 1–3 currency) one "cent" is one 円, so `total_cents = 1000` means ¥1,000. The suffix is a fixed internal convention, not a sub-yen unit | float or DECIMAL money; reading `_cents` as 1/100 yen |
-| **tax rate bps** | Tax rate in basis points (1000 = 10.00%, 800 = 8.00%) | float percentages in DB |
-| **quote-to-cash** | Flow from estimate through invoice to payment | "order-to-cash" (ERP term) |
-| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL) | "rental server" in code |
-| **Tier B** | Docker / VPS deployment | "cloud tier" |
+| **reconciliation** (消込) | A confirmed link between one bank transaction (or a portion) and one or more upstream invoice payments | "matching" as a stored noun; "clearing" in code identifiers |
+| **bank transaction** | One imported credit (deposit) line on the operator's bank account | "deposit row", "ledger line" |
+| **bank import batch** | One CSV import with provenance (file hash, source filename, actor, timestamp) | "upload", "job" |
+| **allocation** | One row of a reconciliation assigning an amount from a bank transaction to a single invoice (一括入金の按分) | "split", "distribution" in code |
+| **partial payment** | A bank credit that covers only part of an invoice's outstanding balance; invoice becomes `partially_paid` upstream | "underpayment" |
+| **overpayment** | A bank credit exceeding the invoice outstanding; the excess is recorded as **client credit**, never discarded | "surplus", "extra" |
+| **client credit** | An overpayment balance held for a client and applied to a future invoice only by explicit operator action | "prepayment", "deposit" |
+| **transfer fee mismatch** (振込手数料) | When the client pays net of bank transfer fee, so the credit is less than the invoice total; resolved by partial payment, fee absorption, or separate expense — never a silent write-off | "shortfall write-off" |
+| **reversal** | Undoing a confirmed reconciliation by creating a reversal record (never a hard delete); upstream invoice outstanding is restored | "unmatch delete", "rollback" |
+| **dunning** (督促) | Operator-controlled professional payment reminders for overdue/unpaid invoices, with logged send history; **not** debt collection or legal enforcement | "collection", "chasing" |
+| **dunning notice** | One immutable send record (invoice, recipient, outstanding at send, template version, actor, timestamp) | "reminder log row" without the audit fields |
+| **minimum interval** | The shortest allowed gap between dunning notices for the same invoice (default 7 days) | "cooldown", "throttle" in docs |
+| **upstream / Invoice upstream** | NeNe Invoice, the required HTTP source of truth for invoices, outstanding balances, and payments (ADR 0009) | "backend", "billing service" loosely |
+| **invoice** (upstream read model) | A billing document (請求書) owned by NeNe Invoice; Clear reads its number, dates, outstanding, and status read-only | treating it as a Clear-owned entity; recomputing its tax |
+| **client** (upstream read model) | Customer / buyer (取引先) owned by NeNe Invoice; Clear reads name/contact for match hints and dunning | "customer" in code identifiers; storing as SSOT |
+| **payment** (upstream) | A receipt against an invoice (入金); Clear creates/updates it via the Invoice API after a confirmed match, and stores only the link | recording payments as a primary Clear workflow |
+| **outstanding balance** | `invoice.total_cents − sum(allocated payments)` for an invoice, as reported by the Invoice upstream | recomputing locally from cached figures |
+| **degraded mode** | Operation when the Invoice API is unavailable: bank import still works, but match confirmation (which writes upstream) is blocked with an operator warning | "offline mode" |
+| **paid_at** | The date a deposit was credited (bank value date), written to the upstream payment on match — not the date the operator clicked confirm | "match date", "confirm date" |
+| **cents** | Integer amount in the **smallest currency unit**. For JPY (the only Phase 1–3 currency) one "cent" is one 円, so `amount_cents = 1000` means ¥1,000. The suffix is a fixed internal convention, not a sub-yen unit | float or DECIMAL money; reading `_cents` as 1/100 yen |
+| **overdue** | An upstream invoice past `due_at` with unpaid balance — a computed flag owned by Invoice, mirrored read-only for dunning eligibility | treating it as a Clear-owned stored status |
+| **audit event** | An immutable record of an import, match, reversal, dunning send, or credit creation (who / when / what) | "log line" without actor/timestamp |
+| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL), beside NeNe Invoice on the same server | "rental server" in code |
+| **Tier B** | Docker / VPS deployment — Invoice + Clear as two services | "cloud tier" |
 | **handler** | HTTP entry point class | "controller" |
 | **use case** | Business logic class with `execute()` | "service" (UseCase sense) |
-| **sync PDF download** | Single HTTP response returning PDF bytes | "streaming PDF" |
-| **overdue** | Invoice past `due_at` with unpaid balance — computed status | stored status in Phase 1 (optional) |
-| **UI locale** | Admin UI / operator-facing language. Bound to **ja (primary) + en (secondary) only** — not multilingual (ADR 0005). Distinct from the English-only dev-docs language policy | adding locales beyond ja/en; conflating UI locale with statutory invoice language |
+| **UI locale** | Admin UI / operator-facing language. Bound to **ja (primary) + en (secondary) only** — not multilingual (ADR 0005). Distinct from the English-only dev-docs language policy | adding locales beyond ja/en |
 
 When adding terms, update this table in the same PR.

--- a/docs/explanation/payment-reconciliation-dunning-compliance.md
+++ b/docs/explanation/payment-reconciliation-dunning-compliance.md
@@ -92,8 +92,10 @@ affected features.
   clicked "match" unless they explicitly override with documented reason.
 - If import date and bank value date differ, **bank value date wins** unless an
   ADR documents a per-bank-format exception.
-- Manual payment entry (without bank import) is allowed in Phase 1–2 core; from
-  Expansion #1 onward, **reconciled payments SHOULD prefer bank-sourced dates**.
+- Clear records payments via **bank import + confirmed reconciliation**, so
+  `paid_at` is bank-sourced by default. Manual payment entry without a bank line
+  is Invoice's domain (ADR 0009); any operator override of `paid_at` MUST carry a
+  documented reason.
 
 ### 2.3 Partial payment — MUST
 
@@ -169,12 +171,12 @@ used as evidence MUST be handled as **electronic transaction data** (電子取�
 | Immutability | After import, `bank_transaction` amount, date, and counterparty text MUST NOT be edited in place |
 | Correction | Erroneous imports are voided via reversal import batch, not silent edit |
 | Provenance | Store `import_batch_id`, source filename, file hash (SHA-256), `imported_at`, `imported_by` |
-| Account scope | Each batch tied to one company bank account registered in `company_settings` |
+| Account scope | Each batch tied to one company bank account registered in `clear_settings` |
 | Duplicate detection | Same file hash or duplicate line key MUST warn or block re-import |
 
 ### 3.2 Retention — MUST
 
-- Imported bank lines and reconciliation links follow **§6 of
+- Imported bank lines and reconciliation links follow **§3 (Retention) of
   [`accounting-compliance.md`](./accounting-compliance.md)** — minimum **7 years**,
   up to **10 years** where applicable; no auto-purge.
 - Searchability: list/filter by date, amount, match status, client, invoice number.
@@ -182,7 +184,7 @@ used as evidence MUST be handled as **electronic transaction data** (電子取�
 ### 3.3 Timestamps and audit — MUST
 
 - System clock used for `imported_at` MUST be documented in operator guide.
-- All match/unmatch actions logged per §8 of `accounting-compliance.md`.
+- All match/unmatch actions logged per §4 (Audit trail) of `accounting-compliance.md`.
 
 ---
 
@@ -217,7 +219,7 @@ Dunning MUST NOT target `draft` invoices.
 - Issuer legal name and contact
 - Invoice number, issue date, due date
 - **Outstanding amount** (current, not original total if partially paid)
-- Payment instructions (bank name, branch, account type, account number from `company_settings`)
+- Payment instructions (bank name, branch, account type, account number from `clear_settings`)
 - Professional closing; no abusive or threatening language
 
 ### 4.4 Template content — MUST NOT include (unless operator custom template + advisor review)
@@ -270,9 +272,9 @@ Tax advisor uses export to prepare returns; NeNe Clear does not file.
 
 ---
 
-## 6. Audit trail — MUST (Expansion #1)
+## 6. Audit trail — MUST
 
-In addition to [`accounting-compliance.md`](./accounting-compliance.md) §8:
+In addition to [`accounting-compliance.md`](./accounting-compliance.md) §4 (Audit trail):
 
 | Event | Minimum audit fields |
 | --- | --- |
@@ -288,7 +290,7 @@ Audit records follow the same no-silent-mutation rule as issued invoices.
 
 ## 7. Professional review checklist
 
-Before Expansion #1 ships, a licensed **税理士 or 公認会計士** SHOULD sign off on:
+Before Phase 1 (reconciliation API) ships, a licensed **税理士 or 公認会計士** SHOULD sign off on:
 
 1. Payment date sourcing from bank import
 2. Partial / overpayment / fee mismatch flows
@@ -296,7 +298,7 @@ Before Expansion #1 ships, a licensed **税理士 or 公認会計士** SHOULD si
 4. Default dunning template wording (Japanese primary)
 5. Confirmation that subledger export columns meet their journal import workflow
 
-Record sign-off in the Expansion #1 milestone Issue or ADR.
+Record sign-off in the Phase 1 milestone Issue or ADR.
 
 ---
 
@@ -315,14 +317,17 @@ If unsure whether a change has compliance impact, **assume it does**.
 
 ## Related entities (register before code)
 
-| Concept | Working table name |
-| --- | --- |
-| Imported bank line | `bank_transaction` |
-| Import batch | `bank_import_batch` |
-| Match link | `payment_reconciliation` |
-| Client overpayment credit | `client_credit` |
-| Dunning send | `dunning_notice` |
+| Concept | Entity | Canonical table (terminology.md §1) |
+| --- | --- | --- |
+| Imported bank line | `BankTransaction` | `bank_transactions` |
+| Import batch | `BankImportBatch` | `bank_import_batches` |
+| Match link | `PaymentReconciliation` | `payment_reconciliations` |
+| Allocation row | `ReconciliationAllocation` | `reconciliation_allocations` |
+| Client overpayment credit | `ClientCredit` | `client_credits` |
+| Dunning send | `DunningNotice` | `dunning_notices` |
 
-See [`terminology.md`](./terminology.md) for canonical spellings before implementation.
+[`terminology.md`](./terminology.md) is the **single source of truth** for these
+spellings; register any new term there before implementation. Singular forms used
+in prose above refer to a single row of the corresponding table.
 
 Last updated: 2026-05-29

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -5,6 +5,13 @@ canonical spelling and form of every NeNe Clear term and identifier:
 entities, status values, JSON/DB field names, enums, Problem Details slugs, and
 `operationId` stems.
 
+> **Domain (ADR 0009):** NeNe Clear owns **payment reconciliation and dunning**
+> (入金消込・督促管理) only. Quote, invoice, line item, and qualified-invoice
+> identifiers belong to [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice).
+> Invoice and client figures are **read from the Invoice upstream API** — Clear
+> references them by id and may cache them read-only; it does **not** own their
+> spelling here beyond the upstream read models in §6.
+
 If an identifier appears anywhere in the codebase, OpenAPI, database, tests, or
 docs, its spelling **MUST** match this registry **exactly** — same characters,
 same case, same separators. There is no "close enough."
@@ -39,21 +46,27 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 
 ---
 
-## 1. Domain entities
+## 1. Domain entities (owned by Clear)
+
+Tenant-scoped tables carry `organization_id`. Tables are **snake_case plural**;
+domain folders are **PascalCase singular**.
 
 | Concept | PHP class / domain folder | Table | Primary FK in JSON/DB |
 | --- | --- | --- | --- |
 | Tenant | `Organization` | `organizations` | `organization_id` |
 | Operator account | `User` | `users` | `user_id` |
-| Issuer profile | `Company` (folder); `CompanySettings` (entity) | `company_settings` | — (one per `organization_id`) |
-| Buyer | `Client` | `clients` | `client_id` |
-| Estimate | `Quote` | `quotes` | `quote_id` |
-| Bill | `Invoice` | `invoices` | `invoice_id` |
-| Document row | `LineItem` | `line_items` | `line_item_id` |
-| Receipt | `Payment` | `payments` | `payment_id` |
-| Number generator | `DocumentSequence` | `document_sequences` | — |
+| Clear settings (singleton per org) | `ClearSettings` (entity); `Settings` (folder) | `clear_settings` | — (one per `organization_id`) |
+| Bank CSV import batch | `BankImportBatch` | `bank_import_batches` | `bank_import_batch_id` |
+| Imported bank deposit line | `BankTransaction` | `bank_transactions` | `bank_transaction_id` |
+| Confirmed match link | `PaymentReconciliation` | `payment_reconciliations` | `payment_reconciliation_id` |
+| Allocation row (one match → one invoice) | `ReconciliationAllocation` | `reconciliation_allocations` | `reconciliation_allocation_id` |
+| Overpayment credit balance | `ClientCredit` | `client_credits` | `client_credit_id` |
+| Dunning send record | `DunningNotice` | `dunning_notices` | `dunning_notice_id` |
+| Audit event | `AuditEvent` | `audit_events` | `audit_event_id` |
 
-Domain folders are **PascalCase singular**; tables are **snake_case plural**.
+**Not owned by Clear** (read from Invoice upstream, see §6): `invoice`, `client`,
+`payment`. Clear stores only the upstream id plus reconciliation links; it never
+owns quote, line item, tax, or qualified-invoice fields.
 
 ---
 
@@ -63,17 +76,19 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 
 | Owner | Allowed values |
 | --- | --- |
-| `quote.status` | `draft`, `sent`, `accepted`, `rejected`, `expired` |
-| `invoice.status` | `draft`, `issued`, `partially_paid`, `paid` |
-| invoice computed | `overdue` (computed flag, not a stored status in Phase 1) |
-| `payment.method` | `bank_transfer`, `cash`, `other` |
-| `line_item.parent_type` | `quote`, `invoice` |
+| `bank_transaction.status` | `unmatched`, `partially_matched`, `matched`, `voided` |
+| `bank_import_batch.status` | `imported`, `reversed` |
+| `payment_reconciliation.status` | `confirmed`, `reversed` |
+| `client_credit.status` | `open`, `partially_applied`, `applied` |
+| `dunning_notice.status` | `sent`, `failed` |
 | `user.role` | `superadmin`, `admin`, `member`, `viewer` (ADR 0006) |
 | `user.status` | `active`, `invited` |
-| Capability (enum) | `manage_organizations`, `manage_users`, `manage_company_settings`, `manage_billing`, `view_billing` |
+| Capability (enum) | `manage_organizations`, `manage_users`, `manage_clear_settings`, `manage_reconciliation`, `view_reconciliation`, `send_dunning` (ADR 0006) |
 | Org resolution mode | `single` (default), `path`, `subdomain`, `custom_domain` |
+| **Upstream** `invoice.status` (read-only) | `issued`, `partially_paid`, `paid`; `overdue` is a computed flag — **owned by Invoice**, mirrored read-only for dunning eligibility |
 
-Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering them here first.
+Do not invent `cancelled`, `void`, `pending`, `unpaid`, etc. without registering
+them here first.
 
 ---
 
@@ -85,26 +100,33 @@ Do not invent `cancelled`, `void`, `unpaid`, `pending`, etc. without registering
 | Organization slug | `slug` | `org_slug`, `code` |
 | User role | `role` (values in §2) | `user_role`, `permission` |
 | User credential | `password_hash` | `password`, `pass_hash` |
-| Invoice registration number | `registration_number` | `tax_registration_number`, `invoice_registration_number`, `t_number` |
-| Qualified-invoice flag | `is_qualified_invoice` | `qualified`, `is_qualified` |
 | Soft-delete flag / time | `is_deleted`, `deleted_at` | `deleted`, `is_del` |
-| Subtotal (pre-tax) | `subtotal_cents` | `sub_total_cents`, `subtotal` |
-| Tax amount | `tax_cents` | `tax`, `tax_amount` |
-| Total | `total_cents` | `amount_cents` (on documents), `grand_total` |
-| Unit price | `unit_price_cents` | `price_cents`, `unitprice_cents` |
-| Payment amount | `amount_cents` | `paid_cents`, `payment_cents` |
-| Tax rate | `tax_rate_bps` | `tax_rate`, `rate`, `tax_rate_percent` |
-| Foreign keys | `client_id`, `quote_id`, `invoice_id` | `clientId`, `client` |
-| Polymorphic parent | `parent_type`, `parent_id` | `parentType`, `owner_id` |
-| Numbers | `quote_number`, `invoice_number` | `number`, `quote_no` |
-| Timestamps | `issued_at`, `due_at`, `paid_at`, `valid_until`, `deleted_at` | `issue_date`, `due_date`, `paidAt` |
-| Issuer fields | `legal_name`, `bank_name`, `bank_branch`, `account_type`, `account_number`, `logo_url` | `company_name`, `branch`, `acct_no` |
-| Client fields | `contact_name`, `billing_address` | `contact`, `address` |
+| Bank transaction amount | `amount_cents` | `deposit_cents`, `value_cents` |
+| Bank value date | `value_date` (date type) | `transaction_date`, `valued_at`, `paid_at` (on the bank line) |
+| Counterparty text (remitter) | `counterparty_text` | `payer`, `remitter_name` |
+| Import file hash | `file_hash` (SHA-256 hex) | `hash`, `checksum`, `sha256` |
+| Import source filename | `source_filename` | `filename`, `file_name` |
+| Import row count | `row_count` | `lines`, `count` |
+| Allocation amount | `amount_cents` | `allocated_cents`, `alloc_cents` |
+| Payment date written upstream | `paid_at` | `payment_date`, `paidAt` |
+| Reversal reason | `reversal_reason` | `reason`, `reverse_note` |
+| Reason code (fee absorption etc.) | `reason_code` | `reason`, `code` |
+| Outstanding at send (dunning) | `outstanding_at_send_cents` | `outstanding_cents`, `balance_cents` |
+| Dunning recipient | `recipient_email` | `email`, `to` |
+| Dunning template version | `template_version` | `template`, `version` |
+| Credit remaining balance | `remaining_cents` | `balance_cents`, `left_cents` |
+| Upstream invoice id | `invoice_id` | `upstream_invoice_id`, `invoiceId` |
+| Upstream client id | `client_id` | `upstream_client_id`, `clientId` |
+| Upstream payment id | `payment_id` | `upstream_payment_id`, `paymentId` |
+| Foreign keys (Clear-owned) | `bank_transaction_id`, `bank_import_batch_id`, `payment_reconciliation_id`, `client_credit_id` | camelCase, abbreviations |
+| Actor / timestamps | `imported_by`, `imported_at`, `confirmed_by`, `confirmed_at`, `reversed_at`, `sent_by`, `sent_at`, `created_by`, `created_at` | `issue_date`, `paidAt`, `actor_id` (use role-specific names above) |
+| Audit event type | `event_type` | `type`, `action` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 
-Rules: money columns end in `_cents` (integer); timestamps end in `_at` (except
-the documented `valid_until`); booleans use `is_` / `has_`; foreign keys are
-`{singular_entity}_id`. See `naming-conventions.md` for the full pattern set.
+Rules: money columns end in `_cents` (integer); event timestamps end in `_at`;
+pure calendar dates use `_date` (documented exception: `value_date`); booleans
+use `is_` / `has_`; foreign keys are `{singular_entity}_id`. See
+`naming-conventions.md` for the full pattern set.
 
 ---
 
@@ -115,21 +137,27 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | Slug | Use |
 | --- | --- |
 | `validation-failed` | Request body/field validation error |
-| `invoice-not-found` | Invoice id/token not found |
-| `quote-not-found` | Quote id not found |
-| `client-not-found` | Client id not found |
-| `organization-not-found` | Organization id/slug not found |
-| `user-not-found` | User id not found |
-| `invalid-credentials` | Login failed — wrong email or password |
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
+| `invalid-credentials` | Login failed — wrong email or password |
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request |
-| `invalid-state-transition` | Disallowed status change |
-| `qualified-invoice-incomplete` | Missing required qualified-invoice field |
+| `organization-not-found` | Organization id/slug not found |
+| `user-not-found` | User id not found |
+| `bank-import-batch-not-found` | Import batch id not found |
+| `bank-transaction-not-found` | Bank transaction id not found |
+| `reconciliation-not-found` | Reconciliation id not found |
+| `client-credit-not-found` | Client credit id not found |
+| `dunning-notice-not-found` | Dunning notice id not found |
+| `invalid-state-transition` | Disallowed status change (e.g. reverse an already-reversed match) |
+| `duplicate-bank-import` | Re-import of same file hash / duplicate line key |
+| `allocation-exceeds-outstanding` | Match allocation > invoice outstanding without overpayment handling |
+| `upstream-invoice-unavailable` | Invoice API unreachable; degraded (import-only) mode |
+| `upstream-invoice-not-found` | Referenced invoice not found in Invoice upstream |
+| `dunning-not-eligible` | Invoice not in a dunnable state / outstanding ≤ 0 / interval not elapsed |
 
 Add new slugs here before using them. Validation `errors[].field` uses
-snake_case paths (e.g. `body.registration_number`); `errors[].code` is
-snake_case (e.g. `required`, `invalid_invoice_number`).
+snake_case paths (e.g. `body.value_date`); `errors[].code` is snake_case (e.g.
+`required`, `invalid_amount`).
 
 ---
 
@@ -144,12 +172,35 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `login`, `getCurrentUser` | Auth |
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
-| `listClients`, `getClientById`, `createClient`, `updateClient`, `deleteClient` | Client |
-| `listQuotes`, `getQuoteById`, `createQuote`, `convertQuoteToInvoice` | Quote |
-| `listInvoices`, `getInvoiceById`, `createInvoice`, `issueInvoice` | Invoice |
-| `listPayments`, `createPayment` | Payment |
+| `getClearSettings`, `updateClearSettings`, `testUpstreamConnection` | Clear settings (admin) |
+| `importBankCsv`, `listBankImportBatches`, `getBankImportBatchById`, `reverseBankImportBatch` | Bank import |
+| `listBankTransactions`, `listUnmatchedTransactions`, `getBankTransactionById` | Bank transaction |
+| `listUpstreamInvoices`, `getUpstreamInvoiceById` | Invoice upstream (read-only) |
+| `proposeMatch`, `confirmMatch`, `reverseReconciliation`, `listReconciliations`, `getReconciliationById` | Reconciliation |
+| `listClientCredits`, `applyClientCredit` | Client credit |
+| `listDunningNotices`, `getDunningNoticeById`, `sendDunningNotice` | Dunning |
 
-Extend this list (do not improvise) when adding operations.
+Extend this list (do not improvise) when adding operations. MCP tool names
+mirror these `operationId` values exactly (`listUnmatchedTransactions`,
+`proposeMatch`, `sendDunningNotice` are the Phase 4 MCP set — roadmap §Phase 4).
+
+---
+
+## 6. Upstream read models (Invoice API — not Clear SSOT)
+
+Clear reads these from the Invoice upstream and may cache them read-only with a
+TTL. Field spellings below are the **shape Clear consumes**; the Invoice product
+owns their authoritative definition. Clear MUST NOT persist them as a source of
+truth or expose write operations for them.
+
+| Read model | Fields Clear consumes (read-only) |
+| --- | --- |
+| `invoice` (upstream) | `invoice_id`, `invoice_number`, `issued_at`, `due_at`, `total_cents`, `outstanding_cents`, `status`, `tax_breakdown` (opaque), `client_id` |
+| `client` (upstream) | `client_id`, `contact_name`, `recipient_email` (match hints, dunning recipient) |
+| `payment` (upstream) | `payment_id`, `invoice_id`, `amount_cents`, `paid_at` (created/updated by Clear via Invoice API after a confirmed match) |
+
+`outstanding_cents` = `invoice.total_cents − sum(allocated payment amounts)`, as
+reported by the Invoice upstream. Clear never recomputes invoice tax or totals.
 
 ---
 

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -7,7 +7,7 @@ NeNe Clear inherits engineering governance from [NENE2](https://github.com/hidey
 | Layer | Repository | Role |
 | --- | --- | --- |
 | Framework runtime | [NENE2](https://github.com/hideyukiMORI/NENE2) | HTTP runtime, DI, middleware, Problem Details, OpenAPI/MCP patterns |
-| Application platform | **NeNe Clear** (this repo) | Quote, invoice, payment, client, PDF, admin UI |
+| Application platform | **NeNe Clear** (this repo) | Bank import, payment reconciliation, client credit, dunning, admin UI |
 | Sibling products | [nene-records](https://github.com/hideyukiMORI/nene-records), [nene-corpus](https://github.com/hideyukiMORI/nene-corpus), [nene-concierge](https://github.com/hideyukiMORI/nene-concierge) | Optional upstream HTTP integrations |
 | Reference trials | [NENE2-FT](https://github.com/hideyukiMORI/NENE2-FT) | Patterns and friction notes from field trials |
 
@@ -48,9 +48,9 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 
 | Topic | NeNe Clear choice |
 | --- | --- |
-| Product goal | API-first quote and invoice platform (not general accounting) |
+| Product goal | API-first payment reconciliation & dunning platform (not general accounting, not invoice issuance — ADR 0009) |
 | Public Problem Details base URL | `https://nene-clear.dev/problems/` |
-| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + billing additions |
+| Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + reconciliation/dunning additions |
 | Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
 | Monetary values | Integer **cents** in DB and JSON; no floats |
 | Language policy | **English** for all repository docs, Issues, PRs, commits, OpenAPI, API errors (ADR 0008); admin UI **ja + en** only (ADR 0005) |
@@ -60,12 +60,12 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 
 Record these in ADRs or product docs when they stabilize:
 
-- Client / quote / invoice / payment domain model
-- Japan qualified invoice field validation rules
+- Bank import, reconciliation, client-credit, and dunning domain model
+- Invoice upstream API client contract (read invoices/clients, write payments)
 - Payment reconciliation and dunning compliance rules
-- PDF generation strategy (server-side, no client-side tax calculation)
-- Admin frontend vs public document download boundaries
-- MCP tool catalog for billing operations
+- Degraded-mode behavior when the Invoice API is unavailable
+- Admin frontend boundaries (no public document download — Clear issues no documents)
+- MCP tool catalog for reconciliation/dunning operations
 - Release versioning of the NeNe Clear product (`v0.x` until first stable API)
 
 ## When upstream and local docs conflict

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -1,6 +1,6 @@
 # AI Tools Policy
 
-NeNe Clear inherits NENE2 AI integration principles with billing-specific boundaries.
+NeNe Clear inherits NENE2 AI integration principles with reconciliation/dunning boundaries (human confirms, AI proposes).
 
 ## Agent entry
 
@@ -11,9 +11,10 @@ NeNe Clear inherits NENE2 AI integration principles with billing-specific bounda
 ## MCP boundary
 
 - MCP tools map to **OpenAPI HTTP operations** only.
-- MCP is for **operators and development agents**, not public document download clients.
+- MCP is for **operators and development agents** — not direct database or shell access.
 - Do not add tools that read the database directly or execute shell commands without Issue + security review.
-- Write tools (create invoice, mark paid) require auth review before catalog publication.
+- Match suggestions may be AI-proposed, but **human confirmation is required** before a match is final (compliance §2.8).
+- Write tools (`confirmMatch`, `applyClientCredit`, `sendDunningNotice`) require auth + audit review before catalog publication.
 
 Validate catalog:
 

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -21,4 +21,4 @@ Goal: establish NeNe Clear engineering discipline and product design before bill
 
 Phase 0+ — NENE2 runtime scaffold, health endpoint, OpenAPI stub, CI (Issues #4–#7).
 
-Then Phase 1 — Core billing API (clients, quotes, invoices, payments).
+Then Phase 1 — Reconciliation API (Invoice upstream client, bank import, matching, audit). See [`../roadmap.md`](../roadmap.md).

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -10,7 +10,8 @@ Source policies: `docs/development/backend-standards.md`, `docs/development/nami
 - [ ] Handler stays thin: parse → DTO → UseCase → response.
 - [ ] Business rules live in UseCase, not Handler or Repository.
 - [ ] Money fields use integer cents — no floats.
-- [ ] Japan invoice validation rules enforced in UseCase before persistence/PDF.
+- [ ] Reconciliation/dunning rules enforced in UseCase before persistence and before any upstream write.
+- [ ] No quote/invoice/line-item/PDF/tax logic added — invoices are read via the Invoice upstream API only (ADR 0009).
 - [ ] All identifiers (fields, status values, `operationId`, slugs) match `docs/explanation/terminology.md` exactly — no typos, no unregistered terms.
 - [ ] New routes documented in OpenAPI with `operationId`.
 - [ ] Problem Details used for errors; no stack traces in responses.

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -1,35 +1,34 @@
-# Accounting & Tax Compliance Self-Review
+# Reconciliation, Dunning & Records Compliance Self-Review
 
-**Binding.** Use for **any** change touching quotes, invoices, payments, tax
-calculation, document numbering, PDF rendering, record retention, bank import,
-payment reconciliation, or dunning. If unsure whether a change has compliance
-impact, assume it does and run this list.
+**Binding.** Use for **any** change touching bank import, payment
+reconciliation, allocation, client credit, dunning, record retention, or audit.
+If unsure whether a change has compliance impact, assume it does and run this
+list.
+
+> **Scope (ADR 0009):** quote/invoice/qualified-invoice/tax compliance belongs
+> to [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice). Invoices are
+> read via the upstream API only; Clear never issues documents or computes tax.
 
 Source of truth:
 
-- [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md)
-- [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md)
+- [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) (authoritative)
+- [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) (cross-cutting principles)
 
 Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
 
-## Checklist — invoices & tax
+## Checklist — money, records & audit
 
 - [ ] Change reviewed against binding compliance docs; compliance impact stated in the PR.
-- [ ] Qualified invoice required fields enforced before issuance (issuer name/address/`T`+13 registration number/date, per-rate taxable amount, per-rate consumption tax, total, buyer name).
-- [ ] Reduced-rate (8%) items clearly marked.
-- [ ] Consumption tax rounded **once per tax rate per document**, half-up — never per line (ADR 0004).
-- [ ] Allowed tax rates only (10% / 8%); any rate change carries an ADR.
-- [ ] Registration number treated as **syntax-only** validation; no UI/doc implies it proves existence/validity.
-- [ ] Issued documents are immutable; corrections via credit note, not edit/delete.
-- [ ] Document numbering sequential; no silent gap, reuse, or hard delete that hides a voided document.
-- [ ] No hard delete of billing records (soft delete / void only).
-- [ ] Issued copies retained and tamper-evident; no auto-purge before the statutory period (7y, up to 10y).
-- [ ] All money is integer minimum currency units; no float/DECIMAL in DB, JSON, or tests.
-- [ ] Monetary/tax figures computed once in the UseCase; PDF/API/stored copy do not recalculate independently.
-- [ ] Audit trail recorded for issuance and payment (Phase 2+).
-- [ ] Any deviation from the binding rules carries an ADR with tax/accounting professional sign-off.
+- [ ] No quote/invoice/line-item/PDF/tax logic added to Clear (ADR 0009); invoice figures read from upstream, never recomputed.
+- [ ] All money is integer minimum currency units (`*_cents`); no float/DECIMAL in DB, JSON, or tests.
+- [ ] Allocation math computed once in the UseCase; API/stored rows do not recompute independently.
+- [ ] Imported bank lines immutable; corrections via reversal import batch, not in-place edit.
+- [ ] Import batch stores `file_hash` (SHA-256), `source_filename`, actor, timestamp; duplicate hash/line key warns or blocks.
+- [ ] Bank/match/credit/dunning records retained, tamper-evident, searchable; no auto-purge before the statutory period (7y, up to 10y).
+- [ ] Audit event recorded for import, match confirm, match reverse, dunning send, and client-credit creation.
+- [ ] Any deviation from the binding rules carries an ADR with tax/accounting professional (税理士 / 公認会計士) sign-off.
 
-## Checklist — reconciliation & dunning (Expansion #1+)
+## Checklist — reconciliation & dunning
 
 - [ ] `paid_at` uses bank value date when matched from import (unless documented override).
 - [ ] Partial payments update `partially_paid` / `paid` correctly; no over-allocation without overpayment flow.

--- a/docs/review/middleware-security.md
+++ b/docs/review/middleware-security.md
@@ -6,10 +6,10 @@ Source policies: NENE2 middleware docs, `docs/integrations/ai-tools.md`.
 
 ## Checklist
 
-- [ ] Secrets not logged (JWT, SMTP password, upstream bearer tokens).
-- [ ] Admin JWT not exposed to public document download routes.
+- [ ] Secrets not logged (JWT, SMTP password, Invoice upstream bearer token).
+- [ ] Invoice upstream credentials read from `.env` only; never returned in API responses or logs.
 - [ ] CORS config explicit — no `*` in production paths.
-- [ ] Auth middleware on admin mutating routes.
-- [ ] PDF download tokens time-limited or scoped when public.
-- [ ] No sensitive data in Problem Details `detail` for production.
-- [ ] MCP write tools reviewed for auth and audit requirements.
+- [ ] Auth middleware on admin mutating routes; tenant isolation (`organization_id`) enforced on every query (ADR 0006).
+- [ ] CSV export endpoints scoped to the caller's organization and capability.
+- [ ] No sensitive data (client PII, bank lines) in Problem Details `detail` for production.
+- [ ] MCP write tools (`confirmMatch`, `applyClientCredit`, `sendDunningNotice`) reviewed for auth and audit requirements.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -23,9 +23,9 @@ See also: `docs/inheritance-from-nene2.md`.
 Use Conventional Commit style as the prefix:
 
 - `docs/1-governance-foundation`
-- `feat/5-client-crud`
-- `fix/12-tax-rate-validation`
-- `test/8-invoice-pdf-generation`
+- `feat/5-bank-csv-import`
+- `fix/12-allocation-overpayment-credit`
+- `test/8-dunning-minimum-interval`
 
 ## PR Requirements
 


### PR DESCRIPTION
Closes #7.

## Purpose

Rewrite bootstrap residue that still described NeNe Clear in quote/invoice/PDF/tax terms, aligning all docs with the binding domain split in [ADR 0009](docs/adr/0009-separate-from-nene-invoice.md) — **payment reconciliation & dunning only**. Target model derived from the already-authoritative `requirements.md §2`, ADR 0009, and `payment-reconciliation-dunning-compliance.md`.

## Change summary

**Canonical docs (rewritten):**
- `terminology.md` — Clear entities (`BankTransaction`, `PaymentReconciliation`, `ReconciliationAllocation`, `ClientCredit`, `DunningNotice`, `AuditEvent`, `ClearSettings`), statuses, fields, Problem Details slugs, operationIds. Invoice/client/payment demoted to upstream read models (new §6).
- `glossary.md`, `domain-model.md` — reconciliation/dunning concepts; bank-transaction & reconciliation state machines; allocation logic; upstream integration boundary.

**Compliance:**
- `accounting-compliance.md` slimmed to Clear scope (money / retention / audit); quote/invoice/tax compliance relocated to `nene-invoice`.
- Fixed back-references and dropped the rejected "Expansion #1" framing in the reconciliation/dunning compliance + review docs.

**Standards / ADRs:**
- `naming-conventions.md`, `backend-standards.md`, `inheritance-from-nene2.md`, review checklists, `.cursor/rules/` — Clear-domain examples and module lists.
- ADR 0004 marked **superseded / relocated to `nene-invoice`** (Clear computes no tax).
- ADR 0005/0006 de-Invoiced; ADR 0006 capability set corrected (`manage_clear_settings`, `manage_reconciliation`, `view_reconciliation`, `send_dunning`).
- Fixed incidental ADR 0008 contradictions ("Japanese allowed in commits").

## Notes for review

- Tables are plural per `naming-conventions.md §5`; entities PascalCase singular.
- ADR 0001 and 0006 were **edited in place** (only their illustrative entity/capability lists were wrong; decisions unchanged, with a correction note in 0006) rather than superseded.

## Scope

Phase 0 — documentation only. No runtime code.

## Self-review

docs-policy, compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)