### PR TITLE
feat: bank import HTTP — upload + list endpoints, method-aware capabilities (#35)

### DIFF
--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -149,6 +149,7 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `organization-already-exists` | Create rejected — slug already taken |
 | `user-not-found` | User id not found |
 | `user-already-exists` | Create rejected — email already taken |
+| `bank-account-not-found` | Bank account id not found / not in caller's org |
 | `bank-import-batch-not-found` | Import batch id not found |
 | `bank-transaction-not-found` | Bank transaction id not found |
 | `reconciliation-not-found` | Reconciliation id not found |

--- a/src/Auth/AuthContext.php
+++ b/src/Auth/AuthContext.php
@@ -30,4 +30,15 @@ final readonly class AuthContext
 
         return is_string($role) ? Role::tryFrom($role) : null;
     }
+
+    /**
+     * The authenticated user's id (`sub` claim), or 0 when absent.
+     */
+    public static function userId(ServerRequestInterface $request): int
+    {
+        $claims = (array) $request->getAttribute('nene2.auth.claims', []);
+        $sub = $claims['sub'] ?? null;
+
+        return is_int($sub) ? $sub : (is_numeric($sub) ? (int) $sub : 0);
+    }
 }

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -15,30 +15,39 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * Runs after {@see \Nene2\Auth\BearerTokenMiddleware}, which sets the decoded
  * claims on the `nene2.auth.claims` request attribute. A request whose path
- * starts with a protected prefix requires the mapped {@see Capability}; the
- * authenticated user's `role` claim must grant it, otherwise 403.
+ * starts with a protected prefix requires the mapped {@see CapabilityRule}: the
+ * rule's read capability for safe methods (GET/HEAD/OPTIONS), its write
+ * capability otherwise. The authenticated user's `role` claim must grant it,
+ * otherwise 403.
  *
  * Paths that match no prefix are not capability-gated here (any authenticated
  * user passes); public paths are already excluded upstream.
  */
 final readonly class CapabilityMiddleware implements MiddlewareInterface
 {
+    /** @var list<string> */
+    private const array SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
     /**
-     * @param array<string, Capability> $prefixCapabilities path prefix => required capability
+     * @param array<string, CapabilityRule> $prefixRules path prefix => required capabilities
      */
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
-        private array $prefixCapabilities,
+        private array $prefixRules,
     ) {
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $required = $this->requiredCapability($request->getUri()->getPath() ?: '/');
+        $rule = $this->ruleForPath($request->getUri()->getPath() ?: '/');
 
-        if ($required === null) {
+        if ($rule === null) {
             return $handler->handle($request);
         }
+
+        $required = in_array(strtoupper($request->getMethod()), self::SAFE_METHODS, true)
+            ? $rule->read
+            : $rule->write;
 
         $claims = (array) $request->getAttribute('nene2.auth.claims', []);
         $roleValue = $claims['role'] ?? null;
@@ -57,11 +66,11 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
         return $handler->handle($request);
     }
 
-    private function requiredCapability(string $path): ?Capability
+    private function ruleForPath(string $path): ?CapabilityRule
     {
-        foreach ($this->prefixCapabilities as $prefix => $capability) {
+        foreach ($this->prefixRules as $prefix => $rule) {
             if (str_starts_with($path, $prefix)) {
-                return $capability;
+                return $rule;
             }
         }
 

--- a/src/Auth/CapabilityRule.php
+++ b/src/Auth/CapabilityRule.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+/**
+ * The capabilities a path prefix requires, split by read vs. write so a
+ * read-only role (viewer) can list while only a managing role can mutate.
+ */
+final readonly class CapabilityRule
+{
+    public function __construct(
+        public Capability $read,
+        public Capability $write,
+    ) {
+    }
+
+    /**
+     * Same capability for both reads and writes.
+     */
+    public static function same(Capability $capability): self
+    {
+        return new self($capability, $capability);
+    }
+}

--- a/src/BankImport/BankAccountNotFoundExceptionHandler.php
+++ b/src/BankImport/BankAccountNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankAccountNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankAccountNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'bank-account-not-found',
+            'Bank Account Not Found',
+            404,
+            'The requested bank account was not found.',
+        );
+    }
+}

