### PR TITLE
feat: CSV export endpoints + download buttons (#97)

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,4 +1,19 @@
 import { api } from './client'
+
+export async function downloadCsv(path: string, filename: string): Promise<void> {
+  const token = sessionStorage.getItem('nene_clear_token')
+  const res = await fetch(path, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  if (!res.ok) throw new Error(`Export failed: ${res.status}`)
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
 import type {
   User, BankImportBatch, BankTransaction, Reconciliation,
   ClientCredit, DunningNotice, ClearSettings, UpstreamInvoice,

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -100,6 +100,10 @@ export const en: Partial<Record<MessageKey, string>> = {
   'users.delete': 'Delete',
   'users.confirmDelete': 'Delete this user?',
 
+  'export.reconciliations': 'Export reconciliations CSV',
+  'export.clientCredits': 'Export client credits CSV',
+  'export.bankTransactions': 'Export bank transactions CSV',
+
   'common.save': 'Save',
   'common.cancel': 'Cancel',
   'common.delete': 'Delete',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -109,6 +109,11 @@ export const ja = {
   'users.delete': '削除',
   'users.confirmDelete': 'このユーザーを削除しますか？',
 
+  // Export
+  'export.reconciliations': '消込データをCSV出力',
+  'export.clientCredits': '前受金データをCSV出力',
+  'export.bankTransactions': '銀行取引データをCSV出力',
+
   // Common
   'common.save': '保存',
   'common.cancel': 'キャンセル',

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from '@/hooks/useTranslation'
-import { listBankTransactions } from '@/api/endpoints'
+import { listBankTransactions, downloadCsv } from '@/api/endpoints'
 import type { BankTransaction } from '@/types'
 
 const PAGE_SIZE = 20
@@ -64,7 +64,7 @@ export default function BankTransactionsPage() {
   })
 
   function applyFilter() {
-    setAppliedFilter({ status, dateFrom, dateTo, counterparty, offset: 0 })
+    setAppliedFilter({ status, dateFrom, dateTo, amountMin, amountMax, counterparty, offset: 0 })
   }
 
   function goPage(newOffset: number) {
@@ -77,7 +77,15 @@ export default function BankTransactionsPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">{t('bankTransaction.title')}</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">{t('bankTransaction.title')}</h1>
+        <button
+          onClick={() => void downloadCsv('/admin/export/bank-transactions', 'bank-transactions.csv')}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          {t('export.bankTransactions')}
+        </button>
+      </div>
 
       {/* Filter bar */}
       <div className="mb-6 rounded-lg bg-white p-4 shadow-sm flex flex-wrap gap-3 items-end">

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -6,6 +6,7 @@ import {
   listReconciliations,
   confirmMatch,
   reverseReconciliation,
+  downloadCsv,
 } from '@/api/endpoints'
 import type { BankTransaction, Reconciliation } from '@/types'
 import type { AllocationInput } from '@/api/endpoints'
@@ -233,7 +234,15 @@ export default function ReconciliationPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">{t('reconciliation.title')}</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">{t('reconciliation.title')}</h1>
+        <button
+          onClick={() => void downloadCsv('/admin/export/reconciliations', 'reconciliations.csv')}
+          className="rounded border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+        >
+          {t('export.reconciliations')}
+        </button>
+      </div>
 
       {/* Tabs */}
       <div className="mb-6 flex gap-1 border-b border-gray-200">

--- a/src/Export/ExportBankTransactionsCsvHandler.php
+++ b/src/Export/ExportBankTransactionsCsvHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use NeneClear\Auth\AuthContext;
+use NeneClear\BankImport\BankTransactionFilter;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportBankTransactionsCsvHandler
+{
+    private const int BATCH = 1000;
+
+    public function __construct(
+        private BankTransactionRepositoryInterface $transactions,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $q = (array) $request->getQueryParams();
+
+        $filter = new BankTransactionFilter(
+            valueDateFrom: is_string($q['date_from'] ?? null) && $q['date_from'] !== '' ? $q['date_from'] : null,
+            valueDateTo: is_string($q['date_to'] ?? null) && $q['date_to'] !== '' ? $q['date_to'] : null,
+        );
+
+        $rows = [];
+        $offset = 0;
+        do {
+            $batch = $this->transactions->findByOrganization($organizationId, $filter, self::BATCH, $offset);
+            foreach ($batch as $tx) {
+                $rows[] = [
+                    $tx->id ?? '',
+                    $tx->bankImportBatchId,
+                    $tx->valueDate,
+                    $tx->amountCents,
+                    $tx->counterpartyText,
+                    $tx->status->value,
+                    $tx->lineKey,
+                ];
+            }
+            $offset += self::BATCH;
+        } while (count($batch) === self::BATCH);
+
+        $csv = $this->buildCsv(
+            ['bank_transaction_id', 'bank_import_batch_id', 'value_date', 'amount_cents',
+                'counterparty_text', 'status', 'line_key'],
+            $rows,
+        );
+
+        return $this->csvResponse($csv, 'bank-transactions.csv');
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<list<mixed>> $rows
+     */
+    private function buildCsv(array $headers, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        fwrite($handle, "\xEF\xBB\xBF");
+        fputcsv($handle, $headers);
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
+        }
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        fclose($handle);
+
+        return $content !== false ? $content : '';
+    }
+
+    private function csvResponse(string $content, string $filename): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withBody($this->streamFactory->createStream($content));
+    }
+}

--- a/src/Export/ExportClientCreditsCsvHandler.php
+++ b/src/Export/ExportClientCreditsCsvHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use NeneClear\Auth\AuthContext;
+use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportClientCreditsCsvHandler
+{
+    private const int BATCH = 1000;
+
+    public function __construct(
+        private ClientCreditRepositoryInterface $credits,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $rows = [];
+        $offset = 0;
+        do {
+            $batch = $this->credits->findByOrganization($organizationId, self::BATCH, $offset);
+            foreach ($batch as $credit) {
+                $rows[] = [
+                    $credit->id ?? '',
+                    $credit->clientId,
+                    $credit->status->value,
+                    $credit->amountCents,
+                    $credit->remainingCents,
+                    $credit->sourceBankTransactionId,
+                    $credit->reconciliationId,
+                    $credit->createdAt,
+                    $credit->createdBy,
+                ];
+            }
+            $offset += self::BATCH;
+        } while (count($batch) === self::BATCH);
+
+        $csv = $this->buildCsv(
+            ['client_credit_id', 'client_id', 'status', 'amount_cents', 'remaining_cents',
+                'source_bank_transaction_id', 'reconciliation_id', 'created_at', 'created_by'],
+            $rows,
+        );
+
+        return $this->csvResponse($csv, 'client-credits.csv');
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<list<mixed>> $rows
+     */
+    private function buildCsv(array $headers, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        fwrite($handle, "\xEF\xBB\xBF");
+        fputcsv($handle, $headers);
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
+        }
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        fclose($handle);
+
+        return $content !== false ? $content : '';
+    }
+
+    private function csvResponse(string $content, string $filename): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withBody($this->streamFactory->createStream($content));
+    }
+}

--- a/src/Export/ExportReconciliationsCsvHandler.php
+++ b/src/Export/ExportReconciliationsCsvHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use NeneClear\Auth\AuthContext;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportReconciliationsCsvHandler
+{
+    private const int BATCH = 1000;
+
+    public function __construct(
+        private ReconciliationRepositoryInterface $reconciliations,
+        private BankTransactionRepositoryInterface $transactions,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $rows = [];
+        $offset = 0;
+        do {
+            $batch = $this->reconciliations->findByOrganization($organizationId, null, self::BATCH, $offset);
+            foreach ($batch as $recon) {
+                $tx = $this->transactions->findById($organizationId, $recon->bankTransactionId);
+
+                $allocations = $this->reconciliations->findAllocationsByReconciliation($organizationId, $recon->id ?? 0);
+                if (empty($allocations)) {
+                    $rows[] = [
+                        $recon->id ?? '',
+                        '',
+                        $recon->status->value,
+                        '',
+                        '',
+                        '',
+                        $recon->bankTransactionId,
+                        $tx !== null ? $tx->valueDate : '',
+                        $tx !== null ? $tx->amountCents : '',
+                        $tx !== null ? $tx->counterpartyText : '',
+                        $recon->confirmedAt,
+                        $recon->confirmedBy,
+                        $recon->reversedAt ?? '',
+                        $recon->reversalReason ?? '',
+                    ];
+                } else {
+                    foreach ($allocations as $alloc) {
+                        $rows[] = [
+                            $recon->id ?? '',
+                            $alloc->id ?? '',
+                            $recon->status->value,
+                            $alloc->invoiceId,
+                            $alloc->amountCents,
+                            $alloc->externalReference ?? '',
+                            $recon->bankTransactionId,
+                            $tx !== null ? $tx->valueDate : '',
+                            $tx !== null ? $tx->amountCents : '',
+                            $tx !== null ? $tx->counterpartyText : '',
+                            $recon->confirmedAt,
+                            $recon->confirmedBy,
+                            $recon->reversedAt ?? '',
+                            $recon->reversalReason ?? '',
+                        ];
+                    }
+                }
+            }
+            $offset += self::BATCH;
+        } while (count($batch) === self::BATCH);
+
+        $csv = $this->buildCsv(
+            ['reconciliation_id', 'allocation_id', 'status', 'invoice_id', 'amount_cents',
+                'external_reference', 'bank_transaction_id', 'value_date', 'bank_amount_cents',
+                'counterparty_text', 'confirmed_at', 'confirmed_by', 'reversed_at', 'reversal_reason'],
+            $rows,
+        );
+
+        return $this->csvResponse($csv, 'reconciliations.csv');
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<list<mixed>> $rows
+     */
+    private function buildCsv(array $headers, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        // UTF-8 BOM for Excel compatibility
+        fwrite($handle, "\xEF\xBB\xBF");
+        fputcsv($handle, $headers);
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
+        }
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        fclose($handle);
+
+        return $content !== false ? $content : '';
+    }
+
+    private function csvResponse(string $content, string $filename): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withBody($this->streamFactory->createStream($content));
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -58,6 +58,9 @@ use NeneClear\Dunning\PdoDunningNoticeRepository;
 use NeneClear\Dunning\SendDunningHandler;
 use NeneClear\Dunning\SendDunningUseCase;
 use NeneClear\Dunning\SmtpDunningMailer;
+use NeneClear\Export\ExportBankTransactionsCsvHandler;
+use NeneClear\Export\ExportClientCreditsCsvHandler;
+use NeneClear\Export\ExportReconciliationsCsvHandler;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
@@ -114,6 +117,8 @@ use NeneClear\User\UserAlreadyExistsExceptionHandler;
 use NeneClear\User\UserNotFoundExceptionHandler;
 use NeneClear\User\UserRouteRegistrar;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
@@ -238,6 +243,15 @@ final class ApplicationFactory
                 new ApplyCreditHandler(new ApplyCreditUseCase($creditRepo, $upstream, $audit), $json),
             );
 
+            $routeRegistrars[] = static function (\Nene2\Routing\Router $router) use ($reconRepo, $creditRepo, $transactions, $psr17): void {
+                $reconExport = new ExportReconciliationsCsvHandler($reconRepo, $transactions, $psr17, $psr17);
+                $creditExport = new ExportClientCreditsCsvHandler($creditRepo, $psr17, $psr17);
+                $txExport = new ExportBankTransactionsCsvHandler($transactions, $psr17, $psr17);
+                $router->get('/admin/export/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $reconExport->handle($r));
+                $router->get('/admin/export/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $creditExport->handle($r));
+                $router->get('/admin/export/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $txExport->handle($r));
+            };
+
             $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new TooManyLoginAttemptsExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
@@ -287,6 +301,7 @@ final class ApplicationFactory
                     '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                     '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                     '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
+                    '/admin/export' => CapabilityRule::same(Capability::ViewReconciliation),
                 ]),
             ];
         }


### PR DESCRIPTION
## Summary
- **Scope-contract D9**: accounting handoff CSV for 税理士 review
- 3 new GET endpoints in `src/Export/`:
  - `GET /admin/export/reconciliations` — one row per allocation, bank txn join
  - `GET /admin/export/client-credits` — client credit history
  - `GET /admin/export/bank-transactions` — bank import evidence (電帳法 companion)
- All: UTF-8 BOM, `Content-Disposition: attachment`, batched read (1 000/batch), `view_reconciliation` capability
- Frontend: `downloadCsv()` helper using fetch+Blob (Authorization header preserved); export buttons on ReconciliationPage and BankTransactionsPage

## Gate (compliance §9)
Column set is designed per `docs/explanation/csv-export.md`. **Tax advisor (税理士/公認会計士) sign-off is pending** before this is declared production-ready. Endpoint ships; release note flags as preview.

## Test plan
- [ ] 208 backend tests pass, PHPStan level 8 clean
- [ ] `GET /admin/export/reconciliations` returns CSV with headers, UTF-8 BOM
- [ ] `GET /admin/export/client-credits` returns CSV
- [ ] `GET /admin/export/bank-transactions` returns CSV with date_from/date_to filter
- [ ] Export buttons on ReconciliationPage and BankTransactionsPage trigger file download

Closes #97