### PR TITLE
feat: ClearSettings — GET/PUT /admin/clear-settings + test-upstream (B-7)

### DIFF
--- a/database/migrations/20260531200000_create_clear_settings_table.php
+++ b/database/migrations/20260531200000_create_clear_settings_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateClearSettingsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('clear_settings', ['id' => false, 'primary_key' => ['organization_id']]);
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('upstream_base_url', 'string', ['limit' => 255, 'default' => ''])
+            ->addColumn('upstream_token_ref', 'string', ['limit' => 128, 'default' => ''])
+            ->addColumn('dunning_min_interval_days', 'integer', ['default' => 7])
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('updated_at', 'datetime', ['null' => true, 'default' => null])
+            ->create();
+    }
+}

--- a/src/BankImport/BankAccountRepositoryInterface.php
+++ b/src/BankImport/BankAccountRepositoryInterface.php
@@ -8,5 +8,12 @@ interface BankAccountRepositoryInterface
 {
     public function findById(int $id): ?BankAccount;
 
+    /**
+     * @return list<BankAccount>
+     */
+    public function findByOrganization(int $organizationId): array;
+
     public function save(BankAccount $account): int;
+
+    public function deleteByOrganization(int $organizationId): void;
 }

--- a/src/BankImport/PdoBankAccountRepository.php
+++ b/src/BankImport/PdoBankAccountRepository.php
@@ -23,6 +23,21 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
         return $row !== null ? $this->hydrate($row) : null;
     }
 
+    public function findByOrganization(int $organizationId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE organization_id = ? ORDER BY id ASC',
+            [$organizationId],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function deleteByOrganization(int $organizationId): void
+    {
+        $this->query->execute('DELETE FROM bank_accounts WHERE organization_id = ?', [$organizationId]);
+    }
+
     public function save(BankAccount $account): int
     {
         $this->query->execute(

--- a/src/ClearSettings/ClearSettings.php
+++ b/src/ClearSettings/ClearSettings.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use NeneClear\BankImport\BankAccount;
+
+final readonly class ClearSettings
+{
+    /**
+     * @param list<BankAccount> $bankAccounts
+     */
+    public function __construct(
+        public int $organizationId,
+        public string $upstreamBaseUrl,
+        public string $upstreamTokenRef,
+        public int $dunningMinIntervalDays,
+        public array $bankAccounts = [],
+    ) {
+    }
+}

--- a/src/ClearSettings/ClearSettingsRepositoryInterface.php
+++ b/src/ClearSettings/ClearSettingsRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+interface ClearSettingsRepositoryInterface
+{
+    public function findByOrganization(int $organizationId): ?ClearSettings;
+
+    public function save(ClearSettings $settings): void;
+}

--- a/src/ClearSettings/ClearSettingsResponse.php
+++ b/src/ClearSettings/ClearSettingsResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+final readonly class ClearSettingsResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ClearSettings $settings): array
+    {
+        return [
+            'organization_id' => $settings->organizationId,
+            'upstream_base_url' => $settings->upstreamBaseUrl,
+            'upstream_token_ref' => $settings->upstreamTokenRef,
+            'dunning_min_interval_days' => $settings->dunningMinIntervalDays,
+            'bank_accounts' => array_map(
+                static fn ($account): array => [
+                    'bank_account_id' => $account->id,
+                    'bank_name' => $account->bankName,
+                    'bank_branch' => $account->bankBranch,
+                    'account_type' => $account->accountType->value,
+                    'account_number' => $account->accountNumber,
+                    'csv_encoding' => $account->csvEncoding,
+                    'csv_date_format' => $account->csvDateFormat,
+                    'csv_date_column' => $account->csvDateColumn,
+                    'csv_amount_column' => $account->csvAmountColumn,
+                    'csv_counterparty_column' => $account->csvCounterpartyColumn,
+                    'csv_header_rows' => $account->csvHeaderRows,
+                ],
+                $settings->bankAccounts,
+            ),
+        ];
+    }
+}

--- a/src/ClearSettings/ClearSettingsRouteRegistrar.php
+++ b/src/ClearSettings/ClearSettingsRouteRegistrar.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ClearSettingsRouteRegistrar
+{
+    public function __construct(
+        private GetClearSettingsHandler $getHandler,
+        private UpdateClearSettingsHandler $updateHandler,
+        private TestUpstreamConnectionHandler $testHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler = $this->getHandler;
+        $updateHandler = $this->updateHandler;
+        $testHandler = $this->testHandler;
+
+        $router->get('/admin/clear-settings', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));
+        $router->put('/admin/clear-settings', static fn (ServerRequestInterface $r): ResponseInterface => $updateHandler->handle($r));
+        $router->post('/admin/clear-settings/test-upstream', static fn (ServerRequestInterface $r): ResponseInterface => $testHandler->handle($r));
+    }
+}