--- a/src/BankImport/BankImportBatchRepositoryInterface.php
+++ b/src/BankImport/BankImportBatchRepositoryInterface.php
@@ -11,4 +11,11 @@ interface BankImportBatchRepositoryInterface
     public function existsByFileHash(int $organizationId, string $fileHash): bool;
 
     public function save(BankImportBatch $batch): int;
+
+    /**
+     * @return list<BankImportBatch>
+     */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
 }

--- a/src/BankImport/BankImportBatchResponse.php
+++ b/src/BankImport/BankImportBatchResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class BankImportBatchResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(BankImportBatch $batch): array
+    {
+        return [
+            'bank_import_batch_id' => $batch->id,
+            'organization_id' => $batch->organizationId,
+            'bank_account_id' => $batch->bankAccountId,
+            'file_hash' => $batch->fileHash,
+            'source_filename' => $batch->sourceFilename,
+            'row_count' => $batch->rowCount,
+            'status' => $batch->status->value,
+            'imported_at' => $batch->importedAt,
+        ];
+    }
+}

--- a/src/BankImport/BankImportRouteRegistrar.php
+++ b/src/BankImport/BankImportRouteRegistrar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class BankImportRouteRegistrar
+{
+    public function __construct(
+        private ImportBankCsvHandler $importHandler,
+        private ListBankImportBatchesHandler $listBatchesHandler,
+        private ListBankTransactionsHandler $listTransactionsHandler,
+        private ListUnmatchedTransactionsHandler $listUnmatchedHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $importHandler = $this->importHandler;
+        $listBatchesHandler = $this->listBatchesHandler;
+        $listTransactionsHandler = $this->listTransactionsHandler;
+        $listUnmatchedHandler = $this->listUnmatchedHandler;
+
+        $router->post('/admin/bank-import-batches', static fn (ServerRequestInterface $r): ResponseInterface => $importHandler->handle($r));
+        $router->get('/admin/bank-import-batches', static fn (ServerRequestInterface $r): ResponseInterface => $listBatchesHandler->handle($r));
+        // Unmatched is registered before the generic list so the more specific path wins.
+        $router->get('/admin/bank-transactions/unmatched', static fn (ServerRequestInterface $r): ResponseInterface => $listUnmatchedHandler->handle($r));
+        $router->get('/admin/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $listTransactionsHandler->handle($r));
+    }
+}

--- a/src/BankImport/BankTransactionRepositoryInterface.php
+++ b/src/BankImport/BankTransactionRepositoryInterface.php
@@ -14,4 +14,20 @@ interface BankTransactionRepositoryInterface
      * @return list<BankTransaction>
      */
     public function findByBatch(int $bankImportBatchId): array;
+
+    /**
+     * @return list<BankTransaction>
+     */
+    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int;
+
+    /**
+     * Lines still open for matching (unmatched or partially matched).
+     *
+     * @return list<BankTransaction>
+     */
+    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countUnmatchedByOrganization(int $organizationId): int;
 }

--- a/src/BankImport/BankTransactionResponse.php
+++ b/src/BankImport/BankTransactionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class BankTransactionResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(BankTransaction $transaction): array
+    {
+        return [
+            'bank_transaction_id' => $transaction->id,
+            'organization_id' => $transaction->organizationId,
+            'bank_import_batch_id' => $transaction->bankImportBatchId,
+            'bank_account_id' => $transaction->bankAccountId,
+            'value_date' => $transaction->valueDate,
+            'amount_cents' => $transaction->amountCents,
+            'counterparty_text' => $transaction->counterpartyText,
+            'status' => $transaction->status->value,
+        ];
+    }
+}

--- a/src/BankImport/DuplicateBankImportExceptionHandler.php
+++ b/src/BankImport/DuplicateBankImportExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class DuplicateBankImportExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof DuplicateBankImportException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'duplicate-bank-import',
+            'Duplicate Bank Import',
+            409,
+            'A batch with this file hash was already imported.',
+        );
+    }
+}

