### PR TITLE
feat: i18n message catalog — ja/en locale switching (ADR 0005)

### DIFF
--- a/lang/en.php
+++ b/lang/en.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * English message catalog — single source of truth for all English user-facing strings.
+ * Keys: 'problem.{slug}.title', 'problem.{slug}.detail', 'dunning_email.*'
+ * Slugs must be registered in docs/explanation/terminology.md §4 before use.
+ *
+ * @return array<string, string>
+ */
+return [
+
+    // -------------------------------------------------------------------------
+    // Problem Details — titles and details (API error responses)
+    // -------------------------------------------------------------------------
+
+    'problem.validation-failed.title'  => 'Validation Failed',
+    'problem.validation-failed.detail' => 'One or more input fields are invalid.',
+    'problem.validation-failed.csv-prefix' => 'The uploaded CSV could not be parsed: ',
+
+    'problem.unauthorized.title'  => 'Unauthorized',
+    'problem.unauthorized.detail' => 'The authenticated user no longer exists.',
+
+    'problem.invalid-credentials.title'  => 'Invalid Credentials',
+    'problem.invalid-credentials.detail' => 'Email or password is incorrect.',
+
+    'problem.insufficient-capability.title'  => 'Insufficient Capability',
+    'problem.insufficient-capability.detail' => 'Your role lacks the capability required for this action.',
+
+    'problem.organization-not-found.title'  => 'Organization Not Found',
+    'problem.organization-not-found.detail' => 'The requested organization was not found.',
+
+    'problem.organization-already-exists.title'  => 'Organization Already Exists',
+    'problem.organization-already-exists.detail' => 'An organization with that slug already exists.',
+
+    'problem.user-not-found.title'  => 'User Not Found',
+    'problem.user-not-found.detail' => 'The requested user was not found.',
+
+    'problem.user-already-exists.title'  => 'User Already Exists',
+    'problem.user-already-exists.detail' => 'A user with that email already exists.',
+
+    'problem.bank-account-not-found.title'  => 'Bank Account Not Found',
+    'problem.bank-account-not-found.detail' => 'The requested bank account was not found.',
+
+    'problem.bank-import-batch-not-found.title'  => 'Bank Import Batch Not Found',
+    'problem.bank-import-batch-not-found.detail' => 'The requested bank import batch was not found.',
+
+    'problem.bank-transaction-not-found.title'  => 'Bank Transaction Not Found',
+    'problem.bank-transaction-not-found.detail' => 'The requested bank transaction was not found.',
+
+    'problem.reconciliation-not-found.title'  => 'Reconciliation Not Found',
+    'problem.reconciliation-not-found.detail' => 'The requested reconciliation was not found.',
+
+    'problem.client-credit-not-found.title'  => 'Client Credit Not Found',
+    'problem.client-credit-not-found.detail' => 'The requested client credit was not found.',
+
+    'problem.dunning-notice-not-found.title'  => 'Dunning Notice Not Found',
+    'problem.dunning-notice-not-found.detail' => 'The requested dunning notice was not found.',
+
+    // invalid-state-transition: shared title, context-specific details
+    'problem.invalid-state-transition.title'                          => 'Invalid State Transition',
+    'problem.invalid-state-transition.batch-reversed.detail'          => 'The batch is already reversed.',
+    'problem.invalid-state-transition.batch-has-matched.detail'       => 'One or more transactions are already matched; unmatch them before reversing the batch.',
+    'problem.invalid-state-transition.tx-not-matchable.detail'        => 'The bank transaction cannot be matched in its current status.',
+    'problem.invalid-state-transition.reconciliation-reversed.detail' => 'This reconciliation is already reversed.',
+
+    'problem.duplicate-bank-import.title'  => 'Duplicate Bank Import',
+    'problem.duplicate-bank-import.detail' => 'A batch with this file hash was already imported.',
+
+    'problem.allocation-exceeds-outstanding.title'  => 'Allocation Exceeds Outstanding',
+    'problem.allocation-exceeds-outstanding.detail' => 'The allocation amount exceeds the invoice outstanding balance.',
+
+    'problem.upstream-invoice-unavailable.title'  => 'Invoice Upstream Unavailable',
+    'problem.upstream-invoice-unavailable.detail' => 'The Invoice API is unreachable; match confirmation is blocked.',
+
+    // Entries for upstream-invoice-not-found and upstream-client-not-found are
+    // used by UpstreamInvoiceNotFoundExceptionHandler and
+    // UpstreamClientNotFoundExceptionHandler (PR #62, pending merge).
+    'problem.upstream-invoice-not-found.title'  => 'Invoice Not Found in Upstream',
+    'problem.upstream-invoice-not-found.detail' => 'The referenced invoice or client does not exist in the Invoice system.',
+
+    'problem.upstream-client-not-found.title'  => 'Client Not Found in Upstream',
+    'problem.upstream-client-not-found.detail' => 'The referenced client does not exist (or has been deleted) in the Invoice system.',
+
+    'problem.invoice-not-eligible-for-dunning.title'  => 'Invoice Not Eligible for Dunning',
+    'problem.invoice-not-eligible-for-dunning.detail' => 'The invoice is already paid, voided, or has no outstanding balance.',
+
+    'problem.dunning-too-frequent.title'  => 'Dunning Too Frequent',
+    'problem.dunning-too-frequent.detail' => 'The minimum interval between dunning notices has not elapsed.',
+
+    'problem.credit-exceeds-remaining.title'  => 'Credit Exceeds Remaining Balance',
+    'problem.credit-exceeds-remaining.detail' => 'The requested amount exceeds the remaining credit balance.',
+
+    // -------------------------------------------------------------------------
+    // Dunning email — sent to clients (ADR 0005: Japanese clients; ja.php is
+    // the operative template; this entry is provided for completeness only)
+    // sprintf args: (invoice_number)
+    // -------------------------------------------------------------------------
+    'dunning_email.subject' => '[Reminder] Invoice %s is overdue',
+
+    // sprintf args: (contact_name, invoice_number, due_at, outstanding, due_at, outstanding)
+    'dunning_email.body' => "Dear %s,\n\n"
+        . "This is a reminder that invoice %s (due: %s) has an outstanding balance of \xC2\xA5%s (as of %s).\n\n"
+        . "Outstanding balance: \xC2\xA5%s\n\n"
+        . "Please arrange payment at your earliest convenience.\n\n"
+        . 'If you have already made payment, please disregard this notice.',
+
+];

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * 日本語メッセージカタログ — 全日本語ユーザー向け文言の唯一の管理ファイル。
+ * キー: 'problem.{slug}.title', 'problem.{slug}.detail', 'dunning_email.*'
+ * スラグは使用前に docs/explanation/terminology.md §4 に登録すること。
+ *
+ * @return array<string, string>
+ */
+return [
+
+    // -------------------------------------------------------------------------
+    // Problem Details — タイトルと詳細（APIエラーレスポンス）
+    // -------------------------------------------------------------------------
+
+    'problem.validation-failed.title'  => 'バリデーションエラー',
+    'problem.validation-failed.detail' => '入力内容にエラーがあります。',
+    'problem.validation-failed.csv-prefix' => 'CSVを解析できませんでした: ',
+
+    'problem.unauthorized.title'  => '認証エラー',
+    'problem.unauthorized.detail' => '認証されたユーザーが存在しません。',
+
+    'problem.invalid-credentials.title'  => '認証失敗',
+    'problem.invalid-credentials.detail' => 'メールアドレスまたはパスワードが正しくありません。',
+
+    'problem.insufficient-capability.title'  => '権限不足',
+    'problem.insufficient-capability.detail' => 'このアクションに必要な権限がありません。',
+
+    'problem.organization-not-found.title'  => '組織が見つかりません',
+    'problem.organization-not-found.detail' => '指定された組織は存在しません。',
+
+    'problem.organization-already-exists.title'  => '組織が既に存在します',
+    'problem.organization-already-exists.detail' => '同じスラッグの組織がすでに登録されています。',
+
+    'problem.user-not-found.title'  => 'ユーザーが見つかりません',
+    'problem.user-not-found.detail' => '指定されたユーザーは存在しません。',
+
+    'problem.user-already-exists.title'  => 'ユーザーが既に存在します',
+    'problem.user-already-exists.detail' => 'そのメールアドレスはすでに使用されています。',
+
+    'problem.bank-account-not-found.title'  => '銀行口座が見つかりません',
+    'problem.bank-account-not-found.detail' => '指定された銀行口座は存在しません。',
+
+    'problem.bank-import-batch-not-found.title'  => 'インポートバッチが見つかりません',
+    'problem.bank-import-batch-not-found.detail' => '指定されたインポートバッチは存在しません。',
+
+    'problem.bank-transaction-not-found.title'  => '銀行取引が見つかりません',
+    'problem.bank-transaction-not-found.detail' => '指定された銀行取引は存在しません。',
+
+    'problem.reconciliation-not-found.title'  => '消込が見つかりません',
+    'problem.reconciliation-not-found.detail' => '指定された消込は存在しません。',
+
+    'problem.client-credit-not-found.title'  => '前受金が見つかりません',
+    'problem.client-credit-not-found.detail' => '指定された前受金は存在しません。',
+
+    'problem.dunning-notice-not-found.title'  => '督促記録が見つかりません',
+    'problem.dunning-notice-not-found.detail' => '指定された督促記録は存在しません。',
+
+    // invalid-state-transition: 共通タイトル、コンテキスト別の詳細
+    'problem.invalid-state-transition.title'                          => '無効な状態変更',
+    'problem.invalid-state-transition.batch-reversed.detail'          => 'バッチはすでに取消済みです。',
+    'problem.invalid-state-transition.batch-has-matched.detail'       => '消込済みの取引が含まれているため、バッチを取り消せません。先に消込を解除してください。',
+    'problem.invalid-state-transition.tx-not-matchable.detail'        => 'この銀行取引は現在の状態では消込できません。',
+    'problem.invalid-state-transition.reconciliation-reversed.detail' => 'この消込はすでに取り消されています。',
+
+    'problem.duplicate-bank-import.title'  => 'インポート重複',
+    'problem.duplicate-bank-import.detail' => 'このファイルはすでにインポートされています。',
+
+    'problem.allocation-exceeds-outstanding.title'  => '消込金額超過',
+    'problem.allocation-exceeds-outstanding.detail' => '消込金額が請求書の未収残高を超えています。',
+
+    'problem.upstream-invoice-unavailable.title'  => '請求書サービス利用不可',
+    'problem.upstream-invoice-unavailable.detail' => '請求書APIに接続できません。消込の確定は一時的に停止しています。',
+
+    'problem.upstream-invoice-not-found.title'  => '請求書が見つかりません',
+    'problem.upstream-invoice-not-found.detail' => '上流サービスに指定の請求書が存在しません。',
+
+    'problem.upstream-client-not-found.title'  => '取引先が見つかりません',
+    'problem.upstream-client-not-found.detail' => '上流サービスに指定の取引先が存在しないか、削除されています。',
+
+    'problem.invoice-not-eligible-for-dunning.title'  => '督促対象外',
+    'problem.invoice-not-eligible-for-dunning.detail' => 'この請求書は支払済み、または残高がないため督促できません。',
+
+    'problem.dunning-too-frequent.title'  => '督促間隔未達',
+    'problem.dunning-too-frequent.detail' => '前回の督促から最短間隔が経過していません。',
+
+    'problem.credit-exceeds-remaining.title'  => '前受金残高超過',
+    'problem.credit-exceeds-remaining.detail' => '適用額が前受金の残高を超えています。',
+
+    // -------------------------------------------------------------------------
+    // ダニングメール — 取引先への督促通知
+    // ADR 0005: 取引先向けは常に日本語。このファイルが唯一の使用テンプレート。
+    // sprintf引数: (invoice_number)
+    // -------------------------------------------------------------------------
+    'dunning_email.subject' => '【お支払いのご案内】請求書 %s のご入金をお願いいたします',
+
+    // sprintf引数: (contact_name, invoice_number, due_at, outstanding, due_at, outstanding)
+    'dunning_email.body' => "%s 様\n\n"
+        . "平素より大変お世話になっております。\n\n"
+        . "請求書 %s（お支払期日：%s）について、¥%s のご入金がまだ確認できておりません（%s 現在）。\n\n"
+        . "未収残高：¥%s\n\n"
+        . "お手数ですが、お早めにお支払手続きをお願いいたします。\n\n"
+        . 'すでにお振込み済みの場合は、本メールへのご返信は不要です。',
+
+];

