### PR TITLE
feat: bank import core — schema, CSV parser, import use case (#33)

### DIFF
--- a/database/migrations/20260530130000_create_bank_accounts_table.php
+++ b/database/migrations/20260530130000_create_bank_accounts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBankAccountsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('bank_accounts')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('bank_name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('bank_branch', 'string', ['limit' => 255, 'null' => false, 'default' => ''])
+            ->addColumn('account_type', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('account_number', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('csv_encoding', 'string', ['limit' => 32, 'null' => false, 'default' => 'utf8'])
+            ->addColumn('csv_date_format', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('csv_date_column', 'integer', ['null' => false])
+            ->addColumn('csv_amount_column', 'integer', ['null' => false])
+            ->addColumn('csv_counterparty_column', 'integer', ['null' => false])
+            ->addColumn('csv_header_rows', 'integer', ['null' => false, 'default' => 1])
+            ->addTimestamps()
+            ->addIndex(['organization_id'])
+            ->create();
+    }
+}

--- a/database/migrations/20260530130100_create_bank_import_batches_table.php
+++ b/database/migrations/20260530130100_create_bank_import_batches_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBankImportBatchesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('bank_import_batches')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('bank_account_id', 'integer', ['null' => false])
+            ->addColumn('file_hash', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('source_filename', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('row_count', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('status', 'string', ['limit' => 32, 'null' => false, 'default' => 'imported'])
+            ->addColumn('imported_by', 'integer', ['null' => false])
+            ->addColumn('imported_at', 'datetime', ['null' => false])
+            ->addColumn('reversed_at', 'datetime', ['null' => true])
+            ->addColumn('reversal_reason', 'string', ['limit' => 255, 'null' => true])
+            ->addTimestamps()
+            ->addIndex(['organization_id', 'file_hash'], ['unique' => true])
+            ->addIndex(['organization_id'])
+            ->create();
+    }
+}

--- a/database/migrations/20260530130200_create_bank_transactions_table.php
+++ b/database/migrations/20260530130200_create_bank_transactions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateBankTransactionsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('bank_transactions')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('bank_import_batch_id', 'integer', ['null' => false])
+            ->addColumn('bank_account_id', 'integer', ['null' => false])
+            ->addColumn('value_date', 'date', ['null' => false])
+            ->addColumn('amount_cents', 'biginteger', ['null' => false])
+            ->addColumn('counterparty_text', 'string', ['limit' => 255, 'null' => false, 'default' => ''])
+            ->addColumn('line_key', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('status', 'string', ['limit' => 32, 'null' => false, 'default' => 'unmatched'])
+            ->addColumn('created_at', 'datetime', ['null' => true])
+            ->addIndex(['organization_id', 'status'])
+            ->addIndex(['bank_import_batch_id'])
+            ->addIndex(['value_date'])
+            ->addIndex(['organization_id', 'counterparty_text'])
+            ->create();
+    }
+}

--- a/database/migrations/20260530130300_create_audit_events_table.php
+++ b/database/migrations/20260530130300_create_audit_events_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateAuditEventsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('audit_events')
+            ->addColumn('organization_id', 'integer', ['null' => false])
+            ->addColumn('event_type', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('actor_user_id', 'integer', ['null' => false])
+            ->addColumn('occurred_at', 'datetime', ['null' => false])
+            ->addColumn('payload_json', 'text', ['null' => false])
+            ->addIndex(['organization_id', 'event_type'])
+            ->create();
+    }
+}

--- a/database/schema/audit_events.sql
+++ b/database/schema/audit_events.sql
@@ -1,0 +1,12 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- Immutable audit trail (compliance §6). Append-only.
+CREATE TABLE audit_events (
+    id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    organization_id  BIGINT UNSIGNED NOT NULL,
+    event_type       VARCHAR(64) NOT NULL,
+    actor_user_id    BIGINT UNSIGNED NOT NULL,
+    occurred_at      DATETIME NOT NULL,
+    payload_json     TEXT NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_audit_events_org_type (organization_id, event_type)
+);

--- a/database/schema/bank_accounts.sql
+++ b/database/schema/bank_accounts.sql
@@ -1,0 +1,20 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- Registered company bank account + CSV import profile.
+CREATE TABLE bank_accounts (
+    id                       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    organization_id          BIGINT UNSIGNED NOT NULL,
+    bank_name                VARCHAR(255) NOT NULL,
+    bank_branch              VARCHAR(255) NOT NULL DEFAULT '',
+    account_type             VARCHAR(32) NOT NULL,
+    account_number           VARCHAR(64) NOT NULL,
+    csv_encoding             VARCHAR(32) NOT NULL DEFAULT 'utf8',
+    csv_date_format          VARCHAR(32) NOT NULL,
+    csv_date_column          INT NOT NULL,
+    csv_amount_column        INT NOT NULL,
+    csv_counterparty_column  INT NOT NULL,
+    csv_header_rows          INT NOT NULL DEFAULT 1,
+    created_at               DATETIME NULL,
+    updated_at               DATETIME NULL,
+    PRIMARY KEY (id),
+    KEY idx_bank_accounts_organization_id (organization_id)
+);

--- a/database/schema/bank_import_batches.sql
+++ b/database/schema/bank_import_batches.sql
@@ -1,0 +1,20 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- CSV import provenance (電子帳簿保存法 / ADR 0012). Unique file_hash per org.
+CREATE TABLE bank_import_batches (
+    id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    organization_id  BIGINT UNSIGNED NOT NULL,
+    bank_account_id  BIGINT UNSIGNED NOT NULL,
+    file_hash        VARCHAR(64) NOT NULL,
+    source_filename  VARCHAR(255) NOT NULL,
+    row_count        INT NOT NULL DEFAULT 0,
+    status           VARCHAR(32) NOT NULL DEFAULT 'imported',
+    imported_by      BIGINT UNSIGNED NOT NULL,
+    imported_at      DATETIME NOT NULL,
+    reversed_at      DATETIME NULL,
+    reversal_reason  VARCHAR(255) NULL,
+    created_at       DATETIME NULL,
+    updated_at       DATETIME NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_bank_import_batches_org_file_hash (organization_id, file_hash),
+    KEY idx_bank_import_batches_organization_id (organization_id)
+);

--- a/database/schema/bank_transactions.sql
+++ b/database/schema/bank_transactions.sql
@@ -1,0 +1,19 @@
+-- Schema snapshot (reference). Source of truth: database/migrations/.
+-- Imported deposit lines — immutable evidence (compliance §3.1 / ADR 0012).
+CREATE TABLE bank_transactions (
+    id                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    organization_id       BIGINT UNSIGNED NOT NULL,
+    bank_import_batch_id  BIGINT UNSIGNED NOT NULL,
+    bank_account_id       BIGINT UNSIGNED NOT NULL,
+    value_date            DATE NOT NULL,
+    amount_cents          BIGINT NOT NULL,
+    counterparty_text     VARCHAR(255) NOT NULL DEFAULT '',
+    line_key              VARCHAR(64) NOT NULL,
+    status                VARCHAR(32) NOT NULL DEFAULT 'unmatched',
+    created_at            DATETIME NULL,
+    PRIMARY KEY (id),
+    KEY idx_bank_transactions_org_status (organization_id, status),
+    KEY idx_bank_transactions_batch (bank_import_batch_id),
+    KEY idx_bank_transactions_value_date (value_date),
+    KEY idx_bank_transactions_org_counterparty (organization_id, counterparty_text)
+);

--- a/src/Audit/AuditEvent.php
+++ b/src/Audit/AuditEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+/**
+ * Immutable audit record (compliance §6). Append-only; never updated or deleted.
+ */
+final readonly class AuditEvent
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        public int $organizationId,
+        public string $eventType,
+        public int $actorUserId,
+        public string $occurredAt,
+        public array $payload,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Audit/AuditEventRepositoryInterface.php
+++ b/src/Audit/AuditEventRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+interface AuditEventRepositoryInterface
+{
+    public function record(AuditEvent $event): int;
+}

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoAuditEventRepository implements AuditEventRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function record(AuditEvent $event): int
+    {
+        $this->query->execute(
+            'INSERT INTO audit_events (organization_id, event_type, actor_user_id, occurred_at, payload_json) '
+            . 'VALUES (?, ?, ?, ?, ?)',
+            [
+                $event->organizationId,
+                $event->eventType,
+                $event->actorUserId,
+                $event->occurredAt,
+                json_encode($event->payload, JSON_THROW_ON_ERROR),
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+}

--- a/src/BankImport/AccountType.php
+++ b/src/BankImport/AccountType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+enum AccountType: string
+{
+    case Ordinary = 'ordinary';
+    case Current = 'current';
+}

--- a/src/BankImport/BankAccount.php
+++ b/src/BankImport/BankAccount.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+/**
+ * A registered company bank account plus its CSV import profile. The profile
+ * is what lets one bank's CSV format be parsed; `value_date` sourcing per
+ * account is documentable (compliance §2.2).
+ */
+final readonly class BankAccount
+{
+    public function __construct(
+        public int $organizationId,
+        public string $bankName,
+        public string $bankBranch,
+        public AccountType $accountType,
+        public string $accountNumber,
+        public string $csvEncoding,
+        public string $csvDateFormat,
+        public int $csvDateColumn,
+        public int $csvAmountColumn,
+        public int $csvCounterpartyColumn,
+        public int $csvHeaderRows,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/BankImport/BankAccountNotFoundException.php
+++ b/src/BankImport/BankAccountNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class BankAccountNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Bank account %d was not found.', $id));
+    }
+}

--- a/src/BankImport/BankAccountRepositoryInterface.php
+++ b/src/BankImport/BankAccountRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+interface BankAccountRepositoryInterface
+{
+    public function findById(int $id): ?BankAccount;
+
+    public function save(BankAccount $account): int;
+}

--- a/src/BankImport/BankCsvParser.php
+++ b/src/BankImport/BankCsvParser.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use DateTimeImmutable;
+
+/**
+ * Parses a bank CSV into deposit lines using a {@see BankAccount}'s profile.
+ *
+ * Only credits (deposits) are kept: rows whose amount column is empty or not a
+ * positive value are skipped (they are withdrawals). The amount is read as an
+ * integer in the smallest currency unit (¥1 = 1). Deposit rows with an
+ * unparseable value date fail the whole import rather than being dropped
+ * silently (compliance §3.1 — no silent loss of evidence).
+ */
+final readonly class BankCsvParser
+{
+    /**
+     * @return list<ParsedBankLine>
+     *
+     * @throws InvalidBankCsvException
+     */
+    public function parse(string $contents, BankAccount $account): array
+    {
+        if (strtolower($account->csvEncoding) !== 'utf8' && strtolower($account->csvEncoding) !== 'utf-8') {
+            $converted = @mb_convert_encoding($contents, 'UTF-8', $this->mbEncoding($account->csvEncoding));
+            $contents = is_string($converted) ? $converted : $contents;
+        }
+
+        $rows = preg_split('/\r\n|\r|\n/', $contents) ?: [];
+
+        $lines = [];
+        $index = -1;
+
+        foreach ($rows as $raw) {
+            ++$index;
+
+            if ($index < $account->csvHeaderRows || trim($raw) === '') {
+                continue;
+            }
+
+            $cells = str_getcsv($raw, ',', '"', '\\');
+
+            $amountCents = $this->parseAmount($cells[$account->csvAmountColumn] ?? null);
+            if ($amountCents <= 0) {
+                // Empty/zero/negative deposit column → not a credit line; skip.
+                continue;
+            }
+
+            $valueDate = $this->parseDate((string) ($cells[$account->csvDateColumn] ?? ''), $account->csvDateFormat);
+            $counterparty = trim((string) ($cells[$account->csvCounterpartyColumn] ?? ''));
+            $lineKey = md5($index . '|' . $valueDate . '|' . $amountCents . '|' . $counterparty);
+
+            $lines[] = new ParsedBankLine(
+                valueDate: $valueDate,
+                amountCents: $amountCents,
+                counterpartyText: $counterparty,
+                lineKey: $lineKey,
+            );
+        }
+
+        return $lines;
+    }
+
+    private function parseAmount(?string $raw): int
+    {
+        if ($raw === null) {
+            return 0;
+        }
+
+        $digits = preg_replace('/[^\d-]/', '', $raw) ?? '';
+
+        return $digits === '' || $digits === '-' ? 0 : (int) $digits;
+    }
+
+    /**
+     * @throws InvalidBankCsvException
+     */
+    private function parseDate(string $raw, string $format): string
+    {
+        $date = DateTimeImmutable::createFromFormat($format, trim($raw));
+
+        if ($date === false) {
+            throw new InvalidBankCsvException(sprintf('Could not parse date "%s" with format "%s".', $raw, $format));
+        }
+
+        return $date->format('Y-m-d');
+    }
+
+    private function mbEncoding(string $encoding): string
+    {
+        return match (strtolower($encoding)) {
+            'shift_jis', 'shift-jis', 'sjis', 'cp932', 'ms932' => 'SJIS-win',
+            default => $encoding,
+        };
+    }
+}

--- a/src/BankImport/BankImportBatch.php
+++ b/src/BankImport/BankImportBatch.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+/**
+ * Provenance of one CSV import (電子帳簿保存法 / ADR 0012). `file_hash` is the
+ * SHA-256 of the imported file and drives duplicate-import detection.
+ */
+final readonly class BankImportBatch
+{
+    public function __construct(
+        public int $organizationId,
+        public int $bankAccountId,
+        public string $fileHash,
+        public string $sourceFilename,
+        public int $rowCount,
+        public BankImportBatchStatus $status,
+        public int $importedBy,
+        public string $importedAt,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/BankImport/BankImportBatchRepositoryInterface.php
+++ b/src/BankImport/BankImportBatchRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+interface BankImportBatchRepositoryInterface
+{
+    public function findById(int $id): ?BankImportBatch;
+
+    public function existsByFileHash(int $organizationId, string $fileHash): bool;
+
+    public function save(BankImportBatch $batch): int;
+}

--- a/src/BankImport/BankImportBatchStatus.php
+++ b/src/BankImport/BankImportBatchStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+enum BankImportBatchStatus: string
+{
+    case Imported = 'imported';
+    case Reversed = 'reversed';
+}

--- a/src/BankImport/BankTransaction.php
+++ b/src/BankImport/BankTransaction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+/**
+ * One imported bank deposit line. Immutable evidence: amount, value date, and
+ * counterparty text are never edited after import (compliance §3.1 / ADR 0012);
+ * only `status` changes through reconciliation, and corrections are reversal
+ * import batches.
+ */
+final readonly class BankTransaction
+{
+    public function __construct(
+        public int $organizationId,
+        public int $bankImportBatchId,
+        public int $bankAccountId,
+        public string $valueDate,
+        public int $amountCents,
+        public string $counterpartyText,
+        public string $lineKey,
+        public BankTransactionStatus $status,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/BankImport/BankTransactionRepositoryInterface.php
+++ b/src/BankImport/BankTransactionRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+interface BankTransactionRepositoryInterface
+{
+    public function save(BankTransaction $transaction): int;
+
+    public function countByBatch(int $bankImportBatchId): int;
+
+    /**
+     * @return list<BankTransaction>
+     */
+    public function findByBatch(int $bankImportBatchId): array;
+}

--- a/src/BankImport/BankTransactionStatus.php
+++ b/src/BankImport/BankTransactionStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+enum BankTransactionStatus: string
+{
+    case Unmatched = 'unmatched';
+    case PartiallyMatched = 'partially_matched';
+    case Matched = 'matched';
+    case Voided = 'voided';
+}

--- a/src/BankImport/DuplicateBankImportException.php
+++ b/src/BankImport/DuplicateBankImportException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class DuplicateBankImportException extends RuntimeException
+{
+    public function __construct(public readonly string $fileHash)
+    {
+        parent::__construct('A batch with this file hash was already imported.');
+    }
+}

--- a/src/BankImport/ImportBankCsvInput.php
+++ b/src/BankImport/ImportBankCsvInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class ImportBankCsvInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $bankAccountId,
+        public string $sourceFilename,
+        public string $contents,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/BankImport/ImportBankCsvOutput.php
+++ b/src/BankImport/ImportBankCsvOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class ImportBankCsvOutput
+{
+    public function __construct(
+        public int $bankImportBatchId,
+        public string $fileHash,
+        public int $rowCount,
+    ) {
+    }
+}

--- a/src/BankImport/ImportBankCsvUseCase.php
+++ b/src/BankImport/ImportBankCsvUseCase.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
+final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterface
+{
+    public function __construct(
+        private BankAccountRepositoryInterface $bankAccounts,
+        private BankImportBatchRepositoryInterface $batches,
+        private BankTransactionRepositoryInterface $transactions,
+        private AuditEventRepositoryInterface $auditEvents,
+        private BankCsvParser $parser,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(ImportBankCsvInput $input): ImportBankCsvOutput
+    {
+        $account = $this->bankAccounts->findById($input->bankAccountId);
+
+        if ($account === null || $account->organizationId !== $input->organizationId) {
+            throw new BankAccountNotFoundException($input->bankAccountId);
+        }
+
+        $fileHash = hash('sha256', $input->contents);
+
+        if ($this->batches->existsByFileHash($input->organizationId, $fileHash)) {
+            throw new DuplicateBankImportException($fileHash);
+        }
+
+        $lines = $this->parser->parse($input->contents, $account);
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        $batchId = $this->batches->save(new BankImportBatch(
+            organizationId: $input->organizationId,
+            bankAccountId: $input->bankAccountId,
+            fileHash: $fileHash,
+            sourceFilename: $input->sourceFilename,
+            rowCount: count($lines),
+            status: BankImportBatchStatus::Imported,
+            importedBy: $input->actorUserId,
+            importedAt: $now,
+        ));
+
+        foreach ($lines as $line) {
+            $this->transactions->save(new BankTransaction(
+                organizationId: $input->organizationId,
+                bankImportBatchId: $batchId,
+                bankAccountId: $input->bankAccountId,
+                valueDate: $line->valueDate,
+                amountCents: $line->amountCents,
+                counterpartyText: $line->counterpartyText,
+                lineKey: $line->lineKey,
+                status: BankTransactionStatus::Unmatched,
+            ));
+        }
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'bank_import',
+            actorUserId: $input->actorUserId,
+            occurredAt: $now,
+            payload: [
+                'bank_import_batch_id' => $batchId,
+                'file_hash' => $fileHash,
+                'row_count' => count($lines),
+                'source_filename' => $input->sourceFilename,
+            ],
+        ));
+
+        return new ImportBankCsvOutput(
+            bankImportBatchId: $batchId,
+            fileHash: $fileHash,
+            rowCount: count($lines),
+        );
+    }
+}

--- a/src/BankImport/ImportBankCsvUseCaseInterface.php
+++ b/src/BankImport/ImportBankCsvUseCaseInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+interface ImportBankCsvUseCaseInterface
+{
+    /**
+     * @throws BankAccountNotFoundException
+     * @throws DuplicateBankImportException
+     * @throws InvalidBankCsvException
+     */
+    public function execute(ImportBankCsvInput $input): ImportBankCsvOutput;
+}

--- a/src/BankImport/InvalidBankCsvException.php
+++ b/src/BankImport/InvalidBankCsvException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class InvalidBankCsvException extends RuntimeException
+{
+}

--- a/src/BankImport/ParsedBankLine.php
+++ b/src/BankImport/ParsedBankLine.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+/**
+ * One parsed deposit line from a bank CSV, before persistence.
+ */
+final readonly class ParsedBankLine
+{
+    public function __construct(
+        public string $valueDate,
+        public int $amountCents,
+        public string $counterpartyText,
+        public string $lineKey,
+    ) {
+    }
+}

--- a/src/BankImport/PdoBankAccountRepository.php
+++ b/src/BankImport/PdoBankAccountRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoBankAccountRepository implements BankAccountRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, bank_name, bank_branch, account_type, account_number, '
+        . 'csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?BankAccount
+    {
+        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE id = ?', [$id]);
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function save(BankAccount $account): int
+    {
+        $this->query->execute(
+            'INSERT INTO bank_accounts (organization_id, bank_name, bank_branch, account_type, account_number, '
+            . 'csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $account->organizationId,
+                $account->bankName,
+                $account->bankBranch,
+                $account->accountType->value,
+                $account->accountNumber,
+                $account->csvEncoding,
+                $account->csvDateFormat,
+                $account->csvDateColumn,
+                $account->csvAmountColumn,
+                $account->csvCounterpartyColumn,
+                $account->csvHeaderRows,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): BankAccount
+    {
+        return new BankAccount(
+            organizationId: (int) $row['organization_id'],
+            bankName: (string) $row['bank_name'],
+            bankBranch: (string) $row['bank_branch'],
+            accountType: AccountType::from((string) $row['account_type']),
+            accountNumber: (string) $row['account_number'],
+            csvEncoding: (string) $row['csv_encoding'],
+            csvDateFormat: (string) $row['csv_date_format'],
+            csvDateColumn: (int) $row['csv_date_column'],
+            csvAmountColumn: (int) $row['csv_amount_column'],
+            csvCounterpartyColumn: (int) $row['csv_counterparty_column'],
+            csvHeaderRows: (int) $row['csv_header_rows'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/BankImport/PdoBankImportBatchRepository.php
+++ b/src/BankImport/PdoBankImportBatchRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoBankImportBatchRepository implements BankImportBatchRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, bank_account_id, file_hash, source_filename, row_count, '
+        . 'status, imported_by, imported_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?BankImportBatch
+    {
+        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_import_batches WHERE id = ?', [$id]);
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function existsByFileHash(int $organizationId, string $fileHash): bool
+    {
+        return $this->query->fetchOne(
+            'SELECT 1 FROM bank_import_batches WHERE organization_id = ? AND file_hash = ?',
+            [$organizationId, $fileHash],
+        ) !== null;
+    }
+
+    public function save(BankImportBatch $batch): int
+    {
+        $this->query->execute(
+            'INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, '
+            . 'row_count, status, imported_by, imported_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $batch->organizationId,
+                $batch->bankAccountId,
+                $batch->fileHash,
+                $batch->sourceFilename,
+                $batch->rowCount,
+                $batch->status->value,
+                $batch->importedBy,
+                $batch->importedAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): BankImportBatch
+    {
+        return new BankImportBatch(
+            organizationId: (int) $row['organization_id'],
+            bankAccountId: (int) $row['bank_account_id'],
+            fileHash: (string) $row['file_hash'],
+            sourceFilename: (string) $row['source_filename'],
+            rowCount: (int) $row['row_count'],
+            status: BankImportBatchStatus::from((string) $row['status']),
+            importedBy: (int) $row['imported_by'],
+            importedAt: (string) $row['imported_at'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoBankTransactionRepository implements BankTransactionRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, bank_import_batch_id, bank_account_id, value_date, '
+        . 'amount_cents, counterparty_text, line_key, status';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(BankTransaction $transaction): int
+    {
+        $this->query->execute(
+            'INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date, '
+            . 'amount_cents, counterparty_text, line_key, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $transaction->organizationId,
+                $transaction->bankImportBatchId,
+                $transaction->bankAccountId,
+                $transaction->valueDate,
+                $transaction->amountCents,
+                $transaction->counterpartyText,
+                $transaction->lineKey,
+                $transaction->status->value,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function countByBatch(int $bankImportBatchId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS c FROM bank_transactions WHERE bank_import_batch_id = ?',
+            [$bankImportBatchId],
+        );
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function findByBatch(int $bankImportBatchId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE bank_import_batch_id = ? ORDER BY id ASC',
+            [$bankImportBatchId],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): BankTransaction
+    {
+        return new BankTransaction(
+            organizationId: (int) $row['organization_id'],
+            bankImportBatchId: (int) $row['bank_import_batch_id'],
+            bankAccountId: (int) $row['bank_account_id'],
+            valueDate: (string) $row['value_date'],
+            amountCents: (int) $row['amount_cents'],
+            counterpartyText: (string) $row['counterparty_text'],
+            lineKey: (string) $row['line_key'],
+            status: BankTransactionStatus::from((string) $row['status']),
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/tests/Audit/InMemoryAuditEventRepository.php
+++ b/tests/Audit/InMemoryAuditEventRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Audit;
+
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
+final class InMemoryAuditEventRepository implements AuditEventRepositoryInterface
+{
+    /** @var list<AuditEvent> */
+    public array $events = [];
+
+    public function record(AuditEvent $event): int
+    {
+        $this->events[] = $event;
+
+        return count($this->events);
+    }
+}

--- a/tests/BankImport/BankCsvParserTest.php
+++ b/tests/BankImport/BankCsvParserTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\InvalidBankCsvException;
+use PHPUnit\Framework\TestCase;
+
+final class BankCsvParserTest extends TestCase
+{
+    private function account(string $encoding): BankAccount
+    {
+        // Columns: 0=取引日, 1=入金額, 2=出金額, 3=摘要
+        return new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '1234567',
+            csvEncoding: $encoding,
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        );
+    }
+
+    public function test_parses_deposits_only_and_normalizes_dates_from_shift_jis(): void
+    {
+        $utf8 = "取引日,入金額,出金額,摘要\n"
+            . "2026/04/20,110000,,カ）アクメ\n"
+            . "2026/04/21,,5000,ATM出金\n"
+            . "2026/04/22,\"50,000\",,フリコミ タロウ\n";
+        $sjis = (string) mb_convert_encoding($utf8, 'SJIS-win', 'UTF-8');
+
+        $lines = (new BankCsvParser())->parse($sjis, $this->account('shift_jis'));
+
+        self::assertCount(2, $lines); // the withdrawal row is skipped
+        self::assertSame('2026-04-20', $lines[0]->valueDate);
+        self::assertSame(110000, $lines[0]->amountCents);
+        self::assertSame('カ）アクメ', $lines[0]->counterpartyText);
+        self::assertSame('2026-04-22', $lines[1]->valueDate);
+        self::assertSame(50000, $lines[1]->amountCents); // quoted "50,000"
+        self::assertSame('フリコミ タロウ', $lines[1]->counterpartyText);
+    }
+
+    public function test_throws_on_unparseable_deposit_date(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\nnot-a-date,1000,,X\n";
+
+        $this->expectException(InvalidBankCsvException::class);
+        (new BankCsvParser())->parse($csv, $this->account('utf8'));
+    }
+}

--- a/tests/BankImport/ImportBankCsvUseCaseTest.php
+++ b/tests/BankImport/ImportBankCsvUseCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankAccountNotFoundException;
+use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\DuplicateBankImportException;
+use NeneClear\BankImport\ImportBankCsvInput;
+use NeneClear\BankImport\ImportBankCsvUseCase;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class ImportBankCsvUseCaseTest extends TestCase
+{
+    private const string CSV = "date,deposit,withdrawal,memo\n2026/04/20,110000,,ACME\n2026/04/22,50000,,TARO\n";
+
+    private InMemoryBankAccountRepository $accounts;
+    private InMemoryBankImportBatchRepository $batches;
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryAuditEventRepository $audit;
+    private ImportBankCsvUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->accounts = new InMemoryBankAccountRepository();
+        $this->accounts->save(new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '123',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        ));
+
+        $this->batches = new InMemoryBankImportBatchRepository();
+        $this->transactions = new InMemoryBankTransactionRepository();
+        $this->audit = new InMemoryAuditEventRepository();
+
+        $this->useCase = new ImportBankCsvUseCase(
+            $this->accounts,
+            $this->batches,
+            $this->transactions,
+            $this->audit,
+            new BankCsvParser(),
+            new FixedClock(),
+        );
+    }
+
+    private function input(string $contents): ImportBankCsvInput
+    {
+        return new ImportBankCsvInput(
+            organizationId: 7,
+            bankAccountId: 1,
+            sourceFilename: 'april.csv',
+            contents: $contents,
+            actorUserId: 42,
+        );
+    }
+
+    public function test_import_creates_batch_transactions_and_audit_event(): void
+    {
+        $output = $this->useCase->execute($this->input(self::CSV));
+
+        self::assertSame(2, $output->rowCount);
+        self::assertSame(64, strlen($output->fileHash)); // sha-256 hex
+        self::assertSame(2, $this->transactions->countByBatch($output->bankImportBatchId));
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('bank_import', $this->audit->events[0]->eventType);
+        self::assertSame(42, $this->audit->events[0]->actorUserId);
+    }
+
+    public function test_duplicate_file_hash_is_rejected(): void
+    {
+        $this->useCase->execute($this->input(self::CSV));
+
+        $this->expectException(DuplicateBankImportException::class);
+        $this->useCase->execute($this->input(self::CSV));
+    }
+
+    public function test_unknown_or_cross_tenant_account_is_rejected(): void
+    {
+        $this->expectException(BankAccountNotFoundException::class);
+        $this->useCase->execute(new ImportBankCsvInput(
+            organizationId: 999,
+            bankAccountId: 1,
+            sourceFilename: 'x.csv',
+            contents: self::CSV,
+            actorUserId: 42,
+        ));
+    }
+}

--- a/tests/BankImport/InMemoryBankAccountRepository.php
+++ b/tests/BankImport/InMemoryBankAccountRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+
+final class InMemoryBankAccountRepository implements BankAccountRepositoryInterface
+{
+    /** @var array<int, BankAccount> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function findById(int $id): ?BankAccount
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function save(BankAccount $account): int
+    {
+        $id = $account->id ?? $this->nextId++;
+        $this->byId[$id] = new BankAccount(
+            organizationId: $account->organizationId,
+            bankName: $account->bankName,
+            bankBranch: $account->bankBranch,
+            accountType: $account->accountType,
+            accountNumber: $account->accountNumber,
+            csvEncoding: $account->csvEncoding,
+            csvDateFormat: $account->csvDateFormat,
+            csvDateColumn: $account->csvDateColumn,
+            csvAmountColumn: $account->csvAmountColumn,
+            csvCounterpartyColumn: $account->csvCounterpartyColumn,
+            csvHeaderRows: $account->csvHeaderRows,
+            id: $id,
+        );
+
+        return $id;
+    }
+}

--- a/tests/BankImport/InMemoryBankImportBatchRepository.php
+++ b/tests/BankImport/InMemoryBankImportBatchRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\BankImportBatch;
+use NeneClear\BankImport\BankImportBatchRepositoryInterface;
+
+final class InMemoryBankImportBatchRepository implements BankImportBatchRepositoryInterface
+{
+    /** @var array<int, BankImportBatch> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function findById(int $id): ?BankImportBatch
+    {
+        return $this->byId[$id] ?? null;
+    }
+
+    public function existsByFileHash(int $organizationId, string $fileHash): bool
+    {
+        foreach ($this->byId as $batch) {
+            if ($batch->organizationId === $organizationId && $batch->fileHash === $fileHash) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function save(BankImportBatch $batch): int
+    {
+        $id = $batch->id ?? $this->nextId++;
+        $this->byId[$id] = new BankImportBatch(
+            organizationId: $batch->organizationId,
+            bankAccountId: $batch->bankAccountId,
+            fileHash: $batch->fileHash,
+            sourceFilename: $batch->sourceFilename,
+            rowCount: $batch->rowCount,
+            status: $batch->status,
+            importedBy: $batch->importedBy,
+            importedAt: $batch->importedAt,
+            id: $id,
+        );
+
+        return $id;
+    }
+}

--- a/tests/BankImport/InMemoryBankTransactionRepository.php
+++ b/tests/BankImport/InMemoryBankTransactionRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+
+final class InMemoryBankTransactionRepository implements BankTransactionRepositoryInterface
+{
+    /** @var array<int, BankTransaction> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function save(BankTransaction $transaction): int
+    {
+        $id = $transaction->id ?? $this->nextId++;
+        $this->byId[$id] = new BankTransaction(
+            organizationId: $transaction->organizationId,
+            bankImportBatchId: $transaction->bankImportBatchId,
+            bankAccountId: $transaction->bankAccountId,
+            valueDate: $transaction->valueDate,
+            amountCents: $transaction->amountCents,
+            counterpartyText: $transaction->counterpartyText,
+            lineKey: $transaction->lineKey,
+            status: $transaction->status,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function countByBatch(int $bankImportBatchId): int
+    {
+        return count($this->findByBatch($bankImportBatchId));
+    }
+
+    public function findByBatch(int $bankImportBatchId): array
+    {
+        return array_values(array_filter(
+            $this->byId,
+            static fn (BankTransaction $t): bool => $t->bankImportBatchId === $bankImportBatchId,
+        ));
+    }
+}

--- a/tests/Database/ImportBankCsvPdoTest.php
+++ b/tests/Database/ImportBankCsvPdoTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Audit\PdoAuditEventRepository;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\ImportBankCsvInput;
+use NeneClear\BankImport\ImportBankCsvUseCase;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\BankImport\PdoBankImportBatchRepository;
+use NeneClear\BankImport\PdoBankTransactionRepository;
+use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class ImportBankCsvPdoTest extends TestCase
+{
+    private const string CSV = "date,deposit,withdrawal,memo\n2026/04/20,110000,,ACME\n2026/04/21,,5000,ATM\n2026/04/22,50000,,TARO\n";
+
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private ImportBankCsvUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-import-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createBankAccounts($this->query);
+        SchemaFixture::createBankImportBatches($this->query);
+        SchemaFixture::createBankTransactions($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+
+        $accounts = new PdoBankAccountRepository($this->query);
+        $accounts->save(new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '123',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        ));
+
+        $batches = new PdoBankImportBatchRepository($this->query);
+        $transactions = new PdoBankTransactionRepository($this->query);
+
+        $this->useCase = new ImportBankCsvUseCase(
+            $accounts,
+            $batches,
+            $transactions,
+            new PdoAuditEventRepository($this->query),
+            new BankCsvParser(),
+            new FixedClock(),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function input(string $contents): ImportBankCsvInput
+    {
+        return new ImportBankCsvInput(
+            organizationId: 7,
+            bankAccountId: 1,
+            sourceFilename: 'april.csv',
+            contents: $contents,
+            actorUserId: 42,
+        );
+    }
+
+    public function test_import_persists_immutable_deposit_lines_and_audit(): void
+    {
+        $output = $this->useCase->execute($this->input(self::CSV));
+
+        self::assertSame(2, $output->rowCount); // withdrawal skipped
+
+        $rows = (new PdoBankTransactionRepository($this->query))->findByBatch($output->bankImportBatchId);
+        self::assertCount(2, $rows);
+        self::assertSame('2026-04-20', $rows[0]->valueDate);
+        self::assertSame(110000, $rows[0]->amountCents);
+        self::assertSame('unmatched', $rows[0]->status->value);
+
+        $audit = $this->query->fetchOne('SELECT event_type, actor_user_id FROM audit_events WHERE event_type = ?', ['bank_import']);
+        self::assertNotNull($audit);
+        self::assertSame(42, (int) $audit['actor_user_id']);
+    }
+
+    public function test_reimporting_same_file_is_blocked(): void
+    {
+        $this->useCase->execute($this->input(self::CSV));
+
+        $this->expectException(\NeneClear\BankImport\DuplicateBankImportException::class);
+        $this->useCase->execute($this->input(self::CSV));
+    }
+}

--- a/tests/Support/FixedClock.php
+++ b/tests/Support/FixedClock.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Support;
+
+use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
+
+final readonly class FixedClock implements ClockInterface
+{
+    public function __construct(private string $instant = '2026-05-30T09:00:00+00:00')
+    {
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable($this->instant);
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -42,4 +42,80 @@ final class SchemaFixture
             )'
         );
     }
+
+    public static function createBankAccounts(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE bank_accounts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                bank_name TEXT NOT NULL,
+                bank_branch TEXT NOT NULL DEFAULT \'\',
+                account_type TEXT NOT NULL,
+                account_number TEXT NOT NULL,
+                csv_encoding TEXT NOT NULL DEFAULT \'utf8\',
+                csv_date_format TEXT NOT NULL,
+                csv_date_column INTEGER NOT NULL,
+                csv_amount_column INTEGER NOT NULL,
+                csv_counterparty_column INTEGER NOT NULL,
+                csv_header_rows INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT,
+                updated_at TEXT
+            )'
+        );
+    }
+
+    public static function createBankImportBatches(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE bank_import_batches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                bank_account_id INTEGER NOT NULL,
+                file_hash TEXT NOT NULL,
+                source_filename TEXT NOT NULL,
+                row_count INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT \'imported\',
+                imported_by INTEGER NOT NULL,
+                imported_at TEXT NOT NULL,
+                reversed_at TEXT,
+                reversal_reason TEXT,
+                created_at TEXT,
+                updated_at TEXT,
+                UNIQUE (organization_id, file_hash)
+            )'
+        );
+    }
+
+    public static function createBankTransactions(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE bank_transactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                bank_import_batch_id INTEGER NOT NULL,
+                bank_account_id INTEGER NOT NULL,
+                value_date TEXT NOT NULL,
+                amount_cents INTEGER NOT NULL,
+                counterparty_text TEXT NOT NULL DEFAULT \'\',
+                line_key TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT \'unmatched\',
+                created_at TEXT
+            )'
+        );
+    }
+
+    public static function createAuditEvents(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE audit_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                actor_user_id INTEGER NOT NULL,
+                occurred_at TEXT NOT NULL,
+                payload_json TEXT NOT NULL
+            )'
+        );
+    }
 }


### PR DESCRIPTION
Closes #33.

## Purpose

The compliance heart of NeNe Clear (電子帳簿保存法 / ADR 0012): import bank CSV as immutable evidence, dedup by file hash, with an audit trail. Domain + persistence + parser + use case, fully unit/adapter tested. HTTP endpoints follow in B-5b.

## Change summary

- **Migrations + schema snapshots** — `bank_accounts`, `bank_import_batches`, `bank_transactions`, `audit_events` (verified to apply on SQLite; MySQL-portable).
- **Entities/enums** — `BankAccount`/`AccountType`, `BankImportBatch`/`BankImportBatchStatus`, `BankTransaction`/`BankTransactionStatus`, `AuditEvent`.
- **`BankCsvParser`** — per-account profile (encoding incl. **Shift_JIS** → UTF-8, date format, column mapping, header rows); **deposits only**; integer cents; **fails** (does not silently drop) on an unparseable deposit date.
- **`ImportBankCsvUseCase`** — scoped account load, **SHA-256 `file_hash` dedup** (`DuplicateBankImportException`), **immutable** `bank_transactions` (`unmatched`), `bank_import` audit event; `ClockInterface` injected.
- Repository interfaces + `Pdo*` adapters + in-memory doubles; `AuditEvent` repository.
- **Tests** — parser (Shift_JIS sample, deposits-only, bad-date throws), import use case (in-memory: create / dedup / cross-tenant), PDO adapter (SQLite, real repos).

## Verification

```
composer check → OK (39 tests, 152 assertions); PHPStan: No errors; CS: clean
phinx migrate (SQLite) → organizations, users, bank_accounts, bank_import_batches, bank_transactions, audit_events
```

## Scope

Domain + persistence only. HTTP (`importBankCsv` multipart, list/get batches & transactions, reverse) is B-5b. Follows nene2-compliance.md + payment-reconciliation-dunning-compliance.md §3.

## Self-review

backend-api, compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)