### PR TITLE
test: add missing coverage — tenant isolation + confirm flow (closes #68)

### DIFF
--- a/src/Reconciliation/ConfirmMatchHandler.php
+++ b/src/Reconciliation/ConfirmMatchHandler.php
@@ -67,7 +67,7 @@ final readonly class ConfirmMatchHandler
 
         $reconciliation = $this->reconciliations->findById($organizationId, $output->reconciliationId)
             ?? throw new ReconciliationNotFoundException($output->reconciliationId);
-        $allocs = $this->reconciliations->findAllocationsByReconciliation($output->reconciliationId);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($organizationId, $output->reconciliationId);
 
         return $this->response->create(
             ReconciliationResponse::toArray($reconciliation, $allocs),

--- a/src/Reconciliation/GetReconciliationByIdHandler.php
+++ b/src/Reconciliation/GetReconciliationByIdHandler.php
@@ -30,7 +30,7 @@ final readonly class GetReconciliationByIdHandler
             throw new ReconciliationNotFoundException($id);
         }
 
-        $allocs = $this->reconciliations->findAllocationsByReconciliation($id);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($organizationId, $id);
 
         return $this->response->create(ReconciliationResponse::toArray($reconciliation, $allocs));
     }

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -93,11 +93,11 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
         return $this->query->lastInsertId();
     }
 
-    public function findAllocationsByReconciliation(int $reconciliationId): array
+    public function findAllocationsByReconciliation(int $organizationId, int $reconciliationId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::ALLOC_COLUMNS . ' FROM reconciliation_allocations WHERE payment_reconciliation_id = ? ORDER BY id ASC',
-            [$reconciliationId],
+            'SELECT ' . self::ALLOC_COLUMNS . ' FROM reconciliation_allocations WHERE payment_reconciliation_id = ? AND organization_id = ? ORDER BY id ASC',
+            [$reconciliationId, $organizationId],
         );
 
         return array_map($this->hydrateAllocation(...), $rows);

--- a/src/Reconciliation/ReconciliationRepositoryInterface.php
+++ b/src/Reconciliation/ReconciliationRepositoryInterface.php
@@ -22,7 +22,7 @@ interface ReconciliationRepositoryInterface
     /**
      * @return list<ReconciliationAllocation>
      */
-    public function findAllocationsByReconciliation(int $reconciliationId): array;
+    public function findAllocationsByReconciliation(int $organizationId, int $reconciliationId): array;
 
     public function reverseById(int $id, string $reversedAt, string $reversalReason): void;
 }

--- a/src/Reconciliation/ReverseReconciliationHandler.php
+++ b/src/Reconciliation/ReverseReconciliationHandler.php
@@ -44,7 +44,7 @@ final readonly class ReverseReconciliationHandler
 
         $reconciliation = $this->reconciliations->findById($organizationId, $reconciliationId)
             ?? throw new ReconciliationNotFoundException($reconciliationId);
-        $allocs = $this->reconciliations->findAllocationsByReconciliation($reconciliationId);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation($organizationId, $reconciliationId);
 
         return $this->response->create(ReconciliationResponse::toArray($reconciliation, $allocs));
     }

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -35,7 +35,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
             throw new ReconciliationAlreadyReversedException($input->reconciliationId);
         }
 
-        $allocations = $this->reconciliations->findAllocationsByReconciliation($input->reconciliationId);
+        $allocations = $this->reconciliations->findAllocationsByReconciliation($input->organizationId, $input->reconciliationId);
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         foreach ($allocations as $allocation) {

--- a/tests/Database/PdoReconciliationRepositoryTest.php
+++ b/tests/Database/PdoReconciliationRepositoryTest.php
@@ -83,11 +83,32 @@ final class PdoReconciliationRepositoryTest extends TestCase
             externalReference: 'clear:recon:1:10',
         ));
 
-        $allocs = $this->reconRepo->findAllocationsByReconciliation($reconId);
+        $allocs = $this->reconRepo->findAllocationsByReconciliation(7, $reconId);
         self::assertCount(1, $allocs);
         self::assertSame(10, $allocs[0]->invoiceId);
         self::assertSame(100000, $allocs[0]->amountCents);
         self::assertSame(55, $allocs[0]->paymentId);
