### PR TITLE
feat: Invoice upstream client + reconciliation core — propose/confirm/reverse (B-6a)

### DIFF
--- a/database/migrations/20260531100000_create_payment_reconciliations_table.php
+++ b/database/migrations/20260531100000_create_payment_reconciliations_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreatePaymentReconciliationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('payment_reconciliations');
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('bank_transaction_id', 'biginteger', ['signed' => false])
+            ->addColumn('status', 'string', ['limit' => 32, 'default' => 'confirmed'])
+            ->addColumn('reason_code', 'string', ['limit' => 32, 'null' => true, 'default' => null])
+            ->addColumn('confirmed_by', 'biginteger', ['signed' => false])
+            ->addColumn('confirmed_at', 'datetime')
+            ->addColumn('reversed_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('reversal_reason', 'string', ['limit' => 255, 'null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id'])
+            ->addIndex(['bank_transaction_id'])
+            ->create();
+    }
+}

--- a/database/migrations/20260531100100_create_reconciliation_allocations_table.php
+++ b/database/migrations/20260531100100_create_reconciliation_allocations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateReconciliationAllocationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('reconciliation_allocations');
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('payment_reconciliation_id', 'biginteger', ['signed' => false])
+            ->addColumn('invoice_id', 'biginteger', ['signed' => false])
+            ->addColumn('amount_cents', 'biginteger')
+            ->addColumn('payment_id', 'biginteger', ['signed' => false, 'null' => true, 'default' => null])
+            ->addColumn('external_reference', 'string', ['limit' => 64, 'null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id'])
+            ->addIndex(['payment_reconciliation_id'])
+            ->create();
+    }
+}

--- a/database/migrations/20260531100200_create_client_credits_table.php
+++ b/database/migrations/20260531100200_create_client_credits_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateClientCreditsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('client_credits');
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('client_id', 'biginteger', ['signed' => false])
+            ->addColumn('amount_cents', 'biginteger')
+            ->addColumn('remaining_cents', 'biginteger')
+            ->addColumn('status', 'string', ['limit' => 32, 'default' => 'open'])
+            ->addColumn('source_bank_transaction_id', 'biginteger', ['signed' => false])
+            ->addColumn('reconciliation_id', 'biginteger', ['signed' => false])
+            ->addColumn('created_by', 'biginteger', ['signed' => false])
+            ->addColumn('created_at', 'datetime')
+            ->addIndex(['organization_id'])
+            ->addIndex(['client_id'])
+            ->addIndex(['reconciliation_id'])
+            ->create();
+    }
+}

--- a/src/InvoiceUpstream/FakeInvoiceUpstreamClient.php
+++ b/src/InvoiceUpstream/FakeInvoiceUpstreamClient.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+/**
+ * In-memory implementation for tests. Add invoices with `addInvoice()` before
+ * exercising use cases. Payments are tracked so `voidPayment` works correctly.
+ */
+final class FakeInvoiceUpstreamClient implements InvoiceUpstreamClientInterface
+{
+    /** @var array<int, InvoiceItem> keyed by invoiceId */
+    private array $invoices = [];
+
+    /** @var array<int, list<array{paymentId: int, amountCents: int, paidAt: string, externalReference: string, voided: bool}>> keyed by invoiceId */
+    private array $payments = [];
+
+    private int $nextPaymentId = 1;
+
+    private bool $unavailable = false;
+
+    public function makeUnavailable(): void
+    {
+        $this->unavailable = true;
+    }
+
+    public function addInvoice(InvoiceItem $invoice): void
+    {
+        $this->invoices[$invoice->invoiceId] = $invoice;
+        $this->payments[$invoice->invoiceId] ??= [];
+    }
+
+    public function listInvoices(int $organizationId, array $statuses): array
+    {
+        if ($this->unavailable) {
+            throw new UpstreamInvoiceUnavailableException();
+        }
+
+        return array_values(array_filter(
+            $this->invoices,
+            static fn (InvoiceItem $i): bool => in_array($i->status, $statuses, true),
+        ));
+    }
+
+    public function getInvoice(int $organizationId, int $invoiceId): InvoiceItem
+    {
+        if ($this->unavailable) {
+            throw new UpstreamInvoiceUnavailableException();
+        }
+
+        return $this->invoices[$invoiceId] ?? throw new UpstreamInvoiceNotFoundException($invoiceId);
+    }
+
+    public function createPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $amountCents,
+        string $paidAt,
+        string $externalReference,
+        string $idempotencyKey,
+    ): InvoicePaymentCreated {
+        if ($this->unavailable) {
+            throw new UpstreamInvoiceUnavailableException();
+        }
+
+        if (!isset($this->invoices[$invoiceId])) {
+            throw new UpstreamInvoiceNotFoundException($invoiceId);
+        }
+
+        $paymentId = $this->nextPaymentId++;
+        $this->payments[$invoiceId][] = [
+            'paymentId' => $paymentId,
+            'amountCents' => $amountCents,
+            'paidAt' => $paidAt,
+            'externalReference' => $externalReference,
+            'voided' => false,
+        ];
+
+        $invoice = $this->invoices[$invoiceId];
+        $this->invoices[$invoiceId] = new InvoiceItem(
+            invoiceId: $invoice->invoiceId,
+            invoiceNumber: $invoice->invoiceNumber,
+            clientId: $invoice->clientId,
+            outstandingCents: $invoice->outstandingCents - $amountCents,
+            totalCents: $invoice->totalCents,
+            dueAt: $invoice->dueAt,
+            status: $invoice->outstandingCents - $amountCents <= 0 ? 'paid' : 'partially_paid',
+            currency: $invoice->currency,
+        );
+
+        return new InvoicePaymentCreated(
+            paymentId: $paymentId,
+            invoiceId: $invoiceId,
+            amountCents: $amountCents,
+            paidAt: $paidAt,
+            externalReference: $externalReference,
+        );
+    }
+
+    public function voidPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $paymentId,
+        string $reason,
+        string $idempotencyKey,
+    ): void {
+        if ($this->unavailable) {
+            throw new UpstreamInvoiceUnavailableException();
+        }
+
+        if (!isset($this->payments[$invoiceId])) {
+            return;
+        }
+
+        foreach ($this->payments[$invoiceId] as $index => $payment) {
+            if ($payment['paymentId'] === $paymentId && !$payment['voided']) {
+                $this->payments[$invoiceId][$index]['voided'] = true;
+                $invoice = $this->invoices[$invoiceId];
+                $this->invoices[$invoiceId] = new InvoiceItem(
+                    invoiceId: $invoice->invoiceId,
+                    invoiceNumber: $invoice->invoiceNumber,
+                    clientId: $invoice->clientId,
+                    outstandingCents: $invoice->outstandingCents + $payment['amountCents'],
+                    totalCents: $invoice->totalCents,
+                    dueAt: $invoice->dueAt,
+                    status: 'issued',
+                    currency: $invoice->currency,
+                );
+
+                return;
+            }
+        }
+    }
+
+    /** @return list<array{paymentId: int, amountCents: int, paidAt: string, externalReference: string, voided: bool}> */
+    public function paymentsFor(int $invoiceId): array
+    {
+        return $this->payments[$invoiceId] ?? [];
+    }
+}

