### PR TITLE
docs: MCP tools catalog + policy and CSV export column design (#19)

### DIFF
--- a/docs/explanation/csv-export.md
+++ b/docs/explanation/csv-export.md
@@ -1,0 +1,101 @@
+# CSV Export — Accounting Handoff
+
+**Status: design (binding once a 税理士 signs off the columns — §9 gate).**
+
+NeNe Clear is a reconciliation subledger; it posts **no journal entries** and
+makes **no 貸倒 determination** ([ADR 0013](../adr/0013-no-journal-entries-no-bad-debt.md)).
+It hands reconciliation and payment data to the operator's accounting software
+and tax advisor (税理士) as **CSV** — they post the journals. This document
+defines the export columns.
+
+> Engineering's interpretation — **not legal advice**. The exact column set MUST
+> be confirmed with a 税理士 / 公認会計士 against their journal-import workflow
+> at the [§9 professional review gate](./payment-reconciliation-dunning-compliance.md).
+
+## Principles
+
+- **Evidence chain.** Every exported payment row links the bank line (証憑, owned
+  by Clear) to the upstream invoice and payment (帳簿, owned by NeNe Invoice).
+  An auditor can trace 帳簿 ↔ 証憑 one-to-one.
+- **Read snapshot.** Export is a read-only snapshot; it never mutates records.
+  Re-exporting the same range yields the same rows (plus any new activity).
+- **No journals, no tax math.** Tax figures are **copied from the upstream
+  invoice** (Clear never recomputes them). No debit/credit columns.
+- **Tenant-scoped.** Export is always scoped to the caller's `organization_id`.
+
+## Money & encoding
+
+- Amounts are exported as **integer minimum currency units** in `*_cents`
+  columns. For JPY (Phase 1–3) one unit = ¥1, so `amount_cents = 110000` is
+  ¥110,000. Column headers say `_cents` to prevent a 1/100-yen misread.
+- Encoding: **UTF-8 with BOM** by default (opens cleanly in Excel with Japanese
+  text). A **Shift_JIS (CP932)** option is available for accounting tools that
+  require it. Newlines `\r\n`; RFC 4180 quoting.
+- Dates as `YYYY-MM-DD`; timestamps as ISO 8601.
+
+## Export 1 — Reconciled payments (primary)
+
+One row per **allocation** (a portion of a bank deposit applied to one invoice).
+This is the row an accounting import consumes.
+
+| Column | Source | Notes |
+| --- | --- | --- |
+| `reconciliation_id` | Clear | `payment_reconciliation_id` |
+| `allocation_id` | Clear | `reconciliation_allocation_id` |
+| `status` | Clear | `confirmed` / `reversed` |
+| `invoice_id` | upstream | NeNe Invoice id |
+| `invoice_number` | upstream | e.g. `INV-2026-001` |
+| `client_id` | upstream | |
+| `issued_at` | upstream | invoice issue date |
+| `paid_at` | Clear → upstream | **bank value date** of the deposit (入金日) |
+| `amount_cents` | Clear | amount allocated to this invoice |
+| `invoice_total_cents` | upstream | copied, not recomputed |
+| `tax_breakdown` | upstream | copied as provided (opaque to Clear) |
+| `payment_id` | upstream | payment created in NeNe Invoice |
+| `external_reference` | Clear | `clear:recon:{id}` round-trip key |
+| `bank_transaction_id` | Clear | the deposit line (証憑) |
+| `value_date` | Clear | bank value date of the line |
+| `counterparty_text` | Clear | remitter / 摘要 |
+| `bank_account` | Clear | `bank_name` / `account_number` (registered account) |
+| `confirmed_at` / `confirmed_by` | Clear | actor + time |
+| `reversed_at` / `reversal_reason` | Clear | when `status = reversed` |
+
+Reversed allocations are **included** (not deleted) so the advisor sees the full
+history; the `status`/`reversed_at` columns mark them.
+
+## Export 2 — Client credits
+
+One row per overpayment credit (前受金/預り金 相当) and its applications.
+
+| Column | Source |
+| --- | --- |
+| `client_credit_id`, `client_id`, `status` | Clear |
+| `amount_cents`, `remaining_cents` | Clear |
+| `source_bank_transaction_id` | Clear |
+| `created_at` / `created_by` | Clear |
+
+## Export 3 — Bank import evidence (電帳法 companion)
+
+A faithful dump of imported deposit lines for the electronic-records trail
+(complements, does not replace, the in-app searchable store — compliance §3):
+`bank_import_batch_id`, `file_hash`, `source_filename`, `bank_transaction_id`,
+`value_date`, `amount_cents`, `counterparty_text`, `status`, `imported_at`.
+
+## Out of scope
+
+- Debit/credit journal columns, account codes, or a 仕訳 layout (ADR 0013).
+- Any 貸倒 / write-off classification column (§7 — Clear does not determine it).
+- Consumption-tax filing figures beyond copying the invoice's `tax_breakdown`.
+
+## Gate
+
+Before the export endpoint ships (Phase 1+), the columns above are reviewed with
+a 税理士 / 公認会計士 to confirm they map to the operator's journal-import
+workflow (compliance §9). Record sign-off in the milestone Issue.
+
+## Related
+
+- No journals / no bad debt: [ADR 0013](../adr/0013-no-journal-entries-no-bad-debt.md)
+- Compliance §5 (consumption tax relationship), §9 (review gate): [`payment-reconciliation-dunning-compliance.md`](./payment-reconciliation-dunning-compliance.md)
+- Contract (figures): [`../integrations/invoice-upstream-contract.md`](../integrations/invoice-upstream-contract.md)
+- Terminology (field spellings): [`./terminology.md`](./terminology.md)

--- a/docs/explanation/payment-reconciliation-dunning-compliance.md
+++ b/docs/explanation/payment-reconciliation-dunning-compliance.md
@@ -350,7 +350,7 @@ The system MUST:
 
 - Keep **issued invoice tax figures immutable** after issue
 - Record **payment dates** accurately for advisor export
-- Export CSV columns: invoice number, issue date, paid_at, amount_cents, tax breakdown (from invoice), match id
+- Export CSV columns: invoice number, issue date, paid_at, amount_cents, tax breakdown (from invoice), match id — full column design in [`csv-export.md`](./csv-export.md)
 
 Tax advisor uses export to prepare returns; NeNe Clear does not file.
 

--- a/docs/integrations/ai-tools.md
+++ b/docs/integrations/ai-tools.md
@@ -37,4 +37,4 @@ Agents must not commit:
 - Lead capture API gaps → Issue in **nene-concierge**.
 - Framework bugs → Issue in **NENE2**.
 
-See also: `docs/integrations/sibling-products.md`, ADR 0002.
+See also: `docs/integrations/mcp-tools.md` (tool catalog & policy), `docs/integrations/sibling-products.md`, ADR 0002.

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -1,0 +1,72 @@
+# MCP Tools — Catalog & Policy
+
+NeNe Clear exposes its operations to AI agents through an MCP tool catalog that
+mirrors the OpenAPI contract. This document is the policy; the catalog is
+[`../mcp/tools.json`](../mcp/tools.json).
+
+Follows NENE2 MCP policy (`docs/integrations/mcp-tools.md`, `endpoint-scaffold.md`)
+and Clear's [`nene2-compliance.md`](../development/nene2-compliance.md) §12.
+
+> MCP is for **operators and development agents**, not public/end-client use
+> ([`ai-tools.md`](./ai-tools.md)). Phase 4 on the roadmap; the catalog is
+> designed now because the contract exists.
+
+## Rules
+
+1. **Tool name = OpenAPI `operationId`, exactly.** `title` is short English Title
+   Case; `description` is safe and English. Each tool's `source` points to the
+   `operationId`/method/path in [`../openapi/openapi.yaml`](../openapi/openapi.yaml)
+   and a `responseSchemaRef`. Validate with `composer mcp`.
+2. **Read-only first.** Only tools that read (no side effects) are in the catalog
+   today — including `proposeMatch`, which is a POST but writes nothing.
+3. **Mutation tools are gated** (NENE2 rule): they are **not** added to
+   `tools.json` until authentication, capability checks, audit, request-id
+   propagation, and human confirmation are implemented and documented.
+4. **Human confirms, AI proposes** (compliance §2.8): an agent may call
+   `proposeMatch` to suggest, but **finalizing** a match, reversing one, applying
+   credit, importing, or sending dunning is a human-authorized action — never a
+   silent agent side effect.
+5. **No secrets in the catalog** (no tokens, keys, or `.env` values). The MCP
+   server holds the operator credential/scope out of band.
+
+## Read tools (in the catalog)
+
+`getHealth`, `listUnmatchedTransactions`, `listBankTransactions`,
+`getBankTransactionById`, `listBankImportBatches`, `getBankImportBatchById`,
+`listUpstreamInvoices`, `getUpstreamInvoiceById`, `proposeMatch`,
+`listReconciliations`, `getReconciliationById`, `listClientCredits`.
+
+All except `getHealth` require the configured operator bearer credential and the
+`view_reconciliation` capability; tenant scoping (`organization_id`) applies.
+
+## Gated write tools (NOT in the catalog yet)
+
+| Planned tool | operationId | Required before catalog entry |
+| --- | --- | --- |
+| Confirm match | `confirmMatch` | auth + `manage_reconciliation` + audit + request id + **explicit human confirmation**; writes payment upstream |
+| Reverse reconciliation | `reverseReconciliation` | same + reason recorded |
+| Apply client credit | `applyClientCredit` | same; explicit operator action only |
+| Import bank CSV | `importBankCsv` | auth + `manage_reconciliation` + audit; large-payload handling |
+| Reverse import batch | `reverseBankImportBatch` | same + reason recorded |
+| Send dunning notice | `sendDunningNotice` | **Phase 2**; auth + `send_dunning` + audit + min-interval + 弁護士-reviewed template (compliance §4) |
+
+Each gated tool, when introduced, ships with its OpenAPI security requirements,
+Problem Details responses, audit events, and a confirmation step — added in a
+focused Issue, not by default.
+
+## Validation
+
+```bash
+composer mcp        # validates tools.json against docs/openapi/openapi.yaml
+```
+
+Tool `operationId`, method, path, and `responseSchemaRef` must all resolve in the
+OpenAPI document, and names must match `operationId` exactly (terminology §5).
+
+## Related
+
+- Catalog: [`../mcp/tools.json`](../mcp/tools.json)
+- Contract: [`../openapi/openapi.yaml`](../openapi/openapi.yaml)
+- NENE2 compliance: [`../development/nene2-compliance.md`](../development/nene2-compliance.md) §12
+- AI tools policy: [`./ai-tools.md`](./ai-tools.md)
+- Human-confirms rule: [`../explanation/payment-reconciliation-dunning-compliance.md`](../explanation/payment-reconciliation-dunning-compliance.md) §2.8

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,0 +1,195 @@
+{
+  "version": 1,
+  "source": "docs/openapi/openapi.yaml",
+  "description": "NeNe Clear MCP tool catalog. Read-only tools only. Tool names mirror OpenAPI operationId exactly. Mutation tools (confirmMatch, reverseReconciliation, applyClientCredit, importBankCsv, reverseBankImportBatch, and Phase 2 sendDunningNotice) are intentionally absent until authentication, capability, audit, request-id, and human-confirmation behavior are implemented — see docs/integrations/mcp-tools.md.",
+  "tools": [
+    {
+      "name": "getHealth",
+      "title": "Health",
+      "description": "Read the health endpoint through the documented public API.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "getHealth", "method": "GET", "path": "/health" },
+      "inputSchema": { "type": "object", "additionalProperties": false, "properties": {} },
+      "responseSchemaRef": "#/components/schemas/HealthResponse"
+    },
+    {
+      "name": "listUnmatchedTransactions",
+      "title": "List Unmatched Transactions",
+      "description": "List bank deposit lines that are still unmatched or partially matched.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listUnmatchedTransactions", "method": "GET", "path": "/admin/bank-transactions/unmatched" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/BankTransactionListResponse"
+    },
+    {
+      "name": "listBankTransactions",
+      "title": "List Bank Transactions",
+      "description": "List imported bank deposit lines, searchable by date, amount, counterparty, and status.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listBankTransactions", "method": "GET", "path": "/admin/bank-transactions" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "status": { "type": "string", "enum": ["unmatched", "partially_matched", "matched", "voided"] },
+          "value_date_from": { "type": "string", "format": "date" },
+          "value_date_to": { "type": "string", "format": "date" },
+          "amount_min_cents": { "type": "integer" },
+          "amount_max_cents": { "type": "integer" },
+          "counterparty": { "type": "string" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/BankTransactionListResponse"
+    },
+    {
+      "name": "getBankTransactionById",
+      "title": "Get Bank Transaction",
+      "description": "Read a single imported bank deposit line by id.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "getBankTransactionById", "method": "GET", "path": "/admin/bank-transactions/{id}" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": { "id": { "type": "integer", "format": "int64" } }
+      },
+      "responseSchemaRef": "#/components/schemas/BankTransaction"
+    },
+    {
+      "name": "listBankImportBatches",
+      "title": "List Bank Import Batches",
+      "description": "List bank CSV import batches and their provenance.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listBankImportBatches", "method": "GET", "path": "/admin/bank-import-batches" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/BankImportBatchListResponse"
+    },
+    {
+      "name": "getBankImportBatchById",
+      "title": "Get Bank Import Batch",
+      "description": "Read a single bank CSV import batch by id.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "getBankImportBatchById", "method": "GET", "path": "/admin/bank-import-batches/{id}" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": { "id": { "type": "integer", "format": "int64" } }
+      },
+      "responseSchemaRef": "#/components/schemas/BankImportBatch"
+    },
+    {
+      "name": "listUpstreamInvoices",
+      "title": "List Upstream Invoices",
+      "description": "List open/overdue invoices with outstanding balances from the NeNe Invoice upstream (read-only proxy).",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listUpstreamInvoices", "method": "GET", "path": "/admin/upstream/invoices" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "status": { "type": "string", "enum": ["issued", "partially_paid", "paid"] },
+          "overdue": { "type": "boolean" },
+          "client_id": { "type": "integer", "format": "int64" },
+          "outstanding_gt": { "type": "integer", "format": "int64" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/UpstreamInvoiceListResponse"
+    },
+    {
+      "name": "getUpstreamInvoiceById",
+      "title": "Get Upstream Invoice",
+      "description": "Read a single upstream invoice by id (read-only proxy).",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "getUpstreamInvoiceById", "method": "GET", "path": "/admin/upstream/invoices/{id}" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": { "id": { "type": "integer", "format": "int64" } }
+      },
+      "responseSchemaRef": "#/components/schemas/UpstreamInvoice"
+    },
+    {
+      "name": "proposeMatch",
+      "title": "Propose Match",
+      "description": "Return ranked match suggestions for a bank transaction. Read-only: it writes nothing and finalizes nothing; a human must confirm separately.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "proposeMatch", "method": "POST", "path": "/admin/reconciliations/propose" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bank_transaction_id"],
+        "properties": { "bank_transaction_id": { "type": "integer", "format": "int64" } }
+      },
+      "responseSchemaRef": "#/components/schemas/ProposeMatchResponse"
+    },
+    {
+      "name": "listReconciliations",
+      "title": "List Reconciliations",
+      "description": "List confirmed and reversed reconciliations.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listReconciliations", "method": "GET", "path": "/admin/reconciliations" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "status": { "type": "string", "enum": ["confirmed", "reversed"] },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ReconciliationListResponse"
+    },
+    {
+      "name": "getReconciliationById",
+      "title": "Get Reconciliation",
+      "description": "Read a single reconciliation by id, including its allocations.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "getReconciliationById", "method": "GET", "path": "/admin/reconciliations/{id}" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": { "id": { "type": "integer", "format": "int64" } }
+      },
+      "responseSchemaRef": "#/components/schemas/Reconciliation"
+    },
+    {
+      "name": "listClientCredits",
+      "title": "List Client Credits",
+      "description": "List overpayment credit balances.",
+      "safety": "read",
+      "source": { "type": "openapi", "operationId": "listClientCredits", "method": "GET", "path": "/admin/client-credits" },
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "status": { "type": "string", "enum": ["open", "partially_applied", "applied"] },
+          "client_id": { "type": "integer", "format": "int64" },
+          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
+          "offset": { "type": "integer", "minimum": 0 }
+        }
+      },
+      "responseSchemaRef": "#/components/schemas/ClientCreditListResponse"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #19.

