### PR TITLE
feat: auth domain — JWT token service + LoginUseCase (#25)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
+        "firebase/php-jwt": "^7",
         "hideyukimori/nene2": "@dev"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,72 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "929b9083c548cafbef6f32685b6129f4",
+    "content-hash": "c8d0beaf863bdbebc366f7ace7b375d6",
     "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v7.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.0.5"
+            },
+            "time": "2026-04-01T20:38:03+00:00"
+        },
         {
             "name": "graham-campbell/result-type",
             "version": "v1.1.4",

--- a/src/Auth/InvalidCredentialsException.php
+++ b/src/Auth/InvalidCredentialsException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use RuntimeException;
+
+/**
+ * Login failed. The message is intentionally generic so it never reveals
+ * whether the email exists.
+ */
+final class InvalidCredentialsException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Email or password is incorrect.');
+    }
+}

--- a/src/Auth/JwtTokenService.php
+++ b/src/Auth/JwtTokenService.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Nene2\Auth\TokenVerificationException;
+use Nene2\Auth\TokenVerifierInterface;
+use NeneClear\User\User;
+use Throwable;
+
+/**
+ * Issues and verifies HS256 JWTs for operator authentication.
+ *
+ * Implements the framework {@see TokenVerifierInterface} so it plugs directly
+ * into {@see \Nene2\Auth\BearerTokenMiddleware}. Claims: `sub` (user id),
+ * `org` (organization id or null), `role`, `iat`, `exp`.
+ */
+final readonly class JwtTokenService implements TokenIssuerInterface, TokenVerifierInterface
+{
+    private const string ALGORITHM = 'HS256';
+
+    public function __construct(
+        private string $secret,
+        private int $ttlSeconds = 3600,
+    ) {
+    }
+
+    public function issueForUser(User $user): string
+    {
+        $now = time();
+
+        return JWT::encode(
+            [
+                'sub' => $user->id,
+                'org' => $user->organizationId,
+                'role' => $user->role->value,
+                'iat' => $now,
+                'exp' => $now + $this->ttlSeconds,
+            ],
+            $this->secret,
+            self::ALGORITHM,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws TokenVerificationException
+     */
+    public function verify(string $token): array
+    {
+        try {
+            $decoded = JWT::decode($token, new Key($this->secret, self::ALGORITHM));
+        } catch (Throwable $e) {
+            throw new TokenVerificationException($e->getMessage(), previous: $e);
+        }
+
+        return (array) $decoded;
+    }
+}

--- a/src/Auth/LoginInput.php
+++ b/src/Auth/LoginInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+final readonly class LoginInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+    ) {
+    }
+}

--- a/src/Auth/LoginOutput.php
+++ b/src/Auth/LoginOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+final readonly class LoginOutput
+{
+    public function __construct(
+        public string $token,
+        public int $userId,
+        public string $email,
+        public string $role,
+        public ?int $organizationId,
+    ) {
+    }
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use NeneClear\User\UserRepositoryInterface;
+use NeneClear\User\UserStatus;
+
+final readonly class LoginUseCase implements LoginUseCaseInterface
+{
+    /**
+     * A valid bcrypt hash used to equalize timing when the email is unknown,
+     * so a failed login does not reveal whether the account exists.
+     */
+    private const string TIMING_EQUALIZER_HASH = '$2y$12$zIm0IdtQKFLbeCP4lZhm7upwJ7hz/JAj4krfZ53eGCIVzLq82RwP6';
+
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface $tokens,
+    ) {
+    }
+
+    public function execute(LoginInput $input): LoginOutput
+    {
+        $user = $this->users->findByEmail($input->email);
+
+        $hash = $user !== null ? $user->passwordHash : self::TIMING_EQUALIZER_HASH;
+        $passwordMatches = password_verify($input->password, $hash);
+
+        if ($user === null || $user->status !== UserStatus::Active || !$passwordMatches) {
+            throw new InvalidCredentialsException();
+        }
+
+        return new LoginOutput(
+            token: $this->tokens->issueForUser($user),
+            userId: (int) $user->id,
+            email: $user->email,
+            role: $user->role->value,
+            organizationId: $user->organizationId,
+        );
+    }
+}

--- a/src/Auth/LoginUseCaseInterface.php
+++ b/src/Auth/LoginUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+interface LoginUseCaseInterface
+{
+    public function execute(LoginInput $input): LoginOutput;
+}

--- a/src/Auth/TokenIssuerInterface.php
+++ b/src/Auth/TokenIssuerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use NeneClear\User\User;
+
+interface TokenIssuerInterface
+{
+    public function issueForUser(User $user): string;
+}