--- a/src/Auth/CapabilityMiddleware.php
+++ b/src/Auth/CapabilityMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Auth;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -32,7 +32,7 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
      * @param array<string, CapabilityRule> $prefixRules path prefix => required capabilities
      */
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
         private array $prefixRules,
     ) {
     }
@@ -54,13 +54,7 @@ final readonly class CapabilityMiddleware implements MiddlewareInterface
         $role = is_string($roleValue) ? Role::tryFrom($roleValue) : null;
 
         if ($role === null || !$role->has($required)) {
-            return $this->problemDetails->create(
-                $request,
-                'insufficient-capability',
-                'Insufficient Capability',
-                403,
-                'Your role lacks the capability required for this action.',
-            );
+            return $this->problemDetails->create($request, 'insufficient-capability', 403);
         }
 
         return $handler->handle($request);

--- a/src/Auth/GetCurrentUserHandler.php
+++ b/src/Auth/GetCurrentUserHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Auth;
 
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\User\UserRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -15,7 +15,7 @@ final readonly class GetCurrentUserHandler
     public function __construct(
         private UserRepositoryInterface $users,
         private JsonResponseFactory $response,
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -28,13 +28,7 @@ final readonly class GetCurrentUserHandler
         $user = $userId > 0 ? $this->users->findById($userId) : null;
 
         if ($user === null) {
-            return $this->problemDetails->create(
-                $request,
-                'unauthorized',
-                'Unauthorized',
-                401,
-                'The authenticated user no longer exists.',
-            );
+            return $this->problemDetails->create($request, 'unauthorized', 401);
         }
 
         return $this->response->create([

--- a/src/Auth/InvalidCredentialsExceptionHandler.php
+++ b/src/Auth/InvalidCredentialsExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Auth;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class InvalidCredentialsExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class InvalidCredentialsExceptionHandler implements DomainExcepti
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invalid-credentials',
-            'Invalid Credentials',
-            401,
-            'Email or password is incorrect.',
-        );
+        return $this->problemDetails->create($request, 'invalid-credentials', 401);
     }
 }

