### PR TITLE
feat: client credit apply — POST /admin/client-credits/{id}/apply (Phase 1 final)

### DIFF
--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -56,9 +56,13 @@ use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
 use NeneClear\Organization\OrganizationRouteRegistrar;
 use NeneClear\Organization\PdoOrganizationRepository;
 use NeneClear\Reconciliation\AllocationExceedsOutstandingExceptionHandler;
+use NeneClear\Reconciliation\ApplyCreditHandler;
+use NeneClear\Reconciliation\ApplyCreditUseCase;
 use NeneClear\Reconciliation\BankTransactionNotMatchableExceptionHandler;
+use NeneClear\Reconciliation\ClientCreditNotFoundExceptionHandler;
 use NeneClear\Reconciliation\ConfirmMatchHandler;
 use NeneClear\Reconciliation\ConfirmMatchUseCase;
+use NeneClear\Reconciliation\CreditExceedsRemainingExceptionHandler;
 use NeneClear\Reconciliation\GetReconciliationByIdHandler;
 use NeneClear\Reconciliation\ListClientCreditsHandler;
 use NeneClear\Reconciliation\ListReconciliationsHandler;
@@ -184,6 +188,7 @@ final class ApplicationFactory
                 new GetReconciliationByIdHandler($reconRepo, $json),
                 new ReverseReconciliationHandler(new ReverseReconciliationUseCase($reconRepo, $creditRepo, $transactions, $upstream, $audit, $clock), $reconRepo, $json),
                 new ListClientCreditsHandler($creditRepo, $json),
+                new ApplyCreditHandler(new ApplyCreditUseCase($creditRepo, $upstream, $audit), $json),
             );
 
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
@@ -200,6 +205,8 @@ final class ApplicationFactory
             $domainExceptionHandlers[] = new BankImportBatchHasMatchedLinesExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new ReconciliationNotFoundExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new ReconciliationAlreadyReversedExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new ClientCreditNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new CreditExceedsRemainingExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new AllocationExceedsOutstandingExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new BankTransactionNotMatchableExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new UpstreamInvoiceUnavailableExceptionHandler($problemDetails);

--- a/src/Reconciliation/ApplyCreditHandler.php
+++ b/src/Reconciliation/ApplyCreditHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ApplyCreditHandler
+{
+    public function __construct(
+        private ApplyCreditUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $creditId = (int) ($params['id'] ?? 0);
+
+        $body = (array) $request->getParsedBody();
+        $errors = [];
+
+        $invoiceId = is_numeric($body['invoice_id'] ?? null) ? (int) $body['invoice_id'] : 0;
+        if ($invoiceId <= 0) {
+            $errors[] = new ValidationError('invoice_id', 'A valid invoice id is required.', 'required');
+        }
+
+        $amountCents = is_numeric($body['amount_cents'] ?? null) ? (int) $body['amount_cents'] : 0;
+        if ($amountCents <= 0) {
+            $errors[] = new ValidationError('amount_cents', 'amount_cents must be a positive integer.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new ApplyCreditInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            creditId: $creditId,
+            invoiceId: $invoiceId,
+            amountCents: $amountCents,
+            actorUserId: AuthContext::userId($request),
+        ));
+
+        return $this->response->create(ClientCreditResponse::toArray($output->credit));
+    }
+}

--- a/src/Reconciliation/ApplyCreditInput.php
+++ b/src/Reconciliation/ApplyCreditInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ApplyCreditInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $creditId,
+        public int $invoiceId,
+        public int $amountCents,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/Reconciliation/ApplyCreditOutput.php
+++ b/src/Reconciliation/ApplyCreditOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+final readonly class ApplyCreditOutput
+{
+    public function __construct(
+        public ClientCredit $credit,
+    ) {
+    }
+}

