### PR TITLE
feat: dunning core — SendDunningUseCase, DunningNotice, mailer stub (B-8)

### DIFF
--- a/database/migrations/20260531200100_create_dunning_notices_table.php
+++ b/database/migrations/20260531200100_create_dunning_notices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateDunningNoticesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('dunning_notices');
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('invoice_id', 'biginteger', ['signed' => false])
+            ->addColumn('invoice_number', 'string', ['limit' => 64])
+            ->addColumn('client_id', 'biginteger', ['signed' => false])
+            ->addColumn('recipient_email', 'string', ['limit' => 255])
+            ->addColumn('outstanding_cents', 'biginteger')
+            ->addColumn('due_at', 'date')
+            ->addColumn('channel', 'string', ['limit' => 32, 'default' => 'log'])
+            ->addColumn('sent_by', 'biginteger', ['signed' => false])
+            ->addColumn('sent_at', 'datetime')
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id'])
+            ->addIndex(['organization_id', 'invoice_id'])
+            ->create();
+    }
+}

--- a/src/Dunning/DunningMailPayload.php
+++ b/src/Dunning/DunningMailPayload.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+final readonly class DunningMailPayload
+{
+    public function __construct(
+        public string $to,
+        public string $subject,
+        public string $body,
+        public int $organizationId,
+        public int $invoiceId,
+        public int $dunningNoticeId,
+    ) {
+    }
+}

--- a/src/Dunning/DunningMailerInterface.php
+++ b/src/Dunning/DunningMailerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+interface DunningMailerInterface
+{
+    public function send(DunningMailPayload $payload): void;
+}

--- a/src/Dunning/DunningNotice.php
+++ b/src/Dunning/DunningNotice.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * Immutable record of one sent dunning notice (督促通知). Append-only; never
+ * updated or deleted (compliance §4.7 / ADR 0012).
+ */
+final readonly class DunningNotice
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public string $invoiceNumber,
+        public int $clientId,
+        public string $recipientEmail,
+        public int $outstandingCents,
+        public string $dueAt,
+        public string $channel,
+        public int $sentBy,
+        public string $sentAt,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/Dunning/DunningNoticeRepositoryInterface.php
+++ b/src/Dunning/DunningNoticeRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+interface DunningNoticeRepositoryInterface
+{
+    public function save(DunningNotice $notice): int;
+
+    public function findById(int $organizationId, int $id): ?DunningNotice;
+
+    /**
+     * @return list<DunningNotice>
+     */
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId): int;
+
+    public function findLastByInvoice(int $organizationId, int $invoiceId): ?DunningNotice;
+}

--- a/src/Dunning/DunningTooFrequentException.php
+++ b/src/Dunning/DunningTooFrequentException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use RuntimeException;
+
+final class DunningTooFrequentException extends RuntimeException
+{
+    public function __construct(public readonly string $nextAllowedAt)
+    {
+        parent::__construct(sprintf('Dunning minimum interval not yet reached. Next allowed at %s.', $nextAllowedAt));
+    }
+}

--- a/src/Dunning/InvoiceAlreadyPaidException.php
+++ b/src/Dunning/InvoiceAlreadyPaidException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use RuntimeException;
+
+final class InvoiceAlreadyPaidException extends RuntimeException
+{
+    public function __construct(public readonly int $invoiceId, public readonly string $status)
+    {
+        parent::__construct(sprintf('Invoice %d is not eligible for dunning (status: %s).', $invoiceId, $status));
+    }
+}

