### PR TITLE
feat: User admin CRUD (#31)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -148,6 +148,7 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `organization-not-found` | Organization id/slug not found |
 | `organization-already-exists` | Create rejected — slug already taken |
 | `user-not-found` | User id not found |
+| `user-already-exists` | Create rejected — email already taken |
 | `bank-import-batch-not-found` | Import batch id not found |
 | `bank-transaction-not-found` | Bank transaction id not found |
 | `reconciliation-not-found` | Reconciliation id not found |

--- a/src/Auth/AuthContext.php
+++ b/src/Auth/AuthContext.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Reads the authenticated principal from the JWT claims that
+ * {@see \Nene2\Auth\BearerTokenMiddleware} placed on the request.
+ */
+final readonly class AuthContext
+{
+    /**
+     * The caller's organization id, or null for a cross-tenant superadmin.
+     */
+    public static function organizationId(ServerRequestInterface $request): ?int
+    {
+        $claims = (array) $request->getAttribute('nene2.auth.claims', []);
+        $org = $claims['org'] ?? null;
+
+        return is_int($org) ? $org : (is_numeric($org) ? (int) $org : null);
+    }
+
+    public static function role(ServerRequestInterface $request): ?Role
+    {
+        $claims = (array) $request->getAttribute('nene2.auth.claims', []);
+        $role = $claims['role'] ?? null;
+
+        return is_string($role) ? Role::tryFrom($role) : null;
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -29,7 +29,20 @@ use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
 use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
 use NeneClear\Organization\OrganizationRouteRegistrar;
 use NeneClear\Organization\PdoOrganizationRepository;
+use NeneClear\User\CreateUserHandler;
+use NeneClear\User\CreateUserUseCase;
+use NeneClear\User\DeleteUserHandler;
+use NeneClear\User\DeleteUserUseCase;
+use NeneClear\User\GetUserByIdHandler;
+use NeneClear\User\GetUserByIdUseCase;
+use NeneClear\User\ListUsersHandler;
+use NeneClear\User\ListUsersUseCase;
 use NeneClear\User\PdoUserRepository;
+use NeneClear\User\UpdateUserHandler;
+use NeneClear\User\UpdateUserUseCase;
+use NeneClear\User\UserAlreadyExistsExceptionHandler;
+use NeneClear\User\UserNotFoundExceptionHandler;
+use NeneClear\User\UserRouteRegistrar;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Server\RequestHandlerInterface;
 
@@ -85,15 +98,25 @@ final class ApplicationFactory
                 new GetOrganizationByIdHandler(new GetOrganizationByIdUseCase($organizations), $json),
                 new DeleteOrganizationHandler(new DeleteOrganizationUseCase($organizations), $json),
             );
+            $routeRegistrars[] = new UserRouteRegistrar(
+                new ListUsersHandler(new ListUsersUseCase($users), $json),
+                new CreateUserHandler(new CreateUserUseCase($users), $json),
+                new GetUserByIdHandler(new GetUserByIdUseCase($users), $json),
+                new UpdateUserHandler(new UpdateUserUseCase($users), $json),
+                new DeleteUserHandler(new DeleteUserUseCase($users), $json),
+            );
 
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationAlreadyExistsExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new UserNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new UserAlreadyExistsExceptionHandler($problemDetails);
 
             $authMiddleware = [
                 new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
                 new CapabilityMiddleware($problemDetails, [
                     '/admin/organizations' => Capability::ManageOrganizations,
+                    '/admin/users' => Capability::ManageUsers,
                 ]),
             ];
         }

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use NeneClear\Auth\Role;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateUserHandler
+{
+    public function __construct(
+        private CreateUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $errors = [];
+        $email = trim((string) ($body['email'] ?? ''));
+        $role = Role::tryFrom((string) ($body['role'] ?? ''));
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        }
+
+        if ($role === null) {
+            $errors[] = new ValidationError('role', 'A valid role is required.', 'invalid');
+        }
+
+        if ($errors !== [] || $role === null) {
+            throw new ValidationException($errors);
+        }
+
+        $rawPassword = $body['password'] ?? null;
+        $password = is_string($rawPassword) && $rawPassword !== '' ? $rawPassword : null;
+
+        $user = $this->useCase->execute(new CreateUserInput(
+            organizationId: AuthContext::organizationId($request),
+            email: $email,
+            role: $role,
+            password: $password,
+        ));
+
+        return $this->response->create(UserResponse::toArray($user), 201, ['Location' => '/admin/users/' . $user->id]);
+    }
+}

