### PR TITLE
feat: reconciliation HTTP — handlers, routes, ApplicationFactory wiring (B-6b)

### DIFF
--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -40,6 +40,9 @@ use NeneClear\BankImport\PdoBankImportBatchRepository;
 use NeneClear\BankImport\PdoBankTransactionRepository;
 use NeneClear\BankImport\ReverseBankImportBatchHandler;
 use NeneClear\BankImport\ReverseBankImportBatchUseCase;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableExceptionHandler;
 use NeneClear\Organization\CreateOrganizationHandler;
 use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\DeleteOrganizationHandler;
@@ -52,6 +55,22 @@ use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
 use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
 use NeneClear\Organization\OrganizationRouteRegistrar;
 use NeneClear\Organization\PdoOrganizationRepository;
+use NeneClear\Reconciliation\AllocationExceedsOutstandingExceptionHandler;
+use NeneClear\Reconciliation\BankTransactionNotMatchableExceptionHandler;
+use NeneClear\Reconciliation\ConfirmMatchHandler;
+use NeneClear\Reconciliation\ConfirmMatchUseCase;
+use NeneClear\Reconciliation\GetReconciliationByIdHandler;
+use NeneClear\Reconciliation\ListClientCreditsHandler;
+use NeneClear\Reconciliation\ListReconciliationsHandler;
+use NeneClear\Reconciliation\PdoClientCreditRepository;
+use NeneClear\Reconciliation\PdoReconciliationRepository;
+use NeneClear\Reconciliation\ProposeMatchHandler;
+use NeneClear\Reconciliation\ProposeMatchUseCase;
+use NeneClear\Reconciliation\ReconciliationAlreadyReversedExceptionHandler;
+use NeneClear\Reconciliation\ReconciliationNotFoundExceptionHandler;
+use NeneClear\Reconciliation\ReconciliationRouteRegistrar;
+use NeneClear\Reconciliation\ReverseReconciliationHandler;
+use NeneClear\Reconciliation\ReverseReconciliationUseCase;
 use NeneClear\User\CreateUserHandler;
 use NeneClear\User\CreateUserUseCase;
 use NeneClear\User\DeleteUserHandler;
@@ -97,6 +116,7 @@ final class ApplicationFactory
         array $allowedOrigins = [],
         ?DatabaseQueryExecutorInterface $query = null,
         ?string $jwtSecret = null,
+        ?InvoiceUpstreamClientInterface $invoiceClient = null,
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
         $json = new JsonResponseFactory($psr17, $psr17);
@@ -154,6 +174,18 @@ final class ApplicationFactory
                 new GetBankTransactionByIdHandler($transactions, $json),
             );
 
+            $upstream = $invoiceClient ?? new FakeInvoiceUpstreamClient();
+            $reconRepo = new PdoReconciliationRepository($query);
+            $creditRepo = new PdoClientCreditRepository($query);
+            $routeRegistrars[] = new ReconciliationRouteRegistrar(
+                new ProposeMatchHandler(new ProposeMatchUseCase($transactions, $upstream, $clock), $json),
+                new ConfirmMatchHandler(new ConfirmMatchUseCase($transactions, $reconRepo, $creditRepo, $upstream, $audit, $clock), $reconRepo, $json),
+                new ListReconciliationsHandler($reconRepo, $json),
+                new GetReconciliationByIdHandler($reconRepo, $json),
+                new ReverseReconciliationHandler(new ReverseReconciliationUseCase($reconRepo, $creditRepo, $transactions, $upstream, $audit, $clock), $reconRepo, $json),
+                new ListClientCreditsHandler($creditRepo, $json),
+            );
+
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationAlreadyExistsExceptionHandler($problemDetails);
@@ -166,6 +198,11 @@ final class ApplicationFactory
             $domainExceptionHandlers[] = new BankImportBatchNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new BankImportBatchAlreadyReversedExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new BankImportBatchHasMatchedLinesExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new ReconciliationNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new ReconciliationAlreadyReversedExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new AllocationExceedsOutstandingExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new BankTransactionNotMatchableExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new UpstreamInvoiceUnavailableExceptionHandler($problemDetails);
 
             $authMiddleware = [
                 new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
@@ -174,6 +211,8 @@ final class ApplicationFactory
                     '/admin/users' => CapabilityRule::same(Capability::ManageUsers),
                     '/admin/bank-import-batches' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                     '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                    '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                    '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                 ]),
             ];
         }