--- a/src/Dunning/LogOnlyDunningMailer.php
+++ b/src/Dunning/LogOnlyDunningMailer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+final readonly class LogOnlyDunningMailer implements DunningMailerInterface
+{
+    public function send(DunningMailPayload $payload): void
+    {
+        error_log(sprintf(
+            '[DunningNotice #%d] org=%d invoice=%d to=%s subject=%s',
+            $payload->dunningNoticeId,
+            $payload->organizationId,
+            $payload->invoiceId,
+            $payload->to,
+            $payload->subject,
+        ));
+    }
+}

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoDunningNoticeRepository implements DunningNoticeRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, invoice_id, invoice_number, client_id, '
+        . 'recipient_email, outstanding_cents, due_at, channel, sent_by, sent_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(DunningNotice $notice): int
+    {
+        $this->query->execute(
+            'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, '
+            . 'recipient_email, outstanding_cents, due_at, channel, sent_by, sent_at) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $notice->organizationId,
+                $notice->invoiceId,
+                $notice->invoiceNumber,
+                $notice->clientId,
+                $notice->recipientEmail,
+                $notice->outstandingCents,
+                $notice->dueAt,
+                $notice->channel,
+                $notice->sentBy,
+                $notice->sentAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findById(int $organizationId, int $id): ?DunningNotice
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM dunning_notices WHERE id = ? AND organization_id = ?',
+            [$id, $organizationId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM dunning_notices WHERE organization_id = ? '
+            . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM dunning_notices WHERE organization_id = ?', [$organizationId]);
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    public function findLastByInvoice(int $organizationId, int $invoiceId): ?DunningNotice
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM dunning_notices WHERE organization_id = ? AND invoice_id = ? '
+            . 'ORDER BY id DESC LIMIT 1',
+            [$organizationId, $invoiceId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): DunningNotice
+    {
+        return new DunningNotice(
+            organizationId: (int) $row['organization_id'],
+            invoiceId: (int) $row['invoice_id'],
+            invoiceNumber: (string) $row['invoice_number'],
+            clientId: (int) $row['client_id'],
+            recipientEmail: (string) $row['recipient_email'],
+            outstandingCents: (int) $row['outstanding_cents'],
+            dueAt: (string) $row['due_at'],
+            channel: (string) $row['channel'],
+            sentBy: (int) $row['sent_by'],
+            sentAt: (string) $row['sent_at'],
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Dunning/SendDunningInput.php
+++ b/src/Dunning/SendDunningInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+final readonly class SendDunningInput
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/Dunning/SendDunningOutput.php
+++ b/src/Dunning/SendDunningOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+final readonly class SendDunningOutput
+{
+    public function __construct(
+        public int $dunningNoticeId,
+    ) {
+    }
+}

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use DateInterval;
+use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+
+final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
+{
+    private const int DEFAULT_MIN_INTERVAL_DAYS = 7;
+    private const string CHANNEL = 'log';
+
+    public function __construct(
+        private DunningNoticeRepositoryInterface $notices,
+        private ClearSettingsRepositoryInterface $clearSettings,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private DunningMailerInterface $mailer,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(SendDunningInput $input): SendDunningOutput
+    {
+        $invoice = $this->invoiceClient->getInvoice($input->organizationId, $input->invoiceId);
+
+        if (!in_array($invoice->status, ['issued', 'partially_paid'], true) || $invoice->outstandingCents <= 0) {
+            throw new InvoiceAlreadyPaidException($input->invoiceId, $invoice->status);
+        }
+
+        $settings = $this->clearSettings->findByOrganization($input->organizationId);
+        $minIntervalDays = $settings !== null ? $settings->dunningMinIntervalDays : self::DEFAULT_MIN_INTERVAL_DAYS;
+
+        $lastNotice = $this->notices->findLastByInvoice($input->organizationId, $input->invoiceId);
+        if ($lastNotice !== null) {
+            $lastSentAt = new DateTimeImmutable($lastNotice->sentAt);
+            $nextAllowed = $lastSentAt->add(new DateInterval('P' . $minIntervalDays . 'D'));
+            $now = $this->clock->now();
+            if ($now < $nextAllowed) {
+                throw new DunningTooFrequentException($nextAllowed->format('Y-m-d H:i:s'));
+            }
+        }
+
+        $client = $this->invoiceClient->getClient($input->organizationId, $invoice->clientId);
+
+        $nowStr = $this->clock->now()->format('Y-m-d H:i:s');
+        $subject = sprintf('[Reminder] Invoice %s is overdue', $invoice->invoiceNumber);
+        $body = sprintf(
+            "Dear %s,\n\nThis is a reminder that invoice %s dated %s for ¥%s remains outstanding as of %s.\n\n"
+            . "Outstanding balance: ¥%s\n\nPlease arrange payment at your earliest convenience.\n\n"
+            . 'If you have already made payment, please disregard this notice.',
+            $client->contactName,
+            $invoice->invoiceNumber,
+            $invoice->dueAt,
+            number_format($invoice->outstandingCents / 100),
+            $invoice->dueAt,
+            number_format($invoice->outstandingCents / 100),
+        );
+
+        $notice = new DunningNotice(
+            organizationId: $input->organizationId,
+            invoiceId: $input->invoiceId,
+            invoiceNumber: $invoice->invoiceNumber,
+            clientId: $invoice->clientId,
+            recipientEmail: $client->recipientEmail,
+            outstandingCents: $invoice->outstandingCents,
+            dueAt: $invoice->dueAt,
+            channel: self::CHANNEL,
+            sentBy: $input->actorUserId,
+            sentAt: $nowStr,
+        );
+
+        $noticeId = $this->notices->save($notice);
+
+        $this->mailer->send(new DunningMailPayload(
+            to: $client->recipientEmail,
+            subject: $subject,
+            body: $body,
+            organizationId: $input->organizationId,
+            invoiceId: $input->invoiceId,
+            dunningNoticeId: $noticeId,
+        ));
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'dunning_sent',
+            actorUserId: $input->actorUserId,
+            occurredAt: $nowStr,
+            payload: [
+                'dunning_notice_id' => $noticeId,
+                'invoice_id' => $input->invoiceId,
+                'invoice_number' => $invoice->invoiceNumber,
+                'recipient_email' => $client->recipientEmail,
+                'outstanding_cents' => $invoice->outstandingCents,
+                'channel' => self::CHANNEL,
+            ],
+        ));
+
+        return new SendDunningOutput(dunningNoticeId: $noticeId);
+    }
+}

--- a/src/Dunning/SendDunningUseCaseInterface.php
+++ b/src/Dunning/SendDunningUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+interface SendDunningUseCaseInterface
+{
+    public function execute(SendDunningInput $input): SendDunningOutput;
+}

--- a/src/InvoiceUpstream/FakeInvoiceUpstreamClient.php
+++ b/src/InvoiceUpstream/FakeInvoiceUpstreamClient.php
@@ -16,6 +16,9 @@ final class FakeInvoiceUpstreamClient implements InvoiceUpstreamClientInterface
     /** @var array<int, list<array{paymentId: int, amountCents: int, paidAt: string, externalReference: string, voided: bool}>> keyed by invoiceId */
     private array $payments = [];
 
+    /** @var array<int, InvoiceClientInfo> keyed by clientId */
+    private array $clients = [];
+
     private int $nextPaymentId = 1;
 
     private bool $unavailable = false;
@@ -23,6 +26,11 @@ final class FakeInvoiceUpstreamClient implements InvoiceUpstreamClientInterface
     public function makeUnavailable(): void
     {
         $this->unavailable = true;
+    }
+
+    public function addClient(InvoiceClientInfo $client): void
+    {
+        $this->clients[$client->clientId] = $client;
     }
 
     public function addInvoice(InvoiceItem $invoice): void
@@ -131,6 +139,15 @@ final class FakeInvoiceUpstreamClient implements InvoiceUpstreamClientInterface
                 return;
             }
         }
+    }
+
+    public function getClient(int $organizationId, int $clientId): InvoiceClientInfo
+    {
+        if ($this->unavailable) {
+            throw new UpstreamInvoiceUnavailableException();
+        }
+
+        return $this->clients[$clientId] ?? throw new UpstreamInvoiceNotFoundException($clientId);
     }
 
     /** @return list<array{paymentId: int, amountCents: int, paidAt: string, externalReference: string, voided: bool}> */

--- a/src/InvoiceUpstream/InvoiceClientInfo.php
+++ b/src/InvoiceUpstream/InvoiceClientInfo.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+final readonly class InvoiceClientInfo
+{
+    public function __construct(
+        public int $clientId,
+        public string $contactName,
+        public string $recipientEmail,
+    ) {
+    }
+}

--- a/src/InvoiceUpstream/InvoiceUpstreamClientInterface.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamClientInterface.php
@@ -30,4 +30,6 @@ interface InvoiceUpstreamClientInterface
         string $reason,
         string $idempotencyKey,
     ): void;