--- a/src/BankImport/BankAccountNotFoundExceptionHandler.php
+++ b/src/BankImport/BankAccountNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankAccountNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankAccountNotFoundExceptionHandler implements DomainExcept
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'bank-account-not-found',
-            'Bank Account Not Found',
-            404,
-            'The requested bank account was not found.',
-        );
+        return $this->problemDetails->create($request, 'bank-account-not-found', 404);
     }
 }

--- a/src/BankImport/BankImportBatchAlreadyReversedExceptionHandler.php
+++ b/src/BankImport/BankImportBatchAlreadyReversedExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankImportBatchAlreadyReversedExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankImportBatchAlreadyReversedExceptionHandler implements D
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invalid-state-transition',
-            'Invalid State Transition',
-            409,
-            'The batch is already reversed.',
-        );
+        return $this->problemDetails->create($request, 'invalid-state-transition', 409, 'problem.invalid-state-transition.batch-reversed.detail');
     }
 }

--- a/src/BankImport/BankImportBatchHasMatchedLinesExceptionHandler.php
+++ b/src/BankImport/BankImportBatchHasMatchedLinesExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankImportBatchHasMatchedLinesExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankImportBatchHasMatchedLinesExceptionHandler implements D
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invalid-state-transition',
-            'Invalid State Transition',
-            409,
-            'One or more transactions are already matched; unmatch them before reversing the batch.',
-        );
+        return $this->problemDetails->create($request, 'invalid-state-transition', 409, 'problem.invalid-state-transition.batch-has-matched.detail');
     }
 }

