### PR TITLE
feat: capability middleware + Organization CRUD (#29)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -146,6 +146,7 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `organization-not-resolved` | Tenant could not be resolved for the request |
 | `organization-not-found` | Organization id/slug not found |
+| `organization-already-exists` | Create rejected — slug already taken |
 | `user-not-found` | User id not found |
 | `bank-import-batch-not-found` | Import batch id not found |
 | `bank-transaction-not-found` | Bank transaction id not found |

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Enforces per-route capabilities (ADR 0006) after authentication.
+ *
+ * Runs after {@see \Nene2\Auth\BearerTokenMiddleware}, which sets the decoded
+ * claims on the `nene2.auth.claims` request attribute. A request whose path
+ * starts with a protected prefix requires the mapped {@see Capability}; the
+ * authenticated user's `role` claim must grant it, otherwise 403.
+ *
+ * Paths that match no prefix are not capability-gated here (any authenticated
+ * user passes); public paths are already excluded upstream.
+ */
+final readonly class CapabilityMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param array<string, Capability> $prefixCapabilities path prefix => required capability
+     */
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+        private array $prefixCapabilities,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $required = $this->requiredCapability($request->getUri()->getPath() ?: '/');
+
+        if ($required === null) {
+            return $handler->handle($request);
+        }
+
+        $claims = (array) $request->getAttribute('nene2.auth.claims', []);
+        $roleValue = $claims['role'] ?? null;
+        $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
+
+        if ($role === null || !$role->has($required)) {
+            return $this->problemDetails->create(
+                $request,
+                'insufficient-capability',
+                'Insufficient Capability',
+                403,
+                'Your role lacks the capability required for this action.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+
+    private function requiredCapability(string $path): ?Capability
+    {
+        foreach ($this->prefixCapabilities as $prefix => $capability) {
+            if (str_starts_with($path, $prefix)) {
+                return $capability;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -10,11 +10,25 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use NeneClear\Auth\AuthRouteRegistrar;
+use NeneClear\Auth\Capability;
+use NeneClear\Auth\CapabilityMiddleware;
 use NeneClear\Auth\GetCurrentUserHandler;
 use NeneClear\Auth\InvalidCredentialsExceptionHandler;
 use NeneClear\Auth\JwtTokenService;
 use NeneClear\Auth\LoginHandler;
 use NeneClear\Auth\LoginUseCase;
+use NeneClear\Organization\CreateOrganizationHandler;
+use NeneClear\Organization\CreateOrganizationUseCase;
+use NeneClear\Organization\DeleteOrganizationHandler;
+use NeneClear\Organization\DeleteOrganizationUseCase;
+use NeneClear\Organization\GetOrganizationByIdHandler;
+use NeneClear\Organization\GetOrganizationByIdUseCase;
+use NeneClear\Organization\ListOrganizationsHandler;
+use NeneClear\Organization\ListOrganizationsUseCase;
+use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
+use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
+use NeneClear\Organization\OrganizationRouteRegistrar;
+use NeneClear\Organization\PdoOrganizationRepository;
 use NeneClear\User\PdoUserRepository;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -25,10 +39,10 @@ use Psr\Http\Server\RequestHandlerInterface;
  * The framework baseline pipeline (error handling, request id, security headers,
  * CORS, request size limit) and the built-in `/health` route are always present.
  *
- * Authenticated routes (`/admin/auth/*`, future `/admin/*`) are wired only when
- * **both** a database query executor and a JWT secret are provided. Without them
- * the app still serves the public/health surface, so `/health` never depends on a
- * database. See docs/development/nene2-compliance.md.
+ * Authenticated/admin routes are wired only when **both** a database query
+ * executor and a JWT secret are provided. Without them the app still serves the
+ * public/health surface, so `/health` never depends on a database. See
+ * docs/development/nene2-compliance.md.
  */
 final class ApplicationFactory
 {
@@ -50,7 +64,7 @@ final class ApplicationFactory
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
         $json = new JsonResponseFactory($psr17, $psr17);
-        $problemDetails = new ProblemDetailsResponseFactory($psr17, $psr17);
+        $problemDetails = new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-clear.dev/problems/');
 
         $routeRegistrars = [];
         $domainExceptionHandlers = [];
@@ -59,14 +73,28 @@ final class ApplicationFactory
         if ($query !== null && $jwtSecret !== null && $jwtSecret !== '') {
             $jwt = new JwtTokenService($jwtSecret);
             $users = new PdoUserRepository($query);
+            $organizations = new PdoOrganizationRepository($query);
 
             $routeRegistrars[] = new AuthRouteRegistrar(
                 new LoginHandler(new LoginUseCase($users, $jwt), $json),
                 new GetCurrentUserHandler($users, $json, $problemDetails),
             );
+            $routeRegistrars[] = new OrganizationRouteRegistrar(
+                new ListOrganizationsHandler(new ListOrganizationsUseCase($organizations), $json),
+                new CreateOrganizationHandler(new CreateOrganizationUseCase($organizations), $json),
+                new GetOrganizationByIdHandler(new GetOrganizationByIdUseCase($organizations), $json),
+                new DeleteOrganizationHandler(new DeleteOrganizationUseCase($organizations), $json),
+            );
+
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new OrganizationAlreadyExistsExceptionHandler($problemDetails);
+
             $authMiddleware = [
                 new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
+                new CapabilityMiddleware($problemDetails, [
+                    '/admin/organizations' => Capability::ManageOrganizations,
+                ]),
             ];
         }
 

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateOrganizationHandler
+{
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $slug = trim((string) ($body['slug'] ?? ''));
+        $name = trim((string) ($body['name'] ?? ''));
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        }
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateOrganizationInput(slug: $slug, name: $name));
+
+        return $this->response->create(
+            ['organization_id' => $output->id, 'slug' => $output->slug, 'name' => $output->name],
+            201,
+            ['Location' => '/admin/organizations/' . $output->id],
+        );
+    }
+}

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteOrganizationHandler
+{
+    public function __construct(
+        private DeleteOrganizationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute($id);
+
+        return $this->response->createEmpty(204);
+    }
+}

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(int $id): void
+    {
+        if ($this->organizations->findById($id) === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        $this->organizations->delete($id);
+    }
+}

--- a/src/Organization/DeleteOrganizationUseCaseInterface.php
+++ b/src/Organization/DeleteOrganizationUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+interface DeleteOrganizationUseCaseInterface
+{
+    /**
+     * @throws OrganizationNotFoundException
+     */
+    public function execute(int $id): void;
+}

--- a/src/Organization/GetOrganizationByIdHandler.php
+++ b/src/Organization/GetOrganizationByIdHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetOrganizationByIdHandler
+{
+    public function __construct(
+        private GetOrganizationByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $organization = $this->useCase->execute($id);
+
+        return $this->response->create([
+            'organization_id' => $organization->id,
+            'slug' => $organization->slug,
+            'name' => $organization->name,
+        ]);
+    }
+}

--- a/src/Organization/GetOrganizationByIdUseCase.php
+++ b/src/Organization/GetOrganizationByIdUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class GetOrganizationByIdUseCase implements GetOrganizationByIdUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(int $id): Organization
+    {
+        $organization = $this->organizations->findById($id);
+
+        if ($organization === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        return $organization;
+    }
+}

--- a/src/Organization/GetOrganizationByIdUseCaseInterface.php
+++ b/src/Organization/GetOrganizationByIdUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+interface GetOrganizationByIdUseCaseInterface
+{
+    /**
+     * @throws OrganizationNotFoundException
+     */
+    public function execute(int $id): Organization;
+}

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+// Pagination defaults align with docs/openapi/openapi.yaml (default 50, max 200).
+
+final readonly class ListOrganizationsHandler
+{
+    public function __construct(
+        private ListOrganizationsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $page = PaginationQueryParser::parse($request, 50, 200);
+        $output = $this->useCase->execute($page->limit, $page->offset);
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (Organization $o): array => [
+                    'organization_id' => $o->id,
+                    'slug' => $o->slug,
+                    'name' => $o->name,
+                ],
+                $output->items,
+            ),
+            'limit' => $output->limit,
+            'offset' => $output->offset,
+            'total' => $output->total,
+        ]);
+    }
+}

--- a/src/Organization/ListOrganizationsOutput.php
+++ b/src/Organization/ListOrganizationsOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class ListOrganizationsOutput
+{
+    /**
+     * @param list<Organization> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Organization/ListOrganizationsUseCase.php
+++ b/src/Organization/ListOrganizationsUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+final readonly class ListOrganizationsUseCase implements ListOrganizationsUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(int $limit, int $offset): ListOrganizationsOutput
+    {
+        return new ListOrganizationsOutput(
+            items: $this->organizations->findAll($limit, $offset),
+            total: $this->organizations->countAll(),
+            limit: $limit,
+            offset: $offset,
+        );
+    }
+}

--- a/src/Organization/ListOrganizationsUseCaseInterface.php
+++ b/src/Organization/ListOrganizationsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+interface ListOrganizationsUseCaseInterface
+{
+    public function execute(int $limit, int $offset): ListOrganizationsOutput;
+}

--- a/src/Organization/OrganizationAlreadyExistsExceptionHandler.php
+++ b/src/Organization/OrganizationAlreadyExistsExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class OrganizationAlreadyExistsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof OrganizationAlreadyExistsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'organization-already-exists',
+            'Organization Already Exists',
+            409,
+            'An organization with that slug already exists.',
+        );
+    }
+}

--- a/src/Organization/OrganizationNotFoundException.php
+++ b/src/Organization/OrganizationNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use RuntimeException;
+
+final class OrganizationNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Organization %d was not found.', $id));
+    }
+}

--- a/src/Organization/OrganizationNotFoundExceptionHandler.php
+++ b/src/Organization/OrganizationNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class OrganizationNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof OrganizationNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'organization-not-found',
+            'Organization Not Found',
+            404,
+            'The requested organization was not found.',
+        );
+    }
+}

--- a/src/Organization/OrganizationRouteRegistrar.php
+++ b/src/Organization/OrganizationRouteRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class OrganizationRouteRegistrar
+{
+    public function __construct(
+        private ListOrganizationsHandler $listHandler,
+        private CreateOrganizationHandler $createHandler,
+        private GetOrganizationByIdHandler $getHandler,
+        private DeleteOrganizationHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $createHandler = $this->createHandler;
+        $getHandler = $this->getHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/admin/organizations', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+        $router->post('/admin/organizations', static fn (ServerRequestInterface $r): ResponseInterface => $createHandler->handle($r));
+        $router->get('/admin/organizations/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));
+        $router->delete('/admin/organizations/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $deleteHandler->handle($r));
+    }
+}

--- a/tests/Http/OrganizationCrudHttpTest.php
+++ b/tests/Http/OrganizationCrudHttpTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class OrganizationCrudHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-orgcrud-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createOrganizations($this->query);
+        SchemaFixture::createUsers($this->query);
+
+        $users = new PdoUserRepository($this->query);
+        $users->save(new User(
+            email: 'root@platform.example',
+            role: Role::Superadmin,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: null,
+        ));
+        $users->save(new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 1,
+        ));
+
+        $this->app = ApplicationFactory::create(query: $this->query, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode([
+                'email' => $email,
+                'password' => self::PASSWORD,
+            ])));
+
+        $data = $this->decode($this->app->handle($request));
+        self::assertIsString($data['token'] ?? null);
+
+        return (string) $data['token'];
+    }
+
+    /**
+     * @param array<string, mixed>|null $json
+     */
+    private function request(string $method, string $path, string $token, ?array $json = null): ResponseInterface
+    {
+        $request = $this->psr17->createServerRequest($method, $path)
+            ->withHeader('Authorization', 'Bearer ' . $token);
+
+        if ($json !== null) {
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->psr17->createStream((string) json_encode($json)));
+        }
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_superadmin_can_create_list_get_and_delete(): void
+    {
+        $token = $this->tokenFor('root@platform.example');
+
+        $created = $this->request('POST', '/admin/organizations', $token, ['slug' => 'acme', 'name' => 'Acme Co']);
+        self::assertSame(201, $created->getStatusCode());
+        $id = $this->decode($created)['organization_id'] ?? null;
+        self::assertIsInt($id);
+
+        $list = $this->request('GET', '/admin/organizations', $token);
+        self::assertSame(200, $list->getStatusCode());
+        self::assertSame(1, $this->decode($list)['total'] ?? null);
+
+        $get = $this->request('GET', '/admin/organizations/' . $id, $token);
+        self::assertSame(200, $get->getStatusCode());
+        self::assertSame('acme', $this->decode($get)['slug'] ?? null);
+
+        $deleted = $this->request('DELETE', '/admin/organizations/' . $id, $token);
+        self::assertSame(204, $deleted->getStatusCode());
+
+        $missing = $this->request('GET', '/admin/organizations/' . $id, $token);
+        self::assertSame(404, $missing->getStatusCode());
+    }
+
+    public function test_admin_lacks_manage_organizations_capability(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->request('POST', '/admin/organizations', $token, ['slug' => 'x', 'name' => 'X']);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('insufficient-capability', (string) $response->getBody());
+    }
+
+    public function test_duplicate_slug_is_rejected(): void
+    {
+        $token = $this->tokenFor('root@platform.example');
+        $this->request('POST', '/admin/organizations', $token, ['slug' => 'dup', 'name' => 'First']);
+
+        $second = $this->request('POST', '/admin/organizations', $token, ['slug' => 'dup', 'name' => 'Second']);
+        self::assertSame(409, $second->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #29.

## Purpose

Route authorization (ADR 0006 / nene2-compliance §10) + the first capability-gated admin resource: superadmin Organization CRUD.

## Change summary

- **`CapabilityMiddleware`** — path-prefix → required `Capability`; reads the `role` claim set by `BearerTokenMiddleware`; returns 403 `insufficient-capability` when the role lacks it.
- **Organization use cases** — `List` / `GetById` / `Delete` (+ `OrganizationNotFoundException` → 404); `Create` reused from B-2 (+ `OrganizationAlreadyExistsException` → 409).
- **Handlers + `OrganizationRouteRegistrar`** for `listOrganizations` / `createOrganization` / `getOrganizationById` / `deleteOrganization` (per `openapi.yaml`).
- **Wiring** — `/admin/organizations` requires `manage_organizations`; Problem Details base branded to `https://nene-clear.dev/problems/`.
- **terminology.md** — registered `organization-already-exists` slug (register-before-use).
- **HTTP tests** over SQLite: superadmin create→list→get→delete→404; admin gets 403; duplicate slug 409.

## Verification

```
composer check → OK (28 tests, 104 assertions); PHPStan: No errors; CS: clean
```

## Self-review

backend-api, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)