--- a/src/ClearSettings/GetClearSettingsHandler.php
+++ b/src/ClearSettings/GetClearSettingsHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetClearSettingsHandler
+{
+    public function __construct(
+        private ClearSettingsRepositoryInterface $settings,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $settings = $this->settings->findByOrganization($organizationId)
+            ?? new ClearSettings($organizationId, '', '', 7);
+
+        return $this->response->create(ClearSettingsResponse::toArray($settings));
+    }
+}

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+
+final readonly class PdoClearSettingsRepository implements ClearSettingsRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private BankAccountRepositoryInterface $bankAccounts,
+    ) {
+    }
+
+    public function findByOrganization(int $organizationId): ?ClearSettings
+    {
+        $row = $this->query->fetchOne(
+            'SELECT organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days '
+            . 'FROM clear_settings WHERE organization_id = ?',
+            [$organizationId],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new ClearSettings(
+            organizationId: (int) $row['organization_id'],
+            upstreamBaseUrl: (string) $row['upstream_base_url'],
+            upstreamTokenRef: (string) $row['upstream_token_ref'],
+            dunningMinIntervalDays: (int) $row['dunning_min_interval_days'],
+            bankAccounts: $this->bankAccounts->findByOrganization($organizationId),
+        );
+    }
+
+    public function save(ClearSettings $settings): void
+    {
+        $this->query->execute('DELETE FROM clear_settings WHERE organization_id = ?', [$settings->organizationId]);
+        $this->query->execute(
+            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days) '
+            . 'VALUES (?, ?, ?, ?)',
+            [
+                $settings->organizationId,
+                $settings->upstreamBaseUrl,
+                $settings->upstreamTokenRef,
+                $settings->dunningMinIntervalDays,
+            ],
+        );
+    }
+}

--- a/src/ClearSettings/TestUpstreamConnectionHandler.php
+++ b/src/ClearSettings/TestUpstreamConnectionHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Auth\AuthContext;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class TestUpstreamConnectionHandler
+{
+    public function __construct(
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        try {
+            $this->invoiceClient->listInvoices($organizationId, ['issued']);
+
+            return $this->response->create(['reachable' => true]);
+        } catch (UpstreamInvoiceUnavailableException $e) {
+            return $this->response->create(['reachable' => false, 'detail' => $e->getMessage()]);
+        }
+    }
+}

