### PR TITLE
feat: bank transaction getById + search filters + reverse import batch (B-5c)

### DIFF
--- a/src/BankImport/BankImportBatch.php
+++ b/src/BankImport/BankImportBatch.php
@@ -20,6 +20,8 @@ final readonly class BankImportBatch
         public int $importedBy,
         public string $importedAt,
         public ?int $id = null,
+        public ?string $reversedAt = null,
+        public ?string $reversalReason = null,
     ) {
     }
 }

--- a/src/BankImport/BankImportBatchAlreadyReversedException.php
+++ b/src/BankImport/BankImportBatchAlreadyReversedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class BankImportBatchAlreadyReversedException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Bank import batch %d is already reversed.', $id));
+    }
+}

--- a/src/BankImport/BankImportBatchAlreadyReversedExceptionHandler.php
+++ b/src/BankImport/BankImportBatchAlreadyReversedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankImportBatchAlreadyReversedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankImportBatchAlreadyReversedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-state-transition',
+            'Invalid State Transition',
+            409,
+            'The batch is already reversed.',
+        );
+    }
+}

--- a/src/BankImport/BankImportBatchHasMatchedLinesException.php
+++ b/src/BankImport/BankImportBatchHasMatchedLinesException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class BankImportBatchHasMatchedLinesException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Bank import batch %d has matched or partially matched lines.', $id));
+    }
+}

--- a/src/BankImport/BankImportBatchHasMatchedLinesExceptionHandler.php
+++ b/src/BankImport/BankImportBatchHasMatchedLinesExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankImportBatchHasMatchedLinesExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankImportBatchHasMatchedLinesException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-state-transition',
+            'Invalid State Transition',
+            409,
+            'One or more transactions are already matched; unmatch them before reversing the batch.',
+        );
+    }
+}

--- a/src/BankImport/BankImportBatchNotFoundException.php
+++ b/src/BankImport/BankImportBatchNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class BankImportBatchNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Bank import batch %d was not found.', $id));
+    }
+}

--- a/src/BankImport/BankImportBatchNotFoundExceptionHandler.php
+++ b/src/BankImport/BankImportBatchNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankImportBatchNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankImportBatchNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'bank-import-batch-not-found',
+            'Bank Import Batch Not Found',
+            404,
+            'The requested bank import batch was not found.',
+        );
+    }
+}

--- a/src/BankImport/BankImportBatchRepositoryInterface.php
+++ b/src/BankImport/BankImportBatchRepositoryInterface.php
@@ -18,4 +18,6 @@ interface BankImportBatchRepositoryInterface
     public function findByOrganization(int $organizationId, int $limit, int $offset): array;
 
     public function countByOrganization(int $organizationId): int;
+
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void;
 }

--- a/src/BankImport/BankImportBatchResponse.php
+++ b/src/BankImport/BankImportBatchResponse.php
@@ -20,6 +20,8 @@ final readonly class BankImportBatchResponse
             'row_count' => $batch->rowCount,
             'status' => $batch->status->value,
             'imported_at' => $batch->importedAt,
+            'reversed_at' => $batch->reversedAt,
+            'reversal_reason' => $batch->reversalReason,
         ];
     }
 }

--- a/src/BankImport/BankImportRouteRegistrar.php
+++ b/src/BankImport/BankImportRouteRegistrar.php
@@ -13,8 +13,10 @@ final readonly class BankImportRouteRegistrar
     public function __construct(
         private ImportBankCsvHandler $importHandler,
         private ListBankImportBatchesHandler $listBatchesHandler,
+        private ReverseBankImportBatchHandler $reverseBatchHandler,
         private ListBankTransactionsHandler $listTransactionsHandler,
         private ListUnmatchedTransactionsHandler $listUnmatchedHandler,
+        private GetBankTransactionByIdHandler $getTransactionByIdHandler,
     ) {
     }
 