--- a/src/BankImport/BankImportBatchNotFoundExceptionHandler.php
+++ b/src/BankImport/BankImportBatchNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankImportBatchNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankImportBatchNotFoundExceptionHandler implements DomainEx
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'bank-import-batch-not-found',
-            'Bank Import Batch Not Found',
-            404,
-            'The requested bank import batch was not found.',
-        );
+        return $this->problemDetails->create($request, 'bank-import-batch-not-found', 404);
     }
 }

--- a/src/BankImport/BankTransactionNotFoundExceptionHandler.php
+++ b/src/BankImport/BankTransactionNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankTransactionNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankTransactionNotFoundExceptionHandler implements DomainEx
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'bank-transaction-not-found',
-            'Bank Transaction Not Found',
-            404,
-            'The requested bank transaction was not found.',
-        );
+        return $this->problemDetails->create($request, 'bank-transaction-not-found', 404);
     }
 }

--- a/src/BankImport/DuplicateBankImportExceptionHandler.php
+++ b/src/BankImport/DuplicateBankImportExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class DuplicateBankImportExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class DuplicateBankImportExceptionHandler implements DomainExcept
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'duplicate-bank-import',
-            'Duplicate Bank Import',
-            409,
-            'A batch with this file hash was already imported.',
-        );
+        return $this->problemDetails->create($request, 'duplicate-bank-import', 409);
     }
 }

--- a/src/BankImport/InvalidBankCsvExceptionHandler.php
+++ b/src/BankImport/InvalidBankCsvExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class InvalidBankCsvExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,7 @@ final readonly class InvalidBankCsvExceptionHandler implements DomainExceptionHa
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'validation-failed',
-            'Validation Failed',
-            422,
-            'The uploaded CSV could not be parsed: ' . $exception->getMessage(),
-        );
+        $prefix = $this->problemDetails->get($request, 'problem.validation-failed.csv-prefix');
+        return $this->problemDetails->createWithDetail($request, 'validation-failed', 422, $prefix . $exception->getMessage());
     }
 }

--- a/src/Dunning/DunningNoticeNotFoundExceptionHandler.php
+++ b/src/Dunning/DunningNoticeNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class DunningNoticeNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class DunningNoticeNotFoundExceptionHandler implements DomainExce
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'dunning-notice-not-found',
-            'Dunning Notice Not Found',
-            404,
-            'The requested dunning notice was not found.',
-        );
+        return $this->problemDetails->create($request, 'dunning-notice-not-found', 404);
     }
 }