--- a/src/ClearSettings/UpdateClearSettingsHandler.php
+++ b/src/ClearSettings/UpdateClearSettingsHandler.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateClearSettingsHandler
+{
+    public function __construct(
+        private ClearSettingsRepositoryInterface $settings,
+        private BankAccountRepositoryInterface $bankAccounts,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $body = (array) $request->getParsedBody();
+        $errors = [];
+
+        $upstreamBaseUrl = is_string($body['upstream_base_url'] ?? null) ? trim($body['upstream_base_url']) : '';
+        $upstreamTokenRef = is_string($body['upstream_token_ref'] ?? null) ? trim($body['upstream_token_ref']) : '';
+
+        $dunningMinIntervalDaysRaw = $body['dunning_min_interval_days'] ?? 7;
+        $dunningMinIntervalDays = is_numeric($dunningMinIntervalDaysRaw) ? (int) $dunningMinIntervalDaysRaw : 0;
+        if ($dunningMinIntervalDays < 1) {
+            $errors[] = new ValidationError('dunning_min_interval_days', 'dunning_min_interval_days must be at least 1.', 'invalid');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $rawAccounts = is_array($body['bank_accounts'] ?? null) ? $body['bank_accounts'] : [];
+        $newAccounts = [];
+        foreach ($rawAccounts as $i => $raw) {
+            if (!is_array($raw)) {
+                throw new ValidationException([new ValidationError("bank_accounts.$i", 'Each bank account must be an object.', 'invalid')]);
+            }
+            $accountType = AccountType::tryFrom(is_string($raw['account_type'] ?? null) ? $raw['account_type'] : '');
+            if ($accountType === null) {
+                throw new ValidationException([new ValidationError("bank_accounts.$i.account_type", 'account_type must be "ordinary" or "current".', 'invalid')]);
+            }
+            $newAccounts[] = new BankAccount(
+                organizationId: $organizationId,
+                bankName: is_string($raw['bank_name'] ?? null) ? $raw['bank_name'] : '',
+                bankBranch: is_string($raw['bank_branch'] ?? null) ? $raw['bank_branch'] : '',
+                accountType: $accountType,
+                accountNumber: is_string($raw['account_number'] ?? null) ? $raw['account_number'] : '',
+                csvEncoding: is_string($raw['csv_encoding'] ?? null) ? $raw['csv_encoding'] : 'utf8',
+                csvDateFormat: is_string($raw['csv_date_format'] ?? null) ? $raw['csv_date_format'] : 'Y/m/d',
+                csvDateColumn: is_numeric($raw['csv_date_column'] ?? null) ? (int) $raw['csv_date_column'] : 0,
+                csvAmountColumn: is_numeric($raw['csv_amount_column'] ?? null) ? (int) $raw['csv_amount_column'] : 1,
+                csvCounterpartyColumn: is_numeric($raw['csv_counterparty_column'] ?? null) ? (int) $raw['csv_counterparty_column'] : 2,
+                csvHeaderRows: is_numeric($raw['csv_header_rows'] ?? null) ? (int) $raw['csv_header_rows'] : 1,
+            );
+        }
+
+        $this->bankAccounts->deleteByOrganization($organizationId);
+        foreach ($newAccounts as $account) {
+            $this->bankAccounts->save($account);
+        }
+
+        $this->settings->save(new ClearSettings(
+            organizationId: $organizationId,
+            upstreamBaseUrl: $upstreamBaseUrl,
+            upstreamTokenRef: $upstreamTokenRef,
+            dunningMinIntervalDays: $dunningMinIntervalDays,
+        ));
+
+        $updated = $this->settings->findByOrganization($organizationId)
+            ?? new ClearSettings($organizationId, $upstreamBaseUrl, $upstreamTokenRef, $dunningMinIntervalDays);
+
+        return $this->response->create(ClearSettingsResponse::toArray($updated));
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -40,6 +40,11 @@ use NeneClear\BankImport\PdoBankImportBatchRepository;
 use NeneClear\BankImport\PdoBankTransactionRepository;
 use NeneClear\BankImport\ReverseBankImportBatchHandler;
 use NeneClear\BankImport\ReverseBankImportBatchUseCase;
+use NeneClear\ClearSettings\ClearSettingsRouteRegistrar;
+use NeneClear\ClearSettings\GetClearSettingsHandler;
+use NeneClear\ClearSettings\PdoClearSettingsRepository;
+use NeneClear\ClearSettings\TestUpstreamConnectionHandler;
+use NeneClear\ClearSettings\UpdateClearSettingsHandler;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableExceptionHandler;
@@ -179,6 +184,13 @@ final class ApplicationFactory
             );
 
             $upstream = $invoiceClient ?? new FakeInvoiceUpstreamClient();
+            $clearSettings = new PdoClearSettingsRepository($query, $bankAccounts);
+            $routeRegistrars[] = new ClearSettingsRouteRegistrar(
+                new GetClearSettingsHandler($clearSettings, $json),
+                new UpdateClearSettingsHandler($clearSettings, $bankAccounts, $json),
+                new TestUpstreamConnectionHandler($upstream, $json),
+            );
+
             $reconRepo = new PdoReconciliationRepository($query);
             $creditRepo = new PdoClientCreditRepository($query);
             $routeRegistrars[] = new ReconciliationRouteRegistrar(
@@ -220,6 +232,7 @@ final class ApplicationFactory
                     '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                     '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                     '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                    '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                 ]),
             ];
         }

--- a/tests/BankImport/InMemoryBankAccountRepository.php
+++ b/tests/BankImport/InMemoryBankAccountRepository.php
@@ -19,6 +19,23 @@ final class InMemoryBankAccountRepository implements BankAccountRepositoryInterf
         return $this->byId[$id] ?? null;
     }
 