+
+    public function getClient(int $organizationId, int $clientId): InvoiceClientInfo;
 }

--- a/tests/Dunning/InMemoryClearSettingsRepository.php
+++ b/tests/Dunning/InMemoryClearSettingsRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use NeneClear\ClearSettings\ClearSettings;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+
+final class InMemoryClearSettingsRepository implements ClearSettingsRepositoryInterface
+{
+    /** @var array<int, ClearSettings> keyed by orgId */
+    private array $byOrg = [];
+
+    public function findByOrganization(int $organizationId): ?ClearSettings
+    {
+        return $this->byOrg[$organizationId] ?? null;
+    }
+
+    public function save(ClearSettings $settings): void
+    {
+        $this->byOrg[$settings->organizationId] = $settings;
+    }
+}

--- a/tests/Dunning/InMemoryDunningNoticeRepository.php
+++ b/tests/Dunning/InMemoryDunningNoticeRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use NeneClear\Dunning\DunningNotice;
+use NeneClear\Dunning\DunningNoticeRepositoryInterface;
+
+final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryInterface
+{
+    /** @var array<int, DunningNotice> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function save(DunningNotice $notice): int
+    {
+        $id = $notice->id ?? $this->nextId++;
+        $this->byId[$id] = new DunningNotice(
+            organizationId: $notice->organizationId,
+            invoiceId: $notice->invoiceId,
+            invoiceNumber: $notice->invoiceNumber,
+            clientId: $notice->clientId,
+            recipientEmail: $notice->recipientEmail,
+            outstandingCents: $notice->outstandingCents,
+            dueAt: $notice->dueAt,
+            channel: $notice->channel,
+            sentBy: $notice->sentBy,
+            sentAt: $notice->sentAt,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function findById(int $organizationId, int $id): ?DunningNotice
+    {
+        $n = $this->byId[$id] ?? null;
+
+        return ($n !== null && $n->organizationId === $organizationId) ? $n : null;
+    }
+
+    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->byId,
+            static fn (DunningNotice $n): bool => $n->organizationId === $organizationId,
+        ));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId): int
+    {
+        return count(array_filter(
+            $this->byId,
+            static fn (DunningNotice $n): bool => $n->organizationId === $organizationId,
+        ));
+    }
+
+    public function findLastByInvoice(int $organizationId, int $invoiceId): ?DunningNotice
+    {
+        $matches = array_filter(
+            $this->byId,
+            static fn (DunningNotice $n): bool => $n->organizationId === $organizationId && $n->invoiceId === $invoiceId,
+        );
+
+        if (empty($matches)) {
+            return null;
+        }
+
+        return end($matches);
+    }
+}

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use NeneClear\ClearSettings\ClearSettings;
+use NeneClear\Dunning\DunningTooFrequentException;
+use NeneClear\Dunning\InvoiceAlreadyPaidException;
+use NeneClear\Dunning\SendDunningInput;
+use NeneClear\Dunning\SendDunningUseCase;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceClientInfo;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundException;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class SendDunningUseCaseTest extends TestCase
+{
+    private InMemoryDunningNoticeRepository $notices;
+    private InMemoryClearSettingsRepository $clearSettings;
+    private FakeInvoiceUpstreamClient $invoiceClient;
+    private SpyDunningMailer $mailer;
+    private InMemoryAuditEventRepository $audit;
+    private SendDunningUseCase $useCase;
+
+    protected function setUp(): void
+    {
+        $this->notices = new InMemoryDunningNoticeRepository();
+        $this->clearSettings = new InMemoryClearSettingsRepository();
+        $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->mailer = new SpyDunningMailer();
+        $this->audit = new InMemoryAuditEventRepository();
+        $this->useCase = new SendDunningUseCase(
+            $this->notices,
+            $this->clearSettings,
+            $this->invoiceClient,
+            $this->mailer,
+            $this->audit,
+            new FixedClock('2026-05-31T09:00:00+00:00'),
+        );
+    }
+
+    private function addInvoice(int $id, string $status = 'issued', int $outstandingCents = 110000): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: 'INV-00' . $id,
+            clientId: 100,
+            outstandingCents: $outstandingCents,
+            totalCents: 110000,
+            dueAt: '2026-04-30',
+            status: $status,
+            currency: 'JPY',
+        ));
+    }
+
+    private function addClient(): void
+    {
+        $this->invoiceClient->addClient(new InvoiceClientInfo(
+            clientId: 100,
+            contactName: 'ACME Corp',
+            recipientEmail: 'accounts@acme.example',
+        ));
+    }
+
+    private function input(int $invoiceId = 1): SendDunningInput
+    {
+        return new SendDunningInput(organizationId: 7, invoiceId: $invoiceId, actorUserId: 42);
+    }
+
+    public function test_happy_path_records_notice_and_logs_mail(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $output = $this->useCase->execute($this->input());
+
+        self::assertGreaterThan(0, $output->dunningNoticeId);
+
+        $notice = $this->notices->findById(7, $output->dunningNoticeId);
+        self::assertNotNull($notice);
+        self::assertSame(1, $notice->invoiceId);
+        self::assertSame('accounts@acme.example', $notice->recipientEmail);
+        self::assertSame(110000, $notice->outstandingCents);
+        self::assertSame('log', $notice->channel);
+
+        self::assertCount(1, $this->mailer->sent);
+        self::assertSame('accounts@acme.example', $this->mailer->sent[0]->to);
+        self::assertStringContainsString('INV-001', $this->mailer->sent[0]->subject);
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('dunning_sent', $this->audit->events[0]->eventType);
+    }
+
+    public function test_paid_invoice_throws(): void
+    {
+        $this->addInvoice(1, status: 'paid');
+        $this->addClient();
+
+        $this->expectException(InvoiceAlreadyPaidException::class);
+        $this->useCase->execute($this->input());
+    }
+
+    public function test_zero_outstanding_throws(): void
+    {
+        $this->addInvoice(1, outstandingCents: 0);
+        $this->addClient();
+
+        $this->expectException(InvoiceAlreadyPaidException::class);
+        $this->useCase->execute($this->input());
+    }
+
+    public function test_too_frequent_within_default_interval_throws(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $this->useCase->execute($this->input()); // first send at 2026-05-31
+
+        // Second send on same day — within 7-day default interval
+        $this->expectException(DunningTooFrequentException::class);
+        $this->useCase->execute($this->input());
+    }
+
+    public function test_too_frequent_exception_contains_next_allowed_at(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+        $this->useCase->execute($this->input());
+
+        try {
+            $this->useCase->execute($this->input());
+            self::fail('Expected DunningTooFrequentException');
+        } catch (DunningTooFrequentException $e) {
+            self::assertSame('2026-06-07 09:00:00', $e->nextAllowedAt);
+        }
+    }
+
+    public function test_custom_min_interval_from_settings(): void
+    {
+        $this->clearSettings->save(new ClearSettings(7, '', '', 3));
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $this->useCase->execute($this->input());
+
+        // 3-day interval — same day still too frequent
+        $this->expectException(DunningTooFrequentException::class);
+        $this->useCase->execute($this->input());
+    }
+
+    public function test_unknown_invoice_throws_upstream_not_found(): void
+    {
+        $this->expectException(UpstreamInvoiceNotFoundException::class);
+        $this->useCase->execute($this->input(invoiceId: 9999));
+    }
+}

--- a/tests/Dunning/SpyDunningMailer.php
+++ b/tests/Dunning/SpyDunningMailer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use NeneClear\Dunning\DunningMailerInterface;
+use NeneClear\Dunning\DunningMailPayload;
+
+final class SpyDunningMailer implements DunningMailerInterface
+{
+    /** @var list<DunningMailPayload> */
+    public array $sent = [];
+
+    public function send(DunningMailPayload $payload): void
+    {
+        $this->sent[] = $payload;
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -184,4 +184,24 @@ final class SchemaFixture
             )'
         );
     }