--- a/src/Reconciliation/ApplyCreditUseCase.php
+++ b/src/Reconciliation/ApplyCreditUseCase.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+
+final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
+{
+    public function __construct(
+        private ClientCreditRepositoryInterface $clientCredits,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private AuditEventRepositoryInterface $auditEvents,
+    ) {
+    }
+
+    public function execute(ApplyCreditInput $input): ApplyCreditOutput
+    {
+        $credit = $this->clientCredits->findById($input->organizationId, $input->creditId);
+
+        if ($credit === null) {
+            throw new ClientCreditNotFoundException($input->creditId);
+        }
+
+        if ($credit->status !== ClientCreditStatus::Open || $credit->remainingCents <= 0) {
+            throw new CreditExceedsRemainingException(0);
+        }
+
+        if ($input->amountCents > $credit->remainingCents) {
+            throw new CreditExceedsRemainingException($credit->remainingCents);
+        }
+
+        $externalRef = sprintf('clear:credit:%d:%d', $input->creditId, $input->invoiceId);
+        $idempotencyKey = sprintf('clear:credit:apply:%d:%d', $input->creditId, $input->invoiceId);
+
+        $this->invoiceClient->createPayment(
+            organizationId: $input->organizationId,
+            invoiceId: $input->invoiceId,
+            amountCents: $input->amountCents,
+            paidAt: $credit->createdAt,
+            externalReference: $externalRef,
+            idempotencyKey: $idempotencyKey,
+        );
+
+        $updated = $this->clientCredits->applyAmount($input->creditId, $input->amountCents);
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'client_credit_applied',
+            actorUserId: $input->actorUserId,
+            occurredAt: $credit->createdAt,
+            payload: [
+                'client_credit_id' => $input->creditId,
+                'invoice_id' => $input->invoiceId,
+                'amount_cents' => $input->amountCents,
+                'remaining_cents' => $updated->remainingCents,
+            ],
+        ));
+
+        return new ApplyCreditOutput(credit: $updated);
+    }
+}

--- a/src/Reconciliation/ApplyCreditUseCaseInterface.php
+++ b/src/Reconciliation/ApplyCreditUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+interface ApplyCreditUseCaseInterface
+{
+    public function execute(ApplyCreditInput $input): ApplyCreditOutput;
+}

--- a/src/Reconciliation/ClientCreditNotFoundException.php
+++ b/src/Reconciliation/ClientCreditNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class ClientCreditNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Client credit %d was not found.', $id));
+    }
+}

--- a/src/Reconciliation/ClientCreditNotFoundExceptionHandler.php
+++ b/src/Reconciliation/ClientCreditNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ClientCreditNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ClientCreditNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'client-credit-not-found',
+            'Client Credit Not Found',
+            404,
+            'The requested client credit was not found.',
+        );
+    }
+}

--- a/src/Reconciliation/ClientCreditRepositoryInterface.php
+++ b/src/Reconciliation/ClientCreditRepositoryInterface.php
@@ -8,7 +8,11 @@ interface ClientCreditRepositoryInterface
 {
     public function save(ClientCredit $credit): int;
 
+    public function findById(int $organizationId, int $id): ?ClientCredit;
+
     public function findByReconciliation(int $reconciliationId): ?ClientCredit;
+
+    public function applyAmount(int $id, int $amountCents): ClientCredit;
 
     public function voidByReconciliation(int $reconciliationId): void;
 

--- a/src/Reconciliation/CreditExceedsRemainingException.php
+++ b/src/Reconciliation/CreditExceedsRemainingException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use RuntimeException;
+
+final class CreditExceedsRemainingException extends RuntimeException
+{
+    public function __construct(public readonly int $remainingCents)
+    {
+        parent::__construct(sprintf('Amount exceeds remaining credit balance of %d cents.', $remainingCents));
+    }
+}

--- a/src/Reconciliation/CreditExceedsRemainingExceptionHandler.php
+++ b/src/Reconciliation/CreditExceedsRemainingExceptionHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CreditExceedsRemainingExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof CreditExceedsRemainingException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        assert($exception instanceof CreditExceedsRemainingException);
+
+        return $this->problemDetails->create(
+            $request,
+            'credit-exceeds-remaining',
+            'Credit Exceeds Remaining Balance',
+            422,
+            'The requested amount exceeds the remaining credit balance.',
+            ['remaining_cents' => $exception->remainingCents],
+        );
+    }
+}

--- a/src/Reconciliation/PdoClientCreditRepository.php
+++ b/src/Reconciliation/PdoClientCreditRepository.php
@@ -37,6 +37,36 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
         return $this->query->lastInsertId();
     }
 
