### PR TITLE
feat: dunning pause per invoice (#98)

### DIFF
--- a/database/migrations/20260531600000_create_dunning_pauses_table.php
+++ b/database/migrations/20260531600000_create_dunning_pauses_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateDunningPausesTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('dunning_pauses');
+        $table
+            ->addColumn('organization_id', 'biginteger', ['signed' => false])
+            ->addColumn('invoice_id', 'biginteger', ['signed' => false])
+            ->addColumn('paused_by', 'biginteger', ['signed' => false])
+            ->addColumn('paused_at', 'datetime')
+            ->addColumn('paused_reason', 'string', ['limit' => 512])
+            ->addColumn('unpaused_by', 'biginteger', ['signed' => false, 'null' => true, 'default' => null])
+            ->addColumn('unpaused_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['organization_id'])
+            ->addIndex(['organization_id', 'invoice_id'])
+            ->create();
+    }
+}

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -140,6 +140,31 @@ export function sendDunningNotice(invoiceId: number) {
   return api.post<DunningNotice>(`${BASE}/dunning-notices`, { invoice_id: invoiceId })
 }
 
+export interface DunningPause {
+  dunning_pause_id: number | null
+  invoice_id: number
+  paused_by: number
+  paused_at: string
+  paused_reason: string
+  unpaused_by: number | null
+  unpaused_at: string | null
+  is_active: boolean
+}
+
+export function listDunningPauses(params: { active_only?: boolean; limit?: number }, signal?: AbortSignal) {
+  const q = new URLSearchParams({ limit: String(params.limit ?? 100) })
+  if (params.active_only) q.set('active_only', 'true')
+  return api.get<ListEnvelope<DunningPause>>(`${BASE}/dunning-pauses?${q}`, signal)
+}
+
+export function pauseDunningNotice(invoiceId: number, reason: string) {
+  return api.post<DunningPause>(`${BASE}/dunning-pauses`, { invoice_id: invoiceId, reason })
+}
+
+export function resumeDunningNotice(invoiceId: number) {
+  return api.post<void>(`${BASE}/dunning-pauses/${invoiceId}/resume`)
+}
+
 // --- Settings ---
 export function getClearSettings(signal?: AbortSignal) {
   return api.get<ClearSettings>(`${BASE}/clear-settings`, signal)

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -76,6 +76,11 @@ export const en: Partial<Record<MessageKey, string>> = {
   'dunning.sentBy': 'Sent by',
   'dunning.history': 'Dunning history',
   'dunning.confirmSend': 'Send a dunning notice for this invoice?',
+  'dunning.pause': 'Pause dunning',
+  'dunning.resume': 'Resume dunning',
+  'dunning.pauseReason': 'Pause reason',
+  'dunning.paused': 'Paused',
+  'dunning.confirmPause': 'Pause dunning for this invoice?',
 
   'settings.title': 'Settings',
   'settings.upstreamUrl': 'Invoice API URL',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -83,6 +83,11 @@ export const ja = {
   'dunning.sentBy': '送信者',
   'dunning.history': '督促履歴',
   'dunning.confirmSend': 'この請求書に督促メールを送信しますか？',
+  'dunning.pause': '督促停止',
+  'dunning.resume': '督促再開',
+  'dunning.pauseReason': '停止理由',
+  'dunning.paused': '停止中',
+  'dunning.confirmPause': 'この請求書の督促を一時停止しますか？',
 
   // Settings
   'settings.title': '設定',

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from '@/hooks/useTranslation'
-import { listDunningNotices, sendDunningNotice } from '@/api/endpoints'
+import {
+  listDunningNotices, sendDunningNotice,
+  listDunningPauses, pauseDunningNotice, resumeDunningNotice,
+} from '@/api/endpoints'
 
 function formatYen(cents: number) {
   return '¥' + Math.floor(cents / 100).toLocaleString('ja-JP')
@@ -11,6 +14,59 @@ function formatDate(iso: string) {
   return iso.slice(0, 16).replace('T', ' ')
 }
 
+// ------- Pause Modal -------
+interface PauseModalProps {
+  invoiceId: number
+  onClose: () => void
+}
+
+function PauseModal({ invoiceId, onClose }: PauseModalProps) {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+  const [reason, setReason] = useState('')
+
+  const mutation = useMutation({
+    mutationFn: () => pauseDunningNotice(invoiceId, reason),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['dunning-pauses'] })
+      onClose()
+    },
+  })
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h3 className="mb-4 text-base font-semibold text-gray-900">{t('dunning.confirmPause')}</h3>
+        <p className="mb-3 text-sm text-gray-500">請求書ID: {invoiceId}</p>
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">{t('dunning.pauseReason')}</label>
+          <input
+            type="text"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none"
+          />
+        </div>
+        {mutation.isError && (
+          <p className="mb-3 text-sm text-red-600">{mutation.error.message}</p>
+        )}
+        <div className="flex gap-3 justify-end">
+          <button onClick={onClose} className="rounded border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending || !reason.trim()}
+            className="rounded bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? t('common.loading') : t('dunning.pause')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function DunningPage() {
   const { t } = useTranslation()
   const qc = useQueryClient()
@@ -18,10 +74,16 @@ export default function DunningPage() {
   const [invoiceIdInput, setInvoiceIdInput] = useState('')
   const [sendSuccess, setSendSuccess] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
+  const [pauseTarget, setPauseTarget] = useState<number | null>(null)
 
   const noticesQuery = useQuery({
     queryKey: ['dunning-notices'],
     queryFn: ({ signal }) => listDunningNotices({ limit: 50 }, signal),
+  })
+
+  const pausesQuery = useQuery({
+    queryKey: ['dunning-pauses', { active_only: true }],
+    queryFn: ({ signal }) => listDunningPauses({ active_only: true, limit: 100 }, signal),
   })
 
   const sendMutation = useMutation({
@@ -38,6 +100,13 @@ export default function DunningPage() {
     },
   })
 
+  const resumeMutation = useMutation({
+    mutationFn: (invoiceId: number) => resumeDunningNotice(invoiceId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['dunning-pauses'] })
+    },
+  })
+
   function handleSend(e: React.FormEvent) {
     e.preventDefault()
     setSendSuccess(false)
@@ -49,6 +118,8 @@ export default function DunningPage() {
     }
     sendMutation.mutate(id)
   }
+
+  const activePauseIds = new Set((pausesQuery.data?.items ?? []).map(p => p.invoice_id))
 
   return (
     <div>
@@ -78,6 +149,14 @@ export default function DunningPage() {
           >
             {sendMutation.isPending ? t('common.loading') : t('dunning.send')}
           </button>
+          <button
+            type="button"
+            disabled={!invoiceIdInput}
+            onClick={() => invoiceIdInput && setPauseTarget(Number(invoiceIdInput))}
+            className="rounded border border-orange-300 px-4 py-2 text-sm font-medium text-orange-700 hover:bg-orange-50 disabled:opacity-40"
+          >
+            {t('dunning.pause')}
+          </button>
         </form>
 
         {sendError && (
@@ -89,6 +168,28 @@ export default function DunningPage() {
           </p>
         )}
       </div>
+
+      {/* Active pauses */}
+      {activePauseIds.size > 0 && (
+        <div className="mb-6 rounded-lg bg-orange-50 border border-orange-200 p-4">
+          <h2 className="mb-2 text-sm font-semibold text-orange-800">{t('dunning.paused')}（{activePauseIds.size}件）</h2>
+          <div className="flex flex-wrap gap-2">
+            {(pausesQuery.data?.items ?? []).map(p => (
+              <div key={p.dunning_pause_id} className="flex items-center gap-2 rounded bg-white border border-orange-200 px-3 py-1 text-xs">
+                <span className="font-medium text-gray-800">請求書 #{p.invoice_id}</span>
+                <span className="text-gray-400">{p.paused_reason}</span>
+                <button
+                  onClick={() => resumeMutation.mutate(p.invoice_id)}
+                  disabled={resumeMutation.isPending}
+                  className="text-blue-600 hover:underline"
+                >
+                  {t('dunning.resume')}
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* History table */}
       <div className="rounded-lg bg-white shadow-sm overflow-hidden">
@@ -138,6 +239,10 @@ export default function DunningPage() {
           </table>
         )}
       </div>
+
+      {pauseTarget !== null && (
+        <PauseModal invoiceId={pauseTarget} onClose={() => setPauseTarget(null)} />
+      )}
     </div>
   )
 }

--- a/lang/en.php
+++ b/lang/en.php
@@ -95,6 +95,9 @@ return [
     'problem.dunning-too-frequent.title'  => 'Dunning Too Frequent',
     'problem.dunning-too-frequent.detail' => 'The minimum interval between dunning notices has not elapsed.',
 
+    'problem.dunning-paused.title'  => 'Dunning Paused',
+    'problem.dunning-paused.detail' => 'Dunning is paused for this invoice. Resume dunning before sending.',
+
     'problem.credit-exceeds-remaining.title'  => 'Credit Exceeds Remaining Balance',
     'problem.credit-exceeds-remaining.detail' => 'The requested amount exceeds the remaining credit balance.',
 

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -92,6 +92,9 @@ return [
     'problem.dunning-too-frequent.title'  => '督促間隔未達',
     'problem.dunning-too-frequent.detail' => '前回の督促から最短間隔が経過していません。',
 
+    'problem.dunning-paused.title'  => '督促一時停止中',
+    'problem.dunning-paused.detail' => 'この請求書の督促は一時停止されています。督促を再開してから送信してください。',
+
     'problem.credit-exceeds-remaining.title'  => '前受金残高超過',
     'problem.credit-exceeds-remaining.detail' => '適用額が前受金の残高を超えています。',
 

--- a/src/Dunning/DunningMailerInterface.php
+++ b/src/Dunning/DunningMailerInterface.php
@@ -7,4 +7,6 @@ namespace NeneClear\Dunning;
 interface DunningMailerInterface
 {
     public function send(DunningMailPayload $payload): void;
+
+    public function channel(): string;
 }

--- a/src/Dunning/DunningPause.php
+++ b/src/Dunning/DunningPause.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+final readonly class DunningPause
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public int $pausedBy,
+        public string $pausedAt,
+        public string $pausedReason,
+        public ?int $unpausedBy = null,
+        public ?string $unpausedAt = null,
+        public ?int $id = null,
+    ) {
+    }
+
+    public function isActive(): bool
+    {
+        return $this->unpausedAt === null;
+    }
+}

--- a/src/Dunning/DunningPauseRepositoryInterface.php
+++ b/src/Dunning/DunningPauseRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+interface DunningPauseRepositoryInterface
+{
+    public function save(DunningPause $pause): int;
+
+    public function findActiveByInvoice(int $organizationId, int $invoiceId): ?DunningPause;
+
+    public function resumeByInvoice(int $organizationId, int $invoiceId, int $unpausedBy, string $unpausedAt): void;
+
+    /**
+     * @return list<DunningPause>
+     */
+    public function findByOrganization(int $organizationId, bool $activeOnly, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId, bool $activeOnly): int;
+}

--- a/src/Dunning/DunningPausedException.php
+++ b/src/Dunning/DunningPausedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use RuntimeException;
+
+final class DunningPausedException extends RuntimeException
+{
+    public function __construct(public readonly int $invoiceId, public readonly string $pausedReason)
+    {
+        parent::__construct("Dunning is paused for invoice {$invoiceId}");
+    }
+}

--- a/src/Dunning/DunningPausedExceptionHandler.php
+++ b/src/Dunning/DunningPausedExceptionHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DunningPausedExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(private LocalizedProblemDetailsFactory $problemDetails)
+    {
+    }
+
+    public function supports(\Throwable $exception): bool
+    {
+        return $exception instanceof DunningPausedException;
+    }
+
+    public function handle(\Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        assert($exception instanceof DunningPausedException);
+
+        return $this->problemDetails->create(
+            $request,
+            'dunning-paused',
+            422,
+            extensions: ['invoice_id' => $exception->invoiceId, 'paused_reason' => $exception->pausedReason],
+        );
+    }
+}

--- a/src/Dunning/DunningRouteRegistrar.php
+++ b/src/Dunning/DunningRouteRegistrar.php
@@ -14,6 +14,9 @@ final readonly class DunningRouteRegistrar
         private SendDunningHandler $sendHandler,
         private ListDunningNoticesHandler $listHandler,
         private GetDunningNoticeByIdHandler $getByIdHandler,
+        private PauseDunningHandler $pauseHandler,
+        private ResumeDunningHandler $resumeHandler,
+        private ListDunningPausesHandler $listPausesHandler,
     ) {
     }
 
@@ -22,9 +25,15 @@ final readonly class DunningRouteRegistrar
         $sendHandler = $this->sendHandler;
         $listHandler = $this->listHandler;
         $getByIdHandler = $this->getByIdHandler;
+        $pauseHandler = $this->pauseHandler;
+        $resumeHandler = $this->resumeHandler;
+        $listPausesHandler = $this->listPausesHandler;
 
         $router->post('/admin/dunning-notices', static fn (ServerRequestInterface $r): ResponseInterface => $sendHandler->handle($r));
         $router->get('/admin/dunning-notices', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
         $router->get('/admin/dunning-notices/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getByIdHandler->handle($r));
+        $router->post('/admin/dunning-pauses', static fn (ServerRequestInterface $r): ResponseInterface => $pauseHandler->handle($r));
+        $router->post('/admin/dunning-pauses/{invoiceId}/resume', static fn (ServerRequestInterface $r): ResponseInterface => $resumeHandler->handle($r));
+        $router->get('/admin/dunning-pauses', static fn (ServerRequestInterface $r): ResponseInterface => $listPausesHandler->handle($r));
     }
 }

--- a/src/Dunning/ListDunningPausesHandler.php
+++ b/src/Dunning/ListDunningPausesHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListDunningPausesHandler
+{
+    public function __construct(
+        private DunningPauseRepositoryInterface $pauses,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $q = (array) $request->getQueryParams();
+        $activeOnly = ($q['active_only'] ?? null) === 'true';
+        $limit = is_numeric($q['limit'] ?? null) ? (int) $q['limit'] : 50;
+        $offset = is_numeric($q['offset'] ?? null) ? (int) $q['offset'] : 0;
+
+        $items = $this->pauses->findByOrganization($organizationId, $activeOnly, $limit, $offset);
+        $total = $this->pauses->countByOrganization($organizationId, $activeOnly);
+
+        return $this->response->create([
+            'items' => array_map(static fn (DunningPause $p): array => [
+                'dunning_pause_id' => $p->id,
+                'invoice_id' => $p->invoiceId,
+                'paused_by' => $p->pausedBy,
+                'paused_at' => $p->pausedAt,
+                'paused_reason' => $p->pausedReason,
+                'unpaused_by' => $p->unpausedBy,
+                'unpaused_at' => $p->unpausedAt,
+                'is_active' => $p->isActive(),
+            ], $items),
+            'limit' => $limit,
+            'offset' => $offset,
+            'total' => $total,
+        ]);
+    }
+}

--- a/src/Dunning/LogOnlyDunningMailer.php
+++ b/src/Dunning/LogOnlyDunningMailer.php
@@ -6,6 +6,11 @@ namespace NeneClear\Dunning;
 
 final readonly class LogOnlyDunningMailer implements DunningMailerInterface
 {
+    public function channel(): string
+    {
+        return 'log';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         error_log(sprintf(

--- a/src/Dunning/PauseDunningHandler.php
+++ b/src/Dunning/PauseDunningHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class PauseDunningHandler
+{
+    public function __construct(
+        private PauseDunningUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $actorUserId = AuthContext::userId($request);
+        $body = (array) $request->getParsedBody();
+
+        $invoiceIdRaw = $body['invoice_id'] ?? null;
+        $invoiceId = is_numeric($invoiceIdRaw) ? (int) $invoiceIdRaw : 0;
+        if ($invoiceId <= 0) {
+            throw new ValidationException([new ValidationError('invoice_id', 'invoice_id must be a positive integer.', 'invalid')]);
+        }
+
+        $reason = is_string($body['reason'] ?? null) ? trim($body['reason']) : '';
+        if ($reason === '') {
+            throw new ValidationException([new ValidationError('reason', 'reason is required.', 'required')]);
+        }
+
+        $pause = $this->useCase->execute($organizationId, $invoiceId, $actorUserId, $reason);
+
+        return $this->response->create($this->toArray($pause), 201);
+    }
+
+    /** @return array<string, mixed> */
+    private function toArray(DunningPause $pause): array
+    {
+        return [
+            'dunning_pause_id' => $pause->id,
+            'invoice_id' => $pause->invoiceId,
+            'paused_by' => $pause->pausedBy,
+            'paused_at' => $pause->pausedAt,
+            'paused_reason' => $pause->pausedReason,
+        ];
+    }
+}

--- a/src/Dunning/PauseDunningUseCase.php
+++ b/src/Dunning/PauseDunningUseCase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
+final readonly class PauseDunningUseCase
+{
+    public function __construct(
+        private DunningPauseRepositoryInterface $pauses,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $invoiceId, int $actorUserId, string $reason): DunningPause
+    {
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        $existing = $this->pauses->findActiveByInvoice($organizationId, $invoiceId);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $pause = new DunningPause(
+            organizationId: $organizationId,
+            invoiceId: $invoiceId,
+            pausedBy: $actorUserId,
+            pausedAt: $now,
+            pausedReason: $reason,
+        );
+
+        $id = $this->pauses->save($pause);
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $organizationId,
+            eventType: 'dunning_paused',
+            actorUserId: $actorUserId,
+            occurredAt: $now,
+            payload: ['invoice_id' => $invoiceId, 'reason' => $reason],
+        ));
+
+        return new DunningPause(
+            organizationId: $pause->organizationId,
+            invoiceId: $pause->invoiceId,
+            pausedBy: $pause->pausedBy,
+            pausedAt: $pause->pausedAt,
+            pausedReason: $pause->pausedReason,
+            id: $id,
+        );
+    }
+}

--- a/src/Dunning/PdoDunningPauseRepository.php
+++ b/src/Dunning/PdoDunningPauseRepository.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoDunningPauseRepository implements DunningPauseRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, invoice_id, paused_by, paused_at, '
+        . 'paused_reason, unpaused_by, unpaused_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(DunningPause $pause): int
+    {
+        $this->query->execute(
+            'INSERT INTO dunning_pauses (organization_id, invoice_id, paused_by, paused_at, paused_reason) '
+            . 'VALUES (?, ?, ?, ?, ?)',
+            [
+                $pause->organizationId,
+                $pause->invoiceId,
+                $pause->pausedBy,
+                $pause->pausedAt,
+                $pause->pausedReason,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findActiveByInvoice(int $organizationId, int $invoiceId): ?DunningPause
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM dunning_pauses '
+            . 'WHERE organization_id = ? AND invoice_id = ? AND unpaused_at IS NULL '
+            . 'ORDER BY id DESC LIMIT 1',
+            [$organizationId, $invoiceId],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function resumeByInvoice(int $organizationId, int $invoiceId, int $unpausedBy, string $unpausedAt): void
+    {
+        $this->query->execute(
+            'UPDATE dunning_pauses SET unpaused_by = ?, unpaused_at = ? '
+            . 'WHERE organization_id = ? AND invoice_id = ? AND unpaused_at IS NULL',
+            [$unpausedBy, $unpausedAt, $organizationId, $invoiceId],
+        );
+    }
+
+    public function findByOrganization(int $organizationId, bool $activeOnly, int $limit, int $offset): array
+    {
+        $where = $activeOnly
+            ? 'WHERE organization_id = ? AND unpaused_at IS NULL'
+            : 'WHERE organization_id = ?';
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM dunning_pauses ' . $where
+            . ' ORDER BY id DESC LIMIT ? OFFSET ?',
+            [$organizationId, $limit, $offset],
+        );
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId, bool $activeOnly): int
+    {
+        $where = $activeOnly
+            ? 'WHERE organization_id = ? AND unpaused_at IS NULL'
+            : 'WHERE organization_id = ?';
+
+        $row = $this->query->fetchOne(
+            'SELECT COUNT(*) AS c FROM dunning_pauses ' . $where,
+            [$organizationId],
+        );
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function hydrate(array $row): DunningPause
+    {
+        return new DunningPause(
+            organizationId: (int) $row['organization_id'],
+            invoiceId: (int) $row['invoice_id'],
+            pausedBy: (int) $row['paused_by'],
+            pausedAt: (string) $row['paused_at'],
+            pausedReason: (string) $row['paused_reason'],
+            unpausedBy: $row['unpaused_by'] !== null ? (int) $row['unpaused_by'] : null,
+            unpausedAt: $row['unpaused_at'] !== null ? (string) $row['unpaused_at'] : null,
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/Dunning/ResumeDunningHandler.php
+++ b/src/Dunning/ResumeDunningHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ResumeDunningHandler
+{
+    public function __construct(
+        private ResumeDunningUseCase $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $actorUserId = AuthContext::userId($request);
+        $invoiceIdRaw = $request->getAttribute('invoiceId');
+        $invoiceId = is_numeric($invoiceIdRaw) ? (int) $invoiceIdRaw : 0;
+
+        if ($invoiceId <= 0) {
+            throw new ValidationException([new ValidationError('invoiceId', 'invoiceId must be a positive integer.', 'invalid')]);
+        }
+
+        $this->useCase->execute($organizationId, $invoiceId, $actorUserId);
+
+        return $this->response->create([], 204);
+    }
+}

--- a/src/Dunning/ResumeDunningUseCase.php
+++ b/src/Dunning/ResumeDunningUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
+final readonly class ResumeDunningUseCase
+{
+    public function __construct(
+        private DunningPauseRepositoryInterface $pauses,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(int $organizationId, int $invoiceId, int $actorUserId): void
+    {
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+
+        $this->pauses->resumeByInvoice($organizationId, $invoiceId, $actorUserId, $now);
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $organizationId,
+            eventType: 'dunning_resumed',
+            actorUserId: $actorUserId,
+            occurredAt: $now,
+            payload: ['invoice_id' => $invoiceId],
+        ));
+    }
+}

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -17,7 +17,6 @@ use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
 {
     private const int DEFAULT_MIN_INTERVAL_DAYS = 7;
-    private const string CHANNEL = 'log';
 
     public function __construct(
         private DunningNoticeRepositoryInterface $notices,
@@ -27,6 +26,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
         private AuditEventRepositoryInterface $auditEvents,
         private ClockInterface $clock,
         private MessageCatalog $catalog,
+        private ?DunningPauseRepositoryInterface $pauses = null,
     ) {
     }
 
@@ -36,6 +36,11 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
 
         if (!in_array($invoice->status, ['issued', 'partially_paid'], true) || $invoice->outstandingCents <= 0) {
             throw new InvoiceAlreadyPaidException($input->invoiceId, $invoice->status);
+        }
+
+        $pause = $this->pauses?->findActiveByInvoice($input->organizationId, $input->invoiceId);
+        if ($pause !== null) {
+            throw new DunningPausedException($input->invoiceId, $pause->pausedReason);
         }
 
         $settings = $this->clearSettings->findByOrganization($input->organizationId);
@@ -76,7 +81,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             recipientEmail: $client->recipientEmail,
             outstandingCents: $invoice->outstandingCents,
             dueAt: $invoice->dueAt,
-            channel: self::CHANNEL,
+            channel: $this->mailer->channel(),
             sentBy: $input->actorUserId,
             sentAt: $nowStr,
         );
@@ -109,7 +114,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                     'invoice_number' => $invoice->invoiceNumber,
                     'recipient_email' => $client->recipientEmail,
                     'outstanding_at_send_cents' => $invoice->outstandingCents,
-                    'channel' => self::CHANNEL,
+                    'channel' => $this->mailer->channel(),
                 ],
             ],
         ));

--- a/src/Dunning/SmtpDunningMailer.php
+++ b/src/Dunning/SmtpDunningMailer.php
@@ -32,6 +32,11 @@ final class SmtpDunningMailer implements DunningMailerInterface
         $this->mailer = new Mailer($transport);
     }
 
+    public function channel(): string
+    {
+        return 'email';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         $email = (new Email())

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -48,6 +48,13 @@ use NeneClear\ClearSettings\PdoClearSettingsRepository;
 use NeneClear\ClearSettings\TestUpstreamConnectionHandler;
 use NeneClear\ClearSettings\UpdateClearSettingsHandler;
 use NeneClear\Dunning\DunningNoticeNotFoundExceptionHandler;
+use NeneClear\Dunning\DunningPausedExceptionHandler;
+use NeneClear\Dunning\ListDunningPausesHandler;
+use NeneClear\Dunning\PauseDunningHandler;
+use NeneClear\Dunning\PauseDunningUseCase;
+use NeneClear\Dunning\PdoDunningPauseRepository;
+use NeneClear\Dunning\ResumeDunningHandler;
+use NeneClear\Dunning\ResumeDunningUseCase;
 use NeneClear\Dunning\DunningRouteRegistrar;
 use NeneClear\Dunning\DunningTooFrequentExceptionHandler;
 use NeneClear\Dunning\GetDunningNoticeByIdHandler;
@@ -264,16 +271,21 @@ final class ApplicationFactory
             $domainExceptionHandlers[] = new InvoiceAlreadyPaidExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new DunningTooFrequentExceptionHandler($problemDetails);
             $domainExceptionHandlers[] = new DunningNoticeNotFoundExceptionHandler($problemDetails);
+            $domainExceptionHandlers[] = new DunningPausedExceptionHandler($problemDetails);
 
             $mailer = $smtpHost !== null && $smtpHost !== ''
                 ? new SmtpDunningMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword)
                 : new LogOnlyDunningMailer();
 
             $dunningNotices = new PdoDunningNoticeRepository($query);
+            $dunningPauses = new PdoDunningPauseRepository($query);
             $routeRegistrars[] = new DunningRouteRegistrar(
-                new SendDunningHandler(new SendDunningUseCase($dunningNotices, $clearSettings, $upstream, $mailer, $audit, $clock, new MessageCatalog(dirname(__DIR__, 2) . '/lang')), $dunningNotices, $json),
+                new SendDunningHandler(new SendDunningUseCase($dunningNotices, $clearSettings, $upstream, $mailer, $audit, $clock, new MessageCatalog(dirname(__DIR__, 2) . '/lang'), $dunningPauses), $dunningNotices, $json),
                 new ListDunningNoticesHandler($dunningNotices, $json),
                 new GetDunningNoticeByIdHandler($dunningNotices, $json),
+                new PauseDunningHandler(new PauseDunningUseCase($dunningPauses, $audit, $clock), $json),
+                new ResumeDunningHandler(new ResumeDunningUseCase($dunningPauses, $audit, $clock), $json),
+                new ListDunningPausesHandler($dunningPauses, $json),
             );
 
             $authMiddleware = [
@@ -287,6 +299,7 @@ final class ApplicationFactory
                     '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                     '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                     '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
+                    '/admin/dunning-pauses' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
                 ]),
             ];
         }

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -87,7 +87,7 @@ final class SendDunningUseCaseTest extends TestCase
         self::assertSame(1, $notice->invoiceId);
         self::assertSame('accounts@acme.example', $notice->recipientEmail);
         self::assertSame(110000, $notice->outstandingCents);
-        self::assertSame('log', $notice->channel);
+        self::assertSame('email', $notice->channel);
 
         self::assertCount(1, $this->mailer->sent);
         self::assertSame('accounts@acme.example', $this->mailer->sent[0]->to);

--- a/tests/Dunning/SpyDunningMailer.php
+++ b/tests/Dunning/SpyDunningMailer.php
@@ -12,6 +12,11 @@ final class SpyDunningMailer implements DunningMailerInterface
     /** @var list<DunningMailPayload> */
     public array $sent = [];
 
+    public function channel(): string
+    {
+        return 'email';
+    }
+
     public function send(DunningMailPayload $payload): void
     {
         $this->sent[] = $payload;

--- a/tests/Http/DunningHttpTest.php
+++ b/tests/Http/DunningHttpTest.php
@@ -40,6 +40,7 @@ final class DunningHttpTest extends TestCase
         SchemaFixture::createClearSettings($query);
         SchemaFixture::createAuditEvents($query);
         SchemaFixture::createDunningNotices($query);
+        SchemaFixture::createDunningPauses($query);
 
         $users = new PdoUserRepository($query);
         $users->save($this->user('admin@acme.example', Role::Admin));

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -220,4 +220,20 @@ final class SchemaFixture
             )'
         );
     }