--- a/src/Reconciliation/AllocationExceedsOutstandingExceptionHandler.php
+++ b/src/Reconciliation/AllocationExceedsOutstandingExceptionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class AllocationExceedsOutstandingExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof AllocationExceedsOutstandingException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        assert($exception instanceof AllocationExceedsOutstandingException);
+
+        return $this->problemDetails->create(
+            $request,
+            'allocation-exceeds-outstanding',
+            'Allocation Exceeds Outstanding',
+            422,
+            'The allocation amount exceeds the invoice outstanding balance.',
+            [
+                'invoice_id' => $exception->invoiceId,
+                'outstanding_cents' => $exception->outstandingCents,
+            ],
+        );
+    }
+}

--- a/src/Reconciliation/BankTransactionNotMatchableExceptionHandler.php
+++ b/src/Reconciliation/BankTransactionNotMatchableExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class BankTransactionNotMatchableExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof BankTransactionNotMatchableException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-state-transition',
+            'Invalid State Transition',
+            409,
+            'The bank transaction cannot be matched in its current status.',
+        );
+    }
+}

--- a/src/Reconciliation/ClientCreditResponse.php
+++ b/src/Reconciliation/ClientCreditResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ClientCreditResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ClientCredit $credit): array
+    {
+        return [
+            'client_credit_id' => $credit->id,
+            'organization_id' => $credit->organizationId,
+            'client_id' => $credit->clientId,
+            'amount_cents' => $credit->amountCents,
+            'remaining_cents' => $credit->remainingCents,
+            'status' => $credit->status->value,
+            'source_bank_transaction_id' => $credit->sourceBankTransactionId,
+            'reconciliation_id' => $credit->reconciliationId,
+            'created_at' => $credit->createdAt,
+        ];
+    }
+}

--- a/src/Reconciliation/ConfirmMatchHandler.php
+++ b/src/Reconciliation/ConfirmMatchHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ConfirmMatchHandler
+{
+    public function __construct(
+        private ConfirmMatchUseCaseInterface $useCase,
+        private ReconciliationRepositoryInterface $reconciliations,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = (array) $request->getParsedBody();
+        $errors = [];
+
+        $bankTransactionId = isset($body['bank_transaction_id']) && is_numeric($body['bank_transaction_id'])
+            ? (int) $body['bank_transaction_id']
+            : 0;
+        if ($bankTransactionId <= 0) {
+            $errors[] = new ValidationError('bank_transaction_id', 'A valid bank transaction id is required.', 'required');
+        }
+
+        $rawAllocations = $body['allocations'] ?? null;
+        if (!is_array($rawAllocations) || count($rawAllocations) === 0) {
+            $errors[] = new ValidationError('allocations', 'At least one allocation is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $allocations = [];
+        foreach ((array) $rawAllocations as $i => $raw) {
+            if (!is_array($raw)) {
+                throw new ValidationException([new ValidationError("allocations.$i", 'Each allocation must be an object.', 'invalid')]);
+            }
+            $invoiceId = is_numeric($raw['invoice_id'] ?? null) ? (int) $raw['invoice_id'] : 0;
+            $amountCents = is_numeric($raw['amount_cents'] ?? null) ? (int) $raw['amount_cents'] : 0;
+            if ($invoiceId <= 0 || $amountCents <= 0) {
+                throw new ValidationException([new ValidationError("allocations.$i", 'invoice_id and amount_cents must be positive integers.', 'invalid')]);
+            }
+            $allocations[] = new AllocationInput($invoiceId, $amountCents);
+        }
+
+        $reasonCode = isset($body['reason_code']) && is_string($body['reason_code']) ? $body['reason_code'] : null;
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $output = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: $organizationId,
+            bankTransactionId: $bankTransactionId,
+            allocations: $allocations,
+            actorUserId: AuthContext::userId($request),
+            reasonCode: $reasonCode,
+        ));
+
+        $reconciliation = $this->reconciliations->findById($organizationId, $output->reconciliationId)
+            ?? throw new ReconciliationNotFoundException($output->reconciliationId);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($output->reconciliationId);
+
+        return $this->response->create(
+            ReconciliationResponse::toArray($reconciliation, $allocs),
+            201,
+            ['Location' => '/admin/reconciliations/' . $output->reconciliationId],
+        );
+    }
+}