--- a/src/BankImport/ImportBankCsvHandler.php
+++ b/src/BankImport/ImportBankCsvHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+final readonly class ImportBankCsvHandler
+{
+    public function __construct(
+        private ImportBankCsvUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parsedBody = $request->getParsedBody();
+        $body = is_array($parsedBody) ? $parsedBody : [];
+
+        $errors = [];
+        $bankAccountId = (int) ($body['bank_account_id'] ?? 0);
+        if ($bankAccountId <= 0) {
+            $errors[] = new ValidationError('bank_account_id', 'A bank account id is required.', 'required');
+        }
+
+        $file = $request->getUploadedFiles()['file'] ?? null;
+        if (!$file instanceof UploadedFileInterface) {
+            $errors[] = new ValidationError('file', 'A CSV file upload is required.', 'required');
+        }
+
+        if ($errors !== [] || !$file instanceof UploadedFileInterface) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new ImportBankCsvInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            bankAccountId: $bankAccountId,
+            sourceFilename: $file->getClientFilename() ?? 'upload.csv',
+            contents: (string) $file->getStream(),
+            actorUserId: AuthContext::userId($request),
+        ));
+
+        return $this->response->create(
+            [
+                'bank_import_batch_id' => $output->bankImportBatchId,
+                'file_hash' => $output->fileHash,
+                'row_count' => $output->rowCount,
+            ],
+            201,
+            ['Location' => '/admin/bank-import-batches/' . $output->bankImportBatchId],
+        );
+    }
+}

--- a/src/BankImport/InvalidBankCsvExceptionHandler.php
+++ b/src/BankImport/InvalidBankCsvExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidBankCsvExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidBankCsvException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'validation-failed',
+            'Validation Failed',
+            422,
+            'The uploaded CSV could not be parsed: ' . $exception->getMessage(),
+        );
+    }
+}

--- a/src/BankImport/ListBankImportBatchesHandler.php
+++ b/src/BankImport/ListBankImportBatchesHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListBankImportBatchesHandler
+{
+    public function __construct(
+        private BankImportBatchRepositoryInterface $batches,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        return $this->response->create([
+            'items' => array_map(
+                BankImportBatchResponse::toArray(...),
+                $this->batches->findByOrganization($organizationId, $page->limit, $page->offset),
+            ),
+            'limit' => $page->limit,
+            'offset' => $page->offset,
+            'total' => $this->batches->countByOrganization($organizationId),
+        ]);
+    }
+}

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListBankTransactionsHandler
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        $statusParam = $request->getQueryParams()['status'] ?? null;
+        $status = is_string($statusParam) ? BankTransactionStatus::tryFrom($statusParam) : null;
+
+        return $this->response->create([
+            'items' => array_map(
+                BankTransactionResponse::toArray(...),
+                $this->transactions->findByOrganization($organizationId, $status, $page->limit, $page->offset),
+            ),
+            'limit' => $page->limit,
+            'offset' => $page->offset,
+            'total' => $this->transactions->countByOrganization($organizationId, $status),
+        ]);
+    }
+}

--- a/src/BankImport/ListUnmatchedTransactionsHandler.php
+++ b/src/BankImport/ListUnmatchedTransactionsHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListUnmatchedTransactionsHandler
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        return $this->response->create([
+            'items' => array_map(
+                BankTransactionResponse::toArray(...),
+                $this->transactions->findUnmatchedByOrganization($organizationId, $page->limit, $page->offset),
+            ),
+            'limit' => $page->limit,
+            'offset' => $page->offset,
+            'total' => $this->transactions->countUnmatchedByOrganization($organizationId),
+        ]);
+    }
+}

--- a/src/BankImport/PdoBankImportBatchRepository.php
+++ b/src/BankImport/PdoBankImportBatchRepository.php
@@ -51,6 +51,28 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
         return $this->query->lastInsertId();
     }
 
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_import_batches WHERE organization_id = ? '
+            . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_import_batches WHERE organization_id = ?', [$organizationId]);
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
     /**
      * @param array<string, mixed> $row
      */

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -60,6 +60,63 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         return array_map($this->hydrate(...), $rows);
     }
 
+    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array
+    {
+        if ($status === null) {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? '
+                . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? AND status = ? '
+                . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $status->value, $limit, $offset],
+            );
+        }
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int
+    {
+        $row = $status === null
+            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ?', [$organizationId])
+            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ? AND status = ?', [$organizationId, $status->value]);
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? AND status IN (?, ?) '
+            . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+            [$organizationId, BankTransactionStatus::Unmatched->value, BankTransactionStatus::PartiallyMatched->value, $limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countUnmatchedByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ? AND status IN (?, ?)',
+            [$organizationId, BankTransactionStatus::Unmatched->value, BankTransactionStatus::PartiallyMatched->value],
+        );
+
+        if ($row === null) {
+            return 0;
+        }
+
+        return (int) ($row['c'] ?? 0);
+    }
+
     /**
      * @param array<string, mixed> $row
      */

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -9,14 +9,30 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Auth\AuthRouteRegistrar;
 use NeneClear\Auth\Capability;
 use NeneClear\Auth\CapabilityMiddleware;
