### PR TITLE
feat: DB foundation + Organization/User domain + RBAC enums (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@
 !/public_html/admin/.htaccess
 /storage/
 /build/
+/database/*.sqlite
+/database/*.sqlite3
 /frontend/node_modules/
 /frontend/apps/*/dist/

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^13.1",
+        "robmorgan/phinx": "^0.16.11",
         "symfony/yaml": "^8.0"
     },
     "autoload": {
@@ -45,6 +46,9 @@
         "analyse": "phpstan analyse --memory-limit 512M",
         "cs": "php-cs-fixer check --diff --allow-risky=yes --config=.php-cs-fixer.php",
         "cs:fix": "php-cs-fixer fix --allow-risky=yes --config=.php-cs-fixer.php",
+        "migrations:status": "phinx status -c phinx.php",
+        "migrations:migrate": "phinx migrate -c phinx.php",
+        "migrations:rollback": "phinx rollback -c phinx.php",
         "check": [
             "@test",
             "@analyse",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6b84861bad979850ae3e61d82088fb2",
+    "content-hash": "929b9083c548cafbef6f32685b6129f4",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -1160,6 +1160,330 @@
     ],
     "packages-dev": [
         {
+            "name": "cakephp/chronos",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/chronos.git",
+                "reference": "e6e777b534244911566face8a5dbdbd7f7bda5a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/chronos/zipball/e6e777b534244911566face8a5dbdbd7f7bda5a6",
+                "reference": "e6e777b534244911566face8a5dbdbd7f7bda5a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^5.0",
+                "phpunit/phpunit": "^10.5.58 || ^11.5.3 || ^12.1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Chronos\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                },
+                {
+                    "name": "The CakePHP Team",
+                    "homepage": "https://cakephp.org"
+                }
+            ],
+            "description": "A simple API extension for DateTime.",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/chronos/issues",
+                "source": "https://github.com/cakephp/chronos"
+            },
+            "time": "2026-04-10T02:50:39+00:00"
+        },
+        {
+            "name": "cakephp/core",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/core.git",
+                "reference": "9c458b0e9322ec88bc4c758b33cde6a0abf49d12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/9c458b0e9322ec88bc4c758b33cde6a0abf49d12",
+                "reference": "9c458b0e9322ec88bc4c758b33cde6a0abf49d12",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/utility": "^5.3.0",
+                "league/container": "^5.1",
+                "php": ">=8.2",
+                "psr/container": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^2.0"
+            },
+            "suggest": {
+                "cakephp/cache": "To use Configure::store() and restore().",
+                "cakephp/event": "To use PluginApplicationInterface or plugin applications.",
+                "league/container": "To use Container and ServiceProvider classes"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Cake\\Core\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/core/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Framework Core classes",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "core",
+                "framework"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/core"
+            },
+            "time": "2026-05-15T03:31:14+00:00"
+        },
+        {
+            "name": "cakephp/database",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/database.git",
+                "reference": "442d12bf0a1edeffc555a59de9f955cb0619c7ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/442d12bf0a1edeffc555a59de9f955cb0619c7ca",
+                "reference": "442d12bf0a1edeffc555a59de9f955cb0619c7ca",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/chronos": "^3.3",
+                "cakephp/core": "^5.3.0",
+                "cakephp/datasource": "^5.3.0",
+                "php": ">=8.2",
+                "psr/log": "^3.0"
+            },
+            "require-dev": {
+                "cakephp/i18n": "^5.3.0",
+                "cakephp/log": "^5.3.0"
+            },
+            "suggest": {
+                "cakephp/i18n": "If you are using locale-aware datetime formats.",
+                "cakephp/log": "If you want to use query logging without providing a logger yourself."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Database\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/database/graphs/contributors"
+                }
+            ],
+            "description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "abstraction",
+                "cakephp",
+                "database",
+                "database abstraction",
+                "pdo"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/database"
+            },
+            "time": "2026-05-21T19:38:13+00:00"
+        },
+        {
+            "name": "cakephp/datasource",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/datasource.git",
+                "reference": "b768f0c0bf0fca815f83c4caef14e7fbb2409bf5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/b768f0c0bf0fca815f83c4caef14e7fbb2409bf5",
+                "reference": "b768f0c0bf0fca815f83c4caef14e7fbb2409bf5",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^5.3.0",
+                "php": ">=8.2",
+                "psr/simple-cache": "^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "cakephp/cache": "^5.3.0",
+                "cakephp/collection": "^5.3.0",
+                "cakephp/utility": "^5.3.0"
+            },
+            "suggest": {
+                "cakephp/cache": "If you decide to use Query caching.",
+                "cakephp/collection": "If you decide to use ResultSetInterface.",
+                "cakephp/utility": "If you decide to use EntityTrait."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Datasource\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/datasource/graphs/contributors"
+                }
+            ],
+            "description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "connection management",
+                "datasource",
+                "entity",
+                "query"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/datasource"
+            },
+            "time": "2026-05-20T10:27:33+00:00"
+        },
+        {
+            "name": "cakephp/utility",
+            "version": "5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/utility.git",
+                "reference": "4c703a010b9d955fed44731669e35d3043425cc7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/4c703a010b9d955fed44731669e35d3043425cc7",
+                "reference": "4c703a010b9d955fed44731669e35d3043425cc7",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^5.3.0",
+                "php": ">=8.2"
+            },
+            "suggest": {
+                "ext-intl": "To use Text::transliterate() or Text::slug()",
+                "lib-ICU": "To use Text::transliterate() or Text::slug()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-5.next": "5.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Cake\\Utility\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/utility/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "hash",
+                "inflector",
+                "security",
+                "string",
+                "utility"
+            ],
+            "support": {
+                "forum": "https://stackoverflow.com/tags/cakephp",
+                "irc": "irc://irc.freenode.org/cakephp",
+                "issues": "https://github.com/cakephp/cakephp/issues",
+                "source": "https://github.com/cakephp/utility"
+            },
+            "time": "2026-05-21T19:38:13+00:00"
+        },
+        {
             "name": "clue/ndjson-react",
             "version": "v1.3.0",
             "source": {
@@ -1726,6 +2050,90 @@
                 }
             ],
             "time": "2026-05-15T09:20:44+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "58accbc032f0090a9bd08326f93062c5a658b2c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/58accbc032f0090a9bd08326f93062c5a658b2c5",