+
+    public static function createDunningPauses(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE dunning_pauses (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                invoice_id INTEGER NOT NULL,
+                paused_by INTEGER NOT NULL,
+                paused_at TEXT NOT NULL,
+                paused_reason TEXT NOT NULL,
+                unpaused_by INTEGER,
+                unpaused_at TEXT
+            )'
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Compliance §7: operators may pause dunning for an invoice (logged, no accounting effect).

**Backend:**
- `dunning_pauses` table (migration): `organization_id`, `invoice_id`, `paused_by/at/reason`, `unpaused_by/at`; active = `unpaused_at IS NULL`
- `DunningPause` entity + `PdoDunningPauseRepository`
- `PauseDunningUseCase` / `ResumeDunningUseCase` — both write `audit_event` (`dunning_paused` / `dunning_resumed`)
- New routes: `POST /admin/dunning-pauses`, `POST /admin/dunning-pauses/{invoiceId}/resume`, `GET /admin/dunning-pauses`
- `SendDunningUseCase` checks active pause → throws `DunningPausedException` (422)
- `DunningPausedExceptionHandler` + Problem Details messages in ja/en

**Frontend:**
- Pause button next to send form; opens `PauseModal` with reason input
- Active pauses panel above history table with inline Resume buttons
- API helpers: `pauseDunningNotice`, `resumeDunningNotice`, `listDunningPauses`

## Test plan
- [ ] 208 backend tests pass, PHPStan level 8 clean
- [ ] `POST /admin/dunning-pauses` → 201 with pause record
- [ ] Subsequent send for same invoice → 422 `dunning-paused`
- [ ] `POST /admin/dunning-pauses/{id}/resume` → 204; send now works
- [ ] Both actions create audit events
- [ ] Frontend: pause modal opens; active pauses panel shows; resume clears it

Closes #98