## Purpose

Close the remaining design (Phase C) before coding: the MCP tool catalog/policy and the CSV export columns for accounting handoff.

## Change summary

- **`docs/mcp/tools.json`** — read-only catalog of **12 tools** (NENE2 schema: name=operationId, title, description, safety, source, inputSchema, responseSchemaRef) mapping to the Phase 1 contract. Mutation tools intentionally absent until auth+capability+audit+human-confirmation exist (NENE2 rule).
- **`docs/integrations/mcp-tools.md`** — Clear MCP policy: read set, **gated write set** (`confirmMatch`/`reverseReconciliation`/`applyClientCredit`/`importBankCsv`; Phase 2 `sendDunningNotice`) with their requirements, the human-confirms / AI-proposes boundary (compliance §2.8), and `composer mcp` validation.
- **`docs/explanation/csv-export.md`** — accounting-handoff CSV columns (reconciled payments / client credits / bank evidence), money & encoding (cents, UTF-8 BOM / Shift_JIS option), the 帳簿↔証憑 evidence chain, **no journals / no 貸倒** (ADR 0013), and a 税理士 sign-off gate.
- Cross-linked from compliance §5 and `ai-tools.md`.

## Verification

```
tools.json parses OK; tools: 12
errors: none   (names=operationId, method/path/responseSchemaRef all resolve, all safety=read)
link check: clean
```

## Scope

Design only (Phase 0). The MCP server and export endpoint ship with implementation.

## Self-review

docs-policy, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)