### PR TITLE
fix: add before/after snapshots to all audit event payloads

### DIFF
--- a/src/BankImport/ImportBankCsvUseCase.php
+++ b/src/BankImport/ImportBankCsvUseCase.php
@@ -67,10 +67,12 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
             actorUserId: $input->actorUserId,
             occurredAt: $now,
             payload: [
-                'bank_import_batch_id' => $batchId,
-                'file_hash' => $fileHash,
-                'row_count' => count($lines),
-                'source_filename' => $input->sourceFilename,
+                'after' => [
+                    'bank_import_batch_id' => $batchId,
+                    'file_hash' => $fileHash,
+                    'row_count' => count($lines),
+                    'source_filename' => $input->sourceFilename,
+                ],
             ],
         ));
 

--- a/src/BankImport/ReverseBankImportBatchUseCase.php
+++ b/src/BankImport/ReverseBankImportBatchUseCase.php
@@ -55,8 +55,15 @@ final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportB
             occurredAt: $now,
             payload: [
                 'bank_import_batch_id' => $input->batchId,
-                'reversal_reason' => $input->reversalReason,
-                'rows_voided' => $unmatchedCount,
+                'before' => [
+                    'status' => 'imported',
+                    'row_count' => count($lines),
+                ],
+                'after' => [
+                    'status' => 'reversed',
+                    'reversal_reason' => $input->reversalReason,
+                    'rows_voided' => $unmatchedCount,
+                ],
             ],
         ));
 

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -96,10 +96,17 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             payload: [
                 'dunning_notice_id' => $noticeId,
                 'invoice_id' => $input->invoiceId,
-                'invoice_number' => $invoice->invoiceNumber,
-                'recipient_email' => $client->recipientEmail,
-                'outstanding_cents' => $invoice->outstandingCents,
-                'channel' => self::CHANNEL,
+                'before' => [
+                    'invoice_status' => $invoice->status,
+                    'invoice_outstanding_cents' => $invoice->outstandingCents,
+                    'previous_dunning_sent_at' => $lastNotice?->sentAt,
+                ],
+                'after' => [
+                    'invoice_number' => $invoice->invoiceNumber,
+                    'recipient_email' => $client->recipientEmail,
+                    'outstanding_at_send_cents' => $invoice->outstandingCents,
+                    'channel' => self::CHANNEL,
+                ],
             ],
         ));
 

--- a/src/Reconciliation/ApplyCreditUseCase.php
+++ b/src/Reconciliation/ApplyCreditUseCase.php
@@ -56,7 +56,14 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
                 'client_credit_id' => $input->creditId,
                 'invoice_id' => $input->invoiceId,
                 'amount_cents' => $input->amountCents,
-                'remaining_cents' => $updated->remainingCents,
+                'before' => [
+                    'remaining_cents' => $credit->remainingCents,
+                    'status' => $credit->status->value,
+                ],
+                'after' => [
+                    'remaining_cents' => $updated->remainingCents,
+                    'status' => $updated->status->value,
+                ],
             ],
         ));
 

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -59,7 +59,12 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 idempotencyKey: $idempotencyKey,
             );
 
-            $paymentsCreated[] = ['allocation' => $allocation, 'payment' => $payment, 'externalRef' => $externalRef];
+            $paymentsCreated[] = [
+                'allocation' => $allocation,
+                'payment' => $payment,
+                'externalRef' => $externalRef,
+                'invoiceOutstandingBefore' => $invoice->outstandingCents,
+            ];
         }
 
         $reconciliationId = $this->reconciliations->save(new Reconciliation(
@@ -114,10 +119,31 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
             actorUserId: $input->actorUserId,
             occurredAt: $now,
             payload: [
-                'payment_reconciliation_id' => $reconciliationId,
-                'bank_transaction_id' => $input->bankTransactionId,
-                'total_allocated_cents' => $totalAllocated,
-                'remainder_cents' => $remainder,
+                'before' => [
+                    'bank_transaction_status' => $tx->status->value,
+                    'bank_transaction_amount_cents' => $tx->amountCents,
+                    'allocations' => array_map(
+                        static fn (array $e): array => [
+                            'invoice_id' => $e['allocation']->invoiceId,
+                            'invoice_outstanding_cents' => $e['invoiceOutstandingBefore'],
+                        ],
+                        $paymentsCreated,
+                    ),
+                ],
+                'after' => [
+                    'payment_reconciliation_id' => $reconciliationId,
+                    'bank_transaction_status' => $newStatus->value,
+                    'total_allocated_cents' => $totalAllocated,
+                    'remainder_cents' => $remainder,
+                    'allocations' => array_map(
+                        static fn (array $e): array => [
+                            'invoice_id' => $e['allocation']->invoiceId,
+                            'amount_cents' => $e['allocation']->amountCents,
+                            'payment_id' => $e['payment']->paymentId,
+                        ],
+                        $paymentsCreated,
+                    ),
+                ],
             ],
         ));
 

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -62,8 +62,24 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
             occurredAt: $now,
             payload: [
                 'payment_reconciliation_id' => $input->reconciliationId,
-                'bank_transaction_id' => $reconciliation->bankTransactionId,
-                'reversal_reason' => $input->reversalReason,
+                'before' => [
+                    'status' => 'confirmed',
+                    'bank_transaction_id' => $reconciliation->bankTransactionId,
+                    'confirmed_at' => $reconciliation->confirmedAt,
+                    'allocations' => array_map(
+                        static fn (ReconciliationAllocation $a): array => [
+                            'invoice_id' => $a->invoiceId,
+                            'amount_cents' => $a->amountCents,
+                            'payment_id' => $a->paymentId,
+                        ],
+                        $allocations,
+                    ),
+                ],
+                'after' => [
+                    'status' => 'reversed',
+                    'bank_transaction_status' => 'unmatched',
+                    'reversal_reason' => $input->reversalReason,
+                ],
             ],
         ));
 


### PR DESCRIPTION
## 背景

「全ての操作に関してユーザーが何をどう変えたか・変更前後を記録」という要件に対し、audit_events の payload_json に `before`/`after` サブオブジェクトが存在しなかった。nene-records の `entity_revisions` テーブル（`previous_status`, `previous_slug` カラム）と同等のパターンをClear側に実装。

## 変更内容

スキーマ変更なし — 既存の `payload_json` TEXT カラムに新キーを追加するのみ。既存レコードとの後方互換性あり。

| UseCase | event_type | before | after |
|---|---|---|---|
| ImportBankCsvUseCase | `bank_import` | なし（新規作成） | batch_id, file_hash, row_count, source_filename |
| ReverseBankImportBatchUseCase | `bank_import_batch_reversed` | status=imported, row_count | status=reversed, reversal_reason, rows_voided |
| ConfirmMatchUseCase | `reconciliation_confirmed` | 銀行取引ステータス・金額、請求書別未収残高 | 消込ID・新ステータス・配賦明細（payment_id含む） |
| ReverseReconciliationUseCase | `reconciliation_reversed` | 確認済み消込・配賦明細・確認日時 | 取消済み・取消理由 |
| ApplyCreditUseCase | `client_credit_applied` | remaining_cents, status（適用前） | remaining_cents, status（適用後） |
| SendDunningUseCase | `dunning_sent` | invoice_status, outstanding, 前回督促日時 | 通知先・invoice_number・督促時残高 |

## nene-records 参照結果

- `entity_revisions` テーブルの `previous_status`/`previous_slug` パターンを参考に `before`/`after` 構造を採用
- `RequestScopedHolder` によるテナントID伝播 vs nene-clear の明示的パラメータ渡し → どちらも有効。nene-clear 方式はPHPStan親和性が高く変更不要と判断

## Test plan

- [ ] `composer test` — 126 tests / 5 skipped / 473 assertions
- [ ] `composer analyse` — PHPStan level 8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)