+                "reference": "58accbc032f0090a9bd08326f93062c5a658b2c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "psr/container": "^2.0.2",
+                "psr/event-dispatcher": "^1.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "nette/php-generator": "^4.1",
+                "nikic/php-parser": "^5.0",
+                "phpstan/phpstan": "^2.1.11",
+                "phpunit/phpunit": "^10.5.45|^11.5.15|^12.0",
+                "roave/security-advisories": "dev-latest",
+                "scrutinizer/ocular": "^1.9",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-5.x": "5.x-dev",
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "mail@philbennett.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-19T18:52:39+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2502,6 +2910,54 @@
             "time": "2026-05-27T14:03:08+00:00"
         },
         {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
             "name": "psr/event-dispatcher",
             "version": "1.0.0",
             "source": {
@@ -2550,6 +3006,57 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "react/cache",
@@ -3076,6 +3583,93 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "robmorgan/phinx",
+            "version": "0.16.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/phinx.git",
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/a03014fea316ba021fc0776982e5bed2d10228d4",
+                "reference": "a03014fea316ba021fc0776982e5bed2d10228d4",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/database": "^5.0.2",
+                "composer-runtime-api": "^2.0",
+                "php-64bit": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/config": "^4.0|^5.0|^6.0|^7.0|^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "cakephp/cakephp-codesniffer": "^5.0",
+                "cakephp/i18n": "^5.0",
+                "ext-json": "*",
+                "ext-pdo": "*",
+                "phpunit/phpunit": "^10.5",
+                "symfony/yaml": "^4.0|^5.0|^6.0|^7.0|^8.0"
+            },
+            "suggest": {
+                "ext-json": "Install if using JSON configuration format",
+                "ext-pdo": "PDO extension is needed",
+                "symfony/yaml": "Install if using YAML configuration format"
+            },
+            "bin": [
+                "bin/phinx"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phinx\\": "src/Phinx/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Morgan",
+                    "email": "robbym@gmail.com",
+                    "homepage": "https://robmorgan.id.au",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com",
+                    "homepage": "https://shadowhand.me",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/phinx/graphs/contributors",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Phinx makes it ridiculously easy to manage the database migrations for your PHP app.",
+            "homepage": "https://phinx.org",
+            "keywords": [
+                "database",
+                "database migrations",
+                "db",
+                "migrations",
+                "phinx"
+            ],
+            "support": {
+                "issues": "https://github.com/cakephp/phinx/issues",
+                "source": "https://github.com/cakephp/phinx/tree/0.16.11"
+            },
+            "time": "2026-03-15T00:04:32+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4166,6 +4760,84 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "429783a0c649696f2058ea5ab5315f082dba6de9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/429783a0c649696f2058ea5ab5315f082dba6de9",
+                "reference": "429783a0c649696f2058ea5ab5315f082dba6de9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",

--- a/database/migrations/20260530120000_create_organizations_table.php
+++ b/database/migrations/20260530120000_create_organizations_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateOrganizationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Default Phinx `id` (auto-increment integer PK) for portability across
+        // MySQL (Tier A) and SQLite (tests/local).
+        $this->table('organizations')
+            ->addColumn('slug', 'string', ['limit' => 100, 'null' => false])
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addTimestamps()
+            ->addIndex(['slug'], ['unique' => true])
+            ->create();
+    }
+}