--- a/src/InvoiceUpstream/InvoiceItem.php
+++ b/src/InvoiceUpstream/InvoiceItem.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+final readonly class InvoiceItem
+{
+    public function __construct(
+        public int $invoiceId,
+        public string $invoiceNumber,
+        public int $clientId,
+        public int $outstandingCents,
+        public int $totalCents,
+        public string $dueAt,
+        public string $status,
+        public string $currency,
+    ) {
+    }
+}

--- a/src/InvoiceUpstream/InvoicePaymentCreated.php
+++ b/src/InvoiceUpstream/InvoicePaymentCreated.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+final readonly class InvoicePaymentCreated
+{
+    public function __construct(
+        public int $paymentId,
+        public int $invoiceId,
+        public int $amountCents,
+        public string $paidAt,
+        public string $externalReference,
+    ) {
+    }
+}

--- a/src/InvoiceUpstream/InvoiceUpstreamClientInterface.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamClientInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+interface InvoiceUpstreamClientInterface
+{
+    /**
+     * @param list<string> $statuses e.g. ['issued', 'partially_paid']
+     * @return list<InvoiceItem>
+     */
+    public function listInvoices(int $organizationId, array $statuses): array;
+
+    public function getInvoice(int $organizationId, int $invoiceId): InvoiceItem;
+
+    public function createPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $amountCents,
+        string $paidAt,
+        string $externalReference,
+        string $idempotencyKey,
+    ): InvoicePaymentCreated;
+
+    public function voidPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $paymentId,
+        string $reason,
+        string $idempotencyKey,
+    ): void;
+}

--- a/src/InvoiceUpstream/UpstreamInvoiceNotFoundException.php
+++ b/src/InvoiceUpstream/UpstreamInvoiceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use RuntimeException;
+
+final class UpstreamInvoiceNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $invoiceId)
+    {
+        parent::__construct(sprintf('Invoice %d was not found in the upstream system.', $invoiceId));
+    }
+}

--- a/src/InvoiceUpstream/UpstreamInvoiceUnavailableException.php
+++ b/src/InvoiceUpstream/UpstreamInvoiceUnavailableException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use RuntimeException;
+
+final class UpstreamInvoiceUnavailableException extends RuntimeException
+{
+    public function __construct(string $message = 'The Invoice upstream is currently unavailable.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/InvoiceUpstream/UpstreamInvoiceUnavailableExceptionHandler.php
+++ b/src/InvoiceUpstream/UpstreamInvoiceUnavailableExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class UpstreamInvoiceUnavailableExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof UpstreamInvoiceUnavailableException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'upstream-invoice-unavailable',
+            'Invoice Upstream Unavailable',
+            503,
+            'The Invoice API is unreachable; match confirmation is blocked.',
+        );
+    }
+}

--- a/src/Reconciliation/AllocationExceedsOutstandingException.php
+++ b/src/Reconciliation/AllocationExceedsOutstandingException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class AllocationExceedsOutstandingException extends RuntimeException
+{
+    public function __construct(
+        public readonly int $invoiceId,
+        public readonly int $outstandingCents,
+    ) {
+        parent::__construct(sprintf(
+            'Allocation for invoice %d exceeds outstanding amount of %d cents.',
+            $invoiceId,
+            $outstandingCents,
+        ));
+    }
+}

--- a/src/Reconciliation/AllocationInput.php
+++ b/src/Reconciliation/AllocationInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class AllocationInput
+{
+    public function __construct(
+        public int $invoiceId,
+        public int $amountCents,
+    ) {
+    }
+}

--- a/src/Reconciliation/BankTransactionNotMatchableException.php
+++ b/src/Reconciliation/BankTransactionNotMatchableException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class BankTransactionNotMatchableException extends RuntimeException
+{
+    public function __construct(public readonly int $bankTransactionId, public readonly string $currentStatus)
+    {
+        parent::__construct(sprintf(
+            'Bank transaction %d cannot be matched in status "%s".',
+            $bankTransactionId,
+            $currentStatus,
+        ));
+    }
+}

--- a/src/Reconciliation/ClientCredit.php
+++ b/src/Reconciliation/ClientCredit.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ClientCredit
+{
+    public function __construct(
+        public int $organizationId,
+        public int $clientId,
+        public int $amountCents,
+        public int $remainingCents,
+        public ClientCreditStatus $status,
+        public int $sourceBankTransactionId,
+        public int $reconciliationId,
+        public int $createdBy,
+        public string $createdAt,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Reconciliation/ClientCreditRepositoryInterface.php
+++ b/src/Reconciliation/ClientCreditRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ClientCreditRepositoryInterface
+{
+    public function save(ClientCredit $credit): int;
+
+    public function findByReconciliation(int $reconciliationId): ?ClientCredit;
+
+    public function voidByReconciliation(int $reconciliationId): void;
+
+    /**
+     * @return list<ClientCredit>
+     */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+}

--- a/src/Reconciliation/ClientCreditStatus.php
+++ b/src/Reconciliation/ClientCreditStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+enum ClientCreditStatus: string
+{
+    case Open = 'open';
+    case Voided = 'voided';
+}

--- a/src/Reconciliation/ConfirmMatchInput.php
+++ b/src/Reconciliation/ConfirmMatchInput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ConfirmMatchInput
+{
+    /**
+     * @param list<AllocationInput> $allocations
+     */
+    public function __construct(
+        public int $organizationId,
+        public int $bankTransactionId,
+        public array $allocations,
+        public int $actorUserId,
+        public ?string $reasonCode = null,
+    ) {
+    }
+}

--- a/src/Reconciliation/ConfirmMatchOutput.php
+++ b/src/Reconciliation/ConfirmMatchOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ConfirmMatchOutput
+{
+    public function __construct(
+        public int $reconciliationId,
+    ) {
+    }
+}

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\BankImport\BankTransactionNotFoundException;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+
+final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
+{
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private ReconciliationRepositoryInterface $reconciliations,
+        private ClientCreditRepositoryInterface $clientCredits,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(ConfirmMatchInput $input): ConfirmMatchOutput
+    {
+        $tx = $this->transactions->findById($input->organizationId, $input->bankTransactionId);
+
+        if ($tx === null) {
+            throw new BankTransactionNotFoundException($input->bankTransactionId);
+        }
+
+        if ($tx->status !== BankTransactionStatus::Unmatched && $tx->status !== BankTransactionStatus::PartiallyMatched) {
+            throw new BankTransactionNotMatchableException($input->bankTransactionId, $tx->status->value);
+        }
+
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        // Validate outstanding and call upstream for each allocation.
+        $paymentsCreated = [];
+        foreach ($input->allocations as $allocation) {
+            $invoice = $this->invoiceClient->getInvoice($input->organizationId, $allocation->invoiceId);
+
+            if ($allocation->amountCents > $invoice->outstandingCents) {
+                throw new AllocationExceedsOutstandingException($allocation->invoiceId, $invoice->outstandingCents);
+            }
+
+            $externalRef = sprintf('clear:recon:pending:%s', bin2hex(random_bytes(8)));
+            $idempotencyKey = sprintf('clear:recon:confirm:%d:%d:%s', $input->bankTransactionId, $allocation->invoiceId, bin2hex(random_bytes(8)));
+
+            $payment = $this->invoiceClient->createPayment(
+                organizationId: $input->organizationId,
+                invoiceId: $allocation->invoiceId,
+                amountCents: $allocation->amountCents,
+                paidAt: $tx->valueDate,
+                externalReference: $externalRef,
+                idempotencyKey: $idempotencyKey,
+            );
+
+            $paymentsCreated[] = ['allocation' => $allocation, 'payment' => $payment, 'externalRef' => $externalRef];
+        }
+
+        $reconciliationId = $this->reconciliations->save(new Reconciliation(
+            organizationId: $input->organizationId,
+            bankTransactionId: $input->bankTransactionId,
+            status: ReconciliationStatus::Confirmed,
+            confirmedBy: $input->actorUserId,
+            confirmedAt: $now,
+            reasonCode: $input->reasonCode,
+        ));
+
+        $totalAllocated = 0;
+        foreach ($paymentsCreated as $entry) {
+            /** @var AllocationInput $allocation */
+            $allocation = $entry['allocation'];
+            $payment = $entry['payment'];
+            $externalRef = sprintf('clear:recon:%d:%d', $reconciliationId, $allocation->invoiceId);
+
+            $this->reconciliations->saveAllocation(new ReconciliationAllocation(
+                organizationId: $input->organizationId,
+                reconciliationId: $reconciliationId,
+                invoiceId: $allocation->invoiceId,
+                amountCents: $allocation->amountCents,
+                paymentId: $payment->paymentId,
+                externalReference: $externalRef,
+            ));
+
+            $totalAllocated += $allocation->amountCents;
+        }
+
+        $remainder = $tx->amountCents - $totalAllocated;
+        $newStatus = $remainder <= 0 ? BankTransactionStatus::Matched : BankTransactionStatus::PartiallyMatched;
+        $this->transactions->updateStatusById($input->bankTransactionId, $newStatus);
+
+        if ($remainder > 0) {
+            $this->clientCredits->save(new ClientCredit(
+                organizationId: $input->organizationId,
+                clientId: $paymentsCreated[0]['payment']->invoiceId,
+                amountCents: $remainder,
+                remainingCents: $remainder,
+                status: ClientCreditStatus::Open,
+                sourceBankTransactionId: $input->bankTransactionId,
+                reconciliationId: $reconciliationId,
+                createdBy: $input->actorUserId,
+                createdAt: $now,
+            ));
+        }
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'reconciliation_confirmed',
+            actorUserId: $input->actorUserId,
+            occurredAt: $now,
+            payload: [
+                'payment_reconciliation_id' => $reconciliationId,
+                'bank_transaction_id' => $input->bankTransactionId,
+                'total_allocated_cents' => $totalAllocated,
+                'remainder_cents' => $remainder,
+            ],
+        ));
+
+        return new ConfirmMatchOutput(reconciliationId: $reconciliationId);
+    }
+}