--- a/tests/Auth/JwtTokenServiceTest.php
+++ b/tests/Auth/JwtTokenServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Auth;
+
+use Nene2\Auth\TokenVerificationException;
+use NeneClear\Auth\JwtTokenService;
+use NeneClear\Auth\Role;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class JwtTokenServiceTest extends TestCase
+{
+    private function user(): User
+    {
+        return new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: 'hash',
+            organizationId: 7,
+            id: 42,
+        );
+    }
+
+    public function test_issue_then_verify_round_trips_claims(): void
+    {
+        $service = new JwtTokenService(secret: 'test-secret-test-secret-32chars!', ttlSeconds: 3600);
+
+        $claims = $service->verify($service->issueForUser($this->user()));
+
+        self::assertSame(42, $claims['sub'] ?? null);
+        self::assertSame(7, $claims['org'] ?? null);
+        self::assertSame('admin', $claims['role'] ?? null);
+    }
+
+    public function test_verify_rejects_expired_token(): void
+    {
+        $service = new JwtTokenService(secret: 'test-secret-test-secret-32chars!', ttlSeconds: -10);
+        $expired = $service->issueForUser($this->user());
+
+        $this->expectException(TokenVerificationException::class);
+        $service->verify($expired);
+    }
+
+    public function test_verify_rejects_token_signed_with_other_secret(): void
+    {
+        $issuer = new JwtTokenService(secret: 'secret-one-secret-one-secret-one!', ttlSeconds: 3600);
+        $verifier = new JwtTokenService(secret: 'secret-two-secret-two-secret-two!', ttlSeconds: 3600);
+
+        $this->expectException(TokenVerificationException::class);
+        $verifier->verify($issuer->issueForUser($this->user()));
+    }
+}

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Auth;
+
+use NeneClear\Auth\InvalidCredentialsException;
+use NeneClear\Auth\JwtTokenService;
+use NeneClear\Auth\LoginInput;
+use NeneClear\Auth\LoginUseCase;
+use NeneClear\Auth\Role;
+use NeneClear\Tests\User\InMemoryUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class LoginUseCaseTest extends TestCase
+{
+    private function useCase(InMemoryUserRepository $users): LoginUseCase
+    {
+        return new LoginUseCase($users, new JwtTokenService(secret: 'test-secret-test-secret-32chars!'));
+    }
+
+    private function activeUser(string $password): User
+    {
+        return new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: password_hash($password, PASSWORD_BCRYPT),
+            organizationId: 7,
+        );
+    }
+
+    public function test_successful_login_returns_token_and_user(): void
+    {
+        $users = new InMemoryUserRepository([$this->activeUser('correct horse')]);
+        $output = $this->useCase($users)->execute(new LoginInput('admin@acme.example', 'correct horse'));
+
+        self::assertNotSame('', $output->token);
+        self::assertSame('admin@acme.example', $output->email);
+        self::assertSame('admin', $output->role);
+        self::assertSame(7, $output->organizationId);
+    }
+
+    public function test_wrong_password_is_rejected(): void
+    {
+        $users = new InMemoryUserRepository([$this->activeUser('correct horse')]);
+
+        $this->expectException(InvalidCredentialsException::class);
+        $this->useCase($users)->execute(new LoginInput('admin@acme.example', 'wrong'));
+    }
+
+    public function test_unknown_email_is_rejected(): void
+    {
+        $users = new InMemoryUserRepository();
+
+        $this->expectException(InvalidCredentialsException::class);
+        $this->useCase($users)->execute(new LoginInput('nobody@acme.example', 'whatever'));
+    }
+
+    public function test_invited_user_cannot_log_in(): void
+    {
+        $invited = new User(
+            email: 'invited@acme.example',
+            role: Role::Member,
+            status: UserStatus::Invited,
+            passwordHash: password_hash('correct horse', PASSWORD_BCRYPT),
+            organizationId: 7,
+        );
+        $users = new InMemoryUserRepository([$invited]);
+
+        $this->expectException(InvalidCredentialsException::class);
+        $this->useCase($users)->execute(new LoginInput('invited@acme.example', 'correct horse'));
+    }
+}

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\User\User;
+use NeneClear\User\UserRepositoryInterface;
+
+final class InMemoryUserRepository implements UserRepositoryInterface
+{
+    /** @var array<int, User> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    /**
+     * @param list<User> $seed
+     */
+    public function __construct(array $seed = [])
+    {
+        foreach ($seed as $user) {
+            $this->save($user);
+        }
+    }
+
+    public function findById(int $id): ?User
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        foreach ($this->byId as $user) {
+            if ($user->email === $email) {
+                return $user;
+            }
+        }
+
+        return null;
+    }
+
+    public function existsByEmail(string $email): bool
+    {
+        return $this->findByEmail($email) !== null;
+    }
+
+    public function findAllByOrganization(?int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (User $user): bool => $user->organizationId === $organizationId,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(?int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (User $user): bool => $user->organizationId === $organizationId,
+        ));
+    }
+
+    public function save(User $user): int
+    {
+        $id = $user->id ?? $this->nextId++;
+        $this->byId[$id] = new User(
+            email: $user->email,
+            role: $user->role,
+            status: $user->status,
+            passwordHash: $user->passwordHash,
+            organizationId: $user->organizationId,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function delete(int $id): void
+    {
+        unset($this->byId[$id]);
+    }
+}


### PR DESCRIPTION
Closes #25.

## Purpose

Authentication core (B-3) as unit-tested domain, so the later HTTP pipeline wiring is low-risk.

## Change summary

- **`firebase/php-jwt` ^7** — chosen over ^6 to clear CVE-2025-45769 (weak encryption, affects `<7.0.0`).
- **`JwtTokenService`** — HS256 issue/verify; implements `Nene2\Auth\TokenVerifierInterface` (plugs straight into `BearerTokenMiddleware`) and a local `TokenIssuerInterface`; claims `sub`/`org`/`role`/`iat`/`exp`.
- **`LoginUseCase`** — find by email, **constant-time** `password_verify` (timing equalizer hash so a failed login never reveals whether the account exists), require `active` status, issue token; `InvalidCredentialsException` with a generic message.
- **`InMemoryUserRepository`** test double.
- **Tests** — JWT round-trip / expiry / wrong-secret; login success / wrong password / unknown email / invited user.

## Verification

```
composer check → OK (21 tests, 69 assertions); PHPStan: No errors; CS: clean
composer audit → No advisories
```

## Scope

Auth domain only. HTTP wiring (BearerTokenMiddleware path config + DB runtime + `login`/`getCurrentUser` routes) is the next integration slice.

## Self-review

backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)