--- a/src/User/CreateUserInput.php
+++ b/src/User/CreateUserInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use NeneClear\Auth\Role;
+
+final readonly class CreateUserInput
+{
+    public function __construct(
+        public ?int $organizationId,
+        public string $email,
+        public Role $role,
+        public ?string $password,
+    ) {
+    }
+}

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(CreateUserInput $input): User
+    {
+        if ($this->users->existsByEmail($input->email)) {
+            throw new UserAlreadyExistsException($input->email);
+        }
+
+        // With a password the account is active; without one it is invited and
+        // cannot log in until a password is set (the hash is a random placeholder).
+        $status = $input->password !== null ? UserStatus::Active : UserStatus::Invited;
+        $hash = password_hash($input->password ?? bin2hex(random_bytes(16)), PASSWORD_BCRYPT);
+
+        $id = $this->users->save(new User(
+            email: $input->email,
+            role: $input->role,
+            status: $status,
+            passwordHash: $hash,
+            organizationId: $input->organizationId,
+        ));
+
+        $created = $this->users->findById($id);
+
+        if ($created === null) {
+            throw new UserNotFoundException($id);
+        }
+
+        return $created;
+    }
+}

--- a/src/User/CreateUserUseCaseInterface.php
+++ b/src/User/CreateUserUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface CreateUserUseCaseInterface
+{
+    /**
+     * @throws UserAlreadyExistsException
+     */
+    public function execute(CreateUserInput $input): User;
+}

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteUserHandler
+{
+    public function __construct(
+        private DeleteUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $this->useCase->execute($id, AuthContext::organizationId($request));
+
+        return $this->response->createEmpty(204);
+    }
+}

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(int $id, ?int $callerOrganizationId): void
+    {
+        $user = $this->users->findById($id);
+
+        if ($user === null || $user->organizationId !== $callerOrganizationId) {
+            throw new UserNotFoundException($id);
+        }
+
+        $this->users->delete($id);
+    }
+}

--- a/src/User/DeleteUserUseCaseInterface.php
+++ b/src/User/DeleteUserUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface DeleteUserUseCaseInterface
+{
+    /**
+     * @throws UserNotFoundException
+     */
+    public function execute(int $id, ?int $callerOrganizationId): void;
+}

--- a/src/User/GetUserByIdHandler.php
+++ b/src/User/GetUserByIdHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetUserByIdHandler
+{
+    public function __construct(
+        private GetUserByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $user = $this->useCase->execute($id, AuthContext::organizationId($request));
+
+        return $this->response->create(UserResponse::toArray($user));
+    }
+}

--- a/src/User/GetUserByIdUseCase.php
+++ b/src/User/GetUserByIdUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class GetUserByIdUseCase implements GetUserByIdUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(int $id, ?int $callerOrganizationId): User
+    {
+        $user = $this->users->findById($id);
+
+        if ($user === null || $user->organizationId !== $callerOrganizationId) {
+            throw new UserNotFoundException($id);
+        }
+
+        return $user;
+    }
+}

--- a/src/User/GetUserByIdUseCaseInterface.php
+++ b/src/User/GetUserByIdUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface GetUserByIdUseCaseInterface
+{
+    /**
+     * Scoped to the caller's organization; a user in another tenant is treated
+     * as not found.
+     *
+     * @throws UserNotFoundException
+     */
+    public function execute(int $id, ?int $callerOrganizationId): User;
+}

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListUsersHandler
+{
+    public function __construct(
+        private ListUsersUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $page = PaginationQueryParser::parse($request, 50, 200);
+        $output = $this->useCase->execute(AuthContext::organizationId($request), $page->limit, $page->offset);
+
+        return $this->response->create([
+            'items' => array_map(UserResponse::toArray(...), $output->items),
+            'limit' => $output->limit,
+            'offset' => $output->offset,
+            'total' => $output->total,
+        ]);
+    }
+}

