### PR TITLE
test: backend unit coverage — use cases + boundary tests

### DIFF
--- a/tests/Auth/CapabilityMiddlewareTest.php
+++ b/tests/Auth/CapabilityMiddlewareTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Auth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\Auth\Capability;
+use NeneClear\Auth\CapabilityMiddleware;
+use NeneClear\Auth\CapabilityRule;
+use NeneClear\Auth\Role;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\I18n\MessageCatalog;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Records whether the downstream handler was reached.
+ */
+final class SpyRequestHandler implements RequestHandlerInterface
+{
+    public bool $called = false;
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->called = true;
+
+        return (new Psr17Factory())->createResponse(200);
+    }
+}
+
+final class CapabilityMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private CapabilityMiddleware $middleware;
+    private SpyRequestHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $problemDetails = new LocalizedProblemDetailsFactory(
+            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-clear.dev/problems/'),
+        );
+
+        $this->middleware = new CapabilityMiddleware($problemDetails, [
+            '/admin/organizations' => CapabilityRule::same(Capability::ManageOrganizations),
+            '/admin/users' => CapabilityRule::same(Capability::ManageUsers),
+            '/admin/reconciliations' => new CapabilityRule(
+                read: Capability::ViewReconciliation,
+                write: Capability::ManageReconciliation,
+            ),
+        ]);
+
+        $this->next = new SpyRequestHandler();
+    }
+
+    private function request(string $method, string $path, ?Role $role): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest($method, $path);
+        if ($role !== null) {
+            $request = $request->withAttribute('nene2.auth.claims', ['role' => $role->value]);
+        }
+
+        return $request;
+    }
+
+    public function test_unmatched_path_passes_through_without_capability_check(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('GET', '/admin/dashboard', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($this->next->called);
+    }
+
+    public function test_admin_can_write_users(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/users', Role::Admin),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($this->next->called);
+    }
+
+    public function test_viewer_cannot_write_users(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/users', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->next->called);
+    }
+
+    public function test_viewer_can_read_reconciliations(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('GET', '/admin/reconciliations', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_viewer_cannot_write_reconciliations(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/reconciliations', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->next->called);
+    }
+
+    public function test_member_can_write_reconciliations(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/reconciliations', Role::Member),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_member_cannot_manage_organizations(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('GET', '/admin/organizations', Role::Member),
+            $this->next,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_superadmin_can_manage_organizations(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/organizations', Role::Superadmin),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_missing_claims_is_rejected_on_protected_path(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/users', null),
+            $this->next,
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertFalse($this->next->called);
+    }
+
+    public function test_unknown_role_value_is_rejected(): void
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/users')
+            ->withAttribute('nene2.auth.claims', ['role' => 'wizard']);
+
+        $response = $this->middleware->process($request, $this->next);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function test_head_is_treated_as_safe_method(): void
+    {
+        // HEAD on a write-gated path uses the read capability → viewer allowed.
+        $response = $this->middleware->process(
+            $this->request('HEAD', '/admin/reconciliations', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_403_response_is_problem_json(): void
+    {
+        $response = $this->middleware->process(
+            $this->request('POST', '/admin/users', Role::Viewer),
+            $this->next,
+        );
+
+        self::assertStringContainsString('application/problem+json', $response->getHeaderLine('Content-Type'));
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('insufficient-capability', $body);
+    }
+}

--- a/tests/BankImport/BankCsvParserBoundaryTest.php
+++ b/tests/BankImport/BankCsvParserBoundaryTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\BankImport;
+
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankCsvParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Boundary cases for {@see BankCsvParser}. Deposit detection, encoding,
+ * line endings, header rows, and lineKey uniqueness.
+ */
+final class BankCsvParserBoundaryTest extends TestCase
+{
+    private function account(int $headerRows = 1): BankAccount
+    {
+        // Columns: 0=取引日, 1=入金額, 2=出金額, 3=摘要
+        return new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '1234567',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: $headerRows,
+        );
+    }
+
+    /**
+     * @return list<\NeneClear\BankImport\ParsedBankLine>
+     */
+    private function parse(string $csv, int $headerRows = 1): array
+    {
+        return (new BankCsvParser())->parse($csv, $this->account($headerRows));
+    }
+
+    public function test_empty_file_yields_no_lines(): void
+    {
+        self::assertSame([], $this->parse(''));
+    }
+
+    public function test_header_only_file_yields_no_lines(): void
+    {
+        self::assertSame([], $this->parse("取引日,入金額,出金額,摘要\n"));
+    }
+
+    public function test_zero_amount_is_skipped(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20,0,,Zero\n";
+        self::assertSame([], $this->parse($csv));
+    }
+
+    public function test_negative_amount_is_skipped(): void
+    {
+        // A negative deposit column is not a credit line.
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20,-1000,,Neg\n";
+        self::assertSame([], $this->parse($csv));
+    }
+
+    public function test_blank_and_whitespace_lines_are_skipped(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\n"
+            . "2026/04/20,1000,,A\n"
+            . "\n"
+            . "   \n"
+            . "2026/04/21,2000,,B\n";
+
+        $lines = $this->parse($csv);
+
+        self::assertCount(2, $lines);
+        self::assertSame(1000, $lines[0]->amountCents);
+        self::assertSame(2000, $lines[1]->amountCents);
+    }
+
+    public function test_multiple_header_rows_are_skipped(): void
+    {
+        $csv = "BANK STATEMENT EXPORT\n"
+            . "取引日,入金額,出金額,摘要\n"
+            . "2026/04/20,1000,,A\n";
+
+        $lines = $this->parse($csv, headerRows: 2);
+
+        self::assertCount(1, $lines);
+        self::assertSame('2026-04-20', $lines[0]->valueDate);
+    }
+
+    public function test_crlf_and_cr_line_endings(): void
+    {
+        $crlf = "取引日,入金額,出金額,摘要\r\n2026/04/20,1000,,A\r\n2026/04/21,2000,,B\r\n";
+        self::assertCount(2, $this->parse($crlf));
+
+        $cr = "取引日,入金額,出金額,摘要\r2026/04/20,1000,,A\r";
+        self::assertCount(1, $this->parse($cr));
+    }
+
+    public function test_amount_with_currency_symbol_and_commas(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20,\"¥1,234,567\",,Big\n";
+
+        $lines = $this->parse($csv);
+
+        self::assertCount(1, $lines);
+        self::assertSame(1234567, $lines[0]->amountCents);
+    }
+
+    public function test_missing_amount_cell_is_skipped(): void
+    {
+        // Row shorter than the amount column index → treated as non-credit.
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20\n";
+        self::assertSame([], $this->parse($csv));
+    }
+
+    public function test_missing_counterparty_cell_yields_empty_string(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20,1000\n";
+
+        $lines = $this->parse($csv);
+
+        self::assertCount(1, $lines);
+        self::assertSame('', $lines[0]->counterpartyText);
+    }
+
+    public function test_identical_rows_at_different_positions_get_distinct_line_keys(): void
+    {
+        // lineKey incorporates row index, so duplicate deposits are distinguishable.
+        $csv = "取引日,入金額,出金額,摘要\n"
+            . "2026/04/20,1000,,SAME\n"
+            . "2026/04/20,1000,,SAME\n";
+
+        $lines = $this->parse($csv);
+
+        self::assertCount(2, $lines);
+        self::assertNotSame($lines[0]->lineKey, $lines[1]->lineKey);
+    }
+
+    public function test_file_without_trailing_newline(): void
+    {
+        $csv = "取引日,入金額,出金額,摘要\n2026/04/20,1000,,A";
+
+        $lines = $this->parse($csv);
+
+        self::assertCount(1, $lines);
+        self::assertSame(1000, $lines[0]->amountCents);
+    }
+}

--- a/tests/I18n/LocalizedProblemDetailsFactoryTest.php
+++ b/tests/I18n/LocalizedProblemDetailsFactoryTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\I18n;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\I18n\MessageCatalog;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class LocalizedProblemDetailsFactoryTest extends TestCase
+{
+    private Psr17Factory $psr17;
+    private LocalizedProblemDetailsFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $this->factory = new LocalizedProblemDetailsFactory(
+            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-clear.dev/problems/'),
+        );
+    }
+
+    private function request(?string $acceptLanguage): ServerRequestInterface
+    {
+        $request = $this->psr17->createServerRequest('GET', '/admin/x');
+        if ($acceptLanguage !== null) {
+            $request = $request->withHeader('Accept-Language', $acceptLanguage);
+        }
+
+        return $request;
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(string $json): array
+    {
+        return (array) json_decode($json, true);
+    }
+
+    public function test_no_accept_language_defaults_to_japanese(): void
+    {
+        $res = $this->factory->create($this->request(null), 'unauthorized', 401);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame(401, $res->getStatusCode());
+        self::assertSame('認証エラー', $body['title']);
+    }
+
+    public function test_explicit_english_uses_english(): void
+    {
+        $res = $this->factory->create($this->request('en'), 'unauthorized', 401);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('Unauthorized', $body['title']);
+    }
+
+    public function test_japanese_preferred_over_english_by_qvalue(): void
+    {
+        $res = $this->factory->create($this->request('en;q=0.8, ja;q=0.9'), 'unauthorized', 401);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('認証エラー', $body['title']);
+    }
+
+    public function test_english_preferred_over_japanese_by_qvalue(): void
+    {
+        $res = $this->factory->create($this->request('ja;q=0.7, en;q=0.9'), 'unauthorized', 401);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('Unauthorized', $body['title']);
+    }
+
+    public function test_unrelated_locale_falls_back_to_japanese(): void
+    {
+        $res = $this->factory->create($this->request('fr-FR'), 'unauthorized', 401);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('認証エラー', $body['title']);
+    }
+
+    public function test_type_uri_includes_slug(): void
+    {
+        $res = $this->factory->create($this->request('en'), 'bank-account-not-found', 404);
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('https://nene-clear.dev/problems/bank-account-not-found', $body['type']);
+        self::assertSame(404, $body['status']);
+    }
+
+    public function test_custom_detail_key_is_used(): void
+    {
+        $res = $this->factory->create(
+            $this->request('ja'),
+            'invalid-state-transition',
+            409,
+            'problem.invalid-state-transition.batch-reversed.detail',
+        );
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('バッチはすでに取消済みです。', $body['detail']);
+    }
+
+    public function test_create_with_detail_uses_dynamic_detail(): void
+    {
+        $res = $this->factory->createWithDetail($this->request('ja'), 'validation-failed', 422, 'CSV行3が不正です');
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame('CSV行3が不正です', $body['detail']);
+        self::assertSame('バリデーションエラー', $body['title']);
+    }
+
+    public function test_extensions_are_merged_into_payload(): void
+    {
+        $res = $this->factory->create(
+            $this->request('ja'),
+            'allocation-exceeds-outstanding',
+            422,
+            extensions: ['invoice_id' => 123, 'outstanding_cents' => 50000],
+        );
+        $body = $this->decode((string) $res->getBody());
+
+        self::assertSame(123, $body['invoice_id']);
+        self::assertSame(50000, $body['outstanding_cents']);
+    }
+
+    public function test_get_returns_translated_string(): void
+    {
+        self::assertSame(
+            'CSVを解析できませんでした: ',
+            $this->factory->get($this->request('ja'), 'problem.validation-failed.csv-prefix'),
+        );
+        self::assertSame(
+            'The uploaded CSV could not be parsed: ',
+            $this->factory->get($this->request('en'), 'problem.validation-failed.csv-prefix'),
+        );
+    }
+}

--- a/tests/I18n/MessageCatalogTest.php
+++ b/tests/I18n/MessageCatalogTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\I18n;
+
+use NeneClear\I18n\Locale;
+use NeneClear\I18n\MessageCatalog;
+use PHPUnit\Framework\TestCase;
+
+final class MessageCatalogTest extends TestCase
+{
+    private MessageCatalog $catalog;
+
+    protected function setUp(): void
+    {
+        $this->catalog = new MessageCatalog(dirname(__DIR__, 2) . '/lang');
+    }
+
+    public function test_returns_japanese_string(): void
+    {
+        self::assertSame('バリデーションエラー', $this->catalog->get('problem.validation-failed.title', Locale::Ja));
+    }
+
+    public function test_returns_english_string(): void
+    {
+        self::assertSame('Validation Failed', $this->catalog->get('problem.validation-failed.title', Locale::En));
+    }
+
+    public function test_unknown_key_returns_key_itself(): void
+    {
+        self::assertSame('problem.nonexistent.title', $this->catalog->get('problem.nonexistent.title', Locale::Ja));
+    }
+
+    public function test_missing_lang_dir_falls_back_to_key(): void
+    {
+        $catalog = new MessageCatalog('/nonexistent/lang/dir');
+        self::assertSame('problem.validation-failed.title', $catalog->get('problem.validation-failed.title', Locale::Ja));
+    }
+
+    public function test_catalog_caches_loaded_file_between_calls(): void
+    {
+        // Two calls for the same locale return identical results (load is memoized).
+        $first = $this->catalog->get('problem.unauthorized.title', Locale::Ja);
+        $second = $this->catalog->get('problem.unauthorized.title', Locale::Ja);
+        self::assertSame($first, $second);
+    }
+}

--- a/tests/Organization/DeleteOrganizationUseCaseTest.php
+++ b/tests/Organization/DeleteOrganizationUseCaseTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Organization;
+
+use NeneClear\Organization\DeleteOrganizationUseCase;
+use NeneClear\Organization\Organization;
+use NeneClear\Organization\OrganizationNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteOrganizationUseCaseTest extends TestCase
+{
+    public function test_deletes_existing_organization(): void
+    {
+        $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
+        $useCase = new DeleteOrganizationUseCase($repo);
+
+        $useCase->execute(1);
+
+        self::assertNull($repo->findById(1));
+    }
+
+    public function test_unknown_id_throws_not_found(): void
+    {
+        $useCase = new DeleteOrganizationUseCase(new InMemoryOrganizationRepository());
+
+        $this->expectException(OrganizationNotFoundException::class);
+        $useCase->execute(9999);
+    }
+}

--- a/tests/Organization/GetOrganizationByIdUseCaseTest.php
+++ b/tests/Organization/GetOrganizationByIdUseCaseTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Organization;
+
+use NeneClear\Organization\GetOrganizationByIdUseCase;
+use NeneClear\Organization\Organization;
+use NeneClear\Organization\OrganizationNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class GetOrganizationByIdUseCaseTest extends TestCase
+{
+    public function test_returns_existing_organization(): void
+    {
+        $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
+        $useCase = new GetOrganizationByIdUseCase($repo);
+
+        $org = $useCase->execute(1);
+
+        self::assertSame(1, $org->id);
+        self::assertSame('acme', $org->slug);
+    }
+
+    public function test_unknown_id_throws_not_found(): void
+    {
+        $useCase = new GetOrganizationByIdUseCase(new InMemoryOrganizationRepository());
+
+        $this->expectException(OrganizationNotFoundException::class);
+        $useCase->execute(9999);
+    }
+}

--- a/tests/Organization/ListOrganizationsUseCaseTest.php
+++ b/tests/Organization/ListOrganizationsUseCaseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Organization;
+
+use NeneClear\Organization\ListOrganizationsUseCase;
+use NeneClear\Organization\Organization;
+use PHPUnit\Framework\TestCase;
+
+final class ListOrganizationsUseCaseTest extends TestCase
+{
+    public function test_lists_all_with_total(): void
+    {
+        $repo = new InMemoryOrganizationRepository([
+            new Organization(slug: 'a', name: 'A'),
+            new Organization(slug: 'b', name: 'B'),
+        ]);
+        $useCase = new ListOrganizationsUseCase($repo);
+
+        $output = $useCase->execute(50, 0);
+
+        self::assertCount(2, $output->items);
+        self::assertSame(2, $output->total);
+        self::assertSame(50, $output->limit);
+        self::assertSame(0, $output->offset);
+    }
+
+    public function test_pagination(): void
+    {
+        $repo = new InMemoryOrganizationRepository([
+            new Organization(slug: 'a', name: 'A'),
+            new Organization(slug: 'b', name: 'B'),
+            new Organization(slug: 'c', name: 'C'),
+        ]);
+        $useCase = new ListOrganizationsUseCase($repo);
+
+        $page = $useCase->execute(2, 0);
+        self::assertCount(2, $page->items);
+        self::assertSame(3, $page->total);
+
+        $next = $useCase->execute(2, 2);
+        self::assertCount(1, $next->items);
+        self::assertSame(3, $next->total);
+    }
+
+    public function test_empty_returns_empty(): void
+    {
+        $useCase = new ListOrganizationsUseCase(new InMemoryOrganizationRepository());
+
+        $output = $useCase->execute(50, 0);
+
+        self::assertSame([], $output->items);
+        self::assertSame(0, $output->total);
+    }
+}

--- a/tests/User/CreateUserUseCaseTest.php
+++ b/tests/User/CreateUserUseCaseTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\Auth\Role;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCase;
+use NeneClear\User\User;
+use NeneClear\User\UserAlreadyExistsException;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class CreateUserUseCaseTest extends TestCase
+{
+    public function test_with_password_creates_active_user(): void
+    {
+        $repo = new InMemoryUserRepository();
+        $useCase = new CreateUserUseCase($repo);
+
+        $user = $useCase->execute(new CreateUserInput(
+            organizationId: 7,
+            email: 'member@acme.example',
+            role: Role::Member,
+            password: 'secret-pass',
+        ));
+
+        self::assertGreaterThan(0, $user->id);
+        self::assertSame('member@acme.example', $user->email);
+        self::assertSame(Role::Member, $user->role);
+        self::assertSame(UserStatus::Active, $user->status);
+        self::assertSame(7, $user->organizationId);
+        self::assertTrue(password_verify('secret-pass', $user->passwordHash));
+    }
+
+    public function test_without_password_creates_invited_user_with_unusable_hash(): void
+    {
+        $repo = new InMemoryUserRepository();
+        $useCase = new CreateUserUseCase($repo);
+
+        $user = $useCase->execute(new CreateUserInput(
+            organizationId: 7,
+            email: 'invited@acme.example',
+            role: Role::Viewer,
+            password: null,
+        ));
+
+        self::assertSame(UserStatus::Invited, $user->status);
+        // A random placeholder hash must not verify against an empty password.
+        self::assertFalse(password_verify('', $user->passwordHash));
+        self::assertNotSame('', $user->passwordHash);
+    }
+
+    public function test_rejects_duplicate_email(): void
+    {
+        $repo = new InMemoryUserRepository([
+            new User(
+                email: 'taken@acme.example',
+                role: Role::Member,
+                status: UserStatus::Active,
+                passwordHash: 'x',
+                organizationId: 7,
+            ),
+        ]);
+        $useCase = new CreateUserUseCase($repo);
+
+        $this->expectException(UserAlreadyExistsException::class);
+
+        $useCase->execute(new CreateUserInput(
+            organizationId: 7,
+            email: 'taken@acme.example',
+            role: Role::Member,
+            password: 'p',
+        ));
+    }
+
+    public function test_superadmin_user_has_null_organization(): void
+    {
+        $repo = new InMemoryUserRepository();
+        $useCase = new CreateUserUseCase($repo);
+
+        $user = $useCase->execute(new CreateUserInput(
+            organizationId: null,
+            email: 'root@platform.example',
+            role: Role::Superadmin,
+            password: 'p',
+        ));
+
+        self::assertNull($user->organizationId);
+        self::assertSame(Role::Superadmin, $user->role);
+    }
+}

--- a/tests/User/DeleteUserUseCaseTest.php
+++ b/tests/User/DeleteUserUseCaseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\Auth\Role;
+use NeneClear\User\DeleteUserUseCase;
+use NeneClear\User\User;
+use NeneClear\User\UserNotFoundException;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteUserUseCaseTest extends TestCase
+{
+    private function seedUser(int $orgId = 7): InMemoryUserRepository
+    {
+        return new InMemoryUserRepository([
+            new User(
+                email: 'member@acme.example',
+                role: Role::Member,
+                status: UserStatus::Active,
+                passwordHash: 'hash',
+                organizationId: $orgId,
+                id: 1,
+            ),
+        ]);
+    }
+
+    public function test_deletes_own_org_user(): void
+    {
+        $repo = $this->seedUser();
+        $useCase = new DeleteUserUseCase($repo);
+
+        $useCase->execute(1, 7);
+
+        self::assertNull($repo->findById(1));
+    }
+
+    public function test_cross_tenant_delete_throws_not_found_and_keeps_user(): void
+    {
+        $repo = $this->seedUser(orgId: 7);
+        $useCase = new DeleteUserUseCase($repo);
+
+        try {
+            $useCase->execute(1, 999);
+            self::fail('Expected UserNotFoundException');
+        } catch (UserNotFoundException) {
+            // User must still exist — a foreign tenant cannot delete it.
+            self::assertNotNull($repo->findById(1));
+        }
+    }
+
+    public function test_unknown_user_throws_not_found(): void
+    {
+        $repo = new InMemoryUserRepository();
+        $useCase = new DeleteUserUseCase($repo);
+
+        $this->expectException(UserNotFoundException::class);
+
+        $useCase->execute(9999, 7);
+    }
+}

--- a/tests/User/GetUserByIdUseCaseTest.php
+++ b/tests/User/GetUserByIdUseCaseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\Auth\Role;
+use NeneClear\User\GetUserByIdUseCase;
+use NeneClear\User\User;
+use NeneClear\User\UserNotFoundException;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class GetUserByIdUseCaseTest extends TestCase
+{
+    private function seedUser(?int $orgId = 7): InMemoryUserRepository
+    {
+        return new InMemoryUserRepository([
+            new User(
+                email: 'member@acme.example',
+                role: Role::Member,
+                status: UserStatus::Active,
+                passwordHash: 'hash',
+                organizationId: $orgId,
+                id: 1,
+            ),
+        ]);
+    }
+
+    public function test_returns_own_org_user(): void
+    {
+        $useCase = new GetUserByIdUseCase($this->seedUser());
+
+        $user = $useCase->execute(1, 7);
+
+        self::assertSame(1, $user->id);
+        self::assertSame('member@acme.example', $user->email);
+    }
+
+    public function test_cross_tenant_throws_not_found(): void
+    {
+        $useCase = new GetUserByIdUseCase($this->seedUser(orgId: 7));
+
+        $this->expectException(UserNotFoundException::class);
+        $useCase->execute(1, 999);
+    }
+
+    public function test_unknown_user_throws_not_found(): void
+    {
+        $useCase = new GetUserByIdUseCase(new InMemoryUserRepository());
+
+        $this->expectException(UserNotFoundException::class);
+        $useCase->execute(9999, 7);
+    }
+
+    public function test_superadmin_null_org_user_requires_null_caller_org(): void
+    {
+        $useCase = new GetUserByIdUseCase($this->seedUser(orgId: null));
+
+        // A null-org (superadmin) record is only visible to a null-org caller.
+        $user = $useCase->execute(1, null);
+        self::assertSame(1, $user->id);
+
+        $this->expectException(UserNotFoundException::class);
+        $useCase->execute(1, 7);
+    }
+}

--- a/tests/User/ListUsersUseCaseTest.php
+++ b/tests/User/ListUsersUseCaseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\Auth\Role;
+use NeneClear\User\ListUsersUseCase;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class ListUsersUseCaseTest extends TestCase
+{
+    private function user(int $id, int $orgId, string $email): User
+    {
+        return new User(
+            email: $email,
+            role: Role::Member,
+            status: UserStatus::Active,
+            passwordHash: 'h',
+            organizationId: $orgId,
+            id: $id,
+        );
+    }
+
+    public function test_lists_only_callers_organization(): void
+    {
+        $repo = new InMemoryUserRepository([
+            $this->user(1, 7, 'a@x.example'),
+            $this->user(2, 7, 'b@x.example'),
+            $this->user(3, 999, 'c@y.example'),
+        ]);
+        $useCase = new ListUsersUseCase($repo);
+
+        $output = $useCase->execute(7, 50, 0);
+
+        self::assertCount(2, $output->items);
+        self::assertSame(2, $output->total);
+        self::assertSame(50, $output->limit);
+        self::assertSame(0, $output->offset);
+    }
+
+    public function test_pagination_limit_and_offset(): void
+    {
+        $repo = new InMemoryUserRepository([
+            $this->user(1, 7, 'a@x.example'),
+            $this->user(2, 7, 'b@x.example'),
+            $this->user(3, 7, 'c@x.example'),
+        ]);
+        $useCase = new ListUsersUseCase($repo);
+
+        $page = $useCase->execute(7, 2, 0);
+        self::assertCount(2, $page->items);
+        self::assertSame(3, $page->total); // total ignores pagination
+
+        $next = $useCase->execute(7, 2, 2);
+        self::assertCount(1, $next->items);
+        self::assertSame(3, $next->total);
+    }
+
+    public function test_empty_organization_returns_empty(): void
+    {
+        $useCase = new ListUsersUseCase(new InMemoryUserRepository());
+
+        $output = $useCase->execute(7, 50, 0);
+
+        self::assertSame([], $output->items);
+        self::assertSame(0, $output->total);
+    }
+
+    public function test_offset_beyond_total_returns_empty_but_keeps_total(): void
+    {
+        $repo = new InMemoryUserRepository([$this->user(1, 7, 'a@x.example')]);
+        $useCase = new ListUsersUseCase($repo);
+
+        $output = $useCase->execute(7, 50, 100);
+
+        self::assertSame([], $output->items);
+        self::assertSame(1, $output->total);
+    }
+}

--- a/tests/User/UpdateUserUseCaseTest.php
+++ b/tests/User/UpdateUserUseCaseTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\Auth\Role;
+use NeneClear\User\UpdateUserInput;
+use NeneClear\User\UpdateUserUseCase;
+use NeneClear\User\User;
+use NeneClear\User\UserNotFoundException;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateUserUseCaseTest extends TestCase
+{
+    private function seedUser(int $orgId = 7): InMemoryUserRepository
+    {
+        return new InMemoryUserRepository([
+            new User(
+                email: 'member@acme.example',
+                role: Role::Member,
+                status: UserStatus::Invited,
+                passwordHash: 'hash',
+                organizationId: $orgId,
+                id: 1,
+            ),
+        ]);
+    }
+
+    public function test_updates_role_and_status(): void
+    {
+        $repo = $this->seedUser();
+        $useCase = new UpdateUserUseCase($repo);
+
+        $updated = $useCase->execute(new UpdateUserInput(
+            id: 1,
+            callerOrganizationId: 7,
+            role: Role::Admin,
+            status: UserStatus::Active,
+        ));
+
+        self::assertSame(Role::Admin, $updated->role);
+        self::assertSame(UserStatus::Active, $updated->status);
+        // Email and password are preserved.
+        self::assertSame('member@acme.example', $updated->email);
+        self::assertSame('hash', $updated->passwordHash);
+    }
+
+    public function test_null_fields_preserve_existing_values(): void
+    {
+        $repo = $this->seedUser();
+        $useCase = new UpdateUserUseCase($repo);
+
+        $updated = $useCase->execute(new UpdateUserInput(
+            id: 1,
+            callerOrganizationId: 7,
+            role: null,
+            status: null,
+        ));
+
+        self::assertSame(Role::Member, $updated->role);
+        self::assertSame(UserStatus::Invited, $updated->status);
+    }
+
+    public function test_cross_tenant_update_throws_not_found(): void
+    {
+        $repo = $this->seedUser(orgId: 7);
+        $useCase = new UpdateUserUseCase($repo);
+
+        $this->expectException(UserNotFoundException::class);
+
+        $useCase->execute(new UpdateUserInput(
+            id: 1,
+            callerOrganizationId: 999,
+            role: Role::Admin,
+            status: null,
+        ));
+    }
+
+    public function test_unknown_user_throws_not_found(): void
+    {
+        $repo = new InMemoryUserRepository();
+        $useCase = new UpdateUserUseCase($repo);
+
+        $this->expectException(UserNotFoundException::class);
+
+        $useCase->execute(new UpdateUserInput(
+            id: 9999,
+            callerOrganizationId: 7,
+            role: Role::Admin,
+            status: null,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

バックエンド API の単体テストを網羅的に拡充。**133 → 198 テスト**（+65）。

全 UseCase を洗い出し、テストが無かったものと境界が重要なサービスを補完。

## UseCase（これまで未テスト）

| ドメイン | UseCase | 主な検証 |
|---|---|---|
| User | Create | password 有→active / 無→invited、重複メール拒否、superadmin は org=null |
| User | Update | role/status 更新、null は既存値保持、**クロステナント→not-found** |
| User | Delete | 自org削除、**他orgは削除不可でレコード残存** |
| User | GetById | 自org取得、クロステナント拒否、null-org境界 |
| User | List | org絞り込み、ページネーション、offset超過 |
| Organization | GetById / List / Delete | not-found・ページネーション |

## 境界テスト

- **BankCsvParser**（証憑保存の起点）: 空ファイル・ヘッダーのみ・ゼロ/負の金額スキップ・空白行・複数ヘッダー行・CRLF/CR・通貨記号付き金額・セル欠落・同一行のlineKey一意性・末尾改行なし
- **CapabilityMiddleware**（セキュリティ）: role×method×path マトリクス、claims欠落/不正→403、HEADはsafe扱い、Problem+JSON形式
- **MessageCatalog**: ja/en参照、未知キーpassthrough、ディレクトリ欠落フォールバック
- **LocalizedProblemDetailsFactory**: Accept-Language の q-value 解決（ja既定・明示en・タイブレーク・無関係locale→ja）、カスタムdetailキー、動的detail、RFC 9457 extension

## Test plan

- [x] `composer test` — 198 tests / 6 skipped / 602 assertions
- [x] `composer analyse` — PHPStan level 8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)