### PR TITLE
feat: add template_version to DunningNotice (#90)

### DIFF
--- a/database/migrations/20260531500000_add_template_version_to_dunning_notices.php
+++ b/database/migrations/20260531500000_add_template_version_to_dunning_notices.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddTemplateVersionToDunningNotices extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('dunning_notices')
+            ->addColumn('template_version', 'string', ['limit' => 32, 'default' => '1.0', 'after' => 'channel'])
+            ->update();
+    }
+}

--- a/src/Dunning/DunningNotice.php
+++ b/src/Dunning/DunningNotice.php
@@ -19,6 +19,7 @@ final readonly class DunningNotice
         public int $outstandingCents,
         public string $dueAt,
         public string $channel,
+        public string $templateVersion,
         public int $sentBy,
         public string $sentAt,
         public ?int $id = null,

--- a/src/Dunning/DunningNoticeResponse.php
+++ b/src/Dunning/DunningNoticeResponse.php
@@ -21,6 +21,7 @@ final readonly class DunningNoticeResponse
             'outstanding_cents' => $notice->outstandingCents,
             'due_at' => $notice->dueAt,
             'channel' => $notice->channel,
+            'template_version' => $notice->templateVersion,
             'sent_by' => $notice->sentBy,
             'sent_at' => $notice->sentAt,
         ];

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -9,7 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 final readonly class PdoDunningNoticeRepository implements DunningNoticeRepositoryInterface
 {
     private const string COLUMNS = 'id, organization_id, invoice_id, invoice_number, client_id, '
-        . 'recipient_email, outstanding_cents, due_at, channel, sent_by, sent_at';
+        . 'recipient_email, outstanding_cents, due_at, channel, template_version, sent_by, sent_at';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -20,8 +20,8 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
     {
         $this->query->execute(
             'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, '
-            . 'recipient_email, outstanding_cents, due_at, channel, sent_by, sent_at) '
-            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            . 'recipient_email, outstanding_cents, due_at, channel, template_version, sent_by, sent_at) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $notice->organizationId,
                 $notice->invoiceId,
@@ -31,6 +31,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
                 $notice->outstandingCents,
                 $notice->dueAt,
                 $notice->channel,
+                $notice->templateVersion,
                 $notice->sentBy,
                 $notice->sentAt,
             ],
@@ -92,6 +93,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
             outstandingCents: (int) $row['outstanding_cents'],
             dueAt: (string) $row['due_at'],
             channel: (string) $row['channel'],
+            templateVersion: (string) $row['template_version'],
             sentBy: (int) $row['sent_by'],
             sentAt: (string) $row['sent_at'],
             id: (int) $row['id'],

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -17,6 +17,7 @@ use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
 {
     private const int DEFAULT_MIN_INTERVAL_DAYS = 7;
+    private const string TEMPLATE_VERSION = '1.0';
 
     public function __construct(
         private DunningNoticeRepositoryInterface $notices,
@@ -76,6 +77,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             outstandingCents: $invoice->outstandingCents,
             dueAt: $invoice->dueAt,
             channel: $this->mailer->channel(),
+            templateVersion: self::TEMPLATE_VERSION,
             sentBy: $input->actorUserId,
             sentAt: $nowStr,
         );
@@ -109,6 +111,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                     'recipient_email' => $client->recipientEmail,
                     'outstanding_at_send_cents' => $invoice->outstandingCents,
                     'channel' => $this->mailer->channel(),
+                    'template_version' => self::TEMPLATE_VERSION,
                 ],
             ],
         ));

--- a/tests/Dunning/InMemoryDunningNoticeRepository.php
+++ b/tests/Dunning/InMemoryDunningNoticeRepository.php
@@ -26,6 +26,7 @@ final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryIn
             outstandingCents: $notice->outstandingCents,
             dueAt: $notice->dueAt,
             channel: $notice->channel,
+            templateVersion: $notice->templateVersion,
             sentBy: $notice->sentBy,
             sentAt: $notice->sentAt,
             id: $id,

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -88,6 +88,7 @@ final class SendDunningUseCaseTest extends TestCase
         self::assertSame('accounts@acme.example', $notice->recipientEmail);
         self::assertSame(110000, $notice->outstandingCents);
         self::assertSame('email', $notice->channel);
+        self::assertSame('1.0', $notice->templateVersion);
 
         self::assertCount(1, $this->mailer->sent);
         self::assertSame('accounts@acme.example', $this->mailer->sent[0]->to);

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -214,6 +214,7 @@ final class SchemaFixture
                 outstanding_cents INTEGER NOT NULL,
                 due_at TEXT NOT NULL,
                 channel TEXT NOT NULL DEFAULT \'log\',
+                template_version TEXT NOT NULL DEFAULT \'1.0\',
                 sent_by INTEGER NOT NULL,
                 sent_at TEXT NOT NULL,
                 created_at TEXT


### PR DESCRIPTION
## Summary
- Compliance §4.2 requires template version stored on each dunning send record
- DB migration adds `template_version VARCHAR(32) DEFAULT '1.0'` to `dunning_notices`
- `DunningNotice` entity, repository, and response DTO updated
- `SendDunningUseCase` constant `TEMPLATE_VERSION = '1.0'` sets version on each notice
- Also pulls `DunningMailerInterface.channel()` onto this branch to avoid conflicts with #99

## Test plan
- [ ] 208 backend tests pass (6 skipped)
- [ ] PHPStan level 8 clean
- [ ] Migration runs clean on MySQL (Phinx)

Closes #90