--- a/src/Reconciliation/ConfirmMatchUseCaseInterface.php
+++ b/src/Reconciliation/ConfirmMatchUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ConfirmMatchUseCaseInterface
+{
+    public function execute(ConfirmMatchInput $input): ConfirmMatchOutput;
+}

--- a/src/Reconciliation/MatchSuggestion.php
+++ b/src/Reconciliation/MatchSuggestion.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class MatchSuggestion
+{
+    public function __construct(
+        public int $invoiceId,
+        public string $invoiceNumber,
+        public int $amountCents,
+        public int $outstandingCents,
+        public float $score,
+        public string $reason,
+    ) {
+    }
+}

--- a/src/Reconciliation/PdoClientCreditRepository.php
+++ b/src/Reconciliation/PdoClientCreditRepository.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoClientCreditRepository implements ClientCreditRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, client_id, amount_cents, remaining_cents, status, '
+        . 'source_bank_transaction_id, reconciliation_id, created_by, created_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(ClientCredit $credit): int
+    {
+        $this->query->execute(
+            'INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status, '
+            . 'source_bank_transaction_id, reconciliation_id, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $credit->organizationId,
+                $credit->clientId,
+                $credit->amountCents,
+                $credit->remainingCents,
+                $credit->status->value,
+                $credit->sourceBankTransactionId,
+                $credit->reconciliationId,
+                $credit->createdBy,
+                $credit->createdAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findByReconciliation(int $reconciliationId): ?ClientCredit
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM client_credits WHERE reconciliation_id = ? LIMIT 1',
+            [$reconciliationId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function voidByReconciliation(int $reconciliationId): void
+    {
+        $this->query->execute(
+            'UPDATE client_credits SET status = ? WHERE reconciliation_id = ? AND status = ?',
+            [ClientCreditStatus::Voided->value, $reconciliationId, ClientCreditStatus::Open->value],
+        );
+    }
+
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM client_credits WHERE organization_id = ? ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM client_credits WHERE organization_id = ?', [$organizationId]);
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): ClientCredit
+    {
+        return new ClientCredit(
+            organizationId: (int) $row['organization_id'],
+            clientId: (int) $row['client_id'],
+            amountCents: (int) $row['amount_cents'],
+            remainingCents: (int) $row['remaining_cents'],
+            status: ClientCreditStatus::from((string) $row['status']),
+            sourceBankTransactionId: (int) $row['source_bank_transaction_id'],
+            reconciliationId: (int) $row['reconciliation_id'],
+            createdBy: (int) $row['created_by'],
+            createdAt: (string) $row['created_at'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoReconciliationRepository implements ReconciliationRepositoryInterface
+{
+    private const string RECON_COLUMNS = 'id, organization_id, bank_transaction_id, status, reason_code, '
+        . 'confirmed_by, confirmed_at, reversed_at, reversal_reason';
+
+    private const string ALLOC_COLUMNS = 'id, organization_id, payment_reconciliation_id, invoice_id, '
+        . 'amount_cents, payment_id, external_reference';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $organizationId, int $id): ?Reconciliation
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->hydrateReconciliation($row) : null;
+    }
+
+    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array
+    {
+        if ($status === null) {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE organization_id = ? '
+                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE organization_id = ? AND status = ? '
+                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $status->value, $limit, $offset],
+            );
+        }
+
+        return array_map($this->hydrateReconciliation(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int
+    {
+        $row = $status === null
+            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM payment_reconciliations WHERE organization_id = ?', [$organizationId])
+            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM payment_reconciliations WHERE organization_id = ? AND status = ?', [$organizationId, $status->value]);
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function save(Reconciliation $reconciliation): int
+    {
+        $this->query->execute(
+            'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code, confirmed_by, confirmed_at) '
+            . 'VALUES (?, ?, ?, ?, ?, ?)',
+            [
+                $reconciliation->organizationId,
+                $reconciliation->bankTransactionId,
+                $reconciliation->status->value,
+                $reconciliation->reasonCode,
+                $reconciliation->confirmedBy,
+                $reconciliation->confirmedAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function saveAllocation(ReconciliationAllocation $allocation): int
+    {
+        $this->query->execute(
+            'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents, payment_id, external_reference) '
+            . 'VALUES (?, ?, ?, ?, ?, ?)',
+            [
+                $allocation->organizationId,
+                $allocation->reconciliationId,
+                $allocation->invoiceId,
+                $allocation->amountCents,
+                $allocation->paymentId,
+                $allocation->externalReference,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findAllocationsByReconciliation(int $reconciliationId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::ALLOC_COLUMNS . ' FROM reconciliation_allocations WHERE payment_reconciliation_id = ? ORDER BY id ASC',
+            [$reconciliationId],
+        );
+
+        return array_map($this->hydrateAllocation(...), $rows);
+    }
+
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void
+    {
+        $this->query->execute(
+            'UPDATE payment_reconciliations SET status = ?, reversed_at = ?, reversal_reason = ? WHERE id = ?',
+            [ReconciliationStatus::Reversed->value, $reversedAt, $reversalReason, $id],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateReconciliation(array $row): Reconciliation
+    {
+        return new Reconciliation(
+            organizationId: (int) $row['organization_id'],
+            bankTransactionId: (int) $row['bank_transaction_id'],
+            status: ReconciliationStatus::from((string) $row['status']),
+            confirmedBy: (int) $row['confirmed_by'],
+            confirmedAt: (string) $row['confirmed_at'],
+            reasonCode: isset($row['reason_code']) ? (string) $row['reason_code'] : null,
+            reversedAt: isset($row['reversed_at']) ? (string) $row['reversed_at'] : null,
+            reversalReason: isset($row['reversal_reason']) ? (string) $row['reversal_reason'] : null,
+            id: (int) $row['id'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrateAllocation(array $row): ReconciliationAllocation
+    {
+        return new ReconciliationAllocation(
+            organizationId: (int) $row['organization_id'],
+            reconciliationId: (int) $row['payment_reconciliation_id'],
+            invoiceId: (int) $row['invoice_id'],
+            amountCents: (int) $row['amount_cents'],
+            paymentId: isset($row['payment_id']) ? (int) $row['payment_id'] : null,
+            externalReference: isset($row['external_reference']) ? (string) $row['external_reference'] : null,
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Reconciliation/ProposeMatchInput.php
+++ b/src/Reconciliation/ProposeMatchInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ProposeMatchInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $bankTransactionId,
+    ) {
+    }
+}

--- a/src/Reconciliation/ProposeMatchOutput.php
+++ b/src/Reconciliation/ProposeMatchOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ProposeMatchOutput
+{
+    /**
+     * @param list<MatchSuggestion> $suggestions
+     */
+    public function __construct(
+        public int $bankTransactionId,
+        public array $suggestions,
+    ) {
+    }
+}

--- a/src/Reconciliation/ProposeMatchUseCase.php
+++ b/src/Reconciliation/ProposeMatchUseCase.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\BankImport\BankTransactionNotFoundException;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+
+final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
+{
+    private const int MAX_SUGGESTIONS = 10;
+    private const int DUE_SOON_DAYS = 30;
+
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(ProposeMatchInput $input): ProposeMatchOutput
+    {
+        $tx = $this->transactions->findById($input->organizationId, $input->bankTransactionId);
+
+        if ($tx === null) {
+            throw new BankTransactionNotFoundException($input->bankTransactionId);
+        }
+
+        $invoices = $this->invoiceClient->listInvoices($input->organizationId, ['issued', 'partially_paid']);
+
+        $today = $this->clock->now();
+        $suggestions = [];
+
+        foreach ($invoices as $invoice) {
+            $score = 0.0;
+            $reasons = [];
+
+            if ($invoice->outstandingCents === $tx->amountCents) {
+                $score += 0.5;
+                $reasons[] = 'exact amount match';
+            }
+
+            if (stripos($tx->counterpartyText, $invoice->invoiceNumber) !== false) {
+                $score += 0.3;
+                $reasons[] = 'invoice number in counterparty';
+            }
+
+            if ($score > 0.0 || count($reasons) > 0) {
+                $dueAt = new \DateTimeImmutable($invoice->dueAt);
+                $daysUntilDue = (int) $today->diff($dueAt)->days;
+                if ($dueAt >= $today && $daysUntilDue <= self::DUE_SOON_DAYS) {
+                    $score += 0.2;
+                    $reasons[] = 'due soon';
+                }
+            }
+
+            if ($score > 0.0) {
+                $suggestions[] = new MatchSuggestion(
+                    invoiceId: $invoice->invoiceId,
+                    invoiceNumber: $invoice->invoiceNumber,
+                    amountCents: $invoice->totalCents,
+                    outstandingCents: $invoice->outstandingCents,
+                    score: $score,
+                    reason: implode('; ', $reasons),
+                );
+            }
+        }
+
+        usort($suggestions, static fn (MatchSuggestion $a, MatchSuggestion $b): int => $b->score <=> $a->score);
+
+        return new ProposeMatchOutput(
+            bankTransactionId: $input->bankTransactionId,
+            suggestions: array_slice($suggestions, 0, self::MAX_SUGGESTIONS),
+        );
+    }
+}

--- a/src/Reconciliation/ProposeMatchUseCaseInterface.php
+++ b/src/Reconciliation/ProposeMatchUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ProposeMatchUseCaseInterface
+{
+    public function execute(ProposeMatchInput $input): ProposeMatchOutput;
+}

--- a/src/Reconciliation/Reconciliation.php
+++ b/src/Reconciliation/Reconciliation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class Reconciliation
+{
+    public function __construct(
+        public int $organizationId,
+        public int $bankTransactionId,
+        public ReconciliationStatus $status,
+        public int $confirmedBy,
+        public string $confirmedAt,
+        public ?string $reasonCode = null,
+        public ?string $reversedAt = null,
+        public ?string $reversalReason = null,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Reconciliation/ReconciliationAllocation.php
+++ b/src/Reconciliation/ReconciliationAllocation.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ReconciliationAllocation
+{
+    public function __construct(
+        public int $organizationId,
+        public int $reconciliationId,
+        public int $invoiceId,
+        public int $amountCents,
+        public ?int $paymentId = null,
+        public ?string $externalReference = null,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Reconciliation/ReconciliationAlreadyReversedException.php
+++ b/src/Reconciliation/ReconciliationAlreadyReversedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class ReconciliationAlreadyReversedException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Reconciliation %d is already reversed.', $id));
+    }
+}

--- a/src/Reconciliation/ReconciliationNotFoundException.php
+++ b/src/Reconciliation/ReconciliationNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class ReconciliationNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Reconciliation %d was not found.', $id));
+    }
+}

--- a/src/Reconciliation/ReconciliationRepositoryInterface.php
+++ b/src/Reconciliation/ReconciliationRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ReconciliationRepositoryInterface
+{
+    public function findById(int $organizationId, int $id): ?Reconciliation;
+
+    /**
+     * @return list<Reconciliation>
+     */
+    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int;
+
+    public function save(Reconciliation $reconciliation): int;
+
+    public function saveAllocation(ReconciliationAllocation $allocation): int;
+
+    /**
+     * @return list<ReconciliationAllocation>
+     */
+    public function findAllocationsByReconciliation(int $reconciliationId): array;
+
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void;
+}

--- a/src/Reconciliation/ReconciliationStatus.php
+++ b/src/Reconciliation/ReconciliationStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+enum ReconciliationStatus: string
+{
+    case Confirmed = 'confirmed';
+    case Reversed = 'reversed';
+}

--- a/src/Reconciliation/ReverseReconciliationInput.php
+++ b/src/Reconciliation/ReverseReconciliationInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ReverseReconciliationInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $reconciliationId,
+        public int $actorUserId,
+        public string $reversalReason,
+    ) {
+    }
+}

--- a/src/Reconciliation/ReverseReconciliationOutput.php
+++ b/src/Reconciliation/ReverseReconciliationOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ReverseReconciliationOutput
+{
+    public function __construct(
+        public int $reconciliationId,
+    ) {
+    }
+}

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+
+final readonly class ReverseReconciliationUseCase implements ReverseReconciliationUseCaseInterface
+{
+    public function __construct(
+        private ReconciliationRepositoryInterface $reconciliations,
+        private ClientCreditRepositoryInterface $clientCredits,
+        private BankTransactionRepositoryInterface $transactions,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(ReverseReconciliationInput $input): ReverseReconciliationOutput
+    {
+        $reconciliation = $this->reconciliations->findById($input->organizationId, $input->reconciliationId);
+
+        if ($reconciliation === null) {
+            throw new ReconciliationNotFoundException($input->reconciliationId);
+        }
+
+        if ($reconciliation->status !== ReconciliationStatus::Confirmed) {
+            throw new ReconciliationAlreadyReversedException($input->reconciliationId);
+        }
+
+        $allocations = $this->reconciliations->findAllocationsByReconciliation($input->reconciliationId);
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        foreach ($allocations as $allocation) {
+            if ($allocation->paymentId !== null) {
+                $idempotencyKey = sprintf('clear:recon:reverse:%d:%d', $input->reconciliationId, $allocation->invoiceId);
+                $this->invoiceClient->voidPayment(
+                    organizationId: $input->organizationId,
+                    invoiceId: $allocation->invoiceId,
+                    paymentId: $allocation->paymentId,
+                    reason: $input->reversalReason,
+                    idempotencyKey: $idempotencyKey,
+                );
+            }
+        }
+
+        $this->reconciliations->reverseById($input->reconciliationId, $now, $input->reversalReason);
+        $this->transactions->updateStatusById($reconciliation->bankTransactionId, BankTransactionStatus::Unmatched);
+        $this->clientCredits->voidByReconciliation($input->reconciliationId);
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'reconciliation_reversed',
+            actorUserId: $input->actorUserId,
+            occurredAt: $now,
+            payload: [
+                'payment_reconciliation_id' => $input->reconciliationId,
+                'bank_transaction_id' => $reconciliation->bankTransactionId,
+                'reversal_reason' => $input->reversalReason,
+            ],
+        ));
+
+        return new ReverseReconciliationOutput(reconciliationId: $input->reconciliationId);
+    }
+}

--- a/src/Reconciliation/ReverseReconciliationUseCaseInterface.php
+++ b/src/Reconciliation/ReverseReconciliationUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ReverseReconciliationUseCaseInterface
+{
+    public function execute(ReverseReconciliationInput $input): ReverseReconciliationOutput;
+}

--- a/tests/Database/PdoReconciliationRepositoryTest.php
+++ b/tests/Database/PdoReconciliationRepositoryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Reconciliation\ClientCredit;
+use NeneClear\Reconciliation\ClientCreditStatus;
+use NeneClear\Reconciliation\PdoClientCreditRepository;
+use NeneClear\Reconciliation\PdoReconciliationRepository;
+use NeneClear\Reconciliation\Reconciliation;
+use NeneClear\Reconciliation\ReconciliationAllocation;
+use NeneClear\Reconciliation\ReconciliationStatus;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoReconciliationRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoReconciliationRepository $reconRepo;
+    private PdoClientCreditRepository $creditRepo;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-recon-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createPaymentReconciliations($this->query);
+        SchemaFixture::createReconciliationAllocations($this->query);
+        SchemaFixture::createClientCredits($this->query);
+
+        $this->reconRepo = new PdoReconciliationRepository($this->query);
+        $this->creditRepo = new PdoClientCreditRepository($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function makeReconciliation(int $orgId = 7, int $bankTxId = 1): Reconciliation
+    {
+        return new Reconciliation(
+            organizationId: $orgId,
+            bankTransactionId: $bankTxId,
+            status: ReconciliationStatus::Confirmed,
+            confirmedBy: 42,
+            confirmedAt: '2026-05-31 09:00:00',
+        );
+    }
+
+    public function test_save_and_findById(): void
+    {
+        $id = $this->reconRepo->save($this->makeReconciliation());
+        $recon = $this->reconRepo->findById(7, $id);
+
+        self::assertNotNull($recon);
+        self::assertSame($id, $recon->id);
+        self::assertSame(ReconciliationStatus::Confirmed, $recon->status);
+        self::assertSame(1, $recon->bankTransactionId);
+    }
+
+    public function test_findById_cross_tenant_returns_null(): void
+    {
+        $id = $this->reconRepo->save($this->makeReconciliation(orgId: 7));
+
+        self::assertNull($this->reconRepo->findById(999, $id));
+    }
+
+    public function test_save_allocation_and_find(): void
+    {
+        $reconId = $this->reconRepo->save($this->makeReconciliation());
+        $this->reconRepo->saveAllocation(new ReconciliationAllocation(
+            organizationId: 7,
+            reconciliationId: $reconId,
+            invoiceId: 10,
+            amountCents: 100000,
+            paymentId: 55,
+            externalReference: 'clear:recon:1:10',
+        ));
+
+        $allocs = $this->reconRepo->findAllocationsByReconciliation($reconId);
+        self::assertCount(1, $allocs);
+        self::assertSame(10, $allocs[0]->invoiceId);
+        self::assertSame(100000, $allocs[0]->amountCents);
+        self::assertSame(55, $allocs[0]->paymentId);
+    }
+
+    public function test_reverseById(): void
+    {
+        $id = $this->reconRepo->save($this->makeReconciliation());
+        $this->reconRepo->reverseById($id, '2026-06-01 10:00:00', 'wrong entry');
+
+        $recon = $this->reconRepo->findById(7, $id);
+        self::assertNotNull($recon);
+        self::assertSame(ReconciliationStatus::Reversed, $recon->status);
+        self::assertSame('wrong entry', $recon->reversalReason);
+    }
+
+    public function test_findByOrganization_with_status_filter(): void
+    {
+        $id1 = $this->reconRepo->save($this->makeReconciliation(bankTxId: 1));
+        $id2 = $this->reconRepo->save($this->makeReconciliation(bankTxId: 2));
+        $this->reconRepo->reverseById($id2, '2026-06-01 10:00:00', 'reason');
+
+        $confirmed = $this->reconRepo->findByOrganization(7, ReconciliationStatus::Confirmed, 50, 0);
+        self::assertCount(1, $confirmed);
+        self::assertSame($id1, $confirmed[0]->id);
+
+        self::assertSame(2, $this->reconRepo->countByOrganization(7, null));
+    }
+
+    public function test_client_credit_save_and_void(): void
+    {
+        $credit = new ClientCredit(
+            organizationId: 7,
+            clientId: 100,
+            amountCents: 50000,
+            remainingCents: 50000,
+            status: ClientCreditStatus::Open,
+            sourceBankTransactionId: 1,
+            reconciliationId: 1,
+            createdBy: 42,
+            createdAt: '2026-05-31 09:00:00',
+        );
+
+        $this->creditRepo->save($credit);
+
+        $found = $this->creditRepo->findByReconciliation(1);
+        self::assertNotNull($found);
+        self::assertSame(ClientCreditStatus::Open, $found->status);
+
+        $this->creditRepo->voidByReconciliation(1);
+
+        $found = $this->creditRepo->findByReconciliation(1);
+        self::assertSame(ClientCreditStatus::Voided, $found?->status);
+    }
+}

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionNotFoundException;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Reconciliation\AllocationExceedsOutstandingException;
+use NeneClear\Reconciliation\AllocationInput;
+use NeneClear\Reconciliation\BankTransactionNotMatchableException;
+use NeneClear\Reconciliation\ClientCreditStatus;
+use NeneClear\Reconciliation\ConfirmMatchInput;
+use NeneClear\Reconciliation\ConfirmMatchUseCase;
+use NeneClear\Reconciliation\ReconciliationStatus;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class ConfirmMatchUseCaseTest extends TestCase
+{
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryReconciliationRepository $reconciliations;
+    private InMemoryClientCreditRepository $clientCredits;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+    private InMemoryAuditEventRepository $audit;
+    private ConfirmMatchUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->transactions = new InMemoryBankTransactionRepository();
+        $this->reconciliations = new InMemoryReconciliationRepository();
+        $this->clientCredits = new InMemoryClientCreditRepository();
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->audit = new InMemoryAuditEventRepository();
+        $this->useCase = new ConfirmMatchUseCase(
+            $this->transactions,
+            $this->reconciliations,
+            $this->clientCredits,
+            $this->invoiceClient,
+            $this->audit,
+            new FixedClock(),
+        );
+    }
+
+    private function makeTx(int $amountCents, BankTransactionStatus $status = BankTransactionStatus::Unmatched): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 7,
+            bankImportBatchId: 1,
+            bankAccountId: 1,
+            valueDate: '2026-05-28',
+            amountCents: $amountCents,
+            counterpartyText: 'ACME',
+            lineKey: 'k1',
+            status: $status,
+        ));
+    }
+
+    private function makeInvoice(int $id, int $outstandingCents): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: 'INV-00' . $id,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: $outstandingCents,
+            dueAt: '2026-12-31',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+    }
+
+    public function test_exact_match_sets_status_to_matched(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeInvoice(1, 100000);
+
+        $output = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        self::assertGreaterThan(0, $output->reconciliationId);
+
+        $tx = $this->transactions->findById(7, $txId);
+        self::assertSame(BankTransactionStatus::Matched, $tx?->status);
+
+        $recon = $this->reconciliations->findById(7, $output->reconciliationId);
+        self::assertSame(ReconciliationStatus::Confirmed, $recon?->status);
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('reconciliation_confirmed', $this->audit->events[0]->eventType);
+
+        self::assertEmpty($this->clientCredits->all());
+    }
+
+    public function test_partial_match_creates_client_credit(): void
+    {
+        $txId = $this->makeTx(150000);
+        $this->makeInvoice(1, 100000);
+
+        $output = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        $tx = $this->transactions->findById(7, $txId);
+        self::assertSame(BankTransactionStatus::PartiallyMatched, $tx?->status);
+
+        $credits = $this->clientCredits->all();
+        self::assertCount(1, $credits);
+        self::assertSame(50000, $credits[0]->amountCents);
+        self::assertSame(ClientCreditStatus::Open, $credits[0]->status);
+    }
+
+    public function test_multi_invoice_allocation(): void
+    {
+        $txId = $this->makeTx(300000);
+        $this->makeInvoice(1, 200000);
+        $this->makeInvoice(2, 100000);
+
+        $output = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 200000), new AllocationInput(2, 100000)],
+            actorUserId: 42,
+        ));
+
+        $tx = $this->transactions->findById(7, $txId);
+        self::assertSame(BankTransactionStatus::Matched, $tx?->status);
+
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($output->reconciliationId);
+        self::assertCount(2, $allocs);
+    }
+
+    public function test_allocation_exceeds_outstanding_throws(): void
+    {
+        $txId = $this->makeTx(200000);
+        $this->makeInvoice(1, 100000);
+
+        $this->expectException(AllocationExceedsOutstandingException::class);
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 150000)],
+            actorUserId: 42,
+        ));
+    }
+
+    public function test_unknown_transaction_throws_not_found(): void
+    {
+        $this->expectException(BankTransactionNotFoundException::class);
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: 9999,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+    }
+
+    public function test_voided_transaction_throws_not_matchable(): void
+    {
+        $txId = $this->makeTx(100000, BankTransactionStatus::Voided);
+        $this->makeInvoice(1, 100000);
+
+        $this->expectException(BankTransactionNotMatchableException::class);
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+    }
+}