+    public function findByOrganization(int $organizationId): array
+    {
+        return array_values(array_filter(
+            $this->byId,
+            static fn (BankAccount $a): bool => $a->organizationId === $organizationId,
+        ));
+    }
+
+    public function deleteByOrganization(int $organizationId): void
+    {
+        foreach ($this->byId as $id => $account) {
+            if ($account->organizationId === $organizationId) {
+                unset($this->byId[$id]);
+            }
+        }
+    }
+
     public function save(BankAccount $account): int
     {
         $id = $account->id ?? $this->nextId++;

--- a/tests/Http/ClearSettingsHttpTest.php
+++ b/tests/Http/ClearSettingsHttpTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ClearSettingsHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-settings-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createBankAccounts($query);
+        SchemaFixture::createClearSettings($query);
+        SchemaFixture::createAuditEvents($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin));
+        $users->save($this->user('viewer@acme.example', Role::Viewer));
+
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 7,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    private function get(string $token, string $path): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('GET', $path)->withHeader('Authorization', 'Bearer ' . $token),
+        );
+    }
+
+    private function put(string $token, string $path, mixed $body): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('PUT', $path)
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withHeader('Content-Type', 'application/json')
+                ->withParsedBody(is_array($body) ? $body : []),
+        );
+    }
+
+    private function post(string $token, string $path, mixed $body = []): ResponseInterface
+    {
+        return $this->app->handle(
+            $this->psr17->createServerRequest('POST', $path)
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withHeader('Content-Type', 'application/json')
+                ->withParsedBody(is_array($body) ? $body : []),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_get_returns_defaults_when_no_settings_saved(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $response = $this->get($token, '/admin/clear-settings');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertSame(7, $body['dunning_min_interval_days']);
+        self::assertSame('', $body['upstream_base_url']);
+        self::assertSame([], $body['bank_accounts']);
+    }
+
+    public function test_put_saves_and_get_reflects_update(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->put($token, '/admin/clear-settings', [
+            'upstream_base_url' => 'https://invoice.example.com',
+            'upstream_token_ref' => 'NENE_INVOICE_TOKEN',
+            'dunning_min_interval_days' => 14,
+            'bank_accounts' => [
+                [
+                    'bank_name' => 'Test Bank',
+                    'bank_branch' => 'Main',
+                    'account_type' => 'ordinary',
+                    'account_number' => '1234567',
+                    'csv_encoding' => 'utf8',
+                    'csv_date_format' => 'Y/m/d',
+                    'csv_date_column' => 0,
+                    'csv_amount_column' => 1,
+                    'csv_counterparty_column' => 3,
+                    'csv_header_rows' => 1,
+                ],
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertSame('https://invoice.example.com', $body['upstream_base_url']);
+        self::assertSame(14, $body['dunning_min_interval_days']);
+        self::assertCount(1, $body['bank_accounts']);
+        self::assertSame('Test Bank', $body['bank_accounts'][0]['bank_name']);
+
+        $getBody = $this->decode($this->get($token, '/admin/clear-settings'));
+        self::assertSame(14, $getBody['dunning_min_interval_days']);
+        self::assertCount(1, $getBody['bank_accounts']);
+    }
+
+    public function test_viewer_cannot_get_clear_settings(): void
+    {
+        $token = $this->tokenFor('viewer@acme.example');
+        $response = $this->get($token, '/admin/clear-settings');
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_test_upstream_reachable(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $response = $this->post($token, '/admin/clear-settings/test-upstream');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($this->decode($response)['reachable'] ?? false);
+    }
+
+    public function test_test_upstream_unreachable(): void
+    {
+        $this->invoiceClient->makeUnavailable();
+        $token = $this->tokenFor('admin@acme.example');
+        $response = $this->post($token, '/admin/clear-settings/test-upstream');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse($this->decode($response)['reachable'] ?? true);
+    }
+
+    public function test_invalid_dunning_interval_returns_422(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $response = $this->put($token, '/admin/clear-settings', ['dunning_min_interval_days' => 0]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -170,4 +170,18 @@ final class SchemaFixture
             )'
         );
     }
+
+    public static function createClearSettings(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE clear_settings (
+                organization_id INTEGER PRIMARY KEY NOT NULL,
+                upstream_base_url TEXT NOT NULL DEFAULT \'\',
+                upstream_token_ref TEXT NOT NULL DEFAULT \'\',
+                dunning_min_interval_days INTEGER NOT NULL DEFAULT 7,
+                created_at TEXT,
+                updated_at TEXT
+            )'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `GET /admin/clear-settings` — returns per-org settings or org defaults (`dunning_min_interval_days: 7`); requires `manage_clear_settings`
- `PUT /admin/clear-settings` — upserts upstream config + dunning interval + replaces bank accounts (replace-all); requires `manage_clear_settings`
- `POST /admin/clear-settings/test-upstream` — calls Invoice upstream, returns `{reachable: bool}`; requires `manage_clear_settings`
- New table: `clear_settings` (`organization_id` PK, `upstream_base_url`, `upstream_token_ref`, `dunning_min_interval_days`)
- `BankAccountRepositoryInterface` gains `findByOrganization` + `deleteByOrganization` (config replace-all on PUT)
- `PdoClearSettingsRepository`: DELETE + INSERT pattern for portable UPSERT (SQLite/MySQL)

## Test plan

- [x] 105 tests / 416 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `ClearSettingsHttpTest` — GET defaults, PUT → GET reflects, viewer 403, test-upstream reachable/unreachable, invalid interval 422

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)