+
+    public static function createDunningNotices(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE dunning_notices (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                invoice_id INTEGER NOT NULL,
+                invoice_number TEXT NOT NULL,
+                client_id INTEGER NOT NULL,
+                recipient_email TEXT NOT NULL,
+                outstanding_cents INTEGER NOT NULL,
+                due_at TEXT NOT NULL,
+                channel TEXT NOT NULL DEFAULT \'log\',
+                sent_by INTEGER NOT NULL,
+                sent_at TEXT NOT NULL,
+                created_at TEXT
+            )'
+        );
+    }
 }


### PR DESCRIPTION
## Summary

**InvoiceUpstream extension:**
- `InvoiceUpstreamClientInterface`: add `getClient(orgId, clientId): InvoiceClientInfo`
- `FakeInvoiceUpstreamClient`: `addClient()` + `getClient()` (returns `UpstreamInvoiceNotFoundException` if not seeded)

**Dunning mailer:**
- `DunningMailerInterface` + `LogOnlyDunningMailer` — Phase 2 is log-only; SMTP is deferred

**Dunning domain:**
- `DunningNotice` — immutable entity (compliance §4.7 / ADR 0012)
- `DunningNoticeRepositoryInterface` + `PdoDunningNoticeRepository`
- Migration: `dunning_notices` table

**`SendDunningUseCase` (ADR 0011 compliant):**
1. Load invoice from upstream — check `issued`/`partially_paid` AND `outstanding_cents > 0`, else 422
2. Load `ClearSettings` → `dunning_min_interval_days` (default 7 if no settings)
3. Check last notice for invoice — if within interval, throw `DunningTooFrequentException(nextAllowedAt)` → 422
4. Load client info → `recipientEmail`
5. Render template (hardcoded professional tone; no coercive language — ADR 0011 §4.4)
6. Log via `LogOnlyDunningMailer`; save immutable `DunningNotice`; audit `dunning_sent`

## Test plan

- [x] 112 tests / 433 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean
- [x] `SendDunningUseCaseTest` — happy path, paid invoice 422, zero outstanding 422, too frequent 422 (with correct `next_allowed_at`), custom min interval, unknown invoice → upstream not found

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)