### PR TITLE
test: browser scenario (E2E) suite — Playwright, boundary-focused

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -151,4 +151,22 @@ describe('401 handling', () => {
     expect(isAuthenticated()).toBe(false)
     expect(window.location.href).toBe('/login')
   })
+
+  it('does NOT redirect on 401 from the login endpoint', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 401,
+        json: { type: 'invalid-credentials', title: '認証失敗', status: 401, detail: 'wrong' },
+      }),
+    )
+
+    // The login 401 must surface as a normal ApiError (so the form can show it),
+    // not trigger the global redirect.
+    await expect(api.post('/admin/auth/login', {})).rejects.toMatchObject({
+      status: 401,
+      problem: { type: 'invalid-credentials' },
+    })
+    expect(window.location.href).toBe('')
+  })
 })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -52,7 +52,10 @@ async function request<T>(
     signal,
   })
 
-  if (res.status === 401) {
+  // A 401 on a normal call means the session expired → clear and bounce to login.
+  // The login endpoint itself is excluded: its 401 is "wrong credentials" and
+  // must surface to the form, not trigger a redirect loop.
+  if (res.status === 401 && !path.includes('/auth/login')) {
     clearToken()
     window.location.href = '/login'
     throw new ApiError(401, { type: 'unauthorized', title: 'Unauthorized', status: 401 })

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -22,16 +22,34 @@ export function listBankImportBatches(params: { limit?: number; offset?: number 
   return api.get<ListEnvelope<BankImportBatch>>(`${BASE}/bank-import-batches?${q}`, signal)
 }
 
-export function importBankCsv(bankAccountId: number, file: File) {
+export async function importBankCsv(bankAccountId: number, file: File) {
   const form = new FormData()
   form.append('bank_account_id', String(bankAccountId))
   form.append('file', file)
   const token = sessionStorage.getItem('nene_clear_token')
-  return fetch(`${BASE}/bank-import-batches`, {
+  const res = await fetch(`${BASE}/bank-import-batches`, {
     method: 'POST',
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: form,
-  }).then(r => r.json())
+  })
+
+  const data = await res.json().catch(() => null)
+
+  // Multipart upload bypasses the JSON api client, so status handling lives here:
+  // a non-2xx response must surface as an error, not be treated as a successful import.
+  if (!res.ok) {
+    const detail =
+      data && typeof data === 'object' && 'detail' in data
+        ? String((data as { detail?: unknown }).detail ?? '')
+        : ''
+    const title =
+      data && typeof data === 'object' && 'title' in data
+        ? String((data as { title?: unknown }).title ?? '')
+        : `Import failed (${res.status})`
+    throw new Error(detail || title)
+  }
+
+  return data
 }
 
 export function reverseBankImportBatch(batchId: number, reversalReason: string) {

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+.last-run.json

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -1,0 +1,165 @@
+import type { Page, Route } from '@playwright/test'
+
+/**
+ * Admin SPA E2E helpers.
+ *
+ * Auth: the SPA stores a bare JWT string in sessionStorage under
+ * `nene_clear_token`. bypassLogin() injects it before page scripts run.
+ *
+ * API mocking: page routes and API endpoints share the `/admin` prefix
+ * (e.g. /admin/users is both a page route and an API endpoint). apiRoute()
+ * only fulfills fetch/xhr requests; document navigations fall through to the
+ * preview server's SPA fallback.
+ */
+
+export const TOKEN_KEY = 'nene_clear_token'
+export const E2E_TOKEN = 'e2e-test-token'
+
+export async function bypassLogin(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([key, token]) => {
+      sessionStorage.setItem(key, token)
+    },
+    [TOKEN_KEY, E2E_TOKEN],
+  )
+}
+
+/**
+ * Register an API route that only handles fetch/xhr requests. Document
+ * navigations (resourceType 'document') are continued so the SPA loads.
+ */
+export async function apiRoute(
+  page: Page,
+  glob: string,
+  handler: (route: Route) => Promise<void> | void,
+): Promise<void> {
+  await page.route(glob, async (route) => {
+    const rt = route.request().resourceType()
+    if (rt !== 'fetch' && rt !== 'xhr') {
+      return route.continue()
+    }
+    return handler(route)
+  })
+}
+
+export function json(route: Route, status: number, body: unknown): Promise<void> {
+  return route.fulfill({
+    status,
+    contentType: status === 204 ? 'text/plain' : 'application/json',
+    body: status === 204 ? '' : JSON.stringify(body),
+  })
+}
+
+export function problem(
+  route: Route,
+  status: number,
+  type: string,
+  title: string,
+  detail?: string,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  return route.fulfill({
+    status,
+    contentType: 'application/problem+json',
+    body: JSON.stringify({ type, title, status, detail, ...extra }),
+  })
+}
+
+/** Standard list envelope. */
+export function list<T>(items: T[], total?: number, limit = 50, offset = 0) {
+  return { items, total: total ?? items.length, limit, offset }
+}
+
+// ── Domain fixture builders ─────────────────────────────────────────────────
+
+export function bankTransaction(over: Record<string, unknown> = {}) {
+  return {
+    bank_transaction_id: 1,
+    organization_id: 7,
+    bank_import_batch_id: 1,
+    bank_account_id: 1,
+    value_date: '2026-04-20',
+    amount_cents: 110000,
+    counterparty_text: 'カ）アクメ',
+    status: 'unmatched',
+    ...over,
+  }
+}
+
+export function bankImportBatch(over: Record<string, unknown> = {}) {
+  return {
+    bank_import_batch_id: 1,
+    organization_id: 7,
+    bank_account_id: 1,
+    file_hash: 'abc',
+    source_filename: 'april.csv',
+    row_count: 12,
+    status: 'imported',
+    imported_at: '2026-04-21 09:00:00',
+    imported_by: 1,
+    reversed_at: null,
+    reversal_reason: null,
+    ...over,
+  }
+}
+
+export function reconciliation(over: Record<string, unknown> = {}) {
+  return {
+    payment_reconciliation_id: 1,
+    organization_id: 7,
+    bank_transaction_id: 1,
+    status: 'confirmed',
+    reason_code: null,
+    confirmed_by: 1,
+    confirmed_at: '2026-04-21 10:00:00',
+    reversed_at: null,
+    reversal_reason: null,
+    allocations: [],
+    ...over,
+  }
+}
+
+export function dunningNotice(over: Record<string, unknown> = {}) {
+  return {
+    dunning_notice_id: 1,
+    organization_id: 7,
+    invoice_id: 123,
+    invoice_number: 'INV-2026-001',
+    client_id: 45,
+    recipient_email: 'accounts@acme.example',
+    outstanding_at_send_cents: 110000,
+    due_at: '2026-04-30',
+    channel: 'log',
+    sent_by: 1,
+    sent_at: '2026-04-25 09:00:00',
+    ...over,
+  }
+}
+
+export function user(over: Record<string, unknown> = {}) {
+  return {
+    user_id: 1,
+    organization_id: 7,
+    email: 'member@acme.example',
+    role: 'member',
+    status: 'active',
+    ...over,
+  }
+}
+
+export function clearSettings(over: Record<string, unknown> = {}) {
+  return {
+    organization_id: 7,
+    dunning_min_interval_days: 7,
+    bank_accounts: [
+      {
+        bank_account_id: 1,
+        bank_name: 'テスト銀行',
+        bank_branch: '本店',
+        account_type: 'ordinary',
+        account_number: '1234567',
+      },
+    ],
+    ...over,
+  }
+}

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "nene-clear-e2e",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nene-clear-e2e",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nene-clear-e2e",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report playwright-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * NeNe Clear — Admin UI E2E suite.
+ *
+ * The SPA is built and served by `vite preview`. All API calls (/admin/*,
+ * application/json) are intercepted via page.route() — no real backend.
+ * Page navigation (document requests under /admin/*) falls through to the
+ * preview server's SPA fallback.
+ */
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: 'http://localhost:4174',
+    storageState: { cookies: [], origins: [] },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run build && npm run preview -- --port 4174 --strictPort',
+    cwd: '../../frontend',
+    url: 'http://localhost:4174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/tests/e2e/specs/01-login.spec.ts
+++ b/tests/e2e/specs/01-login.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, problem, TOKEN_KEY } from '../fixtures/helpers'
+
+test.describe('Login', () => {
+  test('blocks submit when fields are empty (zod validation)', async ({ page }) => {
+    let loginCalled = false
+    await apiRoute(page, '**/admin/auth/login', (route) => {
+      loginCalled = true
+      return json(route, 200, { token: 'x', user: {} })
+    })
+
+    await page.goto('/login')
+    await page.getByRole('button').click()
+
+    // zod min(1) on email + password prevents the API call.
+    await page.waitForTimeout(300)
+    expect(loginCalled).toBe(false)
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('shows error detail on wrong credentials (401) and stays on login', async ({ page }) => {
+    await apiRoute(page, '**/admin/auth/login', (route) =>
+      problem(route, 401, 'invalid-credentials', '認証失敗', 'メールアドレスまたはパスワードが正しくありません。'),
+    )
+
+    await page.goto('/login')
+    await page.locator('input[name="email"]').fill('admin@nene-clear.dev')
+    await page.locator('input[name="password"]').fill('wrong-pass')
+    await page.getByRole('button').click()
+
+    await expect(
+      page.getByText('メールアドレスまたはパスワードが正しくありません。'),
+    ).toBeVisible()
+    await expect(page).toHaveURL(/\/login/)
+    // Token must not have been stored.
+    const token = await page.evaluate((k) => sessionStorage.getItem(k), TOKEN_KEY)
+    expect(token).toBeNull()
+  })
+
+  test('stores token and redirects to /admin on success', async ({ page }) => {
+    await apiRoute(page, '**/admin/auth/login', (route) =>
+      json(route, 200, {
+        token: 'jwt-success',
+        user: { user_id: 1, email: 'admin@nene-clear.dev', role: 'superadmin', organization_id: null },
+      }),
+    )
+    // Dashboard data after redirect.
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      json(route, 200, { items: [], total: 0, limit: 1, offset: 0 }),
+    )
+    await apiRoute(page, '**/admin/dunning-notices**', (route) =>
+      json(route, 200, { items: [], total: 0, limit: 5, offset: 0 }),
+    )
+
+    await page.goto('/login')
+    await page.locator('input[name="email"]').fill('admin@nene-clear.dev')
+    await page.locator('input[name="password"]').fill('admin1234')
+    await page.getByRole('button').click()
+
+    await expect(page).toHaveURL(/\/admin$/)
+    const token = await page.evaluate((k) => sessionStorage.getItem(k), TOKEN_KEY)
+    expect(token).toBe('jwt-success')
+  })
+})

--- a/tests/e2e/specs/02-auth-guard.spec.ts
+++ b/tests/e2e/specs/02-auth-guard.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, problem, bypassLogin } from '../fixtures/helpers'
+
+test.describe('Auth guard', () => {
+  test('unauthenticated access to /admin redirects to /login', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('root path redirects into the app then to login when unauthenticated', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('expired session (401 mid-session) clears token and bounces to login', async ({ page }) => {
+    await bypassLogin(page)
+
+    // The dashboard's first data call returns 401 → global handler redirects.
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      problem(route, 401, 'unauthorized', 'Unauthorized'),
+    )
+    await apiRoute(page, '**/admin/dunning-notices**', (route) =>
+      json(route, 200, { items: [], total: 0, limit: 5, offset: 0 }),
+    )
+
+    await page.goto('/admin')
+
+    // The global 401 handler clears the token and redirects; the URL is the
+    // reliable signal (the harness re-injects the token on reload).
+    await expect(page).toHaveURL(/\/login/)
+  })
+})

--- a/tests/e2e/specs/03-dashboard.spec.ts
+++ b/tests/e2e/specs/03-dashboard.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin, dunningNotice } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+})
+
+test.describe('Dashboard', () => {
+  test('shows unmatched count and recent dunning', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      json(route, 200, { items: [], total: 7, limit: 1, offset: 0 }),
+    )
+    await apiRoute(page, '**/admin/dunning-notices**', (route) =>
+      json(route, 200, list([dunningNotice({ invoice_number: 'INV-2026-009' })])),
+    )
+
+    await page.goto('/admin')
+
+    await expect(page.locator('p.text-4xl')).toContainText('7')
+    await expect(page.getByText('INV-2026-009')).toBeVisible()
+    await expect(page.getByText('¥1,100')).toBeVisible()
+  })
+
+  test('shows zero and no-data state when empty', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      json(route, 200, { items: [], total: 0, limit: 1, offset: 0 }),
+    )
+    await apiRoute(page, '**/admin/dunning-notices**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin')
+
+    await expect(page.locator('p.text-4xl')).toContainText('0')
+    await expect(page.getByText('データがありません。')).toBeVisible()
+  })
+})