--- a/database/migrations/20260530120100_create_users_table.php
+++ b/database/migrations/20260530120100_create_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUsersTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Default Phinx `id` (auto-increment integer PK) for portability across
+        // MySQL (Tier A) and SQLite (tests/local).
+        $this->table('users')
+            ->addColumn('organization_id', 'integer', ['null' => true])
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('role', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('status', 'string', ['limit' => 32, 'null' => false, 'default' => 'active'])
+            ->addColumn('password_hash', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->addTimestamps()
+            ->addIndex(['organization_id', 'email'], ['unique' => true])
+            ->addIndex(['organization_id'])
+            ->create();
+    }
+}

--- a/database/schema/organizations.sql
+++ b/database/schema/organizations.sql
@@ -1,0 +1,11 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- Tenants (ADR 0006). Shown in portable form.
+CREATE TABLE organizations (
+    id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    slug          VARCHAR(100) NOT NULL,
+    name          VARCHAR(255) NOT NULL,
+    created_at    DATETIME NULL,
+    updated_at    DATETIME NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_organizations_slug (slug)
+);

--- a/database/schema/users.sql
+++ b/database/schema/users.sql
@@ -1,0 +1,17 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- Operator accounts. organization_id is NULL only for a cross-tenant superadmin.
+CREATE TABLE users (
+    id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    organization_id  BIGINT UNSIGNED NULL,
+    email            VARCHAR(255) NOT NULL,
+    role             VARCHAR(32) NOT NULL,
+    status           VARCHAR(32) NOT NULL DEFAULT 'active',
+    password_hash    VARCHAR(255) NOT NULL,
+    is_deleted       TINYINT(1) NOT NULL DEFAULT 0,
+    deleted_at       DATETIME NULL,
+    created_at       DATETIME NULL,
+    updated_at       DATETIME NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_users_organization_email (organization_id, email),
+    KEY idx_users_organization_id (organization_id)
+);