--- a/src/Reconciliation/GetReconciliationByIdHandler.php
+++ b/src/Reconciliation/GetReconciliationByIdHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetReconciliationByIdHandler
+{
+    public function __construct(
+        private ReconciliationRepositoryInterface $reconciliations,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $reconciliation = $this->reconciliations->findById($organizationId, $id);
+
+        if ($reconciliation === null) {
+            throw new ReconciliationNotFoundException($id);
+        }
+
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($id);
+
+        return $this->response->create(ReconciliationResponse::toArray($reconciliation, $allocs));
+    }
+}

--- a/src/Reconciliation/ListClientCreditsHandler.php
+++ b/src/Reconciliation/ListClientCreditsHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListClientCreditsHandler
+{
+    public function __construct(
+        private ClientCreditRepositoryInterface $clientCredits,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        return $this->response->create([
+            'items' => array_map(
+                ClientCreditResponse::toArray(...),
+                $this->clientCredits->findByOrganization($organizationId, $page->limit, $page->offset),
+            ),
+            'limit' => $page->limit,
+            'offset' => $page->offset,
+            'total' => $this->clientCredits->countByOrganization($organizationId),
+        ]);
+    }
+}

--- a/src/Reconciliation/ListReconciliationsHandler.php
+++ b/src/Reconciliation/ListReconciliationsHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListReconciliationsHandler
+{
+    public function __construct(
+        private ReconciliationRepositoryInterface $reconciliations,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        $statusParam = $request->getQueryParams()['status'] ?? null;
+        $status = is_string($statusParam) ? ReconciliationStatus::tryFrom($statusParam) : null;
+
+        $items = $this->reconciliations->findByOrganization($organizationId, $status, $page->limit, $page->offset);
+
+        return $this->response->create([
+            'items' => array_map(
+                static fn (Reconciliation $r): array => ReconciliationResponse::toArray($r),
+                $items,
+            ),
+            'limit' => $page->limit,
+            'offset' => $page->offset,
+            'total' => $this->reconciliations->countByOrganization($organizationId, $status),
+        ]);
+    }
+}

--- a/src/Reconciliation/ProposeMatchHandler.php
+++ b/src/Reconciliation/ProposeMatchHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ProposeMatchHandler
+{
+    public function __construct(
+        private ProposeMatchUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = (array) $request->getParsedBody();
+        $bankTransactionId = isset($body['bank_transaction_id']) && is_numeric($body['bank_transaction_id'])
+            ? (int) $body['bank_transaction_id']
+            : 0;
+
+        if ($bankTransactionId <= 0) {
+            throw new ValidationException([new ValidationError('bank_transaction_id', 'A valid bank transaction id is required.', 'required')]);
+        }
+
+        $output = $this->useCase->execute(new ProposeMatchInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            bankTransactionId: $bankTransactionId,
+        ));
+
+        return $this->response->create([
+            'bank_transaction_id' => $output->bankTransactionId,
+            'suggestions' => array_map(
+                static fn (MatchSuggestion $s): array => [
+                    'invoice_id' => $s->invoiceId,
+                    'invoice_number' => $s->invoiceNumber,
+                    'amount_cents' => $s->amountCents,
+                    'outstanding_cents' => $s->outstandingCents,
+                    'score' => $s->score,
+                    'reason' => $s->reason,
+                ],
+                $output->suggestions,
+            ),
+        ]);
+    }
+}

--- a/src/Reconciliation/ReconciliationAlreadyReversedExceptionHandler.php
+++ b/src/Reconciliation/ReconciliationAlreadyReversedExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ReconciliationAlreadyReversedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ReconciliationAlreadyReversedException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-state-transition',
+            'Invalid State Transition',
+            409,
+            'This reconciliation is already reversed.',
+        );
+    }
+}

