### PR TITLE
feat: auth HTTP wiring — login + me over the pipeline (#27)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -3,6 +3,10 @@
 declare(strict_types=1);
 
 use Dotenv\Dotenv;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Http\ResponseEmitter;
 use NeneClear\Http\ApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -17,9 +21,43 @@ if (is_file($root . '/.env')) {
     Dotenv::createImmutable($root)->safeLoad();
 }
 
-$debug = (($_ENV['APP_DEBUG'] ?? getenv('APP_DEBUG') ?: 'false')) === 'true';
+$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
 
-$application = ApplicationFactory::create(debug: $debug, allowedOrigins: []);
+$debug = $env('APP_DEBUG', 'false') === 'true';
+$jwtSecret = $env('NENE_CLEAR_JWT_SECRET') ?: null;
+
+// Resilient DB wiring: if the database is unconfigured or unreachable, the app
+// still boots and serves /health. Authenticated routes activate only when both
+// the executor and a JWT secret are available (see ApplicationFactory).
+$query = (static function () use ($env): ?DatabaseQueryExecutorInterface {
+    try {
+        $adapter = $env('DB_ADAPTER', 'sqlite');
+        $config = $adapter === 'mysql'
+            ? new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'mysql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '3306'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8mb4'),
+            )
+            : DatabaseConfig::sqlite($env('DB_NAME') ?: dirname(__DIR__) . '/database/nene_clear.sqlite3');
+
+        return new PdoDatabaseQueryExecutor(new PdoConnectionFactory($config));
+    } catch (\Throwable) {
+        return null;
+    }
+})();
+
+$application = ApplicationFactory::create(
+    debug: $debug,
+    allowedOrigins: [],
+    query: $query,
+    jwtSecret: $jwtSecret,
+);
 
 $psr17 = new Psr17Factory();
 $request = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();

--- a/src/Auth/AuthRouteRegistrar.php
+++ b/src/Auth/AuthRouteRegistrar.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AuthRouteRegistrar
+{
+    public function __construct(
+        private LoginHandler $loginHandler,
+        private GetCurrentUserHandler $currentUserHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $loginHandler = $this->loginHandler;
+        $currentUserHandler = $this->currentUserHandler;
+
+        $router->post('/admin/auth/login', static fn (ServerRequestInterface $r): ResponseInterface => $loginHandler->handle($r));
+        $router->get('/admin/auth/me', static fn (ServerRequestInterface $r): ResponseInterface => $currentUserHandler->handle($r));
+    }
+}

--- a/src/Auth/GetCurrentUserHandler.php
+++ b/src/Auth/GetCurrentUserHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\User\UserRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetCurrentUserHandler
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private JsonResponseFactory $response,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $claims = (array) $request->getAttribute('nene2.auth.claims', []);
+        $sub = $claims['sub'] ?? null;
+        $userId = is_int($sub) ? $sub : (is_numeric($sub) ? (int) $sub : 0);
+
+        $user = $userId > 0 ? $this->users->findById($userId) : null;
+
+        if ($user === null) {
+            return $this->problemDetails->create(
+                $request,
+                'unauthorized',
+                'Unauthorized',
+                401,
+                'The authenticated user no longer exists.',
+            );
+        }
+
+        return $this->response->create([
+            'user_id' => $user->id,
+            'organization_id' => $user->organizationId,
+            'email' => $user->email,
+            'role' => $user->role->value,
+            'status' => $user->status->value,
+        ]);
+    }
+}

--- a/src/Auth/InvalidCredentialsExceptionHandler.php
+++ b/src/Auth/InvalidCredentialsExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidCredentialsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidCredentialsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-credentials',
+            'Invalid Credentials',
+            401,
+            'Email or password is incorrect.',
+        );
+    }
+}