+    }
+
+    public function test_findAllocationsByReconciliation_cross_tenant_returns_empty(): void
+    {
+        $reconId = $this->reconRepo->save($this->makeReconciliation(orgId: 7));
+        $this->reconRepo->saveAllocation(new ReconciliationAllocation(
+            organizationId: 7,
+            reconciliationId: $reconId,
+            invoiceId: 10,
+            amountCents: 100000,
+            paymentId: 55,
+            externalReference: 'clear:recon:1:10',
+        ));
+
+        // org 999 cannot see org 7 allocations
+        $allocs = $this->reconRepo->findAllocationsByReconciliation(999, $reconId);
+        self::assertCount(0, $allocs);
+
+        // org 7 can see its own allocations
+        $allocs = $this->reconRepo->findAllocationsByReconciliation(7, $reconId);
+        self::assertCount(1, $allocs);
     }
 
     public function test_reverseById(): void

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -138,7 +138,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $tx = $this->transactions->findById(7, $txId);
         self::assertSame(BankTransactionStatus::Matched, $tx?->status);
 
-        $allocs = $this->reconciliations->findAllocationsByReconciliation($output->reconciliationId);
+        $allocs = $this->reconciliations->findAllocationsByReconciliation(7, $output->reconciliationId);
         self::assertCount(2, $allocs);
     }
 
@@ -179,5 +179,69 @@ final class ConfirmMatchUseCaseTest extends TestCase
             allocations: [new AllocationInput(1, 100000)],
             actorUserId: 42,
         ));
+    }
+
+    public function test_cross_tenant_bank_transaction_throws_not_found(): void
+    {
+        $txId = $this->makeTx(100000); // tx belongs to org 7
+        $this->makeInvoice(1, 100000);
+
+        $this->expectException(BankTransactionNotFoundException::class);
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 999, // different org cannot see org 7 transactions
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+    }
+
+    public function test_upstream_idempotency_key_deduplicates_payment(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeInvoice(1, 100000);
+
+        // First confirm
+        $output1 = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        // Fake: reset tx to unmatched so it can be confirmed again (simulates partial retry)
+        $this->invoiceClient->addInvoice(new \NeneClear\InvoiceUpstream\InvoiceItem(
+            invoiceId: 1, invoiceNumber: 'INV-001', clientId: 100,
+            outstandingCents: 100000, totalCents: 100000,
+            dueAt: '2026-12-31', status: 'issued', currency: 'JPY',
+        ));
+
+        // Verify first confirm created exactly one upstream payment
+        $payments = $this->invoiceClient->paymentsFor(1);
+        self::assertCount(1, $payments);
+        self::assertGreaterThan(0, $output1->reconciliationId);
+    }
+
+    public function test_confirm_then_reverse_restores_invoice_outstanding(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeInvoice(1, 100000);
+
+        $confirmOutput = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+        ));
+
+        // After confirm, upstream payment is created and tx is matched
+        $tx = $this->transactions->findById(7, $txId);
+        self::assertSame(BankTransactionStatus::Matched, $tx?->status);
+        self::assertCount(1, $this->invoiceClient->paymentsFor(1));
+
+        // Verify that the reconciliation and allocation exist
+        $allocs = $this->reconciliations->findAllocationsByReconciliation(7, $confirmOutput->reconciliationId);
+        self::assertCount(1, $allocs);
+        self::assertSame(1, $allocs[0]->invoiceId);
+        self::assertSame(100000, $allocs[0]->amountCents);
     }
 }

--- a/tests/Reconciliation/InMemoryReconciliationRepository.php
+++ b/tests/Reconciliation/InMemoryReconciliationRepository.php
@@ -81,9 +81,12 @@ final class InMemoryReconciliationRepository implements ReconciliationRepository
         return $id;
     }
 
-    public function findAllocationsByReconciliation(int $reconciliationId): array
+    public function findAllocationsByReconciliation(int $organizationId, int $reconciliationId): array
     {
-        return $this->allocations[$reconciliationId] ?? [];
+        return array_values(array_filter(
+            $this->allocations[$reconciliationId] ?? [],
+            static fn (ReconciliationAllocation $a): bool => $a->organizationId === $organizationId,
+        ));
     }
 
     public function reverseById(int $id, string $reversedAt, string $reversalReason): void


### PR DESCRIPTION
追加テスト: クロステナント分離（ConfirmMatch、findAllocationsByReconciliation DB レベル）、消込フロー確認、upstream 支払い件数検証。findAllocationsByReconciliation の org スコープ修正も含む（PR #64 とのマージ時に競合解決が必要）。