+    public function findById(int $organizationId, int $id): ?ClientCredit
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM client_credits WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function applyAmount(int $id, int $amountCents): ClientCredit
+    {
+        $this->query->execute(
+            'UPDATE client_credits SET remaining_cents = remaining_cents - ? WHERE id = ?',
+            [$amountCents, $id],
+        );
+        $this->query->execute(
+            'UPDATE client_credits SET status = ? WHERE id = ? AND remaining_cents <= 0 AND status = ?',
+            [ClientCreditStatus::Voided->value, $id, ClientCreditStatus::Open->value],
+        );
+
+        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM client_credits WHERE id = ?', [$id]);
+
+        if ($row === null) {
+            throw new \RuntimeException("Client credit $id not found after applyAmount.");
+        }
+
+        return $this->hydrate($row);
+    }
+
     public function findByReconciliation(int $reconciliationId): ?ClientCredit
     {
         $row = $this->query->fetchOne(

--- a/src/Reconciliation/ReconciliationRouteRegistrar.php
+++ b/src/Reconciliation/ReconciliationRouteRegistrar.php
@@ -17,6 +17,7 @@ final readonly class ReconciliationRouteRegistrar
         private GetReconciliationByIdHandler $getByIdHandler,
         private ReverseReconciliationHandler $reverseHandler,
         private ListClientCreditsHandler $listCreditsHandler,
+        private ApplyCreditHandler $applyCreditsHandler,
     ) {
     }
 
@@ -28,6 +29,7 @@ final readonly class ReconciliationRouteRegistrar
         $getByIdHandler = $this->getByIdHandler;
         $reverseHandler = $this->reverseHandler;
         $listCreditsHandler = $this->listCreditsHandler;
+        $applyCreditsHandler = $this->applyCreditsHandler;
 
         $router->post('/admin/reconciliations/propose', static fn (ServerRequestInterface $r): ResponseInterface => $proposeHandler->handle($r));
         $router->get('/admin/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
@@ -35,5 +37,6 @@ final readonly class ReconciliationRouteRegistrar
         $router->get('/admin/reconciliations/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getByIdHandler->handle($r));
         $router->post('/admin/reconciliations/{id}/reverse', static fn (ServerRequestInterface $r): ResponseInterface => $reverseHandler->handle($r));
         $router->get('/admin/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $listCreditsHandler->handle($r));
+        $router->post('/admin/client-credits/{id}/apply', static fn (ServerRequestInterface $r): ResponseInterface => $applyCreditsHandler->handle($r));
     }
 }

--- a/tests/Reconciliation/ApplyCreditUseCaseTest.php
+++ b/tests/Reconciliation/ApplyCreditUseCaseTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Reconciliation\ApplyCreditInput;
+use NeneClear\Reconciliation\ApplyCreditUseCase;
+use NeneClear\Reconciliation\ClientCredit;
+use NeneClear\Reconciliation\ClientCreditNotFoundException;
+use NeneClear\Reconciliation\ClientCreditStatus;
+use NeneClear\Reconciliation\CreditExceedsRemainingException;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ApplyCreditUseCaseTest extends TestCase
+{
+    private InMemoryClientCreditRepository $clientCredits;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+    private InMemoryAuditEventRepository $audit;
+    private ApplyCreditUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->clientCredits = new InMemoryClientCreditRepository();
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->audit = new InMemoryAuditEventRepository();
+        $this->useCase = new ApplyCreditUseCase(
+            $this->clientCredits,
+            $this->invoiceClient,
+            $this->audit,
+        );
+    }
+
+    private function makeCredit(int $amountCents, int $orgId = 7): int
+    {
+        return $this->clientCredits->save(new ClientCredit(
+            organizationId: $orgId,
+            clientId: 100,
+            amountCents: $amountCents,
+            remainingCents: $amountCents,
+            status: ClientCreditStatus::Open,
+            sourceBankTransactionId: 1,
+            reconciliationId: 1,
+            createdBy: 42,
+            createdAt: '2026-05-30 09:00:00',
+        ));
+    }
+
+    private function addInvoice(int $id, int $outstandingCents): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: 'INV-00' . $id,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: $outstandingCents,
+            dueAt: '2026-12-31',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+    }
+
+    private function input(int $creditId, int $invoiceId, int $amountCents, int $orgId = 7): ApplyCreditInput
+    {
+        return new ApplyCreditInput(
+            organizationId: $orgId,
+            creditId: $creditId,
+            invoiceId: $invoiceId,
+            amountCents: $amountCents,
+            actorUserId: 42,
+        );
+    }
+
+    public function test_full_apply_voids_credit(): void
+    {
+        $creditId = $this->makeCredit(50000);
+        $this->addInvoice(1, 100000);
+
+        $output = $this->useCase->execute($this->input($creditId, 1, 50000));
+
+        self::assertSame(0, $output->credit->remainingCents);
+        self::assertSame(ClientCreditStatus::Voided, $output->credit->status);
+
+        $payments = $this->invoiceClient->paymentsFor(1);
+        self::assertCount(1, $payments);
+        self::assertSame(50000, $payments[0]['amountCents']);
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('client_credit_applied', $this->audit->events[0]->eventType);
+    }
+
+    public function test_partial_apply_reduces_remaining(): void
+    {
+        $creditId = $this->makeCredit(100000);
+        $this->addInvoice(1, 200000);
+
+        $output = $this->useCase->execute($this->input($creditId, 1, 30000));
+
+        self::assertSame(70000, $output->credit->remainingCents);
+        self::assertSame(ClientCreditStatus::Open, $output->credit->status);
+    }
+
+    public function test_exceeds_remaining_throws(): void
+    {
+        $creditId = $this->makeCredit(50000);
+        $this->addInvoice(1, 200000);
+
+        $this->expectException(CreditExceedsRemainingException::class);
+        $this->useCase->execute($this->input($creditId, 1, 80000));
+    }
+
+    public function test_unknown_credit_throws_not_found(): void
+    {
+        $this->expectException(ClientCreditNotFoundException::class);
+        $this->useCase->execute($this->input(9999, 1, 10000));
+    }
+
+    public function test_cross_tenant_credit_throws_not_found(): void
+    {
+        $creditId = $this->makeCredit(50000, orgId: 7);
+        $this->addInvoice(1, 100000);
+
+        $this->expectException(ClientCreditNotFoundException::class);
+        $this->useCase->execute($this->input($creditId, 1, 50000, orgId: 999));
+    }
+}