+use NeneClear\Auth\CapabilityRule;
 use NeneClear\Auth\GetCurrentUserHandler;
 use NeneClear\Auth\InvalidCredentialsExceptionHandler;
 use NeneClear\Auth\JwtTokenService;
 use NeneClear\Auth\LoginHandler;
 use NeneClear\Auth\LoginUseCase;
+use NeneClear\BankImport\BankAccountNotFoundExceptionHandler;
+use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\BankImportRouteRegistrar;
+use NeneClear\BankImport\DuplicateBankImportExceptionHandler;
+use NeneClear\BankImport\ImportBankCsvHandler;
+use NeneClear\BankImport\ImportBankCsvUseCase;
+use NeneClear\BankImport\InvalidBankCsvExceptionHandler;
+use NeneClear\BankImport\ListBankImportBatchesHandler;
+use NeneClear\BankImport\ListBankTransactionsHandler;
+use NeneClear\BankImport\ListUnmatchedTransactionsHandler;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\BankImport\PdoBankImportBatchRepository;
+use NeneClear\BankImport\PdoBankTransactionRepository;
 use NeneClear\Organization\CreateOrganizationHandler;
 use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\DeleteOrganizationHandler;
@@ -106,17 +122,40 @@ final class ApplicationFactory
                 new DeleteUserHandler(new DeleteUserUseCase($users), $json),
             );
 
+            $bankAccounts = new PdoBankAccountRepository($query);
+            $batches = new PdoBankImportBatchRepository($query);
+            $transactions = new PdoBankTransactionRepository($query);
+            $importUseCase = new ImportBankCsvUseCase(
+                $bankAccounts,
+                $batches,
+                $transactions,
+                new PdoAuditEventRepository($query),
+                new BankCsvParser(),
+                new UtcClock(),
+            );
+            $routeRegistrars[] = new BankImportRouteRegistrar(
+                new ImportBankCsvHandler($importUseCase, $json),
+                new ListBankImportBatchesHandler($batches, $json),
+                new ListBankTransactionsHandler($transactions, $json),
+                new ListUnmatchedTransactionsHandler($transactions, $json),
+            );
+
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationAlreadyExistsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new UserNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new UserAlreadyExistsExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new DuplicateBankImportExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankAccountNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new InvalidBankCsvExceptionHandler($problemDetails);
 
             $authMiddleware = [
                 new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
                 new CapabilityMiddleware($problemDetails, [
-                    '/admin/organizations' => Capability::ManageOrganizations,
-                    '/admin/users' => Capability::ManageUsers,
+                    '/admin/organizations' => CapabilityRule::same(Capability::ManageOrganizations),
+                    '/admin/users' => CapabilityRule::same(Capability::ManageUsers),
+                    '/admin/bank-import-batches' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                    '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                 ]),
             ];
         }

--- a/tests/BankImport/InMemoryBankImportBatchRepository.php
+++ b/tests/BankImport/InMemoryBankImportBatchRepository.php
@@ -30,6 +30,24 @@ final class InMemoryBankImportBatchRepository implements BankImportBatchReposito
         return false;
     }
 
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (BankImportBatch $b): bool => $b->organizationId === $organizationId,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (BankImportBatch $b): bool => $b->organizationId === $organizationId,
+        ));
+    }
+
     public function save(BankImportBatch $batch): int
     {
         $id = $batch->id ?? $this->nextId++;

--- a/tests/BankImport/InMemoryBankTransactionRepository.php
+++ b/tests/BankImport/InMemoryBankTransactionRepository.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\BankImport;
 
 use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\BankImport\BankTransactionStatus;
 
 final class InMemoryBankTransactionRepository implements BankTransactionRepositoryInterface
 {
@@ -42,6 +43,46 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
         return array_values(array_filter(
             $this->byId,
             static fn (BankTransaction $t): bool => $t->bankImportBatchId === $bankImportBatchId,
+        ));
+    }
+
+    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
+                && ($status === null || $t->status === $status),
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
+                && ($status === null || $t->status === $status),
+        ));
+    }
+
+    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
+                && in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true),
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countUnmatchedByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
+                && in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true),
         ));
     }
 }