--- a/src/Dunning/DunningTooFrequentExceptionHandler.php
+++ b/src/Dunning/DunningTooFrequentExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class DunningTooFrequentExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -29,10 +29,8 @@ final readonly class DunningTooFrequentExceptionHandler implements DomainExcepti
         return $this->problemDetails->create(
             $request,
             'dunning-too-frequent',
-            'Dunning Too Frequent',
             422,
-            'The minimum interval between dunning notices has not elapsed.',
-            ['next_allowed_at' => $exception->nextAllowedAt],
+            extensions: ['next_allowed_at' => $exception->nextAllowedAt],
         );
     }
 }

--- a/src/Dunning/InvoiceAlreadyPaidExceptionHandler.php
+++ b/src/Dunning/InvoiceAlreadyPaidExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class InvoiceAlreadyPaidExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class InvoiceAlreadyPaidExceptionHandler implements DomainExcepti
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invoice-not-eligible-for-dunning',
-            'Invoice Not Eligible for Dunning',
-            422,
-            'The invoice is already paid, voided, or has no outstanding balance.',
-        );
+        return $this->problemDetails->create($request, 'invoice-not-eligible-for-dunning', 422);
     }
 }

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -10,6 +10,8 @@ use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+use NeneClear\I18n\Locale;
+use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 
 final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
@@ -24,6 +26,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
         private DunningMailerInterface $mailer,
         private AuditEventRepositoryInterface $auditEvents,
         private ClockInterface $clock,
+        private MessageCatalog $catalog,
     ) {
     }
 
@@ -51,17 +54,18 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
         $client = $this->invoiceClient->getClient($input->organizationId, $invoice->clientId);
 
         $nowStr = $this->clock->now()->format('Y-m-d H:i:s');