--- a/tests/Reconciliation/InMemoryClientCreditRepository.php
+++ b/tests/Reconciliation/InMemoryClientCreditRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\Reconciliation\ClientCredit;
+use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
+use NeneClear\Reconciliation\ClientCreditStatus;
+
+final class InMemoryClientCreditRepository implements ClientCreditRepositoryInterface
+{
+    /** @var array<int, ClientCredit> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function save(ClientCredit $credit): int
+    {
+        $id = $credit->id ?? $this->nextId++;
+        $this->byId[$id] = new ClientCredit(
+            organizationId: $credit->organizationId,
+            clientId: $credit->clientId,
+            amountCents: $credit->amountCents,
+            remainingCents: $credit->remainingCents,
+            status: $credit->status,
+            sourceBankTransactionId: $credit->sourceBankTransactionId,
+            reconciliationId: $credit->reconciliationId,
+            createdBy: $credit->createdBy,
+            createdAt: $credit->createdAt,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function findByReconciliation(int $reconciliationId): ?ClientCredit
+    {
+        foreach ($this->byId as $credit) {
+            if ($credit->reconciliationId === $reconciliationId) {
+                return $credit;
+            }
+        }
+
+        return null;
+    }
+
+    public function voidByReconciliation(int $reconciliationId): void
+    {
+        foreach ($this->byId as $id => $credit) {
+            if ($credit->reconciliationId === $reconciliationId && $credit->status === ClientCreditStatus::Open) {
+                $this->byId[$id] = new ClientCredit(
+                    organizationId: $credit->organizationId,
+                    clientId: $credit->clientId,
+                    amountCents: $credit->amountCents,
+                    remainingCents: $credit->remainingCents,
+                    status: ClientCreditStatus::Voided,
+                    sourceBankTransactionId: $credit->sourceBankTransactionId,
+                    reconciliationId: $credit->reconciliationId,
+                    createdBy: $credit->createdBy,
+                    createdAt: $credit->createdAt,
+                    id: $credit->id,
+                );
+            }
+        }
+    }
+
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (ClientCredit $c): bool => $c->organizationId === $organizationId,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (ClientCredit $c): bool => $c->organizationId === $organizationId,
+        ));
+    }
+
+    /** @return list<ClientCredit> */
+    public function all(): array
+    {
+        return array_values($this->byId);
+    }
+}