--- a/src/Auth/LoginHandler.php
+++ b/src/Auth/LoginHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class LoginHandler
+{
+    public function __construct(
+        private LoginUseCaseInterface $login,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $email = trim((string) ($body['email'] ?? ''));
+        $password = (string) ($body['password'] ?? '');
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->login->execute(new LoginInput(email: $email, password: $password));
+
+        return $this->response->create([
+            'token' => $output->token,
+            'user' => [
+                'user_id' => $output->userId,
+                'email' => $output->email,
+                'role' => $output->role,
+                'organization_id' => $output->organizationId,
+            ],
+        ]);
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -4,32 +4,78 @@ declare(strict_types=1);
 
 namespace NeneClear\Http;
 
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use NeneClear\Auth\AuthRouteRegistrar;
+use NeneClear\Auth\GetCurrentUserHandler;
+use NeneClear\Auth\InvalidCredentialsExceptionHandler;
+use NeneClear\Auth\JwtTokenService;
+use NeneClear\Auth\LoginHandler;
+use NeneClear\Auth\LoginUseCase;
+use NeneClear\User\PdoUserRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Builds the NeNe Clear HTTP application on top of the NENE2 runtime.
  *
- * Wires the framework baseline pipeline (error handling, request id, security
- * headers, CORS, request size limit) and the built-in `/health` route via
- * {@see RuntimeApplicationFactory}. Application routes are added through
- * `$routeRegistrars` as Phase 1 endpoints land; see
- * docs/development/nene2-compliance.md and docs/openapi/openapi.yaml.
+ * The framework baseline pipeline (error handling, request id, security headers,
+ * CORS, request size limit) and the built-in `/health` route are always present.
+ *
+ * Authenticated routes (`/admin/auth/*`, future `/admin/*`) are wired only when
+ * **both** a database query executor and a JWT secret are provided. Without them
+ * the app still serves the public/health surface, so `/health` never depends on a
+ * database. See docs/development/nene2-compliance.md.
  */
 final class ApplicationFactory
 {
     /**
+     * Public paths that never require a bearer token.
+     *
+     * @var list<string>
+     */
+    private const array PUBLIC_PATHS = ['/', '/health', '/machine/health', '/admin/auth/login'];
+
+    /**
      * @param list<string> $allowedOrigins CORS allowlist; empty disables CORS (set explicitly in production).
      */
-    public static function create(bool $debug = false, array $allowedOrigins = []): RequestHandlerInterface
-    {
+    public static function create(
+        bool $debug = false,
+        array $allowedOrigins = [],
+        ?DatabaseQueryExecutorInterface $query = null,
+        ?string $jwtSecret = null,
+    ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
+        $json = new JsonResponseFactory($psr17, $psr17);
+        $problemDetails = new ProblemDetailsResponseFactory($psr17, $psr17);
+
+        $routeRegistrars = [];
+        $domainExceptionHandlers = [];
+        $authMiddleware = null;
+
+        if ($query !== null && $jwtSecret !== null && $jwtSecret !== '') {
+            $jwt = new JwtTokenService($jwtSecret);
+            $users = new PdoUserRepository($query);
+
+            $routeRegistrars[] = new AuthRouteRegistrar(
+                new LoginHandler(new LoginUseCase($users, $jwt), $json),
+                new GetCurrentUserHandler($users, $json, $problemDetails),
+            );
+            $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
+            $authMiddleware = [
+                new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
+            ];
+        }
 
         return (new RuntimeApplicationFactory(
             responseFactory: $psr17,
             streamFactory: $psr17,
-            routeRegistrars: [],
+            domainExceptionHandlers: $domainExceptionHandlers,
+            routeRegistrars: $routeRegistrars,
+            authMiddleware: $authMiddleware,
             debug: $debug,
             allowedOrigins: $allowedOrigins,
         ))->create();

--- a/tests/Http/AuthHttpTest.php
+++ b/tests/Http/AuthHttpTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AuthHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-auth-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createUsers($this->query);
+
+        (new PdoUserRepository($this->query))->save(new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 7,
+        ));
+
+        $this->app = ApplicationFactory::create(query: $this->query, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function postJson(string $path, array $body): ResponseInterface
+    {
+        $request = $this->psr17->createServerRequest('POST', $path)
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode($body)));
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_login_succeeds_with_correct_credentials(): void
+    {
+        $response = $this->postJson('/admin/auth/login', ['email' => 'admin@acme.example', 'password' => self::PASSWORD]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $this->decode($response);
+        self::assertArrayHasKey('token', $data);
+        self::assertIsString($data['token']);
+        self::assertNotSame('', $data['token']);
+    }
+
+    public function test_login_fails_with_wrong_password(): void
+    {
+        $response = $this->postJson('/admin/auth/login', ['email' => 'admin@acme.example', 'password' => 'nope']);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertSame('application/problem+json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+    }
+
+    public function test_me_returns_user_with_valid_token(): void
+    {
+        $token = $this->decode($this->postJson('/admin/auth/login', [
+            'email' => 'admin@acme.example',
+            'password' => self::PASSWORD,
+        ]))['token'];
+        self::assertIsString($token);
+
+        $request = $this->psr17->createServerRequest('GET', '/admin/auth/me')
+            ->withHeader('Authorization', 'Bearer ' . $token);
+        $response = $this->app->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $data = $this->decode($response);
+        self::assertSame('admin@acme.example', $data['email'] ?? null);
+        self::assertSame('admin', $data['role'] ?? null);
+        self::assertSame(7, $data['organization_id'] ?? null);
+    }
+
+    public function test_me_requires_a_token(): void
+    {
+        $response = $this->app->handle($this->psr17->createServerRequest('GET', '/admin/auth/me'));
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #27.

## Purpose

Wire the auth domain into the real HTTP pipeline — first authenticated endpoints (`POST /admin/auth/login`, `GET /admin/auth/me`).

## Change summary

- **ApplicationFactory** — optional `DatabaseQueryExecutorInterface` + JWT secret; wires auth routes/handlers/middleware only when both are present (otherwise health-only, so `/health` never depends on a DB).
- **Handlers** — `LoginHandler` (parse + validate → `LoginUseCase`), `GetCurrentUserHandler` (reads `nene2.auth.claims`), `AuthRouteRegistrar`, `InvalidCredentialsExceptionHandler` (domain → 401 at the error boundary, no try/catch in handlers).
- **BearerTokenMiddleware** in blocklist mode — public: `/`, `/health`, `/machine/health`, `/admin/auth/login`; all other routes require a valid JWT.
- **index.php** — resilient env→executor wiring (health still boots if DB/secret absent); JWT secret from `NENE_CLEAR_JWT_SECRET`.
- **HTTP integration tests** over SQLite (`DatabaseTestKit`): login ok / wrong-password 401, `me` with valid token / without token 401.

## Verification

```
composer check → OK (25 tests, 84 assertions); PHPStan: No errors; CS: clean
/health smoke → 200 after index.php rewrite
```

## Notes

`@internal` PDO classes are constructed only at the composition root (index.php), mirroring `DatabaseTestKit`. Org/User CRUD endpoints and capability middleware are the next slice (B-4).

## Self-review

backend-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)