--- a/src/User/ListUsersOutput.php
+++ b/src/User/ListUsersOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class ListUsersOutput
+{
+    /**
+     * @param list<User> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/User/ListUsersUseCase.php
+++ b/src/User/ListUsersUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class ListUsersUseCase implements ListUsersUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(?int $organizationId, int $limit, int $offset): ListUsersOutput
+    {
+        return new ListUsersOutput(
+            items: $this->users->findAllByOrganization($organizationId, $limit, $offset),
+            total: $this->users->countByOrganization($organizationId),
+            limit: $limit,
+            offset: $offset,
+        );
+    }
+}

--- a/src/User/ListUsersUseCaseInterface.php
+++ b/src/User/ListUsersUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface ListUsersUseCaseInterface
+{
+    public function execute(?int $organizationId, int $limit, int $offset): ListUsersOutput;
+}

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use NeneClear\Auth\Role;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateUserHandler
+{
+    public function __construct(
+        private UpdateUserUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $body = JsonRequestBodyParser::parse($request);
+
+        $role = null;
+        if (isset($body['role'])) {
+            $role = Role::tryFrom((string) $body['role']);
+            if ($role === null) {
+                throw new ValidationException([new ValidationError('role', 'A valid role is required.', 'invalid')]);
+            }
+        }
+
+        $status = null;
+        if (isset($body['status'])) {
+            $status = UserStatus::tryFrom((string) $body['status']);
+            if ($status === null) {
+                throw new ValidationException([new ValidationError('status', 'A valid status is required.', 'invalid')]);
+            }
+        }
+
+        $user = $this->useCase->execute(new UpdateUserInput(
+            id: $id,
+            callerOrganizationId: AuthContext::organizationId($request),
+            role: $role,
+            status: $status,
+        ));
+
+        return $this->response->create(UserResponse::toArray($user));
+    }
+}

--- a/src/User/UpdateUserInput.php
+++ b/src/User/UpdateUserInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use NeneClear\Auth\Role;
+
+final readonly class UpdateUserInput
+{
+    public function __construct(
+        public int $id,
+        public ?int $callerOrganizationId,
+        public ?Role $role,
+        public ?UserStatus $status,
+    ) {
+    }
+}

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+    ) {
+    }
+
+    public function execute(UpdateUserInput $input): User
+    {
+        $existing = $this->users->findById($input->id);
+
+        if ($existing === null || $existing->organizationId !== $input->callerOrganizationId) {
+            throw new UserNotFoundException($input->id);
+        }
+
+        $updated = new User(
+            email: $existing->email,
+            role: $input->role ?? $existing->role,
+            status: $input->status ?? $existing->status,
+            passwordHash: $existing->passwordHash,
+            organizationId: $existing->organizationId,
+            id: $existing->id,
+        );
+
+        $this->users->save($updated);
+
+        return $updated;
+    }
+}

--- a/src/User/UpdateUserUseCaseInterface.php
+++ b/src/User/UpdateUserUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface UpdateUserUseCaseInterface
+{
+    /**
+     * @throws UserNotFoundException
+     */
+    public function execute(UpdateUserInput $input): User;
+}

--- a/src/User/UserAlreadyExistsException.php
+++ b/src/User/UserAlreadyExistsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use RuntimeException;
+
+final class UserAlreadyExistsException extends RuntimeException
+{
+    public function __construct(public readonly string $email)
+    {
+        parent::__construct(sprintf('A user with email "%s" already exists.', $email));
+    }
+}

--- a/src/User/UserAlreadyExistsExceptionHandler.php
+++ b/src/User/UserAlreadyExistsExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserAlreadyExistsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserAlreadyExistsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'user-already-exists',
+            'User Already Exists',
+            409,
+            'A user with that email already exists.',
+        );
+    }
+}

--- a/src/User/UserNotFoundException.php
+++ b/src/User/UserNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use RuntimeException;
+
+final class UserNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('User %d was not found.', $id));
+    }
+}

--- a/src/User/UserNotFoundExceptionHandler.php
+++ b/src/User/UserNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UserNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UserNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'user-not-found',
+            'User Not Found',
+            404,
+            'The requested user was not found.',
+        );
+    }
+}

--- a/src/User/UserResponse.php
+++ b/src/User/UserResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * Maps a {@see User} to its public JSON shape (terminology.md / openapi.yaml).
+ */
+final readonly class UserResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(User $user): array
+    {
+        return [
+            'user_id' => $user->id,
+            'organization_id' => $user->organizationId,
+            'email' => $user->email,
+            'role' => $user->role->value,
+            'status' => $user->status->value,
+        ];
+    }
+}