--- a/tests/Reconciliation/InMemoryReconciliationRepository.php
+++ b/tests/Reconciliation/InMemoryReconciliationRepository.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\Reconciliation\Reconciliation;
+use NeneClear\Reconciliation\ReconciliationAllocation;
+use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
+use NeneClear\Reconciliation\ReconciliationStatus;
+
+final class InMemoryReconciliationRepository implements ReconciliationRepositoryInterface
+{
+    /** @var array<int, Reconciliation> */
+    private array $byId = [];
+
+    /** @var array<int, list<ReconciliationAllocation>> keyed by reconciliationId */
+    private array $allocations = [];
+
+    private int $nextId = 1;
+    private int $nextAllocId = 1;
+
+    public function findById(int $organizationId, int $id): ?Reconciliation
+    {
+        $r = $this->byId[$id] ?? null;
+
+        return ($r !== null && $r->organizationId === $organizationId) ? $r : null;
+    }
+
+    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (Reconciliation $r): bool => $r->organizationId === $organizationId
+                && ($status === null || $r->status === $status),
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (Reconciliation $r): bool => $r->organizationId === $organizationId
+                && ($status === null || $r->status === $status),
+        ));
+    }
+
+    public function save(Reconciliation $reconciliation): int
+    {
+        $id = $reconciliation->id ?? $this->nextId++;
+        $this->byId[$id] = new Reconciliation(
+            organizationId: $reconciliation->organizationId,
+            bankTransactionId: $reconciliation->bankTransactionId,
+            status: $reconciliation->status,
+            confirmedBy: $reconciliation->confirmedBy,
+            confirmedAt: $reconciliation->confirmedAt,
+            reasonCode: $reconciliation->reasonCode,
+            reversedAt: $reconciliation->reversedAt,
+            reversalReason: $reconciliation->reversalReason,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function saveAllocation(ReconciliationAllocation $allocation): int
+    {
+        $id = $this->nextAllocId++;
+        $this->allocations[$allocation->reconciliationId][] = new ReconciliationAllocation(
+            organizationId: $allocation->organizationId,
+            reconciliationId: $allocation->reconciliationId,
+            invoiceId: $allocation->invoiceId,
+            amountCents: $allocation->amountCents,
+            paymentId: $allocation->paymentId,
+            externalReference: $allocation->externalReference,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function findAllocationsByReconciliation(int $reconciliationId): array
+    {
+        return $this->allocations[$reconciliationId] ?? [];
+    }
+
+    public function reverseById(int $id, string $reversedAt, string $reversalReason): void
+    {
+        $r = $this->byId[$id] ?? null;
+        if ($r === null) {
+            return;
+        }
+
+        $this->byId[$id] = new Reconciliation(
+            organizationId: $r->organizationId,
+            bankTransactionId: $r->bankTransactionId,
+            status: ReconciliationStatus::Reversed,
+            confirmedBy: $r->confirmedBy,
+            confirmedAt: $r->confirmedAt,
+            reasonCode: $r->reasonCode,
+            reversedAt: $reversedAt,
+            reversalReason: $reversalReason,
+            id: $r->id,
+        );
+    }
+}

--- a/tests/Reconciliation/ProposeMatchUseCaseTest.php
+++ b/tests/Reconciliation/ProposeMatchUseCaseTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionNotFoundException;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Reconciliation\ProposeMatchInput;
+use NeneClear\Reconciliation\ProposeMatchUseCase;
+use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class ProposeMatchUseCaseTest extends TestCase
+{
+    private InMemoryBankTransactionRepository $transactions;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+    private ProposeMatchUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->transactions = new InMemoryBankTransactionRepository();
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->useCase = new ProposeMatchUseCase(
+            $this->transactions,
+            $this->invoiceClient,
+            new FixedClock('2026-05-30T09:00:00+00:00'),
+        );
+    }
+
+    private function makeTx(int $amountCents, string $counterpartyText = 'ACME'): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 7,
+            bankImportBatchId: 1,
+            bankAccountId: 1,
+            valueDate: '2026-05-28',
+            amountCents: $amountCents,
+            counterpartyText: $counterpartyText,
+            lineKey: 'k1',
+            status: BankTransactionStatus::Unmatched,
+        ));
+    }
+
+    private function makeInvoice(int $id, string $number, int $outstandingCents, string $dueAt = '2026-12-31'): InvoiceItem
+    {
+        return new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: $number,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: $outstandingCents,
+            dueAt: $dueAt,
+            status: 'issued',
+            currency: 'JPY',
+        );
+    }
+
+    public function test_exact_amount_match_scores_highest(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000)); // exact
+        $this->invoiceClient->addInvoice($this->makeInvoice(2, 'INV-002', 50000));  // no match
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(1, $output->suggestions[0]->invoiceId);
+        self::assertSame(0.5, $output->suggestions[0]->score);
+        self::assertStringContainsString('exact amount match', $output->suggestions[0]->reason);
+    }
+
+    public function test_invoice_number_in_counterparty_adds_score(): void
+    {
+        $txId = $this->makeTx(200000, 'Payment for INV-999 ACME');
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-999', 150000));
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(0.3, $output->suggestions[0]->score);
+        self::assertStringContainsString('invoice number in counterparty', $output->suggestions[0]->reason);
+    }
+
+    public function test_exact_amount_and_invoice_number_combine(): void
+    {
+        $txId = $this->makeTx(100000, 'INV-001 payment');
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000));
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(0.8, $output->suggestions[0]->score);
+    }
+
+    public function test_due_soon_adds_score(): void
+    {
+        $txId = $this->makeTx(100000);
+        // Due in 10 days from fixed clock (2026-05-30)
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000, '2026-06-09'));
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertSame(0.7, $output->suggestions[0]->score); // 0.5 + 0.2
+        self::assertStringContainsString('due soon', $output->suggestions[0]->reason);
+    }
+
+    public function test_suggestions_sorted_by_score_descending(): void
+    {
+        $txId = $this->makeTx(100000, 'INV-002');
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000));       // score 0.5
+        $this->invoiceClient->addInvoice($this->makeInvoice(2, 'INV-002', 50000));        // score 0.3
+        $this->invoiceClient->addInvoice($this->makeInvoice(3, 'INV-002', 100000));       // score 0.5+0.3=0.8
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertGreaterThanOrEqual($output->suggestions[0]->score, 1.0);
+        self::assertSame(3, $output->suggestions[0]->invoiceId); // highest score first
+    }
+
+    public function test_unknown_transaction_throws_not_found(): void
+    {
+        $this->expectException(BankTransactionNotFoundException::class);
+        $this->useCase->execute(new ProposeMatchInput(7, 9999));
+    }
+
+    public function test_no_matching_invoices_returns_empty_suggestions(): void
+    {
+        $txId = $this->makeTx(100000, 'RANDOM');
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 50000));
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertEmpty($output->suggestions);
+    }
+}