--- a/phinx.php
+++ b/phinx.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+// Phinx tooling config. Migration tooling is the config boundary, so raw env
+// access is allowed here (docs/development/nene2-compliance.md §15).
+// `composer check` does not run migrations; tests create their own schema.
+
+$adapter = getenv('DB_ADAPTER') ?: 'sqlite';
+
+$environment = $adapter === 'mysql'
+    ? [
+        'adapter' => 'mysql',
+        'host' => getenv('DB_HOST') ?: '127.0.0.1',
+        'name' => getenv('DB_NAME') ?: 'nene_clear',
+        'user' => getenv('DB_USER') ?: 'nene_clear',
+        'pass' => getenv('DB_PASSWORD') ?: 'nene_clear',
+        'port' => (int) (getenv('DB_PORT') ?: 3306),
+        'charset' => getenv('DB_CHARSET') ?: 'utf8mb4',
+    ]
+    : [
+        'adapter' => 'sqlite',
+        'name' => getenv('DB_NAME') ?: __DIR__ . '/database/nene_clear',
+    ];
+
+return [
+    'paths' => [
+        'migrations' => __DIR__ . '/database/migrations',
+        'seeds' => __DIR__ . '/database/seeds',
+    ],
+    'environments' => [
+        'default_migration_table' => 'phinxlog',
+        'default_environment' => 'local',
+        'local' => $environment,
+    ],
+];

--- a/src/Auth/Capability.php
+++ b/src/Auth/Capability.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+/**
+ * Reconciliation/dunning capabilities (ADR 0006). String values are canonical
+ * (docs/explanation/terminology.md §2) and stable.
+ */
+enum Capability: string
+{
+    case ManageOrganizations = 'manage_organizations';
+    case ManageUsers = 'manage_users';
+    case ManageClearSettings = 'manage_clear_settings';
+    case ManageReconciliation = 'manage_reconciliation';
+    case ViewReconciliation = 'view_reconciliation';
+    case SendDunning = 'send_dunning';
+}

--- a/src/Auth/Role.php
+++ b/src/Auth/Role.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+/**
+ * Operator roles (ADR 0006). String values are canonical
+ * (docs/explanation/terminology.md §2).
+ *
+ * - superadmin: cross-tenant; manages organizations
+ * - admin: single org; manages users, settings, reconciliation, dunning
+ * - member: single org; reconciliation operator, may send dunning
+ * - viewer: single org; read-only
+ */
+enum Role: string
+{
+    case Superadmin = 'superadmin';
+    case Admin = 'admin';
+    case Member = 'member';
+    case Viewer = 'viewer';
+
+    /**
+     * @return list<Capability>
+     */
+    public function capabilities(): array
+    {
+        return match ($this) {
+            self::Superadmin => Capability::cases(),
+            self::Admin => [
+                Capability::ManageUsers,
+                Capability::ManageClearSettings,
+                Capability::ManageReconciliation,
+                Capability::ViewReconciliation,
+                Capability::SendDunning,
+            ],
+            self::Member => [
+                Capability::ManageReconciliation,
+                Capability::ViewReconciliation,
+                Capability::SendDunning,
+            ],
+            self::Viewer => [
+                Capability::ViewReconciliation,
+            ],
+        };
+    }
+
+    public function has(Capability $capability): bool
+    {
+        return in_array($capability, $this->capabilities(), true);
+    }
+
+    public function isCrossTenant(): bool
+    {
+        return $this === self::Superadmin;
+    }
+}