@@ -22,13 +24,17 @@ final readonly class BankImportRouteRegistrar
     {
         $importHandler = $this->importHandler;
         $listBatchesHandler = $this->listBatchesHandler;
+        $reverseBatchHandler = $this->reverseBatchHandler;
         $listTransactionsHandler = $this->listTransactionsHandler;
         $listUnmatchedHandler = $this->listUnmatchedHandler;
+        $getTransactionByIdHandler = $this->getTransactionByIdHandler;
 
         $router->post('/admin/bank-import-batches', static fn (ServerRequestInterface $r): ResponseInterface => $importHandler->handle($r));
         $router->get('/admin/bank-import-batches', static fn (ServerRequestInterface $r): ResponseInterface => $listBatchesHandler->handle($r));
+        $router->post('/admin/bank-import-batches/{id}/reverse', static fn (ServerRequestInterface $r): ResponseInterface => $reverseBatchHandler->handle($r));
         // Unmatched is registered before the generic list so the more specific path wins.
         $router->get('/admin/bank-transactions/unmatched', static fn (ServerRequestInterface $r): ResponseInterface => $listUnmatchedHandler->handle($r));
         $router->get('/admin/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $listTransactionsHandler->handle($r));
+        $router->get('/admin/bank-transactions/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getTransactionByIdHandler->handle($r));
     }
 }

--- a/src/BankImport/BankTransactionFilter.php
+++ b/src/BankImport/BankTransactionFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class BankTransactionFilter
+{
+    public function __construct(
+        public ?BankTransactionStatus $status = null,
+        public ?string $valueDateFrom = null,
+        public ?string $valueDateTo = null,
+        public ?int $amountMinCents = null,
+        public ?int $amountMaxCents = null,
+        public ?string $counterparty = null,
+    ) {
+    }
+}

--- a/src/BankImport/BankTransactionNotFoundException.php
+++ b/src/BankImport/BankTransactionNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use RuntimeException;
+
+final class BankTransactionNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Bank transaction %d was not found.', $id));
+    }
+}

--- a/src/BankImport/BankTransactionNotFoundExceptionHandler.php
+++ b/src/BankImport/BankTransactionNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankTransactionNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankTransactionNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'bank-transaction-not-found',
+            'Bank Transaction Not Found',
+            404,
+            'The requested bank transaction was not found.',
+        );
+    }
+}

--- a/src/BankImport/BankTransactionRepositoryInterface.php
+++ b/src/BankImport/BankTransactionRepositoryInterface.php
@@ -8,6 +8,8 @@ interface BankTransactionRepositoryInterface
 {
     public function save(BankTransaction $transaction): int;
 
+    public function findById(int $organizationId, int $id): ?BankTransaction;
+
     public function countByBatch(int $bankImportBatchId): int;
 
     /**
@@ -18,9 +20,9 @@ interface BankTransactionRepositoryInterface
     /**
      * @return list<BankTransaction>
      */
-    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array;
+    public function findByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int;
+    public function countByOrganization(int $organizationId, BankTransactionFilter $filter): int;
 
     /**
      * Lines still open for matching (unmatched or partially matched).
@@ -30,4 +32,8 @@ interface BankTransactionRepositoryInterface
     public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array;
 
     public function countUnmatchedByOrganization(int $organizationId): int;
+
+    public function updateStatusById(int $id, BankTransactionStatus $status): void;
+
+    public function voidByBatchId(int $bankImportBatchId): void;
 }

--- a/src/BankImport/GetBankTransactionByIdHandler.php
+++ b/src/BankImport/GetBankTransactionByIdHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetBankTransactionByIdHandler
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $transaction = $this->transactions->findById($organizationId, $id);
+
+        if ($transaction === null) {
+            throw new BankTransactionNotFoundException($id);
+        }
+
+        return $this->response->create(BankTransactionResponse::toArray($transaction));
+    }
+}

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -22,18 +22,39 @@ final readonly class ListBankTransactionsHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
+        $q = $request->getQueryParams();
 
-        $statusParam = $request->getQueryParams()['status'] ?? null;
+        $statusParam = $q['status'] ?? null;
         $status = is_string($statusParam) ? BankTransactionStatus::tryFrom($statusParam) : null;
+
+        $valueDateFrom = isset($q['value_date_from']) && is_string($q['value_date_from']) ? $q['value_date_from'] : null;
+        $valueDateTo = isset($q['value_date_to']) && is_string($q['value_date_to']) ? $q['value_date_to'] : null;
+
+        $amountMinParam = $q['amount_min_cents'] ?? null;
+        $amountMinCents = is_numeric($amountMinParam) ? (int) $amountMinParam : null;
+
+        $amountMaxParam = $q['amount_max_cents'] ?? null;
+        $amountMaxCents = is_numeric($amountMaxParam) ? (int) $amountMaxParam : null;
+
+        $counterparty = isset($q['counterparty']) && is_string($q['counterparty']) ? $q['counterparty'] : null;
+
+        $filter = new BankTransactionFilter(
+            status: $status,
+            valueDateFrom: $valueDateFrom,
+            valueDateTo: $valueDateTo,
+            amountMinCents: $amountMinCents,
+            amountMaxCents: $amountMaxCents,
+            counterparty: $counterparty,
+        );
 
         return $this->response->create([
             'items' => array_map(
                 BankTransactionResponse::toArray(...),
-                $this->transactions->findByOrganization($organizationId, $status, $page->limit, $page->offset),
+                $this->transactions->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             'limit' => $page->limit,
             'offset' => $page->offset,
-            'total' => $this->transactions->countByOrganization($organizationId, $status),
+            'total' => $this->transactions->countByOrganization($organizationId, $filter),
         ]);
     }
 }

--- a/src/BankImport/PdoBankImportBatchRepository.php
+++ b/src/BankImport/PdoBankImportBatchRepository.php
@@ -9,7 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 final readonly class PdoBankImportBatchRepository implements BankImportBatchRepositoryInterface
 {
     private const string COLUMNS = 'id, organization_id, bank_account_id, file_hash, source_filename, row_count, '
-        . 'status, imported_by, imported_at';
+        . 'status, imported_by, imported_at, reversed_at, reversal_reason';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -73,6 +73,14 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
         return (int) ($row['c'] ?? 0);
     }
 
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void
+    {
+        $this->query->execute(
+            'UPDATE bank_import_batches SET status = ?, reversed_at = ?, reversal_reason = ? WHERE id = ?',
+            [BankImportBatchStatus::Reversed->value, $reversedAt, $reversalReason, $id],
+        );
+    }
+
     /**
      * @param array<string, mixed> $row
      */
@@ -88,6 +96,8 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
             importedBy: (int) $row['imported_by'],
             importedAt: (string) $row['imported_at'],
             id: (int) $row['id'],
+            reversedAt: isset($row['reversed_at']) ? (string) $row['reversed_at'] : null,
+            reversalReason: isset($row['reversal_reason']) ? (string) $row['reversal_reason'] : null,
         );
     }
 }

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -36,6 +36,16 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         return $this->query->lastInsertId();
     }
 