--- a/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
+++ b/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\BankImport\BankTransaction;
+use NeneClear\BankImport\BankTransactionStatus;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Reconciliation\AllocationInput;
+use NeneClear\Reconciliation\ClientCreditStatus;
+use NeneClear\Reconciliation\ConfirmMatchInput;
+use NeneClear\Reconciliation\ConfirmMatchUseCase;
+use NeneClear\Reconciliation\ReconciliationAlreadyReversedException;
+use NeneClear\Reconciliation\ReconciliationNotFoundException;
+use NeneClear\Reconciliation\ReconciliationStatus;
+use NeneClear\Reconciliation\ReverseReconciliationInput;
+use NeneClear\Reconciliation\ReverseReconciliationUseCase;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class ReverseReconciliationUseCaseTest extends TestCase
+{
+    private InMemoryBankTransactionRepository $transactions;
+    private InMemoryReconciliationRepository $reconciliations;
+    private InMemoryClientCreditRepository $clientCredits;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+    private InMemoryAuditEventRepository $audit;
+    private ConfirmMatchUseCase $confirmUseCase;
+    private ReverseReconciliationUseCase $reverseUseCase;
+
+    protected function setUp(): void
+    {
+        $this->transactions = new InMemoryBankTransactionRepository();
+        $this->reconciliations = new InMemoryReconciliationRepository();
+        $this->clientCredits = new InMemoryClientCreditRepository();
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->audit = new InMemoryAuditEventRepository();
+
+        $clock = new FixedClock();
+        $this->confirmUseCase = new ConfirmMatchUseCase(
+            $this->transactions,
+            $this->reconciliations,
+            $this->clientCredits,
+            $this->invoiceClient,
+            $this->audit,
+            $clock,
+        );
+        $this->reverseUseCase = new ReverseReconciliationUseCase(
+            $this->reconciliations,
+            $this->clientCredits,
+            $this->transactions,
+            $this->invoiceClient,
+            $this->audit,
+            $clock,
+        );
+    }
+
+    private function makeTx(int $amountCents): int
+    {
+        return $this->transactions->save(new BankTransaction(
+            organizationId: 7,
+            bankImportBatchId: 1,
+            bankAccountId: 1,
+            valueDate: '2026-05-28',
+            amountCents: $amountCents,
+            counterpartyText: 'ACME',
+            lineKey: 'k1',
+            status: BankTransactionStatus::Unmatched,
+        ));
+    }
+
+    private function addInvoice(int $id, int $outstandingCents): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: 'INV-00' . $id,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: $outstandingCents,
+            dueAt: '2026-12-31',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+    }
+
+    private function reverseInput(int $reconciliationId, int $orgId = 7): ReverseReconciliationInput
+    {
+        return new ReverseReconciliationInput(
+            organizationId: $orgId,
+            reconciliationId: $reconciliationId,
+            actorUserId: 42,
+            reversalReason: 'test reversal',
+        );
+    }
+
+    public function test_reverse_restores_bank_tx_to_unmatched_and_voids_upstream_payment(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->addInvoice(1, 100000);
+        $confirmOutput = $this->confirmUseCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        $reverseOutput = $this->reverseUseCase->execute($this->reverseInput($confirmOutput->reconciliationId));
+
+        self::assertSame($confirmOutput->reconciliationId, $reverseOutput->reconciliationId);
+
+        $tx = $this->transactions->findById(7, $txId);
+        self::assertSame(BankTransactionStatus::Unmatched, $tx?->status);
+
+        $recon = $this->reconciliations->findById(7, $confirmOutput->reconciliationId);
+        self::assertNotNull($recon);
+        self::assertSame(ReconciliationStatus::Reversed, $recon->status);
+        self::assertNotNull($recon->reversedAt);
+
+        $payments = $this->invoiceClient->paymentsFor(1);
+        self::assertTrue($payments[0]['voided']);
+
+        $auditTypes = array_column($this->audit->events, 'eventType');
+        self::assertContains('reconciliation_reversed', $auditTypes);
+    }
+
+    public function test_reverse_voids_client_credit(): void
+    {
+        $txId = $this->makeTx(150000);
+        $this->addInvoice(1, 100000);
+        $confirmOutput = $this->confirmUseCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        $credit = $this->clientCredits->findByReconciliation($confirmOutput->reconciliationId);
+        self::assertSame(ClientCreditStatus::Open, $credit?->status);
+
+        $this->reverseUseCase->execute($this->reverseInput($confirmOutput->reconciliationId));
+
+        $credit = $this->clientCredits->findByReconciliation($confirmOutput->reconciliationId);
+        self::assertSame(ClientCreditStatus::Voided, $credit?->status);
+    }
+
+    public function test_unknown_reconciliation_throws_not_found(): void
+    {
+        $this->expectException(ReconciliationNotFoundException::class);
+        $this->reverseUseCase->execute($this->reverseInput(9999));
+    }
+
+    public function test_cross_tenant_reconciliation_throws_not_found(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->addInvoice(1, 100000);
+        $output = $this->confirmUseCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        $this->expectException(ReconciliationNotFoundException::class);
+        $this->reverseUseCase->execute($this->reverseInput($output->reconciliationId, orgId: 999));
+    }
+
+    public function test_double_reverse_throws_conflict(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->addInvoice(1, 100000);
+        $output = $this->confirmUseCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        $this->reverseUseCase->execute($this->reverseInput($output->reconciliationId));
+
+        $this->expectException(ReconciliationAlreadyReversedException::class);
+        $this->reverseUseCase->execute($this->reverseInput($output->reconciliationId));
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -118,4 +118,56 @@ final class SchemaFixture
             )'
         );
     }
