### PR TITLE
docs: add daily report folder + 2026-05-30 entry (#37)

### DIFF
--- a/docs/daily/2026-05-30.md
+++ b/docs/daily/2026-05-30.md
@@ -1,0 +1,95 @@
+# Daily Report — 2026-05-30
+
+From "what is this project?" to a running application that imports bank
+deposits. The day ran the full arc in one pass: **understand → rules → design →
+implement**.
+
+---
+
+## Summary
+
+- Reconciled all repository docs to the Clear domain, locked the rules and the
+  Invoice boundary, and produced the Phase 1 design + contracts.
+- Stood up the runtime on NENE2 and implemented the reconciliation **input
+  side** end-to-end: authentication, RBAC, organization/user management, and
+  bank CSV import.
+- **8 implementation PRs merged** (#22–#36), all green: **42 tests / 171
+  assertions, PHPStan level 8 clean, PHP-CS-Fixer clean**.
+
+---
+
+## Part 1 — Documentation & rules
+
+| Area | Outcome | PR |
+| --- | --- | --- |
+| Domain reconciliation | Rewrote `nene-invoice` residue across all docs to the Clear domain (reconciliation & dunning) | #8 |
+| Invoice boundary | `invoice-upstream-contract.md` (hand-off spec) → marked **accepted**; SSOT split (帳簿=Invoice / 証憑=Clear) | #10, #14 |
+| Rule hardening | `scope-contract.md` (GOAL/DO/DON'T), legal spine (電帳法・弁護士法72条・民法 弁済充当/貸倒/消滅時効), ADR 0010–0013, professional review gate | #12 |
+| Phase 1 contract | `docs/openapi/openapi.yaml` (OpenAPI 3.1) for the full Phase 1 surface | #14 |
+| MCP + export | `docs/mcp/tools.json` (read-only catalog) + policy; CSV export columns | #20 |
+| NENE2 conventions | `nene2-compliance.md` — binding map of NENE2 rules + framework objects to reuse | #16 |
+
+## Part 2 — Implementation (on NENE2, via Composer path repo)
+
+| PR | Slice |
+| --- | --- |
+| #22 | Runtime scaffold + `GET /health` (front controller, tooling, contract test) |
+| #24 | DB foundation + Organization/User domain + Role/Capability enums (Phinx, SQLite test kit) |
+| #26 | Auth domain — JWT issue/verify (firebase/php-jwt ^7) + LoginUseCase (constant-time) |
+| #28 | Auth HTTP — `login` / `me` + `BearerTokenMiddleware` over the pipeline |
+| #30 | CapabilityMiddleware + Organization CRUD (`manage_organizations`) |
+| #32 | User CRUD — org-scoped, `manage_users`, cross-tenant → 404 |
+| #34 | Bank import core — CSV parser, import use case, file-hash dedup, immutable lines, audit (電帳法/ADR 0012) |
+| #36 | Bank import HTTP — multipart upload + list endpoints, method-aware capabilities |
+
+---
+
+## What works end-to-end (verified by tests)
+
+1. `POST /admin/auth/login` → JWT; `GET /admin/auth/me`.
+2. superadmin manages organizations (`manage_organizations`).
+3. admin manages users in their own organization (`manage_users`; cross-tenant 404).
+4. admin/member upload a bank CSV (`POST /admin/bank-import-batches`, multipart)
+   → immutable `bank_transactions` (SHA-256 dedup, audit event).
+5. list import batches / transactions / unmatched (`view_reconciliation`);
+   **viewer can read but not import (403)** — method-aware capabilities.
+
+Net: a bank deposit is captured as immutable evidence and queued as an unmatched
+line, ready for reconciliation.
+
+---
+
+## Key decisions
+
+- Strict Issue → branch → PR → merge; `composer check` green every slice.
+- NENE2 conventions followed (Handler → UseCase → Repository, explicit DI,
+  Problem Details, reuse framework objects); identifiers per `terminology.md`.
+- `firebase/php-jwt ^7` (clears CVE-2025-45769); login uses a constant-time
+  password check (no user enumeration).
+- Phinx ids are integer-autoincrement for SQLite/MySQL portability; tests build
+  schema inline via `DatabaseTestKit`.
+- Problem Details branded to `https://nene-clear.dev/problems/`.
+
+---
+
+## Notes / open risks
+
+- A large amount of code was merged in one autonomous session. All slices are
+  green and tested, but a consolidated review is worthwhile (esp.
+  `ApplicationFactory` wiring and the auth/tenant boundary).
+- **Professional sign-off not yet obtained** — the legal/compliance docs are
+  engineering interpretation; the 税理士 / 公認会計士 / 弁護士 gate remains a
+  human action before Phase 1 ships.
+- The core is still ahead: **reconciliation matching** (needs the Invoice
+  upstream API — fake until built) and **dunning** (Phase 2, after legal review).
+
+---
+
+## Next
+
+- **B-5c** (small): bank transaction `getById` / `reverse` + date/amount/
+  counterparty search filters (completes 電帳法 §3.3 searchability).
+- **B-6**: reconciliation matching (`proposeMatch` / `confirmMatch` / `reverse`)
+  with an Invoice upstream client + fake — the heart of the product.
+- **Phase 2**: dunning, after the professional review gate.
+- Consolidated review of today's merged PRs.

--- a/docs/daily/README.md
+++ b/docs/daily/README.md
@@ -1,0 +1,6 @@
+# Daily Reports
+
+Dated work logs for NeNe Clear, one file per day: `YYYY-MM-DD.md`.
+
+English only (ADR 0008). Each entry records what was done, key decisions, and
+what remains, so the next session (human or AI) can pick up with full context.


### PR DESCRIPTION
Closes #37.

Adds `docs/daily/` (English, per the NENE2 convention) with a README and the **2026-05-30** report: the day's documentation/rules work and the 8 merged implementation PRs (#22–#36). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)