--- a/tests/Reconciliation/InMemoryClientCreditRepository.php
+++ b/tests/Reconciliation/InMemoryClientCreditRepository.php
@@ -34,6 +34,35 @@ final class InMemoryClientCreditRepository implements ClientCreditRepositoryInte
         return $id;
     }
 
+    public function findById(int $organizationId, int $id): ?ClientCredit
+    {
+        $credit = $this->byId[$id] ?? null;
+
+        return ($credit !== null && $credit->organizationId === $organizationId) ? $credit : null;
+    }
+
+    public function applyAmount(int $id, int $amountCents): ClientCredit
+    {
+        $credit = $this->byId[$id] ?? throw new \RuntimeException("Client credit $id not found.");
+        $newRemaining = $credit->remainingCents - $amountCents;
+        $newStatus = $newRemaining <= 0 ? ClientCreditStatus::Voided : $credit->status;
+
+        $this->byId[$id] = new ClientCredit(
+            organizationId: $credit->organizationId,
+            clientId: $credit->clientId,
+            amountCents: $credit->amountCents,
+            remainingCents: max(0, $newRemaining),
+            status: $newStatus,
+            sourceBankTransactionId: $credit->sourceBankTransactionId,
+            reconciliationId: $credit->reconciliationId,
+            createdBy: $credit->createdBy,
+            createdAt: $credit->createdAt,
+            id: $credit->id,
+        );
+
+        return $this->byId[$id];
+    }
+
     public function findByReconciliation(int $reconciliationId): ?ClientCredit
     {
         foreach ($this->byId as $credit) {


### PR DESCRIPTION
## Summary

Completes Phase 1 by implementing the last remaining OpenAPI endpoint.

**`POST /admin/client-credits/{id}/apply`**
- Validates credit belongs to the org (404 if not)
- Validates `amount_cents <= remaining_cents` (422 + `remaining_cents` extension if over)
- Calls Invoice upstream `createPayment` (idempotent; `paidAt` = credit `created_at`)
- Reduces `remaining_cents`; voids the credit when remaining reaches 0
- Requires `manage_reconciliation`
- Audit event `client_credit_applied`

**Repository changes:** `ClientCreditRepositoryInterface` gains `findById(orgId, id)` and `applyAmount(id, amountCents)`.

## Test plan

- [x] 99 tests / 382 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `ApplyCreditUseCaseTest` — full apply → voided, partial apply → remaining reduced, exceeds remaining → 422, unknown credit → 404, cross-tenant → 404

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)