-        $subject = sprintf('[Reminder] Invoice %s is overdue', $invoice->invoiceNumber);
+        $subject = sprintf(
+            $this->catalog->get('dunning_email.subject', Locale::Ja),
+            $invoice->invoiceNumber,
+        );
         $body = sprintf(
-            "Dear %s,\n\nThis is a reminder that invoice %s dated %s for ¥%s remains outstanding as of %s.\n\n"
-            . "Outstanding balance: ¥%s\n\nPlease arrange payment at your earliest convenience.\n\n"
-            . 'If you have already made payment, please disregard this notice.',
+            $this->catalog->get('dunning_email.body', Locale::Ja),
             $client->contactName,
             $invoice->invoiceNumber,
             $invoice->dueAt,
-            number_format($invoice->outstandingCents / 100),
+            number_format((int) ($invoice->outstandingCents / 100)),
             $invoice->dueAt,
-            number_format($invoice->outstandingCents / 100),
+            number_format((int) ($invoice->outstandingCents / 100)),
         );
 
         $notice = new DunningNotice(

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -8,6 +8,8 @@ use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\I18n\MessageCatalog;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
 use NeneClear\Audit\PdoAuditEventRepository;
@@ -149,7 +151,11 @@ final class ApplicationFactory
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
         $json = new JsonResponseFactory($psr17, $psr17);
-        $problemDetails = new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-clear.dev/problems/');
+        $rawProblemDetails = new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-clear.dev/problems/');
+        $problemDetails = new LocalizedProblemDetailsFactory(
+            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
+            $rawProblemDetails,
+        );
 
         $routeRegistrars = [];
         $domainExceptionHandlers = [];
@@ -256,13 +262,13 @@ final class ApplicationFactory
 
             $dunningNotices = new PdoDunningNoticeRepository($query);
             $routeRegistrars[] = new DunningRouteRegistrar(
-                new SendDunningHandler(new SendDunningUseCase($dunningNotices, $clearSettings, $upstream, $mailer, $audit, $clock), $dunningNotices, $json),
+                new SendDunningHandler(new SendDunningUseCase($dunningNotices, $clearSettings, $upstream, $mailer, $audit, $clock, new MessageCatalog(dirname(__DIR__, 2) . '/lang')), $dunningNotices, $json),
                 new ListDunningNoticesHandler($dunningNotices, $json),
                 new GetDunningNoticeByIdHandler($dunningNotices, $json),
             );
 
             $authMiddleware = [
-                new BearerTokenMiddleware($problemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
+                new BearerTokenMiddleware($rawProblemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
                 new CapabilityMiddleware($problemDetails, [
                     '/admin/organizations' => CapabilityRule::same(Capability::ManageOrganizations),
                     '/admin/users' => CapabilityRule::same(Capability::ManageUsers),

--- a/src/I18n/Locale.php
+++ b/src/I18n/Locale.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\I18n;
+
+enum Locale: string
+{
+    case Ja = 'ja';
+    case En = 'en';
+}

--- a/src/I18n/LocalizedProblemDetailsFactory.php
+++ b/src/I18n/LocalizedProblemDetailsFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\I18n;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Locale-aware wrapper around ProblemDetailsResponseFactory.
+ *
+ * Resolves locale from the Accept-Language header (Japanese is the default per
+ * ADR 0005) and looks up title/detail from the MessageCatalog by slug.
+ *
+ * Usage in exception handlers:
+ *   $this->problemDetails->create($request, 'bank-account-not-found', 404)
+ *
+ * For handlers sharing a type slug but needing different detail text:
+ *   $this->problemDetails->create($request, 'invalid-state-transition', 409, 'problem.invalid-state-transition.batch-reversed.detail')
+ *
+ * For dynamic detail content (e.g. CSV parse errors):
+ *   $this->problemDetails->createWithDetail($request, 'validation-failed', 422, $detail)
+ *
+ * To read a translated string directly (for building dynamic details):
+ *   $this->problemDetails->get($request, 'problem.validation-failed.csv-prefix')
+ */
+final readonly class LocalizedProblemDetailsFactory
+{
+    public function __construct(
+        private MessageCatalog $catalog,
+        private ProblemDetailsResponseFactory $inner,
+    ) {
+    }
+
+    /**
+     * @param string               $detailKey  Catalog key for the detail string.
+     *                                          Empty string → 'problem.{slug}.detail' is used.
+     * @param array<string, mixed> $extensions RFC 9457 extension members (e.g. invoice_id, outstanding_cents).
+     */
+    public function create(
+        ServerRequestInterface $request,
+        string $slug,
+        int $statusCode,
+        string $detailKey = '',
+        array $extensions = [],
+    ): ResponseInterface {
+        $locale = $this->resolveLocale($request);
+        $title = $this->catalog->get("problem.{$slug}.title", $locale);
+        $key = $detailKey !== '' ? $detailKey : "problem.{$slug}.detail";
+        $detail = $this->catalog->get($key, $locale);
+
+        return $this->inner->create($request, $slug, $title, $statusCode, $detail, $extensions);
+    }
+
+    /**
+     * Title from catalog, detail provided directly (use for dynamic content).
+     *
+     * @param array<string, mixed> $extensions RFC 9457 extension members.
+     */
+    public function createWithDetail(
+        ServerRequestInterface $request,
+        string $slug,
+        int $statusCode,
+        string $detail,
+        array $extensions = [],
+    ): ResponseInterface {
+        $locale = $this->resolveLocale($request);
+        $title = $this->catalog->get("problem.{$slug}.title", $locale);
+
+        return $this->inner->create($request, $slug, $title, $statusCode, $detail, $extensions);
+    }
+
+    /**
+     * Returns a translated string for the given catalog key (use to build dynamic detail).
+     */
+    public function get(ServerRequestInterface $request, string $key): string
+    {
+        return $this->catalog->get($key, $this->resolveLocale($request));
+    }
+
+    private function resolveLocale(ServerRequestInterface $request): Locale
+    {
+        $raw = strtolower(trim($request->getHeaderLine('Accept-Language')));
+
+        if ($raw === '') {
+            return Locale::Ja;
+        }
+
+        // Parse quality values: prefer 'en' only when its q-value exceeds 'ja'
+        preg_match_all('/([a-z]{2})(?:[a-z-]*)(?:;q=([0-9.]+))?/', $raw, $m, PREG_SET_ORDER);
+
+        $qJa = 0.0;
+        $qEn = 0.0;
+
+        foreach ($m as $match) {
+            $lang = $match[1];
+            $q = $match[2] ?? '';
+            $quality = ($q !== '') ? (float) $q : 1.0;
+            if ($lang === 'ja') {
+                $qJa = max($qJa, $quality);
+            } elseif ($lang === 'en') {
+                $qEn = max($qEn, $quality);
+            }
+        }
+
+        // Japanese is default; switch to English only when explicitly preferred
+        if ($qEn > 0.0 && $qEn > $qJa) {
+            return Locale::En;
+        }
+
+        return Locale::Ja;
+    }
+}

--- a/src/I18n/MessageCatalog.php
+++ b/src/I18n/MessageCatalog.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\I18n;
+
+final class MessageCatalog
+{
+    /** @var array<string, array<string, string>> */
+    private array $loaded = [];
+
+    public function __construct(private readonly string $langDir)
+    {
+    }
+
+    public function get(string $key, Locale $locale): string
+    {
+        $messages = $this->load($locale);
+
+        return $messages[$key] ?? $key;
+    }
+
+    /** @return array<string, string> */
+    private function load(Locale $locale): array
+    {
+        if (!isset($this->loaded[$locale->value])) {
+            $file = $this->langDir . '/' . $locale->value . '.php';
+            $this->loaded[$locale->value] = is_file($file) ? (array) require $file : [];
+        }
+
+        return $this->loaded[$locale->value];
+    }
+}

--- a/src/InvoiceUpstream/UpstreamInvoiceUnavailableExceptionHandler.php
+++ b/src/InvoiceUpstream/UpstreamInvoiceUnavailableExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\InvoiceUpstream;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class UpstreamInvoiceUnavailableExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class UpstreamInvoiceUnavailableExceptionHandler implements Domai
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'upstream-invoice-unavailable',
-            'Invoice Upstream Unavailable',
-            503,
-            'The Invoice API is unreachable; match confirmation is blocked.',
-        );
+        return $this->problemDetails->create($request, 'upstream-invoice-unavailable', 503);
     }
 }

--- a/src/Organization/OrganizationAlreadyExistsExceptionHandler.php
+++ b/src/Organization/OrganizationAlreadyExistsExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Organization;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class OrganizationAlreadyExistsExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class OrganizationAlreadyExistsExceptionHandler implements Domain
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'organization-already-exists',
-            'Organization Already Exists',
-            409,
-            'An organization with that slug already exists.',
-        );
+        return $this->problemDetails->create($request, 'organization-already-exists', 409);
     }
 }