--- a/src/Organization/CreateOrganizationInput.php
+++ b/src/Organization/CreateOrganizationInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class CreateOrganizationInput
+{
+    public function __construct(
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Organization/CreateOrganizationOutput.php
+++ b/src/Organization/CreateOrganizationOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class CreateOrganizationOutput
+{
+    public function __construct(
+        public int $id,
+        public string $slug,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(CreateOrganizationInput $input): CreateOrganizationOutput
+    {
+        if ($this->organizations->existsBySlug($input->slug)) {
+            throw new OrganizationAlreadyExistsException($input->slug);
+        }
+
+        $id = $this->organizations->save(new Organization(slug: $input->slug, name: $input->name));
+
+        return new CreateOrganizationOutput(id: $id, slug: $input->slug, name: $input->name);
+    }
+}

--- a/src/Organization/CreateOrganizationUseCaseInterface.php
+++ b/src/Organization/CreateOrganizationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+interface CreateOrganizationUseCaseInterface
+{
+    public function execute(CreateOrganizationInput $input): CreateOrganizationOutput;
+}

--- a/src/Organization/Organization.php
+++ b/src/Organization/Organization.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+/**
+ * The tenant (ADR 0006). `id` is null before persistence.
+ */
+final readonly class Organization
+{
+    public function __construct(
+        public string $slug,
+        public string $name,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Organization/OrganizationAlreadyExistsException.php
+++ b/src/Organization/OrganizationAlreadyExistsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use RuntimeException;
+
+final class OrganizationAlreadyExistsException extends RuntimeException
+{
+    public function __construct(public readonly string $slug)
+    {
+        parent::__construct(sprintf('An organization with slug "%s" already exists.', $slug));
+    }
+}

--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+interface OrganizationRepositoryInterface
+{
+    public function findById(int $id): ?Organization;
+
+    public function findBySlug(string $slug): ?Organization;
+
+    public function existsBySlug(string $slug): bool;
+
+    /**
+     * @return list<Organization>
+     */
+    public function findAll(int $limit, int $offset): array;
+
+    public function countAll(): int;
+
+    public function save(Organization $organization): int;
+
+    public function delete(int $id): void;
+}

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, slug, name FROM organizations WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function findBySlug(string $slug): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, slug, name FROM organizations WHERE slug = ?',
+            [$slug],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return $this->query->fetchOne('SELECT 1 FROM organizations WHERE slug = ?', [$slug]) !== null;
+    }
+
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id, slug, name FROM organizations ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countAll(): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM organizations');
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function save(Organization $organization): int
+    {
+        if ($organization->id !== null) {
+            $this->query->execute(
+                'UPDATE organizations SET slug = ?, name = ? WHERE id = ?',
+                [$organization->slug, $organization->name, $organization->id],
+            );
+
+            return $organization->id;
+        }
+
+        $this->query->execute(
+            'INSERT INTO organizations (slug, name) VALUES (?, ?)',
+            [$organization->slug, $organization->name],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function delete(int $id): void
+    {
+        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): Organization
+    {
+        return new Organization(
+            slug: (string) $row['slug'],
+            name: (string) $row['name'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/User/PdoUserRepository.php
+++ b/src/User/PdoUserRepository.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\Auth\Role;
+
+final readonly class PdoUserRepository implements UserRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, email, role, status, password_hash';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE email = ? AND is_deleted = 0',
+            [$email],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function existsByEmail(string $email): bool
+    {
+        return $this->query->fetchOne(
+            'SELECT 1 FROM users WHERE email = ? AND is_deleted = 0',
+            [$email],
+        ) !== null;
+    }
+
+    public function findAllByOrganization(?int $organizationId, int $limit, int $offset): array
+    {
+        if ($organizationId === null) {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id IS NULL AND is_deleted = 0 '
+                . 'ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id = ? AND is_deleted = 0 '
+                . 'ORDER BY id ASC LIMIT ? OFFSET ?',
+                [$organizationId, $limit, $offset],
+            );
+        }
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(?int $organizationId): int
+    {
+        $row = $organizationId === null
+            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id IS NULL AND is_deleted = 0')
+            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id = ? AND is_deleted = 0', [$organizationId]);
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function save(User $user): int
+    {
+        if ($user->id !== null) {
+            $this->query->execute(
+                'UPDATE users SET organization_id = ?, email = ?, role = ?, status = ?, password_hash = ? WHERE id = ?',
+                [$user->organizationId, $user->email, $user->role->value, $user->status->value, $user->passwordHash, $user->id],
+            );
+
+            return $user->id;
+        }
+
+        $this->query->execute(
+            'INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (?, ?, ?, ?, ?, 0)',
+            [$user->organizationId, $user->email, $user->role->value, $user->status->value, $user->passwordHash],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function delete(int $id): void
+    {
+        // Soft delete — financial/audit context never hard-deletes accounts.
+        $this->query->execute('UPDATE users SET is_deleted = 1, deleted_at = ? WHERE id = ?', [date('Y-m-d H:i:s'), $id]);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): User
+    {
+        $organizationId = $row['organization_id'] ?? null;
+
+        return new User(
+            email: (string) $row['email'],
+            role: Role::from((string) $row['role']),
+            status: UserStatus::from((string) $row['status']),
+            passwordHash: (string) $row['password_hash'],
+            organizationId: $organizationId !== null ? (int) $organizationId : null,
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/User/User.php
+++ b/src/User/User.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use NeneClear\Auth\Role;
+
+/**
+ * Operator account. `organizationId` is null only for a cross-tenant superadmin
+ * (ADR 0006). `id` is null before persistence.
+ */
+final readonly class User
+{
+    public function __construct(
+        public string $email,
+        public Role $role,
+        public UserStatus $status,
+        public string $passwordHash,
+        public ?int $organizationId = null,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/User/UserRepositoryInterface.php
+++ b/src/User/UserRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface UserRepositoryInterface
+{
+    public function findById(int $id): ?User;
+
+    public function findByEmail(string $email): ?User;
+
+    public function existsByEmail(string $email): bool;
+
+    /**
+     * @return list<User>
+     */
+    public function findAllByOrganization(?int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(?int $organizationId): int;
+
+    public function save(User $user): int;
+
+    public function delete(int $id): void;
+}

--- a/src/User/UserStatus.php
+++ b/src/User/UserStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * User account status (terminology.md §2).
+ */
+enum UserStatus: string
+{
+    case Active = 'active';
+    case Invited = 'invited';
+}

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Auth;
+
+use NeneClear\Auth\Capability;
+use NeneClear\Auth\Role;
+use PHPUnit\Framework\TestCase;
+
+final class RoleTest extends TestCase
+{
+    public function test_superadmin_has_manage_organizations_and_is_cross_tenant(): void
+    {
+        self::assertTrue(Role::Superadmin->has(Capability::ManageOrganizations));
+        self::assertTrue(Role::Superadmin->isCrossTenant());
+    }
+
+    public function test_admin_manages_users_but_not_organizations(): void
+    {
+        self::assertTrue(Role::Admin->has(Capability::ManageUsers));
+        self::assertTrue(Role::Admin->has(Capability::ManageReconciliation));
+        self::assertFalse(Role::Admin->has(Capability::ManageOrganizations));
+        self::assertFalse(Role::Admin->isCrossTenant());
+    }
+
+    public function test_member_can_reconcile_but_not_manage_users(): void
+    {
+        self::assertTrue(Role::Member->has(Capability::ManageReconciliation));
+        self::assertTrue(Role::Member->has(Capability::SendDunning));
+        self::assertFalse(Role::Member->has(Capability::ManageUsers));
+    }
+
+    public function test_viewer_is_read_only(): void
+    {
+        self::assertTrue(Role::Viewer->has(Capability::ViewReconciliation));
+        self::assertFalse(Role::Viewer->has(Capability::ManageReconciliation));
+        self::assertFalse(Role::Viewer->has(Capability::SendDunning));
+    }
+}

--- a/tests/Database/PdoOrganizationRepositoryTest.php
+++ b/tests/Database/PdoOrganizationRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Organization\Organization;
+use NeneClear\Organization\PdoOrganizationRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoOrganizationRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-org-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
+        SchemaFixture::createOrganizations($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function test_save_then_find_by_id_and_slug(): void
+    {
+        $repo = new PdoOrganizationRepository($this->query);
+        $id = $repo->save(new Organization(slug: 'acme', name: 'Acme Co'));
+
+        self::assertGreaterThan(0, $id);
+
+        $byId = $repo->findById($id);
+        self::assertNotNull($byId);
+        self::assertSame('acme', $byId->slug);
+        self::assertSame('Acme Co', $byId->name);
+
+        $bySlug = $repo->findBySlug('acme');
+        self::assertNotNull($bySlug);
+        self::assertSame($id, $bySlug->id);
+    }
+
+    public function test_exists_count_list_and_delete(): void
+    {
+        $repo = new PdoOrganizationRepository($this->query);
+        $repo->save(new Organization(slug: 'a', name: 'A'));
+        $second = $repo->save(new Organization(slug: 'b', name: 'B'));
+
+        self::assertTrue($repo->existsBySlug('a'));
+        self::assertFalse($repo->existsBySlug('zzz'));
+        self::assertSame(2, $repo->countAll());
+        self::assertCount(2, $repo->findAll(50, 0));
+
+        $repo->delete($second);
+        self::assertSame(1, $repo->countAll());
+        self::assertNull($repo->findById($second));
+    }
+
+    public function test_find_by_id_returns_null_when_absent(): void
+    {
+        $repo = new PdoOrganizationRepository($this->query);
+
+        self::assertNull($repo->findById(99999));
+    }
+}

--- a/tests/Database/PdoUserRepositoryTest.php
+++ b/tests/Database/PdoUserRepositoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class PdoUserRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-user-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
+        SchemaFixture::createUsers($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function test_save_round_trips_role_status_and_organization(): void
+    {
+        $repo = new PdoUserRepository($this->query);
+        $id = $repo->save(new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: 'hash',
+            organizationId: 7,
+        ));
+
+        $user = $repo->findById($id);
+        self::assertNotNull($user);
+        self::assertSame('admin@acme.example', $user->email);
+        self::assertSame(Role::Admin, $user->role);
+        self::assertSame(UserStatus::Active, $user->status);
+        self::assertSame(7, $user->organizationId);
+    }
+
+    public function test_superadmin_has_null_organization(): void
+    {
+        $repo = new PdoUserRepository($this->query);
+        $id = $repo->save(new User(
+            email: 'root@platform.example',
+            role: Role::Superadmin,
+            status: UserStatus::Active,
+            passwordHash: 'hash',
+            organizationId: null,
+        ));
+
+        $user = $repo->findById($id);
+        self::assertNotNull($user);
+        self::assertNull($user->organizationId);
+        self::assertSame(1, $repo->countByOrganization(null));
+    }
+
+    public function test_soft_delete_excludes_user_and_find_by_email(): void
+    {
+        $repo = new PdoUserRepository($this->query);
+        $id = $repo->save(new User(
+            email: 'member@acme.example',
+            role: Role::Member,
+            status: UserStatus::Invited,
+            passwordHash: 'hash',
+            organizationId: 7,
+        ));
+
+        self::assertTrue($repo->existsByEmail('member@acme.example'));
+        self::assertNotNull($repo->findByEmail('member@acme.example'));
+
+        $repo->delete($id);
+
+        self::assertFalse($repo->existsByEmail('member@acme.example'));
+        self::assertNull($repo->findById($id));
+        self::assertSame(0, $repo->countByOrganization(7));
+    }
+}

--- a/tests/Organization/CreateOrganizationUseCaseTest.php
+++ b/tests/Organization/CreateOrganizationUseCaseTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Organization;
+
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationUseCase;
+use NeneClear\Organization\Organization;
+use NeneClear\Organization\OrganizationAlreadyExistsException;
+use PHPUnit\Framework\TestCase;
+
+final class CreateOrganizationUseCaseTest extends TestCase
+{
+    public function test_creates_organization_and_returns_output_with_id(): void
+    {
+        $repo = new InMemoryOrganizationRepository();
+        $useCase = new CreateOrganizationUseCase($repo);
+
+        $output = $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Co'));
+
+        self::assertGreaterThan(0, $output->id);
+        self::assertSame('acme', $output->slug);
+        self::assertSame('Acme Co', $output->name);
+        self::assertNotNull($repo->findBySlug('acme'));
+    }
+
+    public function test_rejects_duplicate_slug(): void
+    {
+        $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
+        $useCase = new CreateOrganizationUseCase($repo);
+
+        $this->expectException(OrganizationAlreadyExistsException::class);
+
+        $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Again'));
+    }
+}

--- a/tests/Organization/InMemoryOrganizationRepository.php
+++ b/tests/Organization/InMemoryOrganizationRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Organization;
+
+use NeneClear\Organization\Organization;
+use NeneClear\Organization\OrganizationRepositoryInterface;
+
+final class InMemoryOrganizationRepository implements OrganizationRepositoryInterface
+{
+    /** @var array<int, Organization> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    /**
+     * @param list<Organization> $seed
+     */
+    public function __construct(array $seed = [])
+    {
+        foreach ($seed as $organization) {
+            $this->save($organization);
+        }
+    }
+
+    public function findById(int $id): ?Organization
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findBySlug(string $slug): ?Organization
+    {
+        foreach ($this->byId as $organization) {
+            if ($organization->slug === $slug) {
+                return $organization;
+            }
+        }
+
+        return null;
+    }
+
+    public function existsBySlug(string $slug): bool
+    {
+        return $this->findBySlug($slug) !== null;
+    }
+
+    public function findAll(int $limit, int $offset): array
+    {
+        return array_slice(array_values($this->byId), $offset, $limit);
+    }
+
+    public function countAll(): int
+    {
+        return count($this->byId);
+    }
+
+    public function save(Organization $organization): int
+    {
+        $id = $organization->id ?? $this->nextId++;
+        $this->byId[$id] = new Organization(slug: $organization->slug, name: $organization->name, id: $id);
+
+        return $id;
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->byId[$id]);
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Support;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Creates SQLite test schema inline (the NENE2 test-database strategy: each test
+ * builds its own schema). Mirrors the Phinx migrations under database/migrations/.
+ */
+final class SchemaFixture
+{
+    public static function createOrganizations(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE organizations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                slug TEXT NOT NULL UNIQUE,
+                name TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT
+            )'
+        );
+    }
+
+    public static function createUsers(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER,
+                email TEXT NOT NULL,
+                role TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT \'active\',
+                password_hash TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                deleted_at TEXT,
+                created_at TEXT,
+                updated_at TEXT
+            )'
+        );
+    }
+}


### PR DESCRIPTION
Closes #23.

## Purpose

Phase 1 foundation (B-2): persistence + the two master entities and the RBAC enums every admin route builds on.

## Change summary

- **Auth** — `Role` / `Capability` enums with the ADR 0006 capability mapping (`has()`, `isCrossTenant()`).
- **Organization** — entity, repository interface, `PdoOrganizationRepository`, `CreateOrganizationUseCase` + `OrganizationAlreadyExistsException`.
- **User** — entity, `UserStatus` enum, repository interface, `PdoUserRepository` (org-scoped, soft delete, role/status round-trip; `organization_id` NULL for superadmin).
- **Schema** — Phinx migrations + `database/schema/*.sql` snapshots for `organizations`, `users` (portable integer PK so they apply on both MySQL and SQLite); `phinx.php`; `migrations:*` scripts.
- **Tests** — Role mapping (unit), CreateOrganization (in-memory repo double), PDO adapters (SQLite via `DatabaseTestKit`, schema created inline per the NENE2 test strategy).

## Verification

```
composer check → OK (14 tests, 57 assertions); PHPStan: No errors; CS: clean
phinx migrate (SQLite) → organizations, users created
```

## Conventions

Follows `docs/development/nene2-compliance.md`: Handler→UseCase→Repository, `DatabaseQueryExecutorInterface` (no raw PDO), domain-grouped folders, identifiers per `terminology.md`. Note: ids are integer-autoincrement (Phinx default) for SQLite/MySQL portability rather than BIGINT — revisit if scale requires.

## Scope

DB + master data + enums. Auth (login/JWT/middleware) is the next slice (B-3).

## Self-review

backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)