--- a/src/Reconciliation/ReconciliationNotFoundExceptionHandler.php
+++ b/src/Reconciliation/ReconciliationNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ReconciliationNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ReconciliationNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'reconciliation-not-found',
+            'Reconciliation Not Found',
+            404,
+            'The requested reconciliation was not found.',
+        );
+    }
+}

--- a/src/Reconciliation/ReconciliationResponse.php
+++ b/src/Reconciliation/ReconciliationResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ReconciliationResponse
+{
+    /**
+     * @param list<ReconciliationAllocation> $allocations
+     * @return array<string, mixed>
+     */
+    public static function toArray(Reconciliation $reconciliation, array $allocations = []): array
+    {
+        return [
+            'payment_reconciliation_id' => $reconciliation->id,
+            'organization_id' => $reconciliation->organizationId,
+            'bank_transaction_id' => $reconciliation->bankTransactionId,
+            'status' => $reconciliation->status->value,
+            'reason_code' => $reconciliation->reasonCode,
+            'confirmed_by' => $reconciliation->confirmedBy,
+            'confirmed_at' => $reconciliation->confirmedAt,
+            'reversed_at' => $reconciliation->reversedAt,
+            'reversal_reason' => $reconciliation->reversalReason,
+            'allocations' => array_map(
+                static fn (ReconciliationAllocation $a): array => [
+                    'reconciliation_allocation_id' => $a->id,
+                    'invoice_id' => $a->invoiceId,
+                    'amount_cents' => $a->amountCents,
+                    'payment_id' => $a->paymentId,
+                    'external_reference' => $a->externalReference,
+                ],
+                $allocations,
+            ),
+        ];
+    }
+}