+    public function findById(int $organizationId, int $id): ?BankTransaction
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
     public function countByBatch(int $bankImportBatchId): int
     {
         $row = $this->query->fetchOne(
@@ -60,34 +70,25 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array
     {
-        if ($status === null) {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? '
-                . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $limit, $offset],
-            );
-        } else {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? AND status = ? '
-                . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $status->value, $limit, $offset],
-            );
-        }
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE ' . $where
+            . ' ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+            [...$params, $limit, $offset],
+        );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int
+    public function countByOrganization(int $organizationId, BankTransactionFilter $filter): int
     {
-        $row = $status === null
-            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ?', [$organizationId])
-            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ? AND status = ?', [$organizationId, $status->value]);
-
-        if ($row === null) {
-            return 0;
-        }
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS c FROM bank_transactions WHERE ' . $where,
+            $params,
+        );
 
         return (int) ($row['c'] ?? 0);
     }
@@ -115,6 +116,58 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         }
 
         return (int) ($row['c'] ?? 0);
+    }
+
+    public function updateStatusById(int $id, BankTransactionStatus $status): void
+    {
+        $this->query->execute(
+            'UPDATE bank_transactions SET status = ? WHERE id = ?',
+            [$status->value, $id],
+        );
+    }
+
+    public function voidByBatchId(int $bankImportBatchId): void
+    {
+        $this->query->execute(
+            'UPDATE bank_transactions SET status = ? WHERE bank_import_batch_id = ? AND status = ?',
+            [BankTransactionStatus::Voided->value, $bankImportBatchId, BankTransactionStatus::Unmatched->value],
+        );
+    }
+
+    /**
+     * @return array{string, list<int|string>}
+     */
+    private function buildWhere(int $organizationId, BankTransactionFilter $filter): array
+    {
+        $wheres = ['organization_id = ?'];
+        $params = [$organizationId];
+
+        if ($filter->status !== null) {
+            $wheres[] = 'status = ?';
+            $params[] = $filter->status->value;
+        }
+        if ($filter->valueDateFrom !== null) {
+            $wheres[] = 'value_date >= ?';
+            $params[] = $filter->valueDateFrom;
+        }
+        if ($filter->valueDateTo !== null) {
+            $wheres[] = 'value_date <= ?';
+            $params[] = $filter->valueDateTo;
+        }
+        if ($filter->amountMinCents !== null) {
+            $wheres[] = 'amount_cents >= ?';
+            $params[] = $filter->amountMinCents;
+        }
+        if ($filter->amountMaxCents !== null) {
+            $wheres[] = 'amount_cents <= ?';
+            $params[] = $filter->amountMaxCents;
+        }
+        if ($filter->counterparty !== null && $filter->counterparty !== '') {
+            $wheres[] = 'LOWER(counterparty_text) LIKE ?';
+            $params[] = '%' . strtolower($filter->counterparty) . '%';
+        }
+
+        return [implode(' AND ', $wheres), $params];
     }
 
     /**

--- a/src/BankImport/ReverseBankImportBatchHandler.php
+++ b/src/BankImport/ReverseBankImportBatchHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ReverseBankImportBatchHandler
+{
+    public function __construct(
+        private ReverseBankImportBatchUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $batchId = (int) ($params['id'] ?? 0);
+
+        $body = (array) $request->getParsedBody();
+        $reversalReason = is_string($body['reversal_reason'] ?? null) ? trim($body['reversal_reason']) : '';
+
+        if ($reversalReason === '') {
+            throw new ValidationException([new ValidationError('reversal_reason', 'A reversal reason is required.', 'required')]);
+        }
+
+        $output = $this->useCase->execute(new ReverseBankImportBatchInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            batchId: $batchId,
+            actorUserId: AuthContext::userId($request),
+            reversalReason: $reversalReason,
+        ));
+
+        return $this->response->create([
+            'bank_import_batch_id' => $output->batchId,
+            'rows_voided' => $output->rowsVoided,
+        ]);
+    }
+}

--- a/src/BankImport/ReverseBankImportBatchInput.php
+++ b/src/BankImport/ReverseBankImportBatchInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class ReverseBankImportBatchInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $batchId,
+        public int $actorUserId,
+        public string $reversalReason,
+    ) {
+    }
+}

--- a/src/BankImport/ReverseBankImportBatchOutput.php
+++ b/src/BankImport/ReverseBankImportBatchOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+final readonly class ReverseBankImportBatchOutput
+{
+    public function __construct(
+        public int $batchId,
+        public int $rowsVoided,
+    ) {
+    }
+}

--- a/src/BankImport/ReverseBankImportBatchUseCase.php
+++ b/src/BankImport/ReverseBankImportBatchUseCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
+final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportBatchUseCaseInterface
+{
+    public function __construct(
+        private BankImportBatchRepositoryInterface $batches,
+        private BankTransactionRepositoryInterface $transactions,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(ReverseBankImportBatchInput $input): ReverseBankImportBatchOutput
+    {
+        $batch = $this->batches->findById($input->batchId);
+
+        if ($batch === null || $batch->organizationId !== $input->organizationId) {
+            throw new BankImportBatchNotFoundException($input->batchId);
+        }
+
+        if ($batch->status !== BankImportBatchStatus::Imported) {
+            throw new BankImportBatchAlreadyReversedException($input->batchId);
+        }
+
+        $lines = $this->transactions->findByBatch($input->batchId);
+
+        foreach ($lines as $line) {
+            if ($line->status === BankTransactionStatus::Matched || $line->status === BankTransactionStatus::PartiallyMatched) {
+                throw new BankImportBatchHasMatchedLinesException($input->batchId);
+            }
+        }
+
+        $unmatchedCount = count(array_filter(
+            $lines,
+            static fn (BankTransaction $t): bool => $t->status === BankTransactionStatus::Unmatched,
+        ));
+
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        $this->transactions->voidByBatchId($input->batchId);
+        $this->batches->reverseById($input->batchId, $now, $input->reversalReason);
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'bank_import_batch_reversed',
+            actorUserId: $input->actorUserId,
+            occurredAt: $now,
+            payload: [
+                'bank_import_batch_id' => $input->batchId,
+                'reversal_reason' => $input->reversalReason,
+                'rows_voided' => $unmatchedCount,
+            ],
+        ));
+
+        return new ReverseBankImportBatchOutput(
+            batchId: $input->batchId,
+            rowsVoided: $unmatchedCount,
+        );
+    }
+}

--- a/src/BankImport/ReverseBankImportBatchUseCaseInterface.php
+++ b/src/BankImport/ReverseBankImportBatchUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+interface ReverseBankImportBatchUseCaseInterface
+{
+    public function execute(ReverseBankImportBatchInput $input): ReverseBankImportBatchOutput;
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -22,8 +22,13 @@ use NeneClear\Auth\LoginHandler;
 use NeneClear\Auth\LoginUseCase;
 use NeneClear\BankImport\BankAccountNotFoundExceptionHandler;
 use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\BankImportBatchAlreadyReversedExceptionHandler;
+use NeneClear\BankImport\BankImportBatchHasMatchedLinesExceptionHandler;
+use NeneClear\BankImport\BankImportBatchNotFoundExceptionHandler;
 use NeneClear\BankImport\BankImportRouteRegistrar;
+use NeneClear\BankImport\BankTransactionNotFoundExceptionHandler;
 use NeneClear\BankImport\DuplicateBankImportExceptionHandler;
+use NeneClear\BankImport\GetBankTransactionByIdHandler;
 use NeneClear\BankImport\ImportBankCsvHandler;
 use NeneClear\BankImport\ImportBankCsvUseCase;
 use NeneClear\BankImport\InvalidBankCsvExceptionHandler;
@@ -33,6 +38,8 @@ use NeneClear\BankImport\ListUnmatchedTransactionsHandler;
 use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\BankImport\PdoBankImportBatchRepository;
 use NeneClear\BankImport\PdoBankTransactionRepository;
+use NeneClear\BankImport\ReverseBankImportBatchHandler;
+use NeneClear\BankImport\ReverseBankImportBatchUseCase;
 use NeneClear\Organization\CreateOrganizationHandler;
 use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\DeleteOrganizationHandler;
@@ -122,22 +129,29 @@ final class ApplicationFactory
                 new DeleteUserHandler(new DeleteUserUseCase($users), $json),
             );
 
+            $audit = new PdoAuditEventRepository($query);
             $bankAccounts = new PdoBankAccountRepository($query);
             $batches = new PdoBankImportBatchRepository($query);
             $transactions = new PdoBankTransactionRepository($query);
+            $clock = new UtcClock();
             $importUseCase = new ImportBankCsvUseCase(
                 $bankAccounts,
                 $batches,
                 $transactions,
-                new PdoAuditEventRepository($query),
+                $audit,
                 new BankCsvParser(),
-                new UtcClock(),
+                $clock,
             );
             $routeRegistrars[] = new BankImportRouteRegistrar(
                 new ImportBankCsvHandler($importUseCase, $json),
                 new ListBankImportBatchesHandler($batches, $json),
+                new ReverseBankImportBatchHandler(
+                    new ReverseBankImportBatchUseCase($batches, $transactions, $audit, $clock),
+                    $json,
+                ),
                 new ListBankTransactionsHandler($transactions, $json),
                 new ListUnmatchedTransactionsHandler($transactions, $json),
+                new GetBankTransactionByIdHandler($transactions, $json),
             );
 
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
@@ -148,6 +162,10 @@ final class ApplicationFactory
             $domainExceptionHandlers[] = new DuplicateBankImportExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new BankAccountNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new InvalidBankCsvExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankTransactionNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankImportBatchNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankImportBatchAlreadyReversedExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankImportBatchHasMatchedLinesExceptionHandler($problemDetails);
 
             $authMiddleware = [
                 new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),

--- a/tests/BankImport/InMemoryBankImportBatchRepository.php
+++ b/tests/BankImport/InMemoryBankImportBatchRepository.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\BankImport;
 
 use NeneClear\BankImport\BankImportBatch;
 use NeneClear\BankImport\BankImportBatchRepositoryInterface;
+use NeneClear\BankImport\BankImportBatchStatus;
 
 final class InMemoryBankImportBatchRepository implements BankImportBatchRepositoryInterface
 {
@@ -61,8 +62,32 @@ final class InMemoryBankImportBatchRepository implements BankImportBatchReposito
             importedBy: $batch->importedBy,
             importedAt: $batch->importedAt,
             id: $id,
+            reversedAt: $batch->reversedAt,
+            reversalReason: $batch->reversalReason,
         );
 
         return $id;
+    }
+
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void
+    {
+        $batch = $this->byId[$id] ?? null;
+        if ($batch === null) {
+            return;
+        }
+
+        $this->byId[$id] = new BankImportBatch(
+            organizationId: $batch->organizationId,
+            bankAccountId: $batch->bankAccountId,
+            fileHash: $batch->fileHash,
+            sourceFilename: $batch->sourceFilename,
+            rowCount: $batch->rowCount,
+            status: BankImportBatchStatus::Reversed,
+            importedBy: $batch->importedBy,
+            importedAt: $batch->importedAt,
+            id: $batch->id,
+            reversedAt: $reversedAt,
+            reversalReason: $reversalReason,
+        );
     }
 }

--- a/tests/BankImport/InMemoryBankTransactionRepository.php
+++ b/tests/BankImport/InMemoryBankTransactionRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Tests\BankImport;
 
 use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionFilter;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\BankTransactionStatus;
 
@@ -33,6 +34,13 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
         return $id;
     }
 
+    public function findById(int $organizationId, int $id): ?BankTransaction
+    {
+        $tx = $this->byId[$id] ?? null;
+
+        return ($tx !== null && $tx->organizationId === $organizationId) ? $tx : null;
+    }
+
     public function countByBatch(int $bankImportBatchId): int
     {
         return count($this->findByBatch($bankImportBatchId));
@@ -46,23 +54,21 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
         ));
     }
 
-    public function findByOrganization(int $organizationId, ?BankTransactionStatus $status, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
-            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
-                && ($status === null || $t->status === $status),
+            fn (BankTransaction $t): bool => $this->matchesFilter($t, $organizationId, $filter),
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId, ?BankTransactionStatus $status): int
+    public function countByOrganization(int $organizationId, BankTransactionFilter $filter): int
     {
         return count(array_filter(
             $this->byId,
-            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
-                && ($status === null || $t->status === $status),
+            fn (BankTransaction $t): bool => $this->matchesFilter($t, $organizationId, $filter),
         ));
     }
 
@@ -84,5 +90,72 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
             static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
                 && in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true),
         ));
+    }
+
+    public function updateStatusById(int $id, BankTransactionStatus $status): void
+    {
+        $tx = $this->byId[$id] ?? null;
+        if ($tx === null) {
+            return;
+        }
+
+        $this->byId[$id] = new BankTransaction(
+            organizationId: $tx->organizationId,
+            bankImportBatchId: $tx->bankImportBatchId,
+            bankAccountId: $tx->bankAccountId,
+            valueDate: $tx->valueDate,
+            amountCents: $tx->amountCents,
+            counterpartyText: $tx->counterpartyText,
+            lineKey: $tx->lineKey,
+            status: $status,
+            id: $tx->id,
+        );
+    }
+
+    public function voidByBatchId(int $bankImportBatchId): void
+    {
+        foreach ($this->byId as $id => $tx) {
+            if ($tx->bankImportBatchId === $bankImportBatchId && $tx->status === BankTransactionStatus::Unmatched) {
+                $this->byId[$id] = new BankTransaction(
+                    organizationId: $tx->organizationId,
+                    bankImportBatchId: $tx->bankImportBatchId,
+                    bankAccountId: $tx->bankAccountId,
+                    valueDate: $tx->valueDate,
+                    amountCents: $tx->amountCents,
+                    counterpartyText: $tx->counterpartyText,
+                    lineKey: $tx->lineKey,
+                    status: BankTransactionStatus::Voided,
+                    id: $tx->id,
+                );
+            }
+        }
+    }
+
+    private function matchesFilter(BankTransaction $t, int $organizationId, BankTransactionFilter $filter): bool
+    {
+        if ($t->organizationId !== $organizationId) {
+            return false;
+        }
+        if ($filter->status !== null && $t->status !== $filter->status) {
+            return false;
+        }
+        if ($filter->valueDateFrom !== null && $t->valueDate < $filter->valueDateFrom) {
+            return false;
+        }
+        if ($filter->valueDateTo !== null && $t->valueDate > $filter->valueDateTo) {
+            return false;
+        }
+        if ($filter->amountMinCents !== null && $t->amountCents < $filter->amountMinCents) {
+            return false;
+        }
+        if ($filter->amountMaxCents !== null && $t->amountCents > $filter->amountMaxCents) {
+            return false;
+        }
+        if ($filter->counterparty !== null && $filter->counterparty !== ''
+            && stripos($t->counterpartyText, $filter->counterparty) === false) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
+++ b/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\BankImportBatch;
+use NeneClear\BankImport\BankImportBatchAlreadyReversedException;
+use NeneClear\BankImport\BankImportBatchHasMatchedLinesException;
+use NeneClear\BankImport\BankImportBatchNotFoundException;
+use NeneClear\BankImport\BankImportBatchStatus;
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\BankImport\ReverseBankImportBatchInput;
+use NeneClear\BankImport\ReverseBankImportBatchUseCase;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class ReverseBankImportBatchUseCaseTest extends TestCase
+{
+    private InMemoryBankImportBatchRepository $batches;
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryAuditEventRepository $audit;
+    private ReverseBankImportBatchUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->batches = new InMemoryBankImportBatchRepository();
+        $this->transactions = new InMemoryBankTransactionRepository();
+        $this->audit = new InMemoryAuditEventRepository();
+        $this->useCase = new ReverseBankImportBatchUseCase(
+            $this->batches,
+            $this->transactions,
+            $this->audit,
+            new FixedClock(),
+        );
+    }
+
+    private function makeBatch(int $orgId = 7, BankImportBatchStatus $status = BankImportBatchStatus::Imported): int
+    {
+        return $this->batches->save(new BankImportBatch(
+            organizationId: $orgId,
+            bankAccountId: 1,
+            fileHash: bin2hex(random_bytes(4)),
+            sourceFilename: 'test.csv',
+            rowCount: 2,
+            status: $status,
+            importedBy: 42,
+            importedAt: '2026-05-31 09:00:00',
+        ));
+    }
+
+    private function makeTransaction(int $batchId, BankTransactionStatus $status = BankTransactionStatus::Unmatched): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 7,
+            bankImportBatchId: $batchId,
+            bankAccountId: 1,
+            valueDate: '2026-04-20',
+            amountCents: 100000,
+            counterpartyText: 'ACME',
+            lineKey: bin2hex(random_bytes(4)),
+            status: $status,
+        ));
+    }
+
+    private function input(int $batchId, int $orgId = 7): ReverseBankImportBatchInput
+    {
+        return new ReverseBankImportBatchInput(
+            organizationId: $orgId,
+            batchId: $batchId,
+            actorUserId: 42,
+            reversalReason: 'test reversal',
+        );
+    }
+
+    public function test_reverse_voids_unmatched_lines_and_marks_batch_reversed(): void
+    {
+        $batchId = $this->makeBatch();
+        $txId1 = $this->makeTransaction($batchId);
+        $txId2 = $this->makeTransaction($batchId);
+
+        $output = $this->useCase->execute($this->input($batchId));
+
+        self::assertSame($batchId, $output->batchId);
+        self::assertSame(2, $output->rowsVoided);
+
+        $batch = $this->batches->findById($batchId);
+        self::assertNotNull($batch);
+        self::assertSame(BankImportBatchStatus::Reversed, $batch->status);
+        self::assertNotNull($batch->reversedAt);
+        self::assertSame('test reversal', $batch->reversalReason);
+
+        self::assertSame(BankTransactionStatus::Voided, $this->transactions->findById(7, $txId1)?->status);
+        self::assertSame(BankTransactionStatus::Voided, $this->transactions->findById(7, $txId2)?->status);
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('bank_import_batch_reversed', $this->audit->events[0]->eventType);
+    }
+
+    public function test_unknown_or_cross_tenant_batch_throws_not_found(): void
+    {
+        $this->makeBatch(orgId: 7);
+
+        $this->expectException(BankImportBatchNotFoundException::class);
+        $this->useCase->execute($this->input(batchId: 999, orgId: 7));
+    }
+
+    public function test_cross_tenant_batch_throws_not_found(): void
+    {
+        $batchId = $this->makeBatch(orgId: 7);
+
+        $this->expectException(BankImportBatchNotFoundException::class);
+        $this->useCase->execute($this->input(batchId: $batchId, orgId: 999));
+    }
+
+    public function test_already_reversed_batch_throws_conflict(): void
+    {
+        $batchId = $this->makeBatch(status: BankImportBatchStatus::Reversed);
+
+        $this->expectException(BankImportBatchAlreadyReversedException::class);
+        $this->useCase->execute($this->input($batchId));
+    }
+
+    public function test_batch_with_matched_line_throws_conflict(): void
+    {
+        $batchId = $this->makeBatch();
+        $this->makeTransaction($batchId, BankTransactionStatus::Unmatched);
+        $this->makeTransaction($batchId, BankTransactionStatus::Matched);
+
+        $this->expectException(BankImportBatchHasMatchedLinesException::class);
+        $this->useCase->execute($this->input($batchId));
+    }
+
+    public function test_batch_with_partially_matched_line_throws_conflict(): void
+    {
+        $batchId = $this->makeBatch();
+        $this->makeTransaction($batchId, BankTransactionStatus::PartiallyMatched);
+
+        $this->expectException(BankImportBatchHasMatchedLinesException::class);
+        $this->useCase->execute($this->input($batchId));
+    }
+
+    public function test_voided_lines_are_skipped_in_void_count(): void
+    {
+        $batchId = $this->makeBatch();
+        $this->makeTransaction($batchId, BankTransactionStatus::Voided);
+        $this->makeTransaction($batchId, BankTransactionStatus::Unmatched);
+
+        $output = $this->useCase->execute($this->input($batchId));
+
+        self::assertSame(1, $output->rowsVoided);
+    }
+}

--- a/tests/Database/PdoBankTransactionRepositoryTest.php
+++ b/tests/Database/PdoBankTransactionRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionFilter;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\BankImport\PdoBankTransactionRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoBankTransactionRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoBankTransactionRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-tx-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createBankTransactions($this->query);
+
+        $this->repo = new PdoBankTransactionRepository($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function tx(
+        int $orgId = 7,
+        int $batchId = 1,
+        string $valueDate = '2026-04-20',
+        int $amountCents = 100000,
+        string $counterpartyText = 'ACME',
+        BankTransactionStatus $status = BankTransactionStatus::Unmatched,
+    ): int {
+        return $this->repo->save(new BankTransaction(
+            organizationId: $orgId,
+            bankImportBatchId: $batchId,
+            bankAccountId: 1,
+            valueDate: $valueDate,
+            amountCents: $amountCents,
+            counterpartyText: $counterpartyText,
+            lineKey: bin2hex(random_bytes(8)),
+            status: $status,
+        ));
+    }
+
+    public function test_findById_returns_own_org_transaction(): void
+    {
+        $id = $this->tx(orgId: 7);
+        $tx = $this->repo->findById(7, $id);
+
+        self::assertNotNull($tx);
+        self::assertSame($id, $tx->id);
+        self::assertSame(7, $tx->organizationId);
+    }
+
+    public function test_findById_cross_tenant_returns_null(): void
+    {
+        $id = $this->tx(orgId: 7);
+
+        self::assertNull($this->repo->findById(999, $id));
+    }
+
+    public function test_findById_missing_returns_null(): void
+    {
+        self::assertNull($this->repo->findById(7, 9999));
+    }
+
+    public function test_filter_by_status(): void
+    {
+        $this->tx(status: BankTransactionStatus::Unmatched);
+        $this->tx(status: BankTransactionStatus::Matched);
+
+        $filter = new BankTransactionFilter(status: BankTransactionStatus::Unmatched);
+        self::assertCount(1, $this->repo->findByOrganization(7, $filter, 50, 0));
+        self::assertSame(1, $this->repo->countByOrganization(7, $filter));
+    }
+
+    public function test_filter_by_date_range(): void
+    {
+        $this->tx(valueDate: '2026-04-01');
+        $this->tx(valueDate: '2026-04-15');
+        $this->tx(valueDate: '2026-04-30');
+
+        $filter = new BankTransactionFilter(valueDateFrom: '2026-04-10', valueDateTo: '2026-04-20');
+        $results = $this->repo->findByOrganization(7, $filter, 50, 0);
+
+        self::assertCount(1, $results);
+        self::assertSame('2026-04-15', $results[0]->valueDate);
+    }
+
+    public function test_filter_by_amount_range(): void
+    {
+        $this->tx(amountCents: 50000);
+        $this->tx(amountCents: 100000);
+        $this->tx(amountCents: 200000);
+
+        $filter = new BankTransactionFilter(amountMinCents: 80000, amountMaxCents: 150000);
+        $results = $this->repo->findByOrganization(7, $filter, 50, 0);
+
+        self::assertCount(1, $results);
+        self::assertSame(100000, $results[0]->amountCents);
+    }
+
+    public function test_filter_by_counterparty_substring(): void
+    {
+        $this->tx(counterpartyText: 'ACME Corporation');
+        $this->tx(counterpartyText: 'Smith & Sons');
+        $this->tx(counterpartyText: 'Acme Ltd');
+
+        $filter = new BankTransactionFilter(counterparty: 'acme');
+        $results = $this->repo->findByOrganization(7, $filter, 50, 0);
+
+        self::assertCount(2, $results);
+    }
+
+    public function test_empty_filter_returns_all_for_org(): void
+    {
+        $this->tx(orgId: 7);
+        $this->tx(orgId: 7);
+        $this->tx(orgId: 999);
+
+        $filter = new BankTransactionFilter();
+        self::assertCount(2, $this->repo->findByOrganization(7, $filter, 50, 0));
+        self::assertSame(2, $this->repo->countByOrganization(7, $filter));
+    }
+
+    public function test_updateStatusById(): void
+    {
+        $id = $this->tx(status: BankTransactionStatus::Unmatched);
+        $this->repo->updateStatusById($id, BankTransactionStatus::Matched);
+
+        $tx = $this->repo->findById(7, $id);
+        self::assertSame(BankTransactionStatus::Matched, $tx?->status);
+    }
+
+    public function test_voidByBatchId_voids_only_unmatched(): void
+    {
+        $this->tx(batchId: 1, status: BankTransactionStatus::Unmatched);
+        $this->tx(batchId: 1, status: BankTransactionStatus::Unmatched);
+        $matchedId = $this->tx(batchId: 1, status: BankTransactionStatus::Matched);
+
+        $this->repo->voidByBatchId(1);
+
+        $filter = new BankTransactionFilter(status: BankTransactionStatus::Voided);
+        self::assertSame(2, $this->repo->countByOrganization(7, $filter));
+
+        $matched = $this->repo->findById(7, $matchedId);
+        self::assertSame(BankTransactionStatus::Matched, $matched?->status);
+    }
+}


### PR DESCRIPTION
## Summary

- `GET /admin/bank-transactions/{id}` — org-scoped single-transaction fetch (cross-tenant → 404)
- Search filters on `GET /admin/bank-transactions`: `value_date_from/to`, `amount_min/max_cents`, `counterparty` (case-insensitive substring) — completes 電帳法 §3.3 searchability
- `POST /admin/bank-import-batches/{id}/reverse` — voids unmatched lines, rejects if any line is `matched`/`partially_matched` (409), double-reverse → 409
- `BankTransactionFilter` readonly DTO replaces raw `?BankTransactionStatus` param in repository interface
- `BankImportBatch` entity exposes `reversedAt` / `reversalReason` (columns were already in schema)
- New exceptions: `BankTransactionNotFound`, `BankImportBatchNotFound`, `AlreadyReversed`, `HasMatchedLines`

## Test plan

- [x] 59 tests / 204 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `PdoBankTransactionRepositoryTest` — filter combinations (status, date range, amount range, counterparty), findById (own org + cross-tenant), updateStatusById, voidByBatchId
- [x] `ReverseBankImportBatchUseCaseTest` — happy path, cross-tenant 404, already-reversed 409, matched-line 409, voided-lines skipped in count

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)