--- a/src/Organization/OrganizationNotFoundExceptionHandler.php
+++ b/src/Organization/OrganizationNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Organization;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class OrganizationNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class OrganizationNotFoundExceptionHandler implements DomainExcep
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'organization-not-found',
-            'Organization Not Found',
-            404,
-            'The requested organization was not found.',
-        );
+        return $this->problemDetails->create($request, 'organization-not-found', 404);
     }
 }

--- a/src/Reconciliation/AllocationExceedsOutstandingExceptionHandler.php
+++ b/src/Reconciliation/AllocationExceedsOutstandingExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class AllocationExceedsOutstandingExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -29,10 +29,8 @@ final readonly class AllocationExceedsOutstandingExceptionHandler implements Dom
         return $this->problemDetails->create(
             $request,
             'allocation-exceeds-outstanding',
-            'Allocation Exceeds Outstanding',
             422,
-            'The allocation amount exceeds the invoice outstanding balance.',
-            [
+            extensions: [
                 'invoice_id' => $exception->invoiceId,
                 'outstanding_cents' => $exception->outstandingCents,
             ],

--- a/src/Reconciliation/BankTransactionNotMatchableExceptionHandler.php
+++ b/src/Reconciliation/BankTransactionNotMatchableExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class BankTransactionNotMatchableExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class BankTransactionNotMatchableExceptionHandler implements Doma
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invalid-state-transition',
-            'Invalid State Transition',
-            409,
-            'The bank transaction cannot be matched in its current status.',
-        );
+        return $this->problemDetails->create($request, 'invalid-state-transition', 409, 'problem.invalid-state-transition.tx-not-matchable.detail');
     }
 }

--- a/src/Reconciliation/ClientCreditNotFoundExceptionHandler.php
+++ b/src/Reconciliation/ClientCreditNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class ClientCreditNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class ClientCreditNotFoundExceptionHandler implements DomainExcep
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'client-credit-not-found',
-            'Client Credit Not Found',
-            404,
-            'The requested client credit was not found.',
-        );
+        return $this->problemDetails->create($request, 'client-credit-not-found', 404);
     }
 }

--- a/src/Reconciliation/CreditExceedsRemainingExceptionHandler.php
+++ b/src/Reconciliation/CreditExceedsRemainingExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class CreditExceedsRemainingExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -26,13 +26,6 @@ final readonly class CreditExceedsRemainingExceptionHandler implements DomainExc
     {
         assert($exception instanceof CreditExceedsRemainingException);
 
-        return $this->problemDetails->create(
-            $request,
-            'credit-exceeds-remaining',
-            'Credit Exceeds Remaining Balance',
-            422,
-            'The requested amount exceeds the remaining credit balance.',
-            ['remaining_cents' => $exception->remainingCents],
-        );
+        return $this->problemDetails->create($request, 'credit-exceeds-remaining', 422);
     }
 }