--- a/tests/Http/BankImportHttpTest.php
+++ b/tests/Http/BankImportHttpTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class BankImportHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+    private const string CSV = "date,deposit,withdrawal,memo\n2026/04/20,110000,,ACME\n2026/04/22,50000,,TARO\n";
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-bankhttp-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createBankAccounts($query);
+        SchemaFixture::createBankImportBatches($query);
+        SchemaFixture::createBankTransactions($query);
+        SchemaFixture::createAuditEvents($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin));
+        $users->save($this->user('viewer@acme.example', Role::Viewer));
+
+        (new PdoBankAccountRepository($query))->save(new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '123',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        ));
+
+        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 7,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    private function upload(string $token, string $csv, int $bankAccountId = 1): ResponseInterface
+    {
+        $file = $this->psr17->createUploadedFile($this->psr17->createStream($csv), strlen($csv), UPLOAD_ERR_OK, 'april.csv', 'text/csv');
+        $request = $this->psr17->createServerRequest('POST', '/admin/bank-import-batches')
+            ->withHeader('Authorization', 'Bearer ' . $token)
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody(['bank_account_id' => $bankAccountId]);
+
+        return $this->app->handle($request);
+    }
+
+    private function get(string $token, string $path): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('GET', $path)->withHeader('Authorization', 'Bearer ' . $token),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_admin_uploads_and_lists_batches_and_transactions(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $imported = $this->upload($token, self::CSV);
+        self::assertSame(201, $imported->getStatusCode());
+        self::assertSame(2, $this->decode($imported)['row_count'] ?? null);
+
+        self::assertSame(1, $this->decode($this->get($token, '/admin/bank-import-batches'))['total'] ?? null);
+        self::assertSame(2, $this->decode($this->get($token, '/admin/bank-transactions'))['total'] ?? null);
+        self::assertSame(2, $this->decode($this->get($token, '/admin/bank-transactions/unmatched'))['total'] ?? null);
+    }
+
+    public function test_duplicate_upload_is_blocked(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $this->upload($token, self::CSV);
+
+        self::assertSame(409, $this->upload($token, self::CSV)->getStatusCode());
+    }
+
+    public function test_viewer_can_read_but_not_import(): void
+    {
+        $token = $this->tokenFor('viewer@acme.example');
+
+        self::assertSame(200, $this->get($token, '/admin/bank-transactions')->getStatusCode());
+
+        $denied = $this->upload($token, self::CSV);
+        self::assertSame(403, $denied->getStatusCode());
+        self::assertStringContainsString('insufficient-capability', (string) $denied->getBody());
+    }
+}


### PR DESCRIPTION
Closes #35.

## Purpose

Expose bank import over HTTP — an operator can upload a CSV and see imported batches/transactions. Completes the reconciliation **input** side.

## Change summary

- **`CapabilityRule`** (read/write) + **method-aware `CapabilityMiddleware`**: safe methods (GET/HEAD/OPTIONS) need the read capability, others the write capability. Organization/User keep the same capability both ways; bank routes use `view_reconciliation` (read) / `manage_reconciliation` (write).
- **`AuthContext::userId`** (`sub` claim).
- **`importBankCsv`** multipart handler (`file` + `bank_account_id`; org/actor from claims) → `ImportBankCsvUseCase`.
- **`listBankImportBatches`**, **`listBankTransactions`** (status filter), **`listUnmatchedTransactions`**; org-scoped repo finders added.
- Domain exception handlers: duplicate → 409, `bank-account-not-found` → 404 (slug registered), invalid CSV → 422; response mappers.
- Wired into `ApplicationFactory` (`UtcClock` in production).
- HTTP tests over SQLite: admin upload → 201 + lists; **viewer reads → 200 but import → 403** (method-aware capability); duplicate → 409.

## Verification

```
composer check → OK (42 tests, 171 assertions); PHPStan: No errors; CS: clean
```

## Scope

`getById` + `reverse` endpoints and full date/amount/counterparty search filters are a follow-up (B-5c). Follows nene2-compliance.md + payment-reconciliation-dunning-compliance.md §3.

## Self-review

backend-api, compliance, openapi-contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)