### PR TITLE
fix: confirm-reconciliation idempotency via Idempotency-Key header (closes #69)

### DIFF
--- a/database/migrations/20260531300000_add_idempotency_key_to_payment_reconciliations.php
+++ b/database/migrations/20260531300000_add_idempotency_key_to_payment_reconciliations.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddIdempotencyKeyToPaymentReconciliations extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('payment_reconciliations')
+            ->addColumn('idempotency_key', 'string', [
+                'limit' => 128,
+                'null' => true,
+                'default' => null,
+                'after' => 'organization_id',
+            ])
+            ->addIndex(['organization_id', 'idempotency_key'], ['unique' => true, 'name' => 'uq_recon_org_idempotency_key'])
+            ->update();
+    }
+}

--- a/src/Reconciliation/ConfirmMatchHandler.php
+++ b/src/Reconciliation/ConfirmMatchHandler.php
@@ -57,22 +57,26 @@ final readonly class ConfirmMatchHandler
         $reasonCode = isset($body['reason_code']) && is_string($body['reason_code']) ? $body['reason_code'] : null;
         $organizationId = AuthContext::organizationId($request) ?? 0;
 
+        $idempotencyKey = $request->getHeaderLine('Idempotency-Key');
+        $idempotencyKey = $idempotencyKey !== '' ? $idempotencyKey : null;
+
         $output = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: $organizationId,
             bankTransactionId: $bankTransactionId,
             allocations: $allocations,
             actorUserId: AuthContext::userId($request),
             reasonCode: $reasonCode,
+            idempotencyKey: $idempotencyKey,
         ));
 
         $reconciliation = $this->reconciliations->findById($organizationId, $output->reconciliationId)
             ?? throw new ReconciliationNotFoundException($output->reconciliationId);
         $allocs = $this->reconciliations->findAllocationsByReconciliation($output->reconciliationId);
 
-        return $this->response->create(
-            ReconciliationResponse::toArray($reconciliation, $allocs),
-            201,
-            ['Location' => '/admin/reconciliations/' . $output->reconciliationId],
-        );
+        // 200 when returning a previously created reconciliation (idempotency replay), 201 for new creation.
+        $statusCode = $output->idempotentReplay ? 200 : 201;
+        $headers = $statusCode === 201 ? ['Location' => '/admin/reconciliations/' . $output->reconciliationId] : [];
+
+        return $this->response->create(ReconciliationResponse::toArray($reconciliation, $allocs), $statusCode, $headers);
     }
 }

--- a/src/Reconciliation/ConfirmMatchInput.php
+++ b/src/Reconciliation/ConfirmMatchInput.php
@@ -15,6 +15,7 @@ final readonly class ConfirmMatchInput
         public array $allocations,
         public int $actorUserId,
         public ?string $reasonCode = null,
+        public ?string $idempotencyKey = null,
     ) {
     }
 }

--- a/src/Reconciliation/ConfirmMatchOutput.php
+++ b/src/Reconciliation/ConfirmMatchOutput.php
@@ -8,6 +8,7 @@ final readonly class ConfirmMatchOutput
 {
     public function __construct(
         public int $reconciliationId,
+        public bool $idempotentReplay = false,
     ) {
     }
 }

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -26,6 +26,15 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
 
     public function execute(ConfirmMatchInput $input): ConfirmMatchOutput
     {
+        // Idempotency: if a key was provided and a reconciliation with that key already
+        // exists for this organization, return it without re-processing.
+        if ($input->idempotencyKey !== null) {
+            $existing = $this->reconciliations->findByIdempotencyKey($input->organizationId, $input->idempotencyKey);
+            if ($existing !== null && $existing->id !== null) {
+                return new ConfirmMatchOutput(reconciliationId: $existing->id, idempotentReplay: true);
+            }
+        }
+
         $tx = $this->transactions->findById($input->organizationId, $input->bankTransactionId);
 
         if ($tx === null) {
@@ -69,6 +78,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
             confirmedBy: $input->actorUserId,
             confirmedAt: $now,
             reasonCode: $input->reasonCode,
+            idempotencyKey: $input->idempotencyKey,
         ));
 
         $totalAllocated = 0;

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -9,7 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 final readonly class PdoReconciliationRepository implements ReconciliationRepositoryInterface
 {
     private const string RECON_COLUMNS = 'id, organization_id, bank_transaction_id, status, reason_code, '
-        . 'confirmed_by, confirmed_at, reversed_at, reversal_reason';
+        . 'confirmed_by, confirmed_at, reversed_at, reversal_reason, idempotency_key';
 
     private const string ALLOC_COLUMNS = 'id, organization_id, payment_reconciliation_id, invoice_id, '
         . 'amount_cents, payment_id, external_reference';
@@ -57,11 +57,21 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
         return (int) ($row['c'] ?? 0);
     }
 