--- a/src/Reconciliation/ReconciliationAlreadyReversedExceptionHandler.php
+++ b/src/Reconciliation/ReconciliationAlreadyReversedExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class ReconciliationAlreadyReversedExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class ReconciliationAlreadyReversedExceptionHandler implements Do
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'invalid-state-transition',
-            'Invalid State Transition',
-            409,
-            'This reconciliation is already reversed.',
-        );
+        return $this->problemDetails->create($request, 'invalid-state-transition', 409, 'problem.invalid-state-transition.reconciliation-reversed.detail');
     }
 }

--- a/src/Reconciliation/ReconciliationNotFoundExceptionHandler.php
+++ b/src/Reconciliation/ReconciliationNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class ReconciliationNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class ReconciliationNotFoundExceptionHandler implements DomainExc
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'reconciliation-not-found',
-            'Reconciliation Not Found',
-            404,
-            'The requested reconciliation was not found.',
-        );
+        return $this->problemDetails->create($request, 'reconciliation-not-found', 404);
     }
 }

--- a/src/User/UserAlreadyExistsExceptionHandler.php
+++ b/src/User/UserAlreadyExistsExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\User;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class UserAlreadyExistsExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class UserAlreadyExistsExceptionHandler implements DomainExceptio
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'user-already-exists',
-            'User Already Exists',
-            409,
-            'A user with that email already exists.',
-        );
+        return $this->problemDetails->create($request, 'user-already-exists', 409);
     }
 }

--- a/src/User/UserNotFoundExceptionHandler.php
+++ b/src/User/UserNotFoundExceptionHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\User;
 
 use Nene2\Error\DomainExceptionHandlerInterface;
-use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -13,7 +13,7 @@ use Throwable;
 final readonly class UserNotFoundExceptionHandler implements DomainExceptionHandlerInterface
 {
     public function __construct(
-        private ProblemDetailsResponseFactory $problemDetails,
+        private LocalizedProblemDetailsFactory $problemDetails,
     ) {
     }
 
@@ -24,12 +24,6 @@ final readonly class UserNotFoundExceptionHandler implements DomainExceptionHand
 
     public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
     {
-        return $this->problemDetails->create(
-            $request,
-            'user-not-found',
-            'User Not Found',
-            404,
-            'The requested user was not found.',
-        );
+        return $this->problemDetails->create($request, 'user-not-found', 404);
     }
 }

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -14,6 +14,7 @@ use NeneClear\InvoiceUpstream\InvoiceClientInfo;
 use NeneClear\InvoiceUpstream\InvoiceItem;
 use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundException;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\I18n\MessageCatalog;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -40,6 +41,7 @@ final class SendDunningUseCaseTest extends TestCase
             $this->mailer,
             $this->audit,
             new FixedClock('2026-05-31T09:00:00+00:00'),
+            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
         );
     }
 


### PR DESCRIPTION
## Summary

- **`lang/ja.php` と `lang/en.php`** を唯一の文言管理ファイルとして新設。全ユーザー向け文字列はここに集約。
- **`Accept-Language` ヘッダー**から locale を自動解決（RFC 7231 q-value 対応）。デフォルトは `ja`（ADR 0005）。
- 全 **22 ExceptionHandler + CapabilityMiddleware + GetCurrentUserHandler** を `LocalizedProblemDetailsFactory` に切り替え。各コードから英語文字列のハードコードを撤去。
- **ダニングメール** を `lang/ja.php` テンプレートへ移行（ADR 0005: 取引先向けは常に日本語）。

## 変更ファイル

| 種別 | ファイル |
|---|---|
| 新規 | `lang/ja.php`, `lang/en.php` |
| 新規 | `src/I18n/Locale.php`, `MessageCatalog.php`, `LocalizedProblemDetailsFactory.php` |
| 更新 | 22 ExceptionHandlers, `CapabilityMiddleware`, `GetCurrentUserHandler` |
| 更新 | `SendDunningUseCase` — catalog 経由でメールテンプレート取得 |
| 更新 | `ApplicationFactory` — wiring |
| 更新 | `tests/Dunning/SendDunningUseCaseTest` — MessageCatalog を注入 |

## 言語切り替えの仕組み

```
Accept-Language: en     →  English responses
Accept-Language: ja     →  Japanese responses (default)
Accept-Language: (none) →  Japanese responses (default)
```

ダニングメールは `Locale::Ja` 固定（ADR 0005: 日本語クライアント向け）。

## Test plan

- [ ] `composer test` — 126 tests / 5 skipped / 473 assertions
- [ ] `composer analyse` — PHPStan level 8 clean
- [ ] `Accept-Language: en` リクエストで英語エラーレスポンスを確認
- [ ] `Accept-Language: ja` (または未指定) で日本語エラーレスポンスを確認
- [ ] ダニング送信でメールログに日本語件名が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)