+
+    public static function createPaymentReconciliations(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE payment_reconciliations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                bank_transaction_id INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT \'confirmed\',
+                reason_code TEXT,
+                confirmed_by INTEGER NOT NULL,
+                confirmed_at TEXT NOT NULL,
+                reversed_at TEXT,
+                reversal_reason TEXT,
+                created_at TEXT
+            )'
+        );
+    }
+
+    public static function createReconciliationAllocations(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE reconciliation_allocations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                payment_reconciliation_id INTEGER NOT NULL,
+                invoice_id INTEGER NOT NULL,
+                amount_cents INTEGER NOT NULL,
+                payment_id INTEGER,
+                external_reference TEXT,
+                created_at TEXT
+            )'
+        );
+    }
+
+    public static function createClientCredits(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE client_credits (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                client_id INTEGER NOT NULL,
+                amount_cents INTEGER NOT NULL,
+                remaining_cents INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT \'open\',
+                source_bank_transaction_id INTEGER NOT NULL,
+                reconciliation_id INTEGER NOT NULL,
+                created_by INTEGER NOT NULL,
+                created_at TEXT NOT NULL
+            )'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The heart of the product: reconciliation matching with Invoice upstream integration.

**InvoiceUpstream domain:**
- `InvoiceUpstreamClientInterface` — `listInvoices`, `getInvoice`, `createPayment`, `voidPayment`
- `FakeInvoiceUpstreamClient` — in-memory, fully controllable for tests
- `UpstreamInvoiceUnavailableException` → 503; `UpstreamInvoiceNotFoundException` → 404

**Reconciliation domain:**
- `Reconciliation`, `ReconciliationAllocation`, `ClientCredit` entities (readonly)
- PDO repos for both
- 3 DB migrations: `payment_reconciliations`, `reconciliation_allocations`, `client_credits`
- `SchemaFixture` additions

**Use cases:**
- `ProposeMatchUseCase` — rules-based scoring (exact amount +0.5, invoice# in counterparty +0.3, due soon +0.2); top 10; read-only
- `ConfirmMatchUseCase` — validates outstanding, calls Invoice `createPayment` per allocation, saves reconciliation + allocations, creates `ClientCredit` for remainder, updates bank_tx status
- `ReverseReconciliationUseCase` — voids upstream payments, restores bank_tx to `unmatched`, voids client credit, audit

**Bug uncovered:** PHP `foreach ($arr ?? [] as &$ref)` creates a copy via `??`, making the reference ineffective. Fixed by explicit isset + direct index assignment.

## Test plan

- [x] 83 tests / 265 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `ProposeMatchUseCaseTest` — exact amount, invoice# in counterparty, due soon, combined, sorted, empty
- [x] `ConfirmMatchUseCaseTest` — exact/partial match, multi-invoice, over-allocation 422, not-found, not-matchable status
- [x] `ReverseReconciliationUseCaseTest` — full happy path, credit voided, not-found, cross-tenant, double-reverse 409
- [x] `PdoReconciliationRepositoryTest` — save/findById, cross-tenant, allocations, reverseById, status filter, client credit void

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)