+    public function findByIdempotencyKey(int $organizationId, string $key): ?Reconciliation
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE organization_id = ? AND idempotency_key = ?',
+            [$organizationId, $key],
+        );
+
+        return $row !== null ? $this->hydrateReconciliation($row) : null;
+    }
+
     public function save(Reconciliation $reconciliation): int
     {
         $this->query->execute(
-            'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code, confirmed_by, confirmed_at) '
-            . 'VALUES (?, ?, ?, ?, ?, ?)',
+            'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code, confirmed_by, confirmed_at, idempotency_key) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?)',
             [
                 $reconciliation->organizationId,
                 $reconciliation->bankTransactionId,
@@ -69,6 +79,7 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
                 $reconciliation->reasonCode,
                 $reconciliation->confirmedBy,
                 $reconciliation->confirmedAt,
+                $reconciliation->idempotencyKey,
             ],
         );
 
@@ -125,6 +136,7 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
             reasonCode: isset($row['reason_code']) ? (string) $row['reason_code'] : null,
             reversedAt: isset($row['reversed_at']) ? (string) $row['reversed_at'] : null,
             reversalReason: isset($row['reversal_reason']) ? (string) $row['reversal_reason'] : null,
+            idempotencyKey: isset($row['idempotency_key']) ? (string) $row['idempotency_key'] : null,
             id: (int) $row['id'],
         );
     }

--- a/src/Reconciliation/Reconciliation.php
+++ b/src/Reconciliation/Reconciliation.php
@@ -15,6 +15,7 @@ final readonly class Reconciliation
         public ?string $reasonCode = null,
         public ?string $reversedAt = null,
         public ?string $reversalReason = null,
+        public ?string $idempotencyKey = null,
         public ?int $id = null,
     ) {
     }

--- a/src/Reconciliation/ReconciliationRepositoryInterface.php
+++ b/src/Reconciliation/ReconciliationRepositoryInterface.php
@@ -8,6 +8,8 @@ interface ReconciliationRepositoryInterface
 {
     public function findById(int $organizationId, int $id): ?Reconciliation;
 
+    public function findByIdempotencyKey(int $organizationId, string $key): ?Reconciliation;
+
     /**
      * @return list<Reconciliation>
      */

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -156,6 +156,63 @@ final class ConfirmMatchUseCaseTest extends TestCase
         ));
     }
 
+    public function test_idempotency_key_returns_same_reconciliation_on_replay(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeInvoice(1, 100000);
+
+        $first = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+            idempotencyKey: 'key-abc-123',
+        ));
+
+        // Replay with the same key — use case returns same reconciliation
+        $replay = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+            idempotencyKey: 'key-abc-123',
+        ));
+
+        self::assertSame($first->reconciliationId, $replay->reconciliationId);
+        self::assertTrue($replay->idempotentReplay);
+        // Upstream should have been called only once
+        self::assertCount(1, $this->invoiceClient->paymentsFor(1));
+    }
+
+    public function test_different_idempotency_key_creates_new_reconciliation(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeInvoice(1, 100000);
+
+        $first = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [new AllocationInput(1, 100000)],
+            actorUserId: 42,
+            idempotencyKey: 'key-abc-111',
+        ));
+
+        // Restore invoice outstanding and tx status for second confirm
+        $this->makeInvoice(2, 50000);
+        $txId2 = $this->makeTx(50000);
+
+        $second = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId2,
+            allocations: [new AllocationInput(2, 50000)],
+            actorUserId: 42,
+            idempotencyKey: 'key-abc-222',
+        ));
+
+        self::assertNotSame($first->reconciliationId, $second->reconciliationId);
+        self::assertFalse($second->idempotentReplay);
+    }
+
     public function test_unknown_transaction_throws_not_found(): void
     {
         $this->expectException(BankTransactionNotFoundException::class);

--- a/tests/Reconciliation/InMemoryReconciliationRepository.php
+++ b/tests/Reconciliation/InMemoryReconciliationRepository.php
@@ -27,6 +27,17 @@ final class InMemoryReconciliationRepository implements ReconciliationRepository
         return ($r !== null && $r->organizationId === $organizationId) ? $r : null;
     }
 
+    public function findByIdempotencyKey(int $organizationId, string $key): ?Reconciliation
+    {
+        foreach ($this->byId as $r) {
+            if ($r->organizationId === $organizationId && $r->idempotencyKey === $key) {
+                return $r;
+            }
+        }
+
+        return null;
+    }
+
     public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
@@ -59,6 +70,7 @@ final class InMemoryReconciliationRepository implements ReconciliationRepository
             reasonCode: $reconciliation->reasonCode,
             reversedAt: $reconciliation->reversedAt,
             reversalReason: $reconciliation->reversalReason,
+            idempotencyKey: $reconciliation->idempotencyKey,
             id: $id,
         );
 

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -125,6 +125,7 @@ final class SchemaFixture
             'CREATE TABLE payment_reconciliations (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 organization_id INTEGER NOT NULL,
+                idempotency_key TEXT,
                 bank_transaction_id INTEGER NOT NULL,
                 status TEXT NOT NULL DEFAULT \'confirmed\',
                 reason_code TEXT,
@@ -132,7 +133,8 @@ final class SchemaFixture
                 confirmed_at TEXT NOT NULL,
                 reversed_at TEXT,
                 reversal_reason TEXT,
-                created_at TEXT
+                created_at TEXT,
+                UNIQUE (organization_id, idempotency_key)
             )'
         );
     }


### PR DESCRIPTION
Stripe スタイルの `Idempotency-Key` ヘッダーを `POST /admin/reconciliation/confirm` に追加。同じキーで再リクエストすると既存消込をそのまま返す（upstream 呼び出しなし）。新規作成 201 / replay 200 で区別。スキーマ: `payment_reconciliations` に `idempotency_key UNIQUE(org, key)` を追加（マイグレーション含む）。