--- a/src/Reconciliation/ReconciliationRouteRegistrar.php
+++ b/src/Reconciliation/ReconciliationRouteRegistrar.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ReconciliationRouteRegistrar
+{
+    public function __construct(
+        private ProposeMatchHandler $proposeHandler,
+        private ConfirmMatchHandler $confirmHandler,
+        private ListReconciliationsHandler $listHandler,
+        private GetReconciliationByIdHandler $getByIdHandler,
+        private ReverseReconciliationHandler $reverseHandler,
+        private ListClientCreditsHandler $listCreditsHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $proposeHandler = $this->proposeHandler;
+        $confirmHandler = $this->confirmHandler;
+        $listHandler = $this->listHandler;
+        $getByIdHandler = $this->getByIdHandler;
+        $reverseHandler = $this->reverseHandler;
+        $listCreditsHandler = $this->listCreditsHandler;
+
+        $router->post('/admin/reconciliations/propose', static fn (ServerRequestInterface $r): ResponseInterface => $proposeHandler->handle($r));
+        $router->get('/admin/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+        $router->post('/admin/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $confirmHandler->handle($r));
+        $router->get('/admin/reconciliations/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getByIdHandler->handle($r));
+        $router->post('/admin/reconciliations/{id}/reverse', static fn (ServerRequestInterface $r): ResponseInterface => $reverseHandler->handle($r));
+        $router->get('/admin/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $listCreditsHandler->handle($r));
+    }
+}

--- a/src/Reconciliation/ReverseReconciliationHandler.php
+++ b/src/Reconciliation/ReverseReconciliationHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ReverseReconciliationHandler
+{
+    public function __construct(
+        private ReverseReconciliationUseCaseInterface $useCase,
+        private ReconciliationRepositoryInterface $reconciliations,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $reconciliationId = (int) ($params['id'] ?? 0);
+
+        $body = (array) $request->getParsedBody();
+        $reversalReason = is_string($body['reversal_reason'] ?? null) ? trim($body['reversal_reason']) : '';
+
+        if ($reversalReason === '') {
+            throw new ValidationException([new ValidationError('reversal_reason', 'A reversal reason is required.', 'required')]);
+        }
+
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $this->useCase->execute(new ReverseReconciliationInput(
+            organizationId: $organizationId,
+            reconciliationId: $reconciliationId,
+            actorUserId: AuthContext::userId($request),
+            reversalReason: $reversalReason,
+        ));
+
+        $reconciliation = $this->reconciliations->findById($organizationId, $reconciliationId)
+            ?? throw new ReconciliationNotFoundException($reconciliationId);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($reconciliationId);
+
+        return $this->response->create(ReconciliationResponse::toArray($reconciliation, $allocs));
+    }
+}

--- a/tests/Http/ReconciliationHttpTest.php
+++ b/tests/Http/ReconciliationHttpTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ReconciliationHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+    private const string CSV = "date,deposit,withdrawal,memo\n2026/04/20,110000,,INV-001 payment\n";
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-recon-http-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createBankAccounts($query);
+        SchemaFixture::createBankImportBatches($query);
+        SchemaFixture::createBankTransactions($query);
+        SchemaFixture::createAuditEvents($query);
+        SchemaFixture::createPaymentReconciliations($query);
+        SchemaFixture::createReconciliationAllocations($query);
+        SchemaFixture::createClientCredits($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin));
+        $users->save($this->user('viewer@acme.example', Role::Viewer));
+
+        (new PdoBankAccountRepository($query))->save(new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '123',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        ));
+
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 7,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    private function importCsv(string $token): int
+    {
+        $file = $this->psr17->createUploadedFile($this->psr17->createStream(self::CSV), strlen(self::CSV), UPLOAD_ERR_OK, 'april.csv', 'text/csv');
+        $request = $this->psr17->createServerRequest('POST', '/admin/bank-import-batches')
+            ->withHeader('Authorization', 'Bearer ' . $token)
+            ->withUploadedFiles(['file' => $file])
+            ->withParsedBody(['bank_account_id' => 1]);
+
+        $response = $this->app->handle($request);
+        self::assertSame(201, $response->getStatusCode());
+
+        $body = $this->decode($response);
+        self::assertArrayHasKey('bank_import_batch_id', $body);
+
+        $txList = $this->decode($this->get($token, '/admin/bank-transactions'));
+        $items = $txList['items'] ?? [];
+        self::assertNotEmpty($items);
+
+        return (int) $items[0]['bank_transaction_id'];
+    }
+
+    private function post(string $token, string $path, mixed $body): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('POST', $path)
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withHeader('Content-Type', 'application/json')
+                ->withParsedBody(is_array($body) ? $body : []),
+        );
+    }
+
+    private function get(string $token, string $path): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('GET', $path)->withHeader('Authorization', 'Bearer ' . $token),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    private function addInvoice(int $id, int $outstandingCents, string $number = ''): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: $number !== '' ? $number : 'INV-00' . $id,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: $outstandingCents,
+            dueAt: '2026-12-31',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+    }
+
+    public function test_propose_returns_suggestions_for_matching_invoice(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000, 'INV-001'); // exact amount + invoice number in counterparty
+
+        $response = $this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertNotEmpty($body['suggestions']);
+        self::assertSame(1, $body['suggestions'][0]['invoice_id']);
+        self::assertGreaterThan(0.0, $body['suggestions'][0]['score']);
+    }
+
+    public function test_confirm_creates_reconciliation_and_marks_tx_matched(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000);
+
+        $response = $this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertArrayHasKey('payment_reconciliation_id', $body);
+        self::assertSame('confirmed', $body['status']);
+        self::assertCount(1, $body['allocations']);
+
+        $txDetail = $this->decode($this->get($token, '/admin/bank-transactions/' . $txId));
+        self::assertSame('matched', $txDetail['status']);
+    }
+
+    public function test_list_reconciliations(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000);
+
+        $this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]);
+
+        $response = $this->get($token, '/admin/reconciliations');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(1, $this->decode($response)['total'] ?? null);
+    }
+
+    public function test_get_reconciliation_by_id(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000);
+
+        $reconBody = $this->decode($this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]));
+        $reconId = $reconBody['payment_reconciliation_id'];
+
+        $response = $this->get($token, '/admin/reconciliations/' . $reconId);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($reconId, $this->decode($response)['payment_reconciliation_id'] ?? null);
+    }
+
+    public function test_reverse_reconciliation(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000);
+
+        $reconId = $this->decode($this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]))['payment_reconciliation_id'];
+
+        $reverseResponse = $this->post($token, '/admin/reconciliations/' . $reconId . '/reverse', [
+            'reversal_reason' => 'wrong invoice',
+        ]);
+        self::assertSame(200, $reverseResponse->getStatusCode());
+        self::assertSame('reversed', $this->decode($reverseResponse)['status']);
+
+        $txDetail = $this->decode($this->get($token, '/admin/bank-transactions/' . $txId));
+        self::assertSame('unmatched', $txDetail['status']);
+    }
+
+    public function test_viewer_cannot_confirm_match(): void
+    {
+        $adminToken = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($adminToken);
+        $this->addInvoice(1, 110000);
+
+        $viewerToken = $this->tokenFor('viewer@acme.example');
+        $response = $this->post($viewerToken, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_viewer_can_list_reconciliations(): void
+    {
+        $viewerToken = $this->tokenFor('viewer@acme.example');
+        $response = $this->get($viewerToken, '/admin/reconciliations');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_allocation_exceeds_outstanding_returns_422(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 50000); // only 50k outstanding, tx is 110k
+
+        $response = $this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertSame(1, $body['invoice_id'] ?? null);
+        self::assertSame(50000, $body['outstanding_cents'] ?? null);
+    }
+
+    public function test_upstream_unavailable_returns_503(): void
+    {
+        $this->invoiceClient->makeUnavailable();
+
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+
+        $response = $this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]);
+
+        self::assertSame(503, $response->getStatusCode());
+    }
+
+    public function test_double_reverse_returns_409(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token);
+        $this->addInvoice(1, 110000);
+
+        $reconId = $this->decode($this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+        ]))['payment_reconciliation_id'];
+
+        $this->post($token, '/admin/reconciliations/' . $reconId . '/reverse', ['reversal_reason' => 'first']);
+
+        $response = $this->post($token, '/admin/reconciliations/' . $reconId . '/reverse', ['reversal_reason' => 'second']);
+        self::assertSame(409, $response->getStatusCode());
+    }
+
+    public function test_list_client_credits(): void
+    {
+        $viewerToken = $this->tokenFor('viewer@acme.example');
+        $response = $this->get($viewerToken, '/admin/client-credits');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(0, $this->decode($response)['total'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary

Exposes the reconciliation domain via HTTP with full capability gating.

**New endpoints:**
| Method | Path | Handler | Capability |
|---|---|---|---|
| POST | `/admin/reconciliations/propose` | `ProposeMatchHandler` | `view_reconciliation` |
| POST | `/admin/reconciliations` | `ConfirmMatchHandler` | `manage_reconciliation` |
| GET | `/admin/reconciliations` | `ListReconciliationsHandler` | `view_reconciliation` |
| GET | `/admin/reconciliations/{id}` | `GetReconciliationByIdHandler` | `view_reconciliation` |
| POST | `/admin/reconciliations/{id}/reverse` | `ReverseReconciliationHandler` | `manage_reconciliation` |
| GET | `/admin/client-credits` | `ListClientCreditsHandler` | `view_reconciliation` |

**Exception handlers:** `ReconciliationNotFound` (404), `ReconciliationAlreadyReversed` (409), `AllocationExceedsOutstanding` (422 + `invoice_id`/`outstanding_cents` extensions), `BankTransactionNotMatchable` (409), `UpstreamInvoiceUnavailable` (503)

**`ApplicationFactory`** gains an optional `InvoiceUpstreamClientInterface $invoiceClient` parameter so tests can inject a pre-seeded `FakeInvoiceUpstreamClient`; `FakeInvoiceUpstreamClient` is used by default (real HTTP client is a future PR).

## Test plan

- [x] 94 tests / 371 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `ReconciliationHttpTest` — propose (with matching invoice), confirm → 201 + tx matched, list, getById, reverse → tx unmatched, viewer 403 on POST, viewer 200 on GET, allocation exceeds outstanding 422 (with extensions), upstream unavailable 503, double-reverse 409, list client credits

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)