--- a/src/User/UserRouteRegistrar.php
+++ b/src/User/UserRouteRegistrar.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UserRouteRegistrar
+{
+    public function __construct(
+        private ListUsersHandler $listHandler,
+        private CreateUserHandler $createHandler,
+        private GetUserByIdHandler $getHandler,
+        private UpdateUserHandler $updateHandler,
+        private DeleteUserHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $createHandler = $this->createHandler;
+        $getHandler = $this->getHandler;
+        $updateHandler = $this->updateHandler;
+        $deleteHandler = $this->deleteHandler;
+
+        $router->get('/admin/users', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+        $router->post('/admin/users', static fn (ServerRequestInterface $r): ResponseInterface => $createHandler->handle($r));
+        $router->get('/admin/users/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));
+        $router->put('/admin/users/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $updateHandler->handle($r));
+        $router->delete('/admin/users/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $deleteHandler->handle($r));
+    }
+}

--- a/tests/Http/UserCrudHttpTest.php
+++ b/tests/Http/UserCrudHttpTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UserCrudHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+    private int $crossTenantUserId;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-usercrud-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createUsers($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin, 7));
+        $users->save($this->user('member@acme.example', Role::Member, 7));
+        $this->crossTenantUserId = $users->save($this->user('other@org8.example', Role::Member, 8));
+
+        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role, int $org): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: $org,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, mixed>|null $json
+     */
+    private function request(string $method, string $path, string $token, ?array $json = null): ResponseInterface
+    {
+        $request = $this->psr17->createServerRequest($method, $path)->withHeader('Authorization', 'Bearer ' . $token);
+        if ($json !== null) {
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->psr17->createStream((string) json_encode($json)));
+        }
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_admin_can_create_list_get_update_and_delete_in_own_org(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $created = $this->request('POST', '/admin/users', $token, [
+            'email' => 'new@acme.example',
+            'role' => 'member',
+            'password' => 'a-strong-password',
+        ]);
+        self::assertSame(201, $created->getStatusCode());
+        $body = $this->decode($created);
+        $id = $body['user_id'] ?? null;
+        self::assertIsInt($id);
+        self::assertSame(7, $body['organization_id'] ?? null);
+
+        $list = $this->request('GET', '/admin/users', $token);
+        self::assertSame(200, $list->getStatusCode());
+        self::assertSame(3, $this->decode($list)['total'] ?? null); // admin + member + new (org 7 only)
+
+        $updated = $this->request('PUT', '/admin/users/' . $id, $token, ['role' => 'viewer']);
+        self::assertSame(200, $updated->getStatusCode());
+        self::assertSame('viewer', $this->decode($updated)['role'] ?? null);
+
+        self::assertSame(204, $this->request('DELETE', '/admin/users/' . $id, $token)->getStatusCode());
+        self::assertSame(404, $this->request('GET', '/admin/users/' . $id, $token)->getStatusCode());
+    }
+
+    public function test_member_lacks_manage_users_capability(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+
+        $response = $this->request('GET', '/admin/users', $token);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertStringContainsString('insufficient-capability', (string) $response->getBody());
+    }
+
+    public function test_cross_tenant_user_is_not_found(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->request('GET', '/admin/users/' . $this->crossTenantUserId, $token);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function test_duplicate_email_is_rejected(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->request('POST', '/admin/users', $token, [
+            'email' => 'admin@acme.example',
+            'role' => 'member',
+            'password' => 'a-strong-password',
+        ]);
+
+        self::assertSame(409, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Closes #31.

## Purpose

Admin manages operator accounts within their organization — second capability-gated, org-scoped resource (ADR 0006).

## Change summary

- **`AuthContext`** — organization id / role from JWT claims.
- **User use cases** — `List` / `Create` / `GetById` / `Update` / `Delete`, all **scoped to the caller's organization**; a user in another tenant returns **404** (no cross-tenant disclosure).
- **Create** — email uniqueness (`UserAlreadyExistsException` → 409); with a password the account is `active`, without one it is `invited` (unusable placeholder hash until set).
- Handlers + `UserRouteRegistrar` for `listUsers`/`createUser`/`getUserById`/`updateUser`/`deleteUser`; `UserResponse` JSON mapper; `UserNotFoundException`/`UserAlreadyExistsException` + handlers.
- Wired: `/admin/users` requires `manage_users`; `user-already-exists` slug registered.
- HTTP tests over SQLite: admin create→list→update→delete→404; member → 403; cross-tenant → 404; duplicate email → 409.

## Verification

```
composer check → OK (32 tests, 128 assertions); PHPStan: No errors; CS: clean
```

## Self-review

backend-api, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)