### PR TITLE
docs: harden rule set — scope contract, legal spine, ADRs 0010-0013 (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,9 @@ Strategy: [publication-strategy `docs/products/nene-clear.md`](https://github.co
 | Purpose | Path |
 | --- | --- |
 | Domain split | `docs/adr/0009-separate-from-nene-invoice.md` |
+| Scope contract (GOAL/DO/DON'T) | `docs/explanation/scope-contract.md` |
 | Scope boundary | `docs/explanation/scope-boundary.md` |
 | Compliance | `docs/explanation/payment-reconciliation-dunning-compliance.md` |
-| Invoice upstream | `docs/integrations/sibling-products.md` |
+| Invoice upstream contract | `docs/integrations/invoice-upstream-contract.md` |
+| Invoice upstream (overview) | `docs/integrations/sibling-products.md` |
 | TODO | `docs/todo/current.md` |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Operators who need both install **two sibling apps** connected via HTTP.
 | Topic | Document |
 | --- | --- |
 | **Domain boundary (read first)** | [`docs/adr/0009-separate-from-nene-invoice.md`](./docs/adr/0009-separate-from-nene-invoice.md) |
+| **Scope contract (GOAL / DO / DON'T)** | [`docs/explanation/scope-contract.md`](./docs/explanation/scope-contract.md) |
+| **Invoice upstream contract** | [`docs/integrations/invoice-upstream-contract.md`](./docs/integrations/invoice-upstream-contract.md) |
 | **Philosophy** | [`docs/explanation/philosophy.md`](./docs/explanation/philosophy.md) |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
 | **Requirements** | [`docs/explanation/requirements.md`](./docs/explanation/requirements.md) |

--- a/docs/adr/0010-payment-system-of-record.md
+++ b/docs/adr/0010-payment-system-of-record.md
@@ -1,0 +1,80 @@
+# ADR 0010: NeNe Invoice is the Payment System of Record; Clear Writes Back
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Clear matches bank deposits to issued invoices. NeNe Invoice already owns
+invoices, payments, and the outstanding balance, and computes
+`partially_paid` / `paid` from its payment records (it is the billing ledger).
+
+If Clear also stored payments and outstanding balances as its **own** source of
+truth and merely "synced" status to Invoice, the two systems could drift. An
+accountant or tax accountant (税理士 / 公認会計士) reviewing the books would then
+face two competing balances and ask "which number is correct?" — exactly the
+failure we must avoid.
+
+We need to fix, unambiguously, where each fact lives, and how Clear records a
+confirmed match without becoming a second ledger.
+
+## Decision
+
+**NeNe Invoice is the single system of record for invoice figures, payment
+records, and outstanding balances.** NeNe Clear is a **reconciliation subledger
+and evidence custodian** that writes payments back to Invoice via HTTP.
+
+System-of-record split (帳簿 ↔ 証憑):
+
+| Fact | Owner |
+| --- | --- |
+| Invoice figures, tax breakdown, outstanding balance | **Invoice** |
+| Payment record against an invoice | **Invoice** (created/voided by Clear via API) |
+| Imported bank deposit line (証憑 / 電子取引データ) | **Clear** |
+| Reconciliation link (deposit ↔ payment) | **Clear** |
+| Overpayment credit (client_credit) | **Clear** |
+| Dunning history, audit trail | **Clear** |
+
+Write-back rules (full detail in
+[`invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)):
+
+- On a **human-confirmed** match, Clear calls Invoice to **create a payment**
+  with `paid_at` = bank value date, an **idempotency key**, and an
+  **`external_reference`** (Clear's reconciliation id).
+- On **reversal**, Clear calls Invoice to **void** that payment (void-with-audit,
+  never hard delete). Invoice recomputes outstanding/status.
+- **Over-allocation is rejected** by Invoice; the excess becomes a `client_credit`
+  in Clear, never a payment beyond outstanding.
+- Clear **never** computes invoice tax, totals, or status, and never stores them
+  as truth. If Invoice is unavailable, Clear enters **degraded mode** (import
+  works; match confirmation is blocked) so the two never silently diverge.
+
+## Consequences
+
+**Benefits**
+
+- One balance, one truth. 帳簿 (Invoice) and 証憑 (Clear) reconcile one-to-one.
+- Idempotency + `external_reference` make the two systems mutually auditable.
+- Clear stays small: evidence + links + dunning, not a ledger.
+
+**Costs**
+
+- Clear depends on an Invoice API that **does not exist yet** — it must be built
+  per the contract doc, tracked as an Issue in `nene-invoice`.
+- Match confirmation requires a successful upstream write (no offline finalize).
+
+**Follow-up**
+
+- Hand off [`invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)
+  to the Invoice team; open the implementation Issue in `nene-invoice`.
+- Clear builds against a fake upstream + contract tests until the API lands.
+
+## Related
+
+- ADR 0009: Separate domain from nene-invoice
+- Invoice upstream contract: [`../integrations/invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)
+- Scope contract: [`../explanation/scope-contract.md`](../explanation/scope-contract.md) (X2)
+- Compliance: [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) §0, §2
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0011-dunning-self-collection-only.md
+++ b/docs/adr/0011-dunning-self-collection-only.md
@@ -1,0 +1,79 @@
+# ADR 0011: Dunning is Self-Collection Support Only; No Automatic Late Interest
+
+## Status
+
+accepted
+
+> Engineering's interpretation of collection-law boundaries — **not legal
+> advice**. Confirm with a 弁護士 before relying on it; statutory values must be
+> verified at implementation.
+
+## Context
+
+NeNe Clear sends overdue payment reminders (督促). Collection touches several
+legal limits that a reviewing professional (税理士 / 弁護士) will check:
+
+- **弁護士法72条 / Servicer Act (債権管理回収業に関する特別措置法):** collecting
+  **others'** debts for a fee, as a business, is reserved for licensed attorneys
+  or licensed servicers (債権回収会社). Reminding your **own** customers about
+  **your own** invoices (self-collection) is lawful.
+- **Tone:** coercive, threatening, or false statements ("we will sue
+  immediately") are improper collection conduct.
+- **Late interest (遅延損害金):** B2B debts may carry interest at a contractual or
+  statutory rate (民法404 statutory rate, currently 3%, reviewed every 3 years).
+  Auto-computing it on the wrong basis, or presenting it as a legal demand,
+  produces an inaccurate claim and a coercive impression.
+- **Over-frequency** reminders can themselves read as harassment, and reminding a
+  customer who has actually paid (stale data) damages the relationship.
+
+## Decision
+
+NeNe Clear's dunning is **support for the operator's self-collection of their own
+receivables only**, within these binding limits:
+
+1. **Self-collection only.** Clear MUST NOT collect third-party debts for a fee
+   or present such a feature, and MUST NOT impersonate or imply a lawyer,
+   collection agency, or court (弁護士法72条 / サービサー法). 督促 (reminder) is
+   distinct from 取立 (enforcement); Clear does only the former.
+2. **No automatic late interest on the balance.** Clear MUST NOT auto-compute
+   遅延損害金 and add it to the outstanding balance, and MUST NOT present interest
+   as a legal demand by default. An **optional, off-by-default** template
+   placeholder for contractually agreed / statutory interest MAY exist; enabling
+   it requires advisor sign-off. The operator owns correctness of any interest
+   claim.
+3. **Operator control + frequency guard.** Default is **manual** send per
+   invoice. Scheduled sending is **org opt-in** and MUST respect a **minimum
+   interval** (default 7 days) per invoice, and MUST reflect the latest
+   reconciliation state at send time (no reminding a paid invoice).
+4. **No coercive or false content** in default templates (§4.4 of the compliance
+   doc). Each send is logged immutably.
+
+Crossing the self-collection boundary (e.g. an agency offering) is a **separate
+product** requiring legal review and a new ADR — not an incremental feature.
+
+## Consequences
+
+**Benefits**
+
+- Keeps the product on the lawful side of 弁護士法72条 / サービサー法.
+- Reminders stay accurate (no mis-computed interest, no stale-data sends).
+- Clear story for reviewers: a reminder tool, not a collection agency.
+
+**Costs**
+
+- Operators wanting automatic interest calculation must enable an opt-in feature
+  with advisor sign-off, or compute it themselves.
+- No fully-automated aggressive collection workflow (by design).
+
+**Follow-up**
+
+- 弁護士 review of default template wording before Phase 2 dunning ships
+  (compliance §9 gate).
+
+## Related
+
+- Compliance: [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) §4 (esp. §4.4, §4.5, §4.8)
+- Scope contract: [`../explanation/scope-contract.md`](../explanation/scope-contract.md) (X8, X9, X10)
+- Personal data handling: compliance §4.6
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0012-electronic-records-bank-data.md
+++ b/docs/adr/0012-electronic-records-bank-data.md
@@ -1,0 +1,79 @@
+# ADR 0012: Electronic-Records Posture for Imported Bank Data (電子帳簿保存法)
+
+## Status
+
+accepted
+
+> Engineering's interpretation of 電子帳簿保存法 — **not legal advice**. Confirm
+> the applicable requirements (and any small-business relaxations) with a 税理士
+> at implementation.
+
+## Context
+
+The bank deposit data NeNe Clear imports (CSV today) is **electronic transaction
+data (電子取引データ)** used as accounting evidence. Under the Act on Electronic
+Books and Records Preservation (電子帳簿保存法), such data must be preserved
+electronically and must satisfy:
+
+- **真実性の確保 (integrity):** by one of — timestamping, a system that retains a
+  **history of corrections/deletions (訂正削除の履歴)**, or an internal handling
+  規程 (事務処理規程).
+- **可視性の確保 (visibility):** monitor/print legibility (見読可能性), a
+  **search capability (検索要件)** over transaction date / amount / counterparty
+  (with range and 2-or-more combinations), and availability of a system-overview
+  document. (Some small-scale operators qualify for relaxed search requirements
+  if they provide data on download request.)
+
+We must choose how Clear meets these, so it is a design constraint from day one
+rather than a retrofit.
+
+## Decision
+
+NeNe Clear meets 電子帳簿保存法 for imported bank data by the **correction-history
+method**, plus full search:
+
+1. **Immutability + reversal-only correction.** Imported `bank_transaction`
+   amount, value date, and counterparty text are never edited or deleted in
+   place. Errors are corrected via a **reversal import batch**; the original
+   remains visible. Every correction is an immutable `audit_event` — this is the
+   "訂正削除の履歴が残るシステム" approach to 真実性の確保.
+2. **Provenance.** Each batch stores `file_hash` (SHA-256), `source_filename`,
+   `row_count`, `imported_at`, `imported_by`; duplicate hash / line key warns or
+   blocks re-import.
+3. **Search (検索要件).** Imported data is searchable by **transaction date
+   (取引年月日, incl. range), amount (取引金額, incl. range), and counterparty
+   (取引先)**, and by **combinations** of two or more. Provided by default even
+   where a relaxation might apply.
+4. **Legibility + documentation.** Data is viewable/printable in an orderly,
+   clear form, and Clear ships a system-overview / operations document
+   describing storage and search.
+5. **Retention.** 7 years minimum, up to 10 where applicable; no auto-purge.
+
+## Consequences
+
+**Benefits**
+
+- A reviewing 税理士 can confirm 電帳法 compliance against concrete, named
+  requirements rather than vague assurances.
+- Immutability + audit history doubles as the reconciliation audit trail.
+
+**Costs**
+
+- No in-place edit of imported data, ever — corrections are always a reversal
+  batch (more steps, but compliant).
+- Search indexing on date/amount/counterparty is a hard requirement, not optional.
+
+**Follow-up**
+
+- Operator guide documents the system clock used for `imported_at` and the
+  search workflow (compliance §3.3, §3.5).
+- When non-CSV ingestion (全銀フォーマット, bank API, ZEDI) is added, re-confirm
+  the same posture applies (separate ADR).
+
+## Related
+
+- Compliance: [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) §3
+- Retention/audit principles: [`../explanation/accounting-compliance.md`](../explanation/accounting-compliance.md) §3, §4
+- Scope contract: [`../explanation/scope-contract.md`](../explanation/scope-contract.md) (D1, D2, X13)
+- Supersedes: none
+- Superseded by: none

--- a/docs/adr/0013-no-journal-entries-no-bad-debt.md
+++ b/docs/adr/0013-no-journal-entries-no-bad-debt.md
@@ -1,0 +1,68 @@
+# ADR 0013: No Journal Entries and No Bad-Debt Determination — Subledger + Export
+
+## Status
+
+accepted
+
+> Engineering's interpretation of accounting/tax boundaries — **not legal
+> advice**. Confirm with a 税理士 / 公認会計士.
+
+## Context
+
+It is tempting for a reconciliation tool to drift toward "doing the accounting":
+posting journal entries (仕訳), or deciding that an unpaid invoice is a bad debt
+and writing it off. Both are out of bounds:
+
+- **Journal entries / general ledger** are the domain of accounting software
+  (freee, Money Forward, Yayoi) and double-entry bookkeeping. Duplicating them in
+  Clear creates a second, conflicting books.
+- **Bad-debt loss (貸倒損失)** is a **tax judgment** under 法人税基本通達
+  9-6-1〜9-6-3 (legal extinguishment, factual uncollectibility, formal/one-year
+  criteria). It depends on facts and judgment the software cannot evaluate, and
+  getting it wrong has tax consequences.
+
+We must state plainly that Clear does neither, so scope creep is rejected by
+reference rather than re-litigated each time.
+
+## Decision
+
+1. **No journal entries.** Clear posts no 仕訳 and maintains no general ledger. It
+   is a **reconciliation subledger** that records which bank line cleared which
+   invoice payment, plus the evidence and audit trail.
+2. **No bad-debt determination.** Clear MUST NOT classify a balance as 貸倒, post
+   a write-off, or reduce a receivable as a tax event. An operator MAY **pause
+   dunning / mark "collection paused"** for workflow purposes — **operational
+   only**, with no accounting or tax effect, recorded in the audit trail.
+3. **Export, don't post.** Clear provides **CSV export** of reconciliation and
+   payment data (invoice number, issue date, `paid_at`, amount, tax breakdown
+   from Invoice, match id) for the operator and their 税理士 to import into
+   accounting software, where the actual journal entries and any 貸倒損失 decision
+   are made.
+
+## Consequences
+
+**Benefits**
+
+- Clear stays a subledger; the single general ledger lives in the operator's
+  accounting software — no competing books.
+- Tax-sensitive judgments (貸倒) remain with the professional who is accountable
+  for them.
+
+**Costs**
+
+- Operators must run accounting software for journals and write-offs; Clear is
+  not a one-stop bookkeeping replacement (by design — and consistent with the
+  product vision).
+
+**Follow-up**
+
+- Define the CSV export columns with a 税理士 so they map cleanly to a
+  journal-import workflow (compliance §9 gate, §5).
+
+## Related
+
+- Compliance: [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) §0, §5, §7
+- Scope contract: [`../explanation/scope-contract.md`](../explanation/scope-contract.md) (X3, X4)
+- Product vision (not full accounting): [`../explanation/product-vision.md`](../explanation/product-vision.md)
+- Supersedes: none
+- Superseded by: none

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -29,6 +29,10 @@ docs/adr/
 ├── 0007-product-identity-nene-clear.md
 ├── 0008-english-only-repository-documentation.md
 ├── 0009-separate-from-nene-invoice.md
+├── 0010-payment-system-of-record.md
+├── 0011-dunning-self-collection-only.md
+├── 0012-electronic-records-bank-data.md
+├── 0013-no-journal-entries-no-bad-debt.md
 └── NNNN-short-title.md
 ```
 

--- a/docs/explanation/payment-reconciliation-dunning-compliance.md
+++ b/docs/explanation/payment-reconciliation-dunning-compliance.md
@@ -16,8 +16,10 @@ interpretation is unclear, **stop and consult a licensed tax accountant
 (税理士) or certified public accountant (公認会計士)** — record the resolution in
 an ADR and update this document.
 
-See also: [`accounting-compliance.md`](./accounting-compliance.md),
+See also: [`scope-contract.md`](./scope-contract.md) (GOAL / DO / DON'T),
+[`accounting-compliance.md`](./accounting-compliance.md),
 [`scope-boundary.md`](./scope-boundary.md),
+[`../integrations/invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md),
 [`philosophy.md`](./philosophy.md) (human confirms, AI proposes),
 [`../review/compliance.md`](../review/compliance.md).
 
@@ -25,32 +27,44 @@ See also: [`accounting-compliance.md`](./accounting-compliance.md),
 
 ## 0. Scope — what NeNe Clear is and is not
 
-### In scope
+The full charter is [`scope-contract.md`](./scope-contract.md) (GOAL / DO /
+DON'T). This section states the accounting-relevant scope.
 
-NeNe Clear maintains a **billing subledger**:
+### In scope — a reconciliation subledger over Invoice's books
 
-- Issued invoices and their outstanding balances
-- Payment records tied to invoices
-- Imported bank deposit lines and reconciliation links between deposits and payments
-- Operator-controlled dunning notices with full send history
+NeNe Clear is a **reconciliation subledger and evidence custodian**, not the
+billing ledger. It owns:
 
-This supports **accounts receivable (売掛金) clearance at the document level** —
-the operator and their advisor can see which invoice was paid, when, and from
-which bank line.
+- **Imported bank deposit lines** as immutable evidence (証憑 / 電子取引データ)
+- **Reconciliation links** between a bank line (or a portion of it) and an
+  invoice payment
+- **Client credit** balances arising from overpayment (前受金 / 預り金 相当)
+- **Operator-controlled dunning** notices with full send history
+- The **audit trail** for all of the above
+
+The **invoice figures, the payment record itself, and the outstanding balance
+are owned by NeNe Invoice** (the system of record — [ADR 0010](../adr/0010-payment-system-of-record.md)).
+Clear reads them and writes payments back via the
+[Invoice upstream contract](../integrations/invoice-upstream-contract.md); it
+never stores them as its own truth. This keeps **帳簿 (Invoice) ↔ 証憑 (Clear)**
+in one-to-one correspondence — the way an auditor expects.
 
 ### Out of scope (by design)
 
 | Capability | Where it belongs |
 | --- | --- |
-| General ledger / journal entries (仕訳) | Accounting software (freee, Money Forward, Yayoi, etc.) |
-| Revenue recognition policy for corporation tax | Operator + tax advisor |
-| Consumption tax filing (申告) | Operator + tax advisor |
-| Statutory interest calculation as legal claim | Operator judgment; optional template text only |
-| Debt collection agency services | Not this product |
-| Credit scoring or third-party collections | Not this product |
+| Quote / invoice / qualified-invoice issuance, consumption-tax calculation | **NeNe Invoice** (ADR 0009) |
+| Payment / outstanding as a source of truth | **NeNe Invoice** (ADR 0010) |
+| General ledger / journal entries (仕訳) | Accounting software (freee, Money Forward, Yayoi, etc.) — ADR 0013 |
+| Bad-debt write-off (貸倒損失) as a tax event | Operator + 税理士 (法人税基本通達 9-6-1〜9-6-3) — §7 |
+| Prescription / time-bar determination (消滅時効) | Operator + 弁護士 — §8 |
+| Revenue recognition policy; consumption tax filing (申告) | Operator + tax advisor |
+| Late/statutory interest (遅延損害金) auto-calculated as a legal claim | Off by default; optional template text only — §4.5, ADR 0011 |
+| Third-party debt collection / 取立代行 / collection-agency conduct | Licensed 弁護士 / 債権回収会社 only — §4.8 (弁護士法72条) |
+| Credit scoring | Not this product |
 
 NeNe Clear **exports** reconciliation and payment data (CSV) for import into
-accounting software. It does **not** replace double-entry bookkeeping.
+accounting software. It does **not** replace double-entry bookkeeping (ADR 0013).
 
 ---
 
@@ -62,15 +76,20 @@ design for*; it is not legal advice.
 
 | Area | Relevant rules (Japan) | NeNe Clear role |
 | --- | --- | --- |
-| Bookkeeping & evidence | Corporation Tax Act bookkeeping duty; Civil Code performance of obligations | Preserve tamper-evident payment and match history |
-| Consumption tax | Consumption Tax Act — taxable period and qualified invoice rules | Payment date recorded accurately; invoice figures unchanged after issue |
-| Electronic records | Act on Electronic Books and Records Preservation (電子帳簿保存法) | Retain imported bank data and reconciliation audit trail with searchability |
-| Personal data | Act on the Protection of Personal Information (個人情報保護法) | Dunning uses client contact data only as operator instructs; log sends |
-| Late payment | Civil Code; Interest Rate Act (法定利率) | Reminders state facts; no automated legal threats or coercive language |
-| Fair business practice | Act against Unjustifiable Premiums and Misleading Representations (B2B context: professional tone) | Templates reviewed; operator controls send |
+| Bookkeeping & record retention | Corporation Tax Act / Income Tax Act bookkeeping & document retention (法人税法・所得税法 帳簿書類の保存) | Retain bank evidence, match, and dunning history 7–10 years; no auto-purge (§3.2) |
+| Electronic records | Act on Electronic Books and Records Preservation (電子帳簿保存法) — electronic transaction data (電子取引データ) | 真実性の確保 (immutability + 訂正削除履歴) and 可視性の確保 (search by date/amount/counterparty) — §3 |
+| Consumption tax | Consumption Tax Act (消費税法) — taxable period, qualified invoice rules | Record payment date accurately; **never compute tax**; invoice figures owned by Invoice (§5) |
+| Appropriation of payments | Civil Code arts. 488–491 (民法 弁済の充当) | Operator directs allocation across debts; no silent auto-appropriation (§2.9) |
+| Prescription of claims | Civil Code art. 166 (民法 消滅時効 — receivables generally 5 years) | Surface aging as information only; **no** legal time-bar determination (§10) |
+| Late payment / interest | Civil Code art. 404 statutory rate (民法 法定利率, currently 3%, reviewed every 3 years); Interest Rate Act (利息制限法) | Reminders state facts; statutory interest off by default, not auto-added to balance (§4.5) |
+| Non-lawyer legal services | Attorney Act art. 72 (弁護士法72条); Servicer Act (債権管理回収業に関する特別措置法) | Support **self-collection** of the operator's own receivables only; no third-party 取立代行 (§4.8) |
+| Personal data | Act on the Protection of Personal Information (個人情報保護法) | Dunning uses client contact data only as operator instructs; log sends; tenant isolation (§4.6) |
+| Receipts & stamp duty | Stamp Tax Act (印紙税法) — receipts (領収書) ≥ ¥50,000 | Clear does **not** issue 領収書; out of scope (scope-contract X15) |
 
-When rules change, open a **P0 Issue** and update this document before shipping
-affected features.
+This table states *what we design for*; it is **not** legal advice, and statutory
+values (e.g. the 3% statutory rate, retention periods) **MUST be confirmed with a
+licensed professional at implementation time**. When any rule changes, open a
+**P0 Issue** and update this document before shipping affected features.
 
 ---
 
@@ -157,6 +176,21 @@ transfer reference) with professional sign-off.
 
 See [`philosophy.md`](./philosophy.md) §2.2.
 
+### 2.9 Appropriation of payments (弁済の充当) — MUST
+
+When one deposit could satisfy **several** invoices but does not cover them all,
+*which* invoices it clears is a legal question of appropriation (民法 488–491),
+not a system default.
+
+- The **operator chooses** how a deposit is appropriated across invoices
+  (指定充当). Clear MAY suggest an order (e.g. oldest-first) but MUST present it
+  as a suggestion to confirm, never apply it silently.
+- Clear MUST NOT bake in a fixed statutory-appropriation order (法定充当) as if
+  it were the only correct outcome; the parties' agreement and the operator's
+  designation govern.
+- The chosen appropriation is recorded in the allocation rows and the audit
+  trail, so an advisor can see exactly which invoice each portion cleared.
+
 ---
 
 ## 3. Bank import — electronic records rules
@@ -174,16 +208,46 @@ used as evidence MUST be handled as **electronic transaction data** (電子取�
 | Account scope | Each batch tied to one company bank account registered in `clear_settings` |
 | Duplicate detection | Same file hash or duplicate line key MUST warn or block re-import |
 
-### 3.2 Retention — MUST
+### 3.2 Integrity of the record (真実性の確保) — MUST
+
+電子帳簿保存法 lets a business satisfy the integrity requirement for electronic
+transaction data by one of several means; NeNe Clear's chosen means is the
+**"訂正削除の履歴が残るシステム"** approach (a system that retains a history of
+corrections and deletions):
+
+- Imported bank data is **never edited or deleted in place** (§3.1). Any
+  correction is a **reversal import batch** that leaves the original visible.
+- Every correction/reversal is recorded as an immutable `audit_event` (who /
+  when / what / reason), so the full history of changes is preserved.
+- This is the design rationale recorded in
+  [ADR 0012](../adr/0012-electronic-records-bank-data.md). Operators who instead
+  rely on timestamps or an internal handling규程 (事務処理規程) do so outside the
+  software; Clear's guarantee is the correction-history method.
+
+### 3.3 Visibility and search (可視性の確保 / 検索要件) — MUST
+
+- **見読可能性:** imported data and reconciliation results MUST be viewable on
+  screen and printable in an "整然・明瞭" (orderly and clear) form.
+- **検索要件:** the system MUST allow searching imported bank data by, at minimum:
+  1. **transaction date (取引年月日)** — including **range** (範囲指定),
+  2. **amount (取引金額)** — including range,
+  3. **counterparty (取引先)**,
+  and by **combinations of two or more** of these. (For operators eligible for
+  the relaxed requirement — e.g. small-scale businesses able to provide data on
+  download request — the combination/range search may be waived; Clear still
+  provides it by default.)
+- **システム概要書等の備付け:** Clear ships a system-overview / operations
+  document describing how electronic transaction data is stored and searched.
+
+### 3.4 Retention — MUST
 
 - Imported bank lines and reconciliation links follow **§3 (Retention) of
   [`accounting-compliance.md`](./accounting-compliance.md)** — minimum **7 years**,
-  up to **10 years** where applicable; no auto-purge.
-- Searchability: list/filter by date, amount, match status, client, invoice number.
+  up to **10 years** where applicable (e.g. loss carryforward); no auto-purge.
 
-### 3.3 Timestamps and audit — MUST
+### 3.5 Timestamps and audit — MUST
 
-- System clock used for `imported_at` MUST be documented in operator guide.
+- System clock used for `imported_at` MUST be documented in the operator guide.
 - All match/unmatch actions logged per §4 (Audit trail) of `accounting-compliance.md`.
 
 ---
@@ -255,6 +319,26 @@ Clear:
 - Each send creates immutable `dunning_notice` row
 - Future channels (postal log-only) require ADR
 
+### 4.8 Self-collection boundary (弁護士法72条 / サービサー法) — MUST
+
+Dunning in NeNe Clear is a tool for the operator to **remind their own customers
+about the operator's own receivables**. That is lawful self-collection. The
+following are hard prohibitions ([ADR 0011](../adr/0011-dunning-self-collection-only.md)):
+
+- Clear MUST NOT be used to **collect a third party's debts for a fee**, nor
+  present a feature that does so. Collecting others' claims as a business is
+  reserved for **licensed attorneys (弁護士)** or **licensed servicers (債権回収
+  会社)** under 弁護士法72条 and the Servicer Act (債権管理回収業に関する特別措置法).
+- Dunning messages MUST NOT impersonate, or imply the involvement of, a lawyer,
+  a collection agency, or a court.
+- The product distinguishes **督促 (reminder)** from **取立 (collection
+  enforcement)**: Clear sends factual reminders; it does not pursue coercive
+  collection, and it MUST NOT include threatening or intimidating content (§4.4).
+
+If a future feature would cross this line (e.g. an agency offering, or acting on
+behalf of other businesses' receivables), it requires a separate product, legal
+review by a 弁護士, and an ADR — it is **not** an incremental change here.
+
 ---
 
 ## 5. Relationship to consumption tax accounting
@@ -288,21 +372,56 @@ Audit records follow the same no-silent-mutation rule as issued invoices.
 
 ---
 
-## 7. Professional review checklist
+## 7. Bad debt (貸倒) — out of scope, MUST NOT determine
 
-Before Phase 1 (reconciliation API) ships, a licensed **税理士 or 公認会計士** SHOULD sign off on:
+Whether a receivable becomes a **bad-debt loss (貸倒損失)** is a **tax judgment**
+governed by 法人税基本通達 9-6-1〜9-6-3 (legal extinguishment, factual
+uncollectibility, and the formal/one-year criteria). It depends on facts the
+software cannot evaluate.
 
-1. Payment date sourcing from bank import
-2. Partial / overpayment / fee mismatch flows
-3. Immutability and retention of bank + match records
-4. Default dunning template wording (Japanese primary)
-5. Confirmation that subledger export columns meet their journal import workflow
-
-Record sign-off in the Phase 1 milestone Issue or ADR.
+- NeNe Clear MUST NOT auto-classify any balance as 貸倒, post a write-off, or
+  reduce a receivable as a tax event ([ADR 0013](../adr/0013-no-journal-entries-no-bad-debt.md), scope-contract X4).
+- An operator MAY **pause dunning** or mark an invoice "collection paused" for
+  their own workflow. This is **operational only** — it has **no** accounting or
+  tax effect, is not a 貸倒 determination, and is recorded in the audit trail.
+- The actual 貸倒損失 decision and its journal entry are made by the operator and
+  their 税理士 in accounting software, using Clear's CSV export as evidence.
 
 ---
 
-## 8. How this rule applies to every change
+## 8. Prescription / time-bar (消滅時効) — information only, MUST NOT determine
+
+Receivables are generally subject to a **5-year** prescription period under 民法
+166 (from when the creditor could exercise the right; the pre-2020 short-term
+professional periods were abolished). Whether a specific claim is time-barred —
+and whether prescription was interrupted/renewed (時効の更新・完成猶予) — is a
+**legal question**.
+
+- NeNe Clear MAY **surface aging** (days overdue, age buckets) as operator
+  information.
+- It MUST NOT assert that a claim is time-barred, MUST NOT auto-expire or hide a
+  receivable on age, and MUST NOT compute a prescription date as a legal fact.
+- Any legal determination is for the operator and a 弁護士.
+
+---
+
+## 9. Professional review gate
+
+Sign-off is a **gate**, not a nicety. The following MUST occur before the named
+milestone ships, and the sign-off MUST be recorded in the milestone Issue or an ADR.
+
+| Reviewer | Scope of review | Required before |
+| --- | --- | --- |
+| **税理士 / 公認会計士** | Payment-date sourcing; partial / overpayment / transfer-fee flows; appropriation (§2.9); immutability, 電帳法 integrity & search (§3); retention; CSV export columns map to their journal-import workflow | Phase 1 (reconciliation API) |
+| **税理士 / 公認会計士** | Confirmation that Clear posts **no** journal entries and makes **no** 貸倒 determination (§7, ADR 0013) | Phase 1 |
+| **弁護士** (or advisor competent in collection law) | Default dunning template wording; the self-collection boundary (§4.8, 弁護士法72条); statutory-interest handling (§4.5); absence of coercive/false content (§4.4) | Phase 2 (dunning) |
+
+Any change that **deviates** from a rule in this document also re-triggers the
+relevant reviewer's sign-off via an ADR (§0.2 of [`accounting-compliance.md`](./accounting-compliance.md)).
+
+---
+
+## 10. How this rule applies to every change
 
 Any change touching bank import, matching, payment allocation, client credit,
 dunning templates, or send scheduling **MUST**:
@@ -330,4 +449,4 @@ If unsure whether a change has compliance impact, **assume it does**.
 spellings; register any new term there before implementation. Singular forms used
 in prose above refer to a single row of the corresponding table.
 
-Last updated: 2026-05-29
+Last updated: 2026-05-30

--- a/docs/explanation/scope-boundary.md
+++ b/docs/explanation/scope-boundary.md
@@ -47,6 +47,7 @@ if compliance impact.
 ## Related
 
 - [ADR 0009](../adr/0009-separate-from-nene-invoice.md)
+- [`scope-contract.md`](./scope-contract.md) — the binding GOAL / DO / DON'T charter
 - [`product-vision.md`](./product-vision.md)
 - [`requirements.md`](./requirements.md)
 

--- a/docs/explanation/scope-contract.md
+++ b/docs/explanation/scope-contract.md
@@ -1,0 +1,128 @@
+# Scope Contract — GOAL / DO / DON'T (binding)
+
+**Status: binding (non-negotiable).** This is the charter for what NeNe Clear
+**is**, what it **does**, and what it **must never do**. Every Issue, ADR, and PR
+is measured against it. When a request conflicts with this contract, the contract
+wins; changing the contract requires an ADR (and, where a row cites law,
+professional sign-off).
+
+> This is engineering's interpretation of accounting, record-keeping, and
+> collection-law boundaries — **not legal advice**. Rows that touch tax or law
+> name the statute so a 税理士 / 公認会計士 / 弁護士 can verify them. Confirm
+> before relying on any of it.
+
+Read first: [ADR 0009](../adr/0009-separate-from-nene-invoice.md) (domain split),
+[`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+(binding detail), [`invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)
+(the Invoice boundary).
+
+---
+
+## GOAL
+
+> **NeNe Clear lets a Japan SMB clear bank deposits against issued invoices and
+> send professional overdue reminders — with an audit trail and evidence
+> retention that an accountant or tax accountant can review without finding a
+> single silent deviation.**
+
+Concretely, the goal is reached when an operator can:
+
+1. Connect to NeNe Invoice (upstream) and import a bank CSV.
+2. See unmatched deposits beside open/overdue invoices.
+3. **Propose → confirm (by a human)** a match; Clear writes the payment back to
+   Invoice and stores the bank evidence + reconciliation link + audit entry.
+4. Handle partial payment, overpayment (→ client credit), and transfer-fee
+   mismatch **without any silent write-off**.
+5. Send a logged dunning notice for an overdue invoice, within legal tone and
+   frequency limits.
+6. Hand a tax advisor a CSV and a searchable evidence trail that maps every
+   cleared invoice to the exact bank line and date.
+
+A reviewing professional is the real acceptance test: **帳簿 (Invoice) ↔ 証憑
+(Clear) line up one-to-one, and nothing was changed in a way that isn't logged.**
+
+---
+
+## DO — Clear owns these
+
+| # | Clear does | Grounded in |
+| --- | --- | --- |
+| D1 | Import bank deposit lines from CSV and preserve them as **immutable evidence** (証憑) | 電子帳簿保存法 (電子取引データ) |
+| D2 | Keep imported data **searchable** by transaction date / amount / counterparty | 電子帳簿保存法 可視性の確保 |
+| D3 | Propose matches (rules / AI) and require **human confirmation** before finalizing | Internal control; [`philosophy.md`](./philosophy.md) |
+| D4 | Write the resulting **payment back to Invoice** (idempotent), keeping Invoice the system of record | ADR 0010 |
+| D5 | Record **partial payment**, **overpayment → client credit (前受金/預り金 相当)**, and **transfer-fee** handling with audit, no silent write-off | 会計実務 |
+| D6 | Let the operator **direct how a deposit is appropriated** across multiple invoices (指定充当) | 民法 488–491（弁済の充当） |
+| D7 | Send **operator-controlled** overdue reminders (督促) for the operator's **own** receivables, with logged history and a minimum interval | 弁護士法72条 self-collection boundary; ADR 0011 |
+| D8 | Maintain an **immutable audit trail** (import, match, reverse, dunning, credit) and **7–10 year retention** | 法人税法/所得税法 帳簿保存; 電子帳簿保存法 |
+| D9 | **Export CSV** of reconciliation/payment data for accounting software | Subledger handoff; ADR 0013 |
+| D10 | Surface **aging / overdue** information for operator awareness | Operational; informational only (see X5) |
+
+---
+
+## DON'T — Clear must never do these
+
+| # | Clear must NOT | Why (risk) | Belongs to |
+| --- | --- | --- | --- |
+| X1 | Issue quotes / invoices / qualified-invoice PDFs, or compute consumption tax | Two issuers of the same document = two truths; tax errors | **NeNe Invoice** (ADR 0009) |
+| X2 | Hold invoices, outstanding balances, or payments as its **own** source of truth | Competing balances → "which number is right?" at audit | **NeNe Invoice** (ADR 0010) |
+| X3 | Post journal entries (仕訳) or replace double-entry bookkeeping | Clear is a reconciliation subledger, not a ledger | Accounting software (ADR 0013) |
+| X4 | **Determine bad debt (貸倒損失)** or write off a receivable as a tax event | 貸倒 is a tax judgment (法人税基本通達 9-6-1〜9-6-3) | Operator + 税理士 |
+| X5 | Make **legal determinations** about prescription/time-bar (消滅時効, 売掛金 5年 — 民法166) | Misstating a legal status creates liability | Operator + 弁護士 |
+| X6 | **Silently write off** a fee difference, overpayment, or shortfall | Hides money movement from the books | — (operator chooses, logged) |
+| X7 | **Auto-appropriate** a payment across debts without operator choice | Contradicts 指定充当; can misstate which invoice is paid | Operator (民法 488–491) |
+| X8 | **Auto-compute statutory/late interest (遅延損害金) and add it to the balance**, or present it as a legal demand by default | Wrong rate/basis = inaccurate claim; coercive tone risk | Optional, off by default + advisor (ADR 0011) |
+| X9 | Act as a **third-party debt collector** or present itself/its messages as a collection agency or lawyer | 非弁行為 (弁護士法72条) / unlicensed servicer (サービサー法) | Licensed 弁護士 / 債権回収会社 only |
+| X10 | Send dunning that is **threatening, coercive, or false** ("we will sue immediately") | Improper collection conduct; misrepresentation | — (prohibited) |
+| X11 | Finalize a match **without human confirmation** (no silent auto-match in MVP) | Removes the control an auditor expects | — (ADR-gated exception only) |
+| X12 | **Hard-delete** bank lines, matches, payments, or dunning records | Destroys evidence / audit trail | — (reversal/void only) |
+| X13 | Mutate **imported bank data** in place | Breaks 真実性の確保 | — (reversal import batch only) |
+| X14 | Share a database with Invoice or any sibling | Couples schemas, bypasses the contract | — (HTTP only, ADR 0002/0009) |
+| X15 | Issue receipts (領収書) | 印紙税 and document issuance are not Clear's domain | Invoice / operator |
+
+---
+
+## Boundaries that are easy to get wrong (clarifications)
+
+- **督促 (reminder) ≠ 取立 (collection).** Clear reminds the operator's own
+  customers about the operator's own invoices. That is lawful self-collection.
+  The moment a feature would collect **others'** debts for a fee, or dress the
+  message as a collection agency, it crosses 弁護士法72条 / サービサー法 — and is
+  out of scope (X9, X10).
+- **Clear records dates and amounts; it does not judge tax.** `paid_at` (bank
+  value date) is captured accurately for the advisor, but Clear takes no position
+  on revenue recognition, consumption-tax basis, or 貸倒 (X4).
+- **Overpayment is a liability, not revenue.** Excess over outstanding becomes a
+  **client credit** in Clear and is **not** posted to the invoice (the Invoice
+  API rejects over-allocation — see the contract). Applying it later is an
+  explicit operator action.
+- **"Mark uncollectible" is operational, not accounting.** An operator may pause
+  dunning for an invoice (logged), but that has **no** accounting or tax effect
+  and is **not** a 貸倒 determination.
+
+---
+
+## Definition of done (rules layer)
+
+The rule set is "done enough to start coding" when:
+
+- [ ] This contract, the compliance doc, and the Invoice upstream contract agree
+      with each other (no conflicting statements).
+- [ ] Every DON'T has either a statute/ADR citation or an explicit owner.
+- [ ] A 税理士 / 公認会計士 has reviewed the reconciliation + retention + export
+      rules; a 弁護士 (or the same advisor) has reviewed the dunning boundary.
+- [ ] `terminology.md` registers every entity the rules reference.
+
+---
+
+## Related
+
+- Domain split: [ADR 0009](../adr/0009-separate-from-nene-invoice.md)
+- Binding detail: [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+- Invoice boundary: [`invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)
+- Payment SSOT: [ADR 0010](../adr/0010-payment-system-of-record.md)
+- Dunning boundary: [ADR 0011](../adr/0011-dunning-self-collection-only.md)
+- Electronic records: [ADR 0012](../adr/0012-electronic-records-bank-data.md)
+- No journals / no bad-debt: [ADR 0013](../adr/0013-no-journal-entries-no-bad-debt.md)
+
+Last updated: 2026-05-30

--- a/docs/review/compliance.md
+++ b/docs/review/compliance.md
@@ -30,15 +30,20 @@ Do not delete items to pass. Mark `N/A` only when genuinely not applicable.
 
 ## Checklist — reconciliation & dunning
 
+- [ ] Invoice remains the payment/outstanding system of record; Clear writes back via the upstream contract (idempotency key + `external_reference`) — no local payment SSOT (ADR 0010).
 - [ ] `paid_at` uses bank value date when matched from import (unless documented override).
 - [ ] Partial payments update `partially_paid` / `paid` correctly; no over-allocation without overpayment flow.
 - [ ] Transfer-fee mismatch handled per compliance doc §2.4 — no silent write-off.
-- [ ] Overpayment creates `client_credit`; excess not discarded.
-- [ ] Multi-invoice allocation sums to bank transaction amount.
+- [ ] Overpayment creates `client_credit`; excess not discarded (Invoice rejects over-allocation).
+- [ ] Multi-invoice allocation sums to bank transaction amount; appropriation is operator-directed, not silent auto (§2.9, 民法488–491).
 - [ ] Match reversal creates audit record; no hard delete of payment/bank history.
 - [ ] Human confirmation required before match is final (unless ADR exception).
-- [ ] Bank import batch stores file hash, actor, timestamp; imported lines immutable.
+- [ ] Bank import immutable; corrections via reversal batch with audit history (真実性の確保, ADR 0012); search by date/amount/counterparty available (§3.3).
+- [ ] No journal entries posted; no 貸倒 determination — pause/mark is operational only (ADR 0013, §7).
+- [ ] Aging is informational only; no prescription/time-bar (消滅時効) determination (§8).
 - [ ] Dunning only for issued/partially_paid/overdue with outstanding > 0.
-- [ ] Dunning send logged; minimum interval enforced for scheduled sends.
-- [ ] Default dunning templates: no threats, no auto statutory interest on balance.
+- [ ] Dunning is self-collection of the operator's own receivables; no third-party 取立代行, no agency/lawyer impersonation (弁護士法72条, §4.8, ADR 0011).
+- [ ] Dunning send logged; minimum interval enforced; send reflects latest reconciliation state (no reminding a paid invoice).
+- [ ] Default dunning templates: no threats/false claims, no auto statutory interest on balance (§4.4, §4.5).
 - [ ] CSV export columns suitable for advisor handoff (document in PR if changed).
+- [ ] Professional review gate (§9) satisfied for the milestone: 税理士/公認会計士 (reconciliation/retention/export), 弁護士 (dunning) — sign-off recorded.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,8 +17,10 @@ Operators self-host Clear beside NeNe Invoice to:
 
 - Governance docs, ADR 0001/0002/0009 ✅
 - Product vision scoped to reconciliation/dunning ✅
+- Scope contract + legal spine (ADR 0010–0013) ✅
+- Invoice upstream contract (hand-off to nene-invoice) ✅
 - NENE2 scaffold + `GET /health` 🔲 Issue #4+
-- Invoice upstream client contract 🔲
+- Professional review gate (税理士/公認会計士; 弁護士 for dunning) 🔲 before Phase 1/2
 
 ## Phase 1: Reconciliation API
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -28,9 +28,11 @@ Last updated: 2026-05-29
 ## Next steps
 
 1. Issue #4 — NENE2 runtime scaffold + `GET /health`
-2. Invoice upstream OpenAPI client (read invoices, write payments on match)
-3. Phase 1 — bank import + reconciliation API
-4. Phase 2 — admin UI + dunning
+2. Hand off [`invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md) → open implementation Issue in `nene-invoice`
+3. Secure professional review gate sign-off (税理士/公認会計士; 弁護士 for dunning) — compliance §9
+4. Invoice upstream OpenAPI client (read invoices, write payments on match)
+5. Phase 1 — bank import + reconciliation API
+6. Phase 2 — admin UI + dunning
 
 ## Handoff
 


### PR DESCRIPTION
Closes #11.

## Purpose

Make NeNe Clear's rules rock-solid for review by accountants / tax accountants (税理士 / 公認会計士) and, for dunning, lawyers (弁護士) — an explicit do/don't/goal charter plus a fuller legal spine with professional-review gates.

> Not legal advice. Rows touching tax/law name the statute; docs carry "confirm with 税理士/弁護士" gates. Statutory values must be verified at implementation.

## Change summary

**New — `docs/explanation/scope-contract.md`**
- Binding **GOAL**, **DO** (D1–D10), **DON'T** (X1–X15) — every DON'T tied to a statute or an owner
- "Easy to get wrong" clarifications (督促 ≠ 取立; overpayment is a liability; "mark uncollectible" is operational not accounting) + definition of done

**Expanded — `payment-reconciliation-dunning-compliance.md`**
- §0 realigned to the **system-of-record split** (Invoice owns payment/outstanding; Clear owns evidence + link)
- §1 statutory basis expanded: 法人税法/所得税法 保存, 民法 弁済充当/消滅時効/法定利率, 弁護士法72条/サービサー法, 印紙税 boundary
- §2.9 appropriation of payments (民法488–491; operator-directed, no silent auto)
- §3 電子帳簿保存法 detail: 真実性の確保 (訂正削除履歴方式) + 可視性の確保 / 検索要件 (取引年月日・取引金額・取引先, range, combinations)
- §4.8 self-collection boundary (弁護士法72条; 督促 ≠ 取立)
- §7 貸倒 not determined; §8 消滅時効 informational only; §9 professional review **gate** (who signs off, before which milestone)

**New ADRs**
- 0010 — Invoice is the payment system of record; Clear writes back idempotently
- 0011 — Dunning is self-collection support only; no automatic 遅延損害金 on balance
- 0012 — Electronic-records posture for imported bank data (電子帳簿保存法)
- 0013 — No journal entries / no 貸倒 determination; subledger + CSV export

**Synced** — CLAUDE.md canonical paths, README docs table, `adr.md` listing, `review/compliance.md` checklist, roadmap Phase 0, todo next-steps.

## Verification

- Compliance doc sections renumber cleanly 0–10; forward-refs (§7 貸倒, §8 消滅時効) match
- No broken relative links in new/changed docs

## Scope

Documentation only (Phase 0). The Invoice side is implemented later in `nene-invoice` (not edited here, ADR 0009).

## Self-review

docs-policy, compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)