--- a/tests/e2e/specs/04-bank-transactions.spec.ts
+++ b/tests/e2e/specs/04-bank-transactions.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin, bankTransaction } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+})
+
+test.describe('Bank transactions — list, filter, pagination boundaries', () => {
+  test('empty list shows no-data message', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/bank-transactions')
+
+    await expect(page.getByText('データがありません。')).toBeVisible()
+  })
+
+  test('renders rows with yen formatting and status badge', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) =>
+      json(route, 200, list([bankTransaction({ amount_cents: 5000000, counterparty_text: 'カ）テスト' })])),
+    )
+
+    await page.goto('/admin/bank-transactions')
+
+    await expect(page.getByText('¥50,000')).toBeVisible()
+    await expect(page.getByText('カ）テスト')).toBeVisible()
+  })
+
+  test('pagination: first page has Back disabled, Next enabled', async ({ page }) => {
+    // total 45 > PAGE_SIZE 20 → 3 pages
+    const items = Array.from({ length: 20 }, (_, i) => bankTransaction({ bank_transaction_id: i + 1 }))
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => json(route, 200, list(items, 45, 20, 0)))
+
+    await page.goto('/admin/bank-transactions')
+
+    await expect(page.getByText('1 / 3')).toBeVisible()
+    await expect(page.getByRole('button', { name: '戻る' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '次へ' })).toBeEnabled()
+  })
+
+  test('pagination: last page has Next disabled', async ({ page }) => {
+    // Serve different pages based on the offset query param.
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => {
+      const url = new URL(route.request().url())
+      const offset = Number(url.searchParams.get('offset') ?? '0')
+      const items = Array.from({ length: offset >= 40 ? 5 : 20 }, (_, i) =>
+        bankTransaction({ bank_transaction_id: offset + i + 1 }),
+      )
+      return json(route, 200, list(items, 45, 20, offset))
+    })
+
+    await page.goto('/admin/bank-transactions')
+    await page.getByRole('button', { name: '次へ' }).click() // → page 2
+    await page.getByRole('button', { name: '次へ' }).click() // → page 3 (last)
+
+    await expect(page.getByText('3 / 3')).toBeVisible()
+    await expect(page.getByRole('button', { name: '次へ' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '戻る' })).toBeEnabled()
+  })
+
+  test('no pagination controls when total fits one page', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) =>
+      json(route, 200, list([bankTransaction()], 1, 20, 0)),
+    )
+
+    await page.goto('/admin/bank-transactions')
+
+    await expect(page.getByRole('button', { name: '次へ' })).toHaveCount(0)
+  })
+
+  test('status filter triggers a scoped query', async ({ page }) => {
+    let lastUrl = ''
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => {
+      lastUrl = route.request().url()
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/bank-transactions')
+    await page.locator('select').selectOption('matched')
+    await page.getByRole('button', { name: '検索' }).click()
+
+    await expect.poll(() => lastUrl).toContain('status=matched')
+  })
+})

--- a/tests/e2e/specs/05-bank-import.spec.ts
+++ b/tests/e2e/specs/05-bank-import.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+import {
+  apiRoute, json, problem, list, bypassLogin, bankImportBatch, clearSettings,
+} from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  await apiRoute(page, '**/admin/clear-settings', (route) => json(route, 200, clearSettings()))
+})
+
+test.describe('Bank import — upload + reverse boundaries', () => {
+  test('upload without file/account shows a validation error', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-import-batches**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/bank-import')
+    await page.getByRole('button', { name: '取込む' }).click()
+
+    await expect(page.getByText('銀行口座とファイルを選択してください')).toBeVisible()
+  })
+
+  test('duplicate import (409) surfaces the upstream error', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-import-batches', (route) => {
+      if (route.request().method() === 'POST') {
+        return problem(route, 409, 'duplicate-bank-import', 'インポート重複', 'このファイルはすでにインポートされています。')
+      }
+      return json(route, 200, list([]))
+    })
+    // The batch list GET (with query string or trailing) — separate glob.
+    await apiRoute(page, '**/admin/bank-import-batches?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/bank-import')
+    await page.locator('select').selectOption('1')
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'dup.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('取引日,入金額\n2026/04/20,1000\n'),
+    })
+    await page.getByRole('button', { name: '取込む' }).click()
+
+    // importBankCsv uses raw fetch and surfaces the JSON body's title via err.message;
+    // the page shows whatever the rejected error carries. The 409 body is rendered.
+    await expect(page.getByText(/インポート重複|すでにインポート/)).toBeVisible()
+  })
+
+  test('reverse dialog: button disabled until a reason is entered', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-import-batches**', (route) =>
+      json(route, 200, list([bankImportBatch({ status: 'imported' })])),
+    )
+
+    await page.goto('/admin/bank-import')
+    await page.getByRole('button', { name: '取消' }).first().click()
+
+    const confirmBtn = page.locator('.fixed').getByRole('button', { name: '取消' })
+    await expect(confirmBtn).toBeDisabled()
+
+    await page.locator('.fixed input[type="text"]').fill('誤った取込のため')
+    await expect(confirmBtn).toBeEnabled()
+  })
+
+  test('reverse succeeds and closes the dialog', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-import-batches', (route) => json(route, 200, list([bankImportBatch()])))
+    await apiRoute(page, '**/admin/bank-import-batches?**', (route) => json(route, 200, list([bankImportBatch()])))
+    await apiRoute(page, '**/admin/bank-import-batches/*/reverse', (route) => json(route, 204, null))
+
+    await page.goto('/admin/bank-import')
+    await page.getByRole('button', { name: '取消' }).first().click()
+    await page.locator('.fixed input[type="text"]').fill('誤った取込のため')
+    await page.locator('.fixed').getByRole('button', { name: '取消' }).click()
+
+    // Dialog closes (reversal reason input disappears).
+    await expect(page.locator('.fixed input[type="text"]')).toHaveCount(0)
+  })
+
+  test('reversed batch row shows no reverse button', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-import-batches**', (route) =>
+      json(route, 200, list([bankImportBatch({ status: 'reversed' })])),
+    )
+
+    await page.goto('/admin/bank-import')
+
+    await expect(page.getByText('取消済')).toBeVisible()
+    await expect(page.getByRole('button', { name: '取消' })).toHaveCount(0)
+  })
+})

--- a/tests/e2e/specs/06-reconciliation.spec.ts
+++ b/tests/e2e/specs/06-reconciliation.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test'
+import {
+  apiRoute, json, problem, list, bypassLogin, bankTransaction, reconciliation,
+} from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  // The page loads on the "unmatched" tab and always fires this query. Default
+  // it to empty so history-tab tests don't fall through to the preview server.
+  // Tests that need rows register their own (later → higher priority) route.
+  await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+    json(route, 200, list([])),
+  )
+})
+
+test.describe('Reconciliation — confirm + reverse boundaries', () => {
+  test('confirm with allocation exceeding outstanding shows 422 error', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      json(route, 200, list([bankTransaction({ amount_cents: 110000 })])),
+    )
+    await apiRoute(page, '**/admin/reconciliations/confirm', (route) =>
+      problem(route, 422, 'allocation-exceeds-outstanding', '消込金額が請求書の未収残高を超えています', undefined, {
+        invoice_id: 1,
+        outstanding_cents: 50000,
+      }),
+    )
+
+    await page.goto('/admin/reconciliation')
+    await page.getByRole('button', { name: '消込を確定' }).first().click()
+
+    // Fill the allocation (invoice id + amount in yen).
+    const modal = page.locator('.fixed')
+    await modal.locator('input[type="number"]').nth(0).fill('1')
+    await modal.locator('input[type="number"]').nth(1).fill('1100')
+    await modal.getByRole('button', { name: '消込を確定' }).click()
+
+    await expect(page.getByText('消込金額が請求書の未収残高を超えています')).toBeVisible()
+  })
+
+  test('confirm succeeds and closes the modal', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+      json(route, 200, list([bankTransaction()])),
+    )
+    await apiRoute(page, '**/admin/reconciliations/confirm', (route) =>
+      json(route, 201, reconciliation({ allocations: [] })),
+    )
+
+    await page.goto('/admin/reconciliation')
+    await page.getByRole('button', { name: '消込を確定' }).first().click()
+    const modal = page.locator('.fixed')
+    await modal.locator('input[type="number"]').nth(0).fill('1')
+    await modal.locator('input[type="number"]').nth(1).fill('1100')
+    await modal.getByRole('button', { name: '消込を確定' }).click()
+
+    await expect(page.locator('.fixed')).toHaveCount(0)
+  })
+
+  test('history: reverse button disabled until reason entered, then succeeds', async ({ page }) => {
+    await apiRoute(page, '**/admin/reconciliations?**', (route) =>
+      json(route, 200, list([reconciliation({ status: 'confirmed' })])),
+    )
+    await apiRoute(page, '**/admin/reconciliations/*/reverse', (route) => json(route, 204, null))
+
+    await page.goto('/admin/reconciliation')
+    await page.getByRole('button', { name: '消込一覧' }).click()
+    await page.getByRole('button', { name: '消込を取消' }).first().click()
+
+    const confirmBtn = page.locator('.fixed').getByRole('button', { name: '消込を取消' })
+    await expect(confirmBtn).toBeDisabled()
+    await page.locator('.fixed input[type="text"]').fill('オペレーター誤操作')
+    await expect(confirmBtn).toBeEnabled()
+    await confirmBtn.click()
+
+    await expect(page.locator('.fixed')).toHaveCount(0)
+  })
+
+  test('reverse of an already-reversed match (409) shows the conflict', async ({ page }) => {
+    await apiRoute(page, '**/admin/reconciliations?**', (route) =>
+      json(route, 200, list([reconciliation({ status: 'confirmed' })])),
+    )
+    await apiRoute(page, '**/admin/reconciliations/*/reverse', (route) =>
+      problem(route, 409, 'invalid-state-transition', 'この消込はすでに取り消されています。'),
+    )
+
+    await page.goto('/admin/reconciliation')
+    await page.getByRole('button', { name: '消込一覧' }).click()
+    await page.getByRole('button', { name: '消込を取消' }).first().click()
+    await page.locator('.fixed input[type="text"]').fill('二重取消')
+    await page.locator('.fixed').getByRole('button', { name: '消込を取消' }).click()
+
+    await expect(page.getByText('この消込はすでに取り消されています。')).toBeVisible()
+  })
+
+  test('reversed rows expose no reverse button', async ({ page }) => {
+    await apiRoute(page, '**/admin/reconciliations?**', (route) =>
+      json(route, 200, list([reconciliation({ status: 'reversed' })])),
+    )
+
+    await page.goto('/admin/reconciliation')
+    await page.getByRole('button', { name: '消込一覧' }).click()
+
+    await expect(page.getByText('取消済')).toBeVisible()
+    await expect(page.getByRole('button', { name: '消込を取消' })).toHaveCount(0)
+  })
+})

--- a/tests/e2e/specs/07-dunning.spec.ts
+++ b/tests/e2e/specs/07-dunning.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, problem, list, bypassLogin, dunningNotice } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  await apiRoute(page, '**/admin/dunning-notices?**', (route) => json(route, 200, list([])))
+})
+
+test.describe('Dunning — send boundaries', () => {
+  test('empty / zero invoice id shows client-side validation error', async ({ page }) => {
+    let posted = false
+    await apiRoute(page, '**/admin/dunning-notices', (route) => {
+      if (route.request().method() === 'POST') {
+        posted = true
+        return json(route, 201, dunningNotice())
+      }
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/dunning')
+    await page.getByRole('button', { name: '督促を送信' }).click()
+
+    await expect(page.getByText('有効な請求書IDを入力してください')).toBeVisible()
+    expect(posted).toBe(false)
+  })
+
+  test('invoice not eligible (422) surfaces the upstream error', async ({ page }) => {
+    await apiRoute(page, '**/admin/dunning-notices', (route) => {
+      if (route.request().method() === 'POST') {
+        return problem(route, 422, 'invoice-not-eligible-for-dunning', 'この請求書は支払済み、または残高がないため督促できません。')
+      }
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/dunning')
+    await page.locator('input[type="number"]').fill('123')
+    await page.getByRole('button', { name: '督促を送信' }).click()
+
+    await expect(page.getByText('この請求書は支払済み、または残高がないため督促できません。')).toBeVisible()
+  })
+
+  test('too frequent (422) surfaces the interval error', async ({ page }) => {
+    await apiRoute(page, '**/admin/dunning-notices', (route) => {
+      if (route.request().method() === 'POST') {
+        return problem(route, 422, 'dunning-too-frequent', '前回の督促から最短間隔が経過していません。', undefined, {
+          next_allowed_at: '2026-05-01 09:00:00',
+        })
+      }
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/dunning')
+    await page.locator('input[type="number"]').fill('123')
+    await page.getByRole('button', { name: '督促を送信' }).click()
+
+    await expect(page.getByText('前回の督促から最短間隔が経過していません。')).toBeVisible()
+  })
+
+  test('successful send shows the confirmation message', async ({ page }) => {
+    await apiRoute(page, '**/admin/dunning-notices', (route) => {
+      if (route.request().method() === 'POST') {
+        return json(route, 201, dunningNotice())
+      }
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/dunning')
+    await page.locator('input[type="number"]').fill('123')
+    await page.getByRole('button', { name: '督促を送信' }).click()
+
+    await expect(page.getByText('督促メールを送信しました。')).toBeVisible()
+  })
+})

--- a/tests/e2e/specs/08-settings.spec.ts
+++ b/tests/e2e/specs/08-settings.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, bypassLogin, clearSettings } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  await apiRoute(page, '**/admin/clear-settings', (route) => {
+    if (route.request().method() === 'PUT') {
+      return json(route, 200, clearSettings({ dunning_min_interval_days: 14 }))
+    }
+    return json(route, 200, clearSettings({ dunning_min_interval_days: 7 }))
+  })
+})
+
+test.describe('Settings — dunning interval + connection test', () => {
+  test('loads current settings and bank accounts', async ({ page }) => {
+    await page.goto('/admin/settings')
+
+    await expect(page.locator('input[type="number"]')).toHaveValue('7')
+    await expect(page.getByText(/テスト銀行/)).toBeVisible()
+  })
+
+  test('save shows the saved confirmation', async ({ page }) => {
+    await page.goto('/admin/settings')
+    await page.locator('input[type="number"]').fill('14')
+    await page.getByRole('button', { name: '保存' }).click()
+
+    await expect(page.getByText('保存しました')).toBeVisible()
+  })
+
+  test('interval below 1 is rejected by client validation', async ({ page }) => {
+    let putCalled = false
+    await page.route('**/admin/clear-settings', async (route) => {
+      if (route.request().method() === 'PUT' && route.request().resourceType() !== 'document') {
+        putCalled = true
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/admin/settings')
+    await page.locator('input[type="number"]').fill('0')
+    await page.getByRole('button', { name: '保存' }).click()
+
+    // zod min(1) blocks the request and shows a field error.
+    await page.waitForTimeout(300)
+    expect(putCalled).toBe(false)
+  })
+
+  test('test connection shows success', async ({ page }) => {
+    await apiRoute(page, '**/admin/clear-settings/test-upstream', (route) =>
+      json(route, 200, { ok: true }),
+    )
+
+    await page.goto('/admin/settings')
+    await page.getByRole('button', { name: '接続テスト' }).click()
+
+    await expect(page.getByText('接続成功')).toBeVisible()
+  })
+
+  test('test connection shows failure', async ({ page }) => {
+    await apiRoute(page, '**/admin/clear-settings/test-upstream', (route) =>
+      json(route, 200, { ok: false }),
+    )
+
+    await page.goto('/admin/settings')
+    await page.getByRole('button', { name: '接続テスト' }).click()
+
+    await expect(page.getByText('接続失敗')).toBeVisible()
+  })
+})

--- a/tests/e2e/specs/09-users.spec.ts
+++ b/tests/e2e/specs/09-users.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, problem, list, bypassLogin, user } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+})
+
+test.describe('Users — invite + delete boundaries', () => {
+  test('empty list shows no-data', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/users')
+
+    await expect(page.getByText('データがありません。')).toBeVisible()
+  })
+
+  test('renders role and status badges', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) =>
+      json(route, 200, list([user({ role: 'admin', status: 'invited', email: 'a@acme.example' })])),
+    )
+
+    await page.goto('/admin/users')
+
+    await expect(page.getByText('a@acme.example')).toBeVisible()
+    await expect(page.getByText('招待中')).toBeVisible()
+  })
+
+  test('invite with empty email shows client-side error', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/users')
+    await page.getByRole('button', { name: 'ユーザーを招待' }).click()
+    // Submit the modal form without an email.
+    await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
+
+    await expect(page.getByText('メールアドレスを入力してください')).toBeVisible()
+  })
+
+  test('invite duplicate email (409) surfaces the upstream error', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) => json(route, 200, list([])))
+    await apiRoute(page, '**/admin/users', (route) => {
+      if (route.request().method() === 'POST') {
+        return problem(route, 409, 'user-already-exists', 'そのメールアドレスはすでに使用されています。')
+      }
+      return json(route, 200, list([]))
+    })
+
+    await page.goto('/admin/users')
+    await page.getByRole('button', { name: 'ユーザーを招待' }).click()
+    await page.locator('.fixed input[type="email"]').fill('taken@acme.example')
+    await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
+
+    await expect(page.getByText('そのメールアドレスはすでに使用されています。')).toBeVisible()
+  })
+
+  test('delete confirmation then success removes the dialog', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) =>
+      json(route, 200, list([user({ email: 'gone@acme.example' })])),
+    )
+    await apiRoute(page, '**/admin/users/*', (route) => json(route, 204, null))
+
+    await page.goto('/admin/users')
+    await page.getByRole('button', { name: '削除' }).first().click()
+
+    await expect(page.getByText('このユーザーを削除しますか？')).toBeVisible()
+    await page.locator('.fixed').getByRole('button', { name: '削除' }).click()
+
+    await expect(page.getByText('このユーザーを削除しますか？')).toHaveCount(0)
+  })
+})

--- a/tests/e2e/specs/10-locale.spec.ts
+++ b/tests/e2e/specs/10-locale.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin } from '../fixtures/helpers'
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+    json(route, 200, { items: [], total: 0, limit: 1, offset: 0 }),
+  )
+  await apiRoute(page, '**/admin/dunning-notices**', (route) => json(route, 200, list([])))
+})
+
+test.describe('Locale switching (ADR 0005)', () => {
+  test('defaults to Japanese and switches to English', async ({ page }) => {
+    await page.goto('/admin')
+
+    // Japanese default — sidebar nav.
+    await expect(page.getByRole('link', { name: 'ダッシュボード' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'EN' }).click()
+
+    await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'ダッシュボード' })).toHaveCount(0)
+  })
+
+  test('locale choice persists across navigation', async ({ page }) => {
+    await page.goto('/admin')
+    await page.getByRole('button', { name: 'EN' }).click()
+    await page.getByRole('link', { name: 'Settings' }).click()
+
+    await expect(page).toHaveURL(/\/admin\/settings/)
+    // html lang attribute reflects the chosen locale.
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en')
+  })
+})


### PR DESCRIPTION
## Summary

Playwright によるブラウザシナリオ(E2E)テストを実装。全機能・**40 シナリオ**、境界とエラーパスを重点的にカバー。API は `page.route()` で全モック（バックエンド不要）、`vite preview` でビルド済み SPA を配信。

## カバレッジ（境界重点）

| spec | 主な境界・エラー |
|---|---|
| 01-login | 空欄でブロック、401 でエラー表示し残留、成功でトークン保存+遷移 |
| 02-auth-guard | 未認証 → /login、セッション切れ 401 → /login |
| 03-dashboard | 未消込件数、最近の督促、空状態 |
| 04-bank-transactions | 空、¥整形、ページネーション境界（先頭=戻る無効/末尾=次へ無効）、1ページ時は操作なし、フィルタ |
| 05-bank-import | ファイル/口座未選択、重複(409)、取消理由ゲート、取消成功、取消済は不可 |
| 06-reconciliation | 過剰配賦(422)、確定成功、取消理由ゲート+成功、二重取消(409)、取消済は不可 |
| 07-dunning | 無効ID、督促対象外(422)、間隔未達(422)、成功 |
| 08-settings | 読込、保存、間隔<1ブロック、接続テスト成功/失敗 |
| 09-users | 空、バッジ、招待空欄/重複(409)、削除確認+成功 |
| 10-locale | JA既定、EN切替、永続化+html lang |

## テスト中に発見・修正した実バグ 2件

1. **`client.ts`**: `/auth/login` の 401 もグローバル 401 ハンドラがリダイレクトしていたため、ログイン失敗メッセージが表示されなかった（リロードで消える）。login パスを除外（参照実装と同じ）。
2. **`endpoints.ts` importBankCsv**: multipart アップロードが HTTP ステータスを無視し、409/4xx を「取込成功」扱いしていた。`!res.ok` で throw するよう修正し、重複インポート等のエラーが表示されるように。

ユニットテストにも login パス 401 除外のケースを追加（27 ユニット）。

## 実行

```bash
npm install --prefix tests/e2e
npx playwright install chromium
cd tests/e2e && npx playwright test   # 40 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)