### PR TITLE
fix: resolve 3 dunning/reconciliation bugs (#87 #88 #89)

### DIFF
--- a/src/Dunning/DunningMailerInterface.php
+++ b/src/Dunning/DunningMailerInterface.php
@@ -7,4 +7,6 @@ namespace NeneClear\Dunning;
 interface DunningMailerInterface
 {
     public function send(DunningMailPayload $payload): void;
+
+    public function channel(): string;
 }

--- a/src/Dunning/LogOnlyDunningMailer.php
+++ b/src/Dunning/LogOnlyDunningMailer.php
@@ -6,6 +6,11 @@ namespace NeneClear\Dunning;
 
 final readonly class LogOnlyDunningMailer implements DunningMailerInterface
 {
+    public function channel(): string
+    {
+        return 'log';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         error_log(sprintf(

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -17,7 +17,6 @@ use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
 {
     private const int DEFAULT_MIN_INTERVAL_DAYS = 7;
-    private const string CHANNEL = 'log';
 
     public function __construct(
         private DunningNoticeRepositoryInterface $notices,
@@ -34,7 +33,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
     {
         $invoice = $this->invoiceClient->getInvoice($input->organizationId, $input->invoiceId);
 
-        if (!in_array($invoice->status, ['issued', 'partially_paid'], true) || $invoice->outstandingCents <= 0) {
+        if (!in_array($invoice->status, ['issued', 'partially_paid', 'overdue'], true) || $invoice->outstandingCents <= 0) {
             throw new InvoiceAlreadyPaidException($input->invoiceId, $invoice->status);
         }
 
@@ -76,7 +75,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             recipientEmail: $client->recipientEmail,
             outstandingCents: $invoice->outstandingCents,
             dueAt: $invoice->dueAt,
-            channel: self::CHANNEL,
+            channel: $this->mailer->channel(),
             sentBy: $input->actorUserId,
             sentAt: $nowStr,
         );
@@ -109,7 +108,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                     'invoice_number' => $invoice->invoiceNumber,
                     'recipient_email' => $client->recipientEmail,
                     'outstanding_at_send_cents' => $invoice->outstandingCents,
-                    'channel' => self::CHANNEL,
+                    'channel' => $this->mailer->channel(),
                 ],
             ],
         ));

--- a/src/Dunning/SmtpDunningMailer.php
+++ b/src/Dunning/SmtpDunningMailer.php
@@ -32,6 +32,11 @@ final class SmtpDunningMailer implements DunningMailerInterface
         $this->mailer = new Mailer($transport);
     }
 
+    public function channel(): string
+    {
+        return 'email';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         $email = (new Email())

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -73,6 +73,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 'payment' => $payment,
                 'externalRef' => $externalRef,
                 'invoiceOutstandingBefore' => $invoice->outstandingCents,
+                'clientId' => $invoice->clientId,
             ];
         }
 
@@ -112,7 +113,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
         if ($remainder > 0) {
             $this->clientCredits->save(new ClientCredit(
                 organizationId: $input->organizationId,
-                clientId: $paymentsCreated[0]['payment']->invoiceId,
+                clientId: $paymentsCreated[0]['clientId'],
                 amountCents: $remainder,
                 remainingCents: $remainder,
                 status: ClientCreditStatus::Open,

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -87,7 +87,7 @@ final class SendDunningUseCaseTest extends TestCase
         self::assertSame(1, $notice->invoiceId);
         self::assertSame('accounts@acme.example', $notice->recipientEmail);
         self::assertSame(110000, $notice->outstandingCents);
-        self::assertSame('log', $notice->channel);
+        self::assertSame('email', $notice->channel);
 
         self::assertCount(1, $this->mailer->sent);
         self::assertSame('accounts@acme.example', $this->mailer->sent[0]->to);

--- a/tests/Dunning/SpyDunningMailer.php
+++ b/tests/Dunning/SpyDunningMailer.php
@@ -12,6 +12,11 @@ final class SpyDunningMailer implements DunningMailerInterface
     /** @var list<DunningMailPayload> */
     public array $sent = [];
 
+    public function channel(): string
+    {
+        return 'email';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         $this->sent[] = $payload;


### PR DESCRIPTION
## Summary
- **#87** `SendDunningUseCase`: added `'overdue'` to eligibility status check (compliance §4.1)
- **#88** `ConfirmMatchUseCase`: `ClientCredit.clientId` was incorrectly set to `invoiceId`; now retains `$invoice->clientId` in `$paymentsCreated` and uses it
- **#89** `DunningMailerInterface`: added `channel(): string`; `SmtpDunningMailer` → `'email'`, `LogOnlyDunningMailer` → `'log'`; UseCase uses `$this->mailer->channel()`

## Test plan
- [ ] All 208 backend tests pass (6 skipped = contract tests)
- [ ] PHPStan level 8 clean

Closes #87, closes #88, closes #89