### PR TITLE
fix: SMTP credentials via EsmtpTransport instead of DSN string (closes #67)

### DIFF
--- a/src/Dunning/SmtpDunningMailer.php
+++ b/src/Dunning/SmtpDunningMailer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Symfony\Component\Mailer\Mailer;
-use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 
@@ -19,11 +19,17 @@ final class SmtpDunningMailer implements DunningMailerInterface
         private readonly string $fromAddress,
         private readonly string $fromName,
         string $username = '',
-        string $password = '',
+        #[\SensitiveParameter] string $password = '',
     ) {
-        $userInfo = $username !== '' ? sprintf('%s:%s@', urlencode($username), urlencode($password)) : '';
-        $dsn = sprintf('smtp://%s%s:%d', $userInfo, $smtpHost, $smtpPort);
-        $this->mailer = new Mailer(Transport::fromDsn($dsn));
+        // Credentials are passed directly to EsmtpTransport instead of embedding
+        // them in a DSN string, which prevents accidental credential exposure in
+        // exception messages or logs if the SMTP connection fails.
+        $transport = new EsmtpTransport($smtpHost, $smtpPort);
+        if ($username !== '') {
+            $transport->setUsername($username);
+            $transport->setPassword($password);
+        }
+        $this->mailer = new Mailer($transport);
     }
 
     public function send(DunningMailPayload $payload): void


### PR DESCRIPTION
DSN URI に認証情報を埋め込む方式を廃止。EsmtpTransport::setUsername/setPassword を使って DSN から分離。接続失敗時の例外メッセージに認証情報が露出しない。#[SensitiveParameter] を password に付与。