### PR TITLE
feat: InvoiceUpstreamHttpClient — real HTTP client + contract tests + ApplicationFactory wiring

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -53,6 +53,7 @@ $query = (static function () use ($env): ?DatabaseQueryExecutorInterface {
 })();
 
 $smtpHost = $env('SMTP_HOST') ?: null;
+$invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
 
 $application = ApplicationFactory::create(
     debug: $debug,
@@ -65,6 +66,8 @@ $application = ApplicationFactory::create(
     smtpPassword: $env('SMTP_PASSWORD'),
     smtpFromAddress: $env('SMTP_FROM_ADDRESS', 'noreply@nene-clear.dev'),
     smtpFromName: $env('SMTP_FROM_NAME', 'NeNe Clear'),
+    invoiceApiBaseUrl: $invoiceApiBaseUrl,
+    invoiceBearerToken: $env('NENE_INVOICE_BEARER_TOKEN'),
 );
 
 $psr17 = new Psr17Factory();

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -58,6 +58,7 @@ use NeneClear\Dunning\SendDunningUseCase;
 use NeneClear\Dunning\SmtpDunningMailer;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamHttpClient;
 use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableExceptionHandler;
 use NeneClear\Organization\CreateOrganizationHandler;
 use NeneClear\Organization\CreateOrganizationUseCase;
@@ -143,6 +144,8 @@ final class ApplicationFactory
         string $smtpPassword = '',
         string $smtpFromAddress = 'noreply@nene-clear.dev',
         string $smtpFromName = 'NeNe Clear',
+        ?string $invoiceApiBaseUrl = null,
+        string $invoiceBearerToken = '',
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
         $json = new JsonResponseFactory($psr17, $psr17);
@@ -200,7 +203,11 @@ final class ApplicationFactory
                 new GetBankTransactionByIdHandler($transactions, $json),
             );
 
-            $upstream = $invoiceClient ?? new FakeInvoiceUpstreamClient();
+            $upstream = $invoiceClient ?? (
+                $invoiceApiBaseUrl !== null && $invoiceApiBaseUrl !== '' && $invoiceBearerToken !== ''
+                    ? new InvoiceUpstreamHttpClient($invoiceApiBaseUrl, $invoiceBearerToken)
+                    : new FakeInvoiceUpstreamClient()
+            );
             $clearSettings = new PdoClearSettingsRepository($query, $bankAccounts);
             $routeRegistrars[] = new ClearSettingsRouteRegistrar(
                 new GetClearSettingsHandler($clearSettings, $json),

--- a/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use NeneClear\Reconciliation\AllocationExceedsOutstandingException;
+
+/**
+ * Real HTTP implementation of InvoiceUpstreamClientInterface.
+ * Targets the binding contract in docs/integrations/invoice-upstream-contract.md.
+ *
+ * Use when NENE_INVOICE_API_BASE_URL + NENE_INVOICE_BEARER_TOKEN are set.
+ * Falls back to FakeInvoiceUpstreamClient when env vars are absent.
+ */
+final readonly class InvoiceUpstreamHttpClient implements InvoiceUpstreamClientInterface
+{
+    private const int CONNECT_TIMEOUT = 5;
+    private const int READ_TIMEOUT = 10;
+
+    public function __construct(
+        private string $baseUrl,
+        private string $bearerToken,
+    ) {
+    }
+
+    public function listInvoices(int $organizationId, array $statuses): array
+    {
+        $query = http_build_query(['status' => $statuses, 'limit' => 200, 'offset' => 0]);
+        $body = $this->request('GET', '/api/invoices?' . $query);
+
+        return array_values(array_map(
+            static fn (array $item): InvoiceItem => new InvoiceItem(
+                invoiceId: (int) $item['invoice_id'],
+                invoiceNumber: (string) $item['invoice_number'],
+                clientId: (int) $item['client_id'],
+                outstandingCents: (int) $item['outstanding_cents'],
+                totalCents: (int) $item['total_cents'],
+                dueAt: (string) $item['due_at'],
+                status: (string) $item['status'],
+                currency: (string) ($item['currency'] ?? 'JPY'),
+            ),
+            (array) ($body['items'] ?? []),
+        ));
+    }
+
+    public function getInvoice(int $organizationId, int $invoiceId): InvoiceItem
+    {
+        $body = $this->request('GET', '/api/invoices/' . $invoiceId, invoiceId: $invoiceId);
+
+        return new InvoiceItem(
+            invoiceId: (int) $body['invoice_id'],
+            invoiceNumber: (string) $body['invoice_number'],
+            clientId: (int) $body['client_id'],
+            outstandingCents: (int) $body['outstanding_cents'],
+            totalCents: (int) $body['total_cents'],
+            dueAt: (string) $body['due_at'],
+            status: (string) $body['status'],
+            currency: (string) ($body['currency'] ?? 'JPY'),
+        );
+    }
+
+    public function createPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $amountCents,
+        string $paidAt,
+        string $externalReference,
+        string $idempotencyKey,
+    ): InvoicePaymentCreated {
+        $body = $this->request(
+            'POST',
+            '/api/invoices/' . $invoiceId . '/payments',
+            [
+                'amount_cents' => $amountCents,
+                'paid_at' => $paidAt,
+                'method' => 'bank_transfer',
+                'external_reference' => $externalReference,
+                'idempotency_key' => $idempotencyKey,
+            ],
+            idempotencyKey: $idempotencyKey,
+            invoiceId: $invoiceId,
+        );
+
+        return new InvoicePaymentCreated(
+            paymentId: (int) $body['payment_id'],
+            invoiceId: $invoiceId,
+            amountCents: (int) $body['amount_cents'],
+            paidAt: (string) $body['paid_at'],
+            externalReference: (string) $body['external_reference'],
+        );
+    }
+
+    public function voidPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $paymentId,
+        string $reason,
+        string $idempotencyKey,
+    ): void {
+        $this->request(
+            'POST',
+            '/api/invoices/' . $invoiceId . '/payments/' . $paymentId . '/void',
+            ['reason' => $reason, 'idempotency_key' => $idempotencyKey],
+            idempotencyKey: $idempotencyKey,
+        );
+    }
+
+    public function getClient(int $organizationId, int $clientId): InvoiceClientInfo
+    {
+        $body = $this->request('GET', '/api/clients/' . $clientId, invoiceId: $clientId);
+
+        return new InvoiceClientInfo(
+            clientId: (int) $body['client_id'],
+            contactName: (string) $body['contact_name'],
+            recipientEmail: (string) $body['recipient_email'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     * @return array<string, mixed>
+     */
+    private function request(
+        string $method,
+        string $path,
+        ?array $payload = null,
+        string $idempotencyKey = '',
+        int $invoiceId = 0,
+    ): array {
+        $ch = curl_init(rtrim($this->baseUrl, '/') . $path);
+
+        if ($ch === false) {
+            throw new UpstreamInvoiceUnavailableException('Failed to initialise cURL handle.');
+        }
+
+        $headers = [
+            'Authorization: Bearer ' . $this->bearerToken,
+            'Accept: application/json',
+        ];
+
+        if ($payload !== null) {
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        if ($idempotencyKey !== '') {
+            $headers[] = 'Idempotency-Key: ' . $idempotencyKey;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_CONNECTTIMEOUT => self::CONNECT_TIMEOUT,
+            CURLOPT_TIMEOUT => self::READ_TIMEOUT,
+            CURLOPT_CUSTOMREQUEST => $method,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        if ($payload !== null) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload, JSON_THROW_ON_ERROR));
+        }
+
+        $raw = curl_exec($ch);
+        $curlError = curl_error($ch);
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($raw === false || $curlError !== '') {
+            throw new UpstreamInvoiceUnavailableException('Invoice API unreachable: ' . $curlError);
+        }
+
+        $rawStr = (string) $raw;
+
+        if ($statusCode === 0) {
+            throw new UpstreamInvoiceUnavailableException('Invoice API did not respond.');
+        }
+
+        if ($statusCode >= 500) {
+            throw new UpstreamInvoiceUnavailableException(sprintf('Invoice API returned %d.', $statusCode));
+        }
+
+        $body = json_decode($rawStr, true);
+        $body = is_array($body) ? $body : [];
+
+        if ($statusCode === 404) {
+            throw new UpstreamInvoiceNotFoundException($invoiceId);
+        }
+
+        if ($statusCode === 422) {
+            $type = (string) ($body['type'] ?? '');
+            if (str_contains($type, 'payment-exceeds-outstanding')) {
+                throw new AllocationExceedsOutstandingException(
+                    $invoiceId,
+                    (int) ($body['outstanding_cents'] ?? 0),
+                );
+            }
+
+            throw new UpstreamInvoiceUnavailableException(sprintf('Invoice API returned 422: %s', $body['detail'] ?? ''));
+        }
+
+        if ($statusCode >= 400) {
+            throw new UpstreamInvoiceUnavailableException(sprintf('Invoice API returned %d.', $statusCode));
+        }
+
+        return $body;
+    }
+}

--- a/tests/Contract/InvoiceUpstreamContractTest.php
+++ b/tests/Contract/InvoiceUpstreamContractTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Contract;
+
+use NeneClear\InvoiceUpstream\InvoiceUpstreamHttpClient;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for the Invoice upstream API (docs/integrations/invoice-upstream-contract.md).
+ *
+ * These tests skip automatically when NENE_INVOICE_API_BASE_URL and
+ * NENE_INVOICE_BEARER_TOKEN are not set, so CI passes without a running Invoice API.
+ * Run manually against a live Invoice instance to verify the contract.
+ *
+ * Required env vars:
+ *   NENE_INVOICE_API_BASE_URL   — e.g. http://localhost:8080
+ *   NENE_INVOICE_BEARER_TOKEN   — service token scoped to the test org
+ *   NENE_INVOICE_CONTRACT_ORG   — org id used for contract tests (default: 1)
+ */
+final class InvoiceUpstreamContractTest extends TestCase
+{
+    private InvoiceUpstreamHttpClient $client;
+    private int $orgId;
+
+    protected function setUp(): void
+    {
+        $baseUrl = getenv('NENE_INVOICE_API_BASE_URL') ?: '';
+        $token = getenv('NENE_INVOICE_BEARER_TOKEN') ?: '';
+
+        if ($baseUrl === '' || $token === '') {
+            $this->markTestSkipped('NENE_INVOICE_API_BASE_URL / NENE_INVOICE_BEARER_TOKEN not set — skipping contract tests.');
+        }
+
+        $this->client = new InvoiceUpstreamHttpClient($baseUrl, $token);
+        $this->orgId = (int) (getenv('NENE_INVOICE_CONTRACT_ORG') ?: '1');
+    }
+
+    public function test_list_invoices_returns_array(): void
+    {
+        $invoices = $this->client->listInvoices($this->orgId, ['issued', 'partially_paid']);
+
+        // list<InvoiceItem> is always an array — just verify each item's structure
+        foreach ($invoices as $invoice) {
+            self::assertGreaterThan(0, $invoice->invoiceId);
+            self::assertNotEmpty($invoice->invoiceNumber);
+            self::assertGreaterThanOrEqual(0, $invoice->outstandingCents);
+            self::assertGreaterThan(0, $invoice->totalCents);
+            self::assertNotEmpty($invoice->dueAt);
+            self::assertContains($invoice->status, ['issued', 'partially_paid', 'paid']);
+            self::assertSame('JPY', $invoice->currency);
+        }
+    }
+
+    public function test_get_invoice_returns_detail_for_existing(): void
+    {
+        $invoices = $this->client->listInvoices($this->orgId, ['issued', 'partially_paid', 'paid']);
+
+        if (count($invoices) === 0) {
+            $this->markTestSkipped('No invoices found in the test org — create at least one in nene-invoice.');
+        }
+
+        $detail = $this->client->getInvoice($this->orgId, $invoices[0]->invoiceId);
+
+        self::assertSame($invoices[0]->invoiceId, $detail->invoiceId);
+        self::assertSame($invoices[0]->invoiceNumber, $detail->invoiceNumber);
+        self::assertGreaterThanOrEqual(0, $detail->outstandingCents);
+    }
+
+    public function test_get_invoice_throws_not_found_for_missing(): void
+    {
+        $this->expectException(UpstreamInvoiceNotFoundException::class);
+        $this->client->getInvoice($this->orgId, PHP_INT_MAX);
+    }
+
+    public function test_get_client_returns_contact_info(): void
+    {
+        $invoices = $this->client->listInvoices($this->orgId, ['issued', 'partially_paid']);
+
+        if (count($invoices) === 0) {
+            $this->markTestSkipped('No open invoices in test org.');
+        }
+
+        $clientInfo = $this->client->getClient($this->orgId, $invoices[0]->clientId);
+
+        self::assertSame($invoices[0]->clientId, $clientInfo->clientId);
+        self::assertNotEmpty($clientInfo->contactName);
+        self::assertStringContainsString('@', $clientInfo->recipientEmail);
+    }
+
+    public function test_create_and_void_payment_idempotent(): void
+    {
+        $invoices = $this->client->listInvoices($this->orgId, ['issued', 'partially_paid']);
+
+        if (count($invoices) === 0) {
+            $this->markTestSkipped('No open invoices in test org.');
+        }
+
+        $invoice = $invoices[0];
+        $amountCents = min(1, $invoice->outstandingCents); // pay 1 yen to avoid over-allocation
+        if ($amountCents <= 0) {
+            $this->markTestSkipped('Invoice has zero outstanding.');
+        }
+
+        $idempotencyKey = 'clear:contract-test:' . $invoice->invoiceId . ':' . time();
+        $externalRef = 'clear:contract-test:' . $invoice->invoiceId;
+
+        $payment = $this->client->createPayment(
+            $this->orgId,
+            $invoice->invoiceId,
+            $amountCents,
+            date('Y-m-d'),
+            $externalRef,
+            $idempotencyKey,
+        );
+
+        self::assertGreaterThan(0, $payment->paymentId);
+        self::assertSame($invoice->invoiceId, $payment->invoiceId);
+        self::assertSame($amountCents, $payment->amountCents);
+        self::assertSame($externalRef, $payment->externalReference);
+
+        // Idempotency: second call returns same payment (no error)
+        $payment2 = $this->client->createPayment(
+            $this->orgId,
+            $invoice->invoiceId,
+            $amountCents,
+            date('Y-m-d'),
+            $externalRef,
+            $idempotencyKey,
+        );
+        self::assertSame($payment->paymentId, $payment2->paymentId);
+
+        // Void the payment (cleanup)
+        $this->client->voidPayment(
+            $this->orgId,
+            $invoice->invoiceId,
+            $payment->paymentId,
+            'contract test cleanup',
+            $idempotencyKey . ':void',
+        );
+
+        // Idempotent void (no-op)
+        $this->client->voidPayment(
+            $this->orgId,
+            $invoice->invoiceId,
+            $payment->paymentId,
+            'contract test cleanup',
+            $idempotencyKey . ':void',
+        );
+
+        $this->addToAssertionCount(1); // void succeeded without exception
+    }
+}


### PR DESCRIPTION
## Summary

**`InvoiceUpstreamHttpClient`** (`src/InvoiceUpstream/InvoiceUpstreamHttpClient.php`)
- cURL-based implementation targeting the binding contract in `docs/integrations/invoice-upstream-contract.md`
- Implements all 5 interface methods: `listInvoices`, `getInvoice`, `createPayment`, `voidPayment`, `getClient`
- Error mapping: 404 → `UpstreamInvoiceNotFoundException`; 422 `payment-exceeds-outstanding` → `AllocationExceedsOutstandingException`; 5xx/network → `UpstreamInvoiceUnavailableException`
- Timeouts: 5s connect, 10s read; `Idempotency-Key` header on writes; `Authorization: Bearer` on all requests

**`ApplicationFactory` wiring**
- New params: `invoiceApiBaseUrl` + `invoiceBearerToken`
- Selects `InvoiceUpstreamHttpClient` when both are non-empty; falls back to `FakeInvoiceUpstreamClient`
- `public_html/index.php` reads `NENE_INVOICE_API_BASE_URL` + `NENE_INVOICE_BEARER_TOKEN`

**Contract tests** (`tests/Contract/InvoiceUpstreamContractTest.php`)
- 5 tests covering: list, getById, getClient, createPayment (idempotency), voidPayment (idempotency)
- Auto-skip when env vars absent → CI passes without nene-invoice API
- Run manually with `NENE_INVOICE_API_BASE_URL=... NENE_INVOICE_BEARER_TOKEN=... composer test` once Invoice API ships

## Status
nene-invoice API is not built yet — contract tests skip in CI. When Invoice ships, setting env vars activates the real client with no code change needed.

## Test plan

- [x] 126 tests (5 skipped) / 473 assertions — all green
- [x] PHPStan level 8 — no errors
- [x] PHP-CS-Fixer — clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)