### PR TITLE
feat(backend): NENE2-compliant DI, soft-delete only, full audit coverage

### DIFF
--- a/database/migrations/20260602120000_add_soft_delete_to_organizations.php
+++ b/database/migrations/20260602120000_add_soft_delete_to_organizations.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddSoftDeleteToOrganizations extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Auditable history is never hard-deleted: tenants are retired via
+        // soft delete so audit events keep referencing a resolvable organization.
+        $this->table('organizations')
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->update();
+    }
+}

--- a/database/migrations/20260602120100_add_soft_delete_to_bank_accounts.php
+++ b/database/migrations/20260602120100_add_soft_delete_to_bank_accounts.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddSoftDeleteToBankAccounts extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Bank accounts are referenced by imported transactions and batches, so
+        // replacing an organization's CSV profiles soft-deletes the old rows
+        // instead of hard-deleting them (no orphaned references, full history).
+        $this->table('bank_accounts')
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->update();
+    }
+}

--- a/database/schema/bank_accounts.sql
+++ b/database/schema/bank_accounts.sql
@@ -13,6 +13,8 @@ CREATE TABLE bank_accounts (
     csv_amount_column        INT NOT NULL,
     csv_counterparty_column  INT NOT NULL,
     csv_header_rows          INT NOT NULL DEFAULT 1,
+    is_deleted               TINYINT(1) NOT NULL DEFAULT 0,
+    deleted_at               DATETIME NULL,
     created_at               DATETIME NULL,
     updated_at               DATETIME NULL,
     PRIMARY KEY (id),

--- a/database/schema/organizations.sql
+++ b/database/schema/organizations.sql
@@ -4,6 +4,8 @@ CREATE TABLE organizations (
     id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     slug          VARCHAR(100) NOT NULL,
     name          VARCHAR(255) NOT NULL,
+    is_deleted    TINYINT(1) NOT NULL DEFAULT 0,
+    deleted_at    DATETIME NULL,
     created_at    DATETIME NULL,
     updated_at    DATETIME NULL,
     PRIMARY KEY (id),

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -91,6 +91,36 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 Do not invent `cancelled`, `void`, `pending`, `unpaid`, etc. without registering
 them here first.
 
+### Audit event types (`audit_events.event_type`, exact strings)
+
+Append-only audit trail (`AuditEvent`, compliance §6). Every state-changing
+operation records exactly one event from this closed set. New mutating
+operations MUST register their `event_type` here **before** first use; spelling
+follows `{entity}_{past-tense-verb}` in lowercase snake_case.
+
+| `event_type` | Operation | Payload shape |
+| --- | --- | --- |
+| `bank_import` | Bank CSV imported | `after` |
+| `bank_import_batch_reversed` | Import batch reversed | `before` + `after` |
+| `reconciliation_confirmed` | Match confirmed | `before` + `after` |
+| `reconciliation_reversed` | Match reversed | `before` + `after` |
+| `client_credit_applied` | Overpayment credit applied | `before` + `after` |
+| `dunning_sent` | Dunning notice sent | `before` + `after` |
+| `dunning_paused` | Dunning paused for an invoice | `before` + `after` |
+| `dunning_resumed` | Dunning resumed for an invoice | `before` + `after` |
+| `user_created` | Operator account created | `after` |
+| `user_updated` | Operator role/status changed | `before` + `after` |
+| `user_deleted` | Operator account deleted | `before` |
+| `organization_created` | Tenant created | `after` |
+| `organization_deleted` | Tenant deleted | `before` |
+| `clear_settings_updated` | Upstream/dunning/bank-account settings changed | `before` + `after` |
+| `login_succeeded` | Authentication succeeded | `after` |
+| `login_failed` | Authentication rejected | `after` (attempted `email` + `failure_reason`) |
+
+Mutations that create a resource carry only `after`; deletions carry only
+`before`; in-place changes carry both. Payload keys reuse canonical field names
+(§3); booleans follow the `is_` rule (e.g. `is_paused`).
+
 ---
 
 ## 3. Canonical field / column names (snake_case)
@@ -125,6 +155,8 @@ them here first.
 | Foreign keys (Clear-owned) | `bank_transaction_id`, `bank_import_batch_id`, `bank_account_id`, `payment_reconciliation_id`, `client_credit_id` | camelCase, abbreviations |
 | Actor / timestamps | `imported_by`, `imported_at`, `confirmed_by`, `confirmed_at`, `reversed_at`, `sent_by`, `sent_at`, `created_by`, `created_at` | `issue_date`, `paidAt`, `actor_id` (use role-specific names above) |
 | Audit event type | `event_type` | `type`, `action` |
+| Audit actor / time | `actor_user_id`, `occurred_at` | `user_id`, `actor_id`, `created_at` (on audit rows) |
+| Login failure reason (audit) | `failure_reason` | `reason`, `error`, `code` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 
 Rules: money columns end in `_cents` (integer); event timestamps end in `_at`;
@@ -191,6 +223,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `proposeMatch`, `confirmMatch`, `reverseReconciliation`, `listReconciliations`, `getReconciliationById` | Reconciliation |
 | `listClientCredits`, `applyClientCredit` | Client credit |
 | `listDunningNotices`, `getDunningNoticeById`, `sendDunningNotice` | Dunning |
+| `listAuditEvents` | Audit trail (admin) |
 
 Extend this list (do not improvise) when adding operations. MCP tool names
 mirror these `operationId` values exactly (`listUnmatchedTransactions`,

--- a/src/Audit/AuditEventRepositoryInterface.php
+++ b/src/Audit/AuditEventRepositoryInterface.php
@@ -7,4 +7,14 @@ namespace NeneClear\Audit;
 interface AuditEventRepositoryInterface
 {
     public function record(AuditEvent $event): int;
+
+    /**
+     * Tenant-scoped, newest first. `$eventType` filters to a single
+     * `event_type` when non-null (see terminology §2 for the closed set).
+     *
+     * @return list<AuditEvent>
+     */
+    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId, ?string $eventType): int;
 }

--- a/src/Audit/AuditEventResponse.php
+++ b/src/Audit/AuditEventResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+final readonly class AuditEventResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(AuditEvent $event): array
+    {
+        return [
+            'audit_event_id' => $event->id,
+            'organization_id' => $event->organizationId,
+            'event_type' => $event->eventType,
+            'actor_user_id' => $event->actorUserId,
+            'occurred_at' => $event->occurredAt,
+            'payload' => $event->payload,
+        ];
+    }
+}

--- a/src/Audit/AuditRouteRegistrar.php
+++ b/src/Audit/AuditRouteRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AuditRouteRegistrar
+{
+    public function __construct(
+        private ListAuditEventsHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+
+        $router->get('/admin/audit-events', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+    }
+}

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Http\ServiceResolver;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the append-only audit trail. The repository is shared by every
+ * state-changing use case across domains (compliance §6).
+ */
+final readonly class AuditServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AuditEventRepositoryInterface::class,
+                static fn (ContainerInterface $c): AuditEventRepositoryInterface => new PdoAuditEventRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                AuditRouteRegistrar::class,
+                static fn (ContainerInterface $c): AuditRouteRegistrar => new AuditRouteRegistrar(
+                    new ListAuditEventsHandler(
+                        ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            );
+    }
+}

--- a/src/Audit/ListAuditEventsHandler.php
+++ b/src/Audit/ListAuditEventsHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListAuditEventsHandler
+{
+    public function __construct(
+        private AuditEventRepositoryInterface $auditEvents,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $page = PaginationQueryParser::parse($request, 50, 200);
+
+        $eventTypeParam = $request->getQueryParams()['event_type'] ?? null;
+        $eventType = is_string($eventTypeParam) && $eventTypeParam !== '' ? $eventTypeParam : null;
+
+        $items = $this->auditEvents->findByOrganization($organizationId, $eventType, $page->limit, $page->offset);
+
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
+                static fn (AuditEvent $e): array => AuditEventResponse::toArray($e),
+                $items,
+            ),
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->auditEvents->countByOrganization($organizationId, $eventType),
+        ))->toArray());
+    }
+}

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -8,6 +8,8 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final readonly class PdoAuditEventRepository implements AuditEventRepositoryInterface
 {
+    private const string COLUMNS = 'id, organization_id, event_type, actor_user_id, occurred_at, payload_json';
+
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
     ) {
@@ -28,5 +30,51 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
         );
 
         return $this->query->lastInsertId();
+    }
+
+    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
+    {
+        if ($eventType === null) {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE organization_id = ? '
+                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $limit, $offset],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE organization_id = ? AND event_type = ? '
+                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
+                [$organizationId, $eventType, $limit, $offset],
+            );
+        }
+
+        return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId, ?string $eventType): int
+    {
+        $row = $eventType === null
+            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE organization_id = ?', [$organizationId])
+            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE organization_id = ? AND event_type = ?', [$organizationId, $eventType]);
+
+        return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): AuditEvent
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $row['payload_json'], true, 512, JSON_THROW_ON_ERROR);
+
+        return new AuditEvent(
+            organizationId: (int) $row['organization_id'],
+            eventType: (string) $row['event_type'],
+            actorUserId: (int) $row['actor_user_id'],
+            occurredAt: (string) $row['occurred_at'],
+            payload: $payload,
+            id: (int) $row['id'],
+        );
     }
 }

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Auth;
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\User\UserRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Server\MiddlewareInterface;
+
+/**
+ * Wires authentication: login (use case, throttle, handler), the current-user
+ * endpoint, auth exception handlers, and the bearer + capability middleware
+ * stack (NENE2 `authentication-boundary.md`, ADR 0006/0008).
+ */
+final readonly class AuthServiceProvider implements ServiceProviderInterface
+{
+    /** Container key for the ordered authentication middleware stack. */
+    public const string AUTH_MIDDLEWARE = 'nene_clear.auth_middleware';
+
+    /**
+     * Public paths that never require a bearer token.
+     *
+     * @var list<string>
+     */
+    private const array PUBLIC_PATHS = ['/', '/health', '/machine/health', '/admin/auth/login'];
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                LoginThrottleInterface::class,
+                static fn (ContainerInterface $c): LoginThrottleInterface => new PdoLoginThrottle(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                LoginUseCaseInterface::class,
+                static fn (ContainerInterface $c): LoginUseCaseInterface => new LoginUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, TokenIssuerInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                AuthRouteRegistrar::class,
+                static fn (ContainerInterface $c): AuthRouteRegistrar => new AuthRouteRegistrar(
+                    new LoginHandler(
+                        ServiceResolver::get($c, LoginUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, LoginThrottleInterface::class),
+                    ),
+                    new GetCurrentUserHandler(
+                        ServiceResolver::get($c, UserRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                InvalidCredentialsExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidCredentialsExceptionHandler => new InvalidCredentialsExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                TooManyLoginAttemptsExceptionHandler::class,
+                static fn (ContainerInterface $c): TooManyLoginAttemptsExceptionHandler => new TooManyLoginAttemptsExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                self::AUTH_MIDDLEWARE,
+                static function (ContainerInterface $c): array {
+                    // Bearer verification uses the framework (non-localized) Problem
+                    // Details factory; capability checks use the localized one.
+                    $bearer = new BearerTokenMiddleware(
+                        ServiceResolver::get($c, ProblemDetailsResponseFactory::class),
+                        ServiceResolver::get($c, TokenVerifierInterface::class),
+                        excludedPaths: self::PUBLIC_PATHS,
+                    );
+
+                    $capabilities = new CapabilityMiddleware(
+                        ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                        [
+                            '/admin/organizations' => CapabilityRule::same(Capability::ManageOrganizations),
+                            '/admin/users' => CapabilityRule::same(Capability::ManageUsers),
+                            '/admin/audit-events' => CapabilityRule::same(Capability::ManageUsers),
+                            '/admin/bank-import-batches' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
+                            '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
+                            '/admin/invoices' => CapabilityRule::same(Capability::ViewReconciliation),
+                            '/admin/export' => CapabilityRule::same(Capability::ViewReconciliation),
+                            '/admin/dunning-pauses' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
+                        ],
+                    );
+
+                    /** @var list<MiddlewareInterface> $stack */
+                    $stack = [$bearer, $capabilities];
+
+                    return $stack;
+                },
+            );
+    }
+}

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\Auth;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
 use NeneClear\User\UserRepositoryInterface;
 use NeneClear\User\UserStatus;
 
@@ -18,6 +21,8 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
     public function __construct(
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokens,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -29,8 +34,38 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
         $passwordMatches = password_verify($input->password, $hash);
 
         if ($user === null || $user->status !== UserStatus::Active || !$passwordMatches) {
+            // Audit a rejected attempt. The actor is unknown (0) and the event is
+            // not tenant-scoped (organization 0): recording the would-be org —
+            // like recording the password — could leak whether the account
+            // exists. Only the attempted email and a coarse reason are kept.
+            $this->auditEvents->record(new AuditEvent(
+                organizationId: 0,
+                eventType: 'login_failed',
+                actorUserId: 0,
+                occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+                payload: [
+                    'after' => [
+                        'email' => $input->email,
+                        'failure_reason' => 'invalid_credentials',
+                    ],
+                ],
+            ));
+
             throw new InvalidCredentialsException();
         }
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $user->organizationId ?? 0,
+            eventType: 'login_succeeded',
+            actorUserId: (int) $user->id,
+            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+            payload: [
+                'after' => [
+                    'user_id' => (int) $user->id,
+                    'email' => $user->email,
+                ],
+            ],
+        ));
 
         return new LoginOutput(
             token: $this->tokens->issueForUser($user),

--- a/src/Auth/PdoLoginThrottle.php
+++ b/src/Auth/PdoLoginThrottle.php
@@ -91,6 +91,10 @@ final readonly class PdoLoginThrottle implements LoginThrottleInterface
 
     public function clear(string $identifier): void
     {
+        // Intentional hard delete: login_attempts holds transient rate-limit
+        // counters, not auditable business history. Resetting the counter on a
+        // successful login is the table's purpose, so the soft-delete policy
+        // (which covers business entities) does not apply here.
         $this->query->execute(
             'DELETE FROM login_attempts WHERE identifier_hash = ?',
             [$this->hash($identifier)],

--- a/src/BankImport/BankAccountRepositoryInterface.php
+++ b/src/BankImport/BankAccountRepositoryInterface.php
@@ -15,5 +15,5 @@ interface BankAccountRepositoryInterface
 
     public function save(BankAccount $account): int;
 
-    public function deleteByOrganization(int $organizationId): void;
+    public function deleteByOrganization(int $organizationId, string $deletedAt): void;
 }

--- a/src/BankImport/BankImportServiceProvider.php
+++ b/src/BankImport/BankImportServiceProvider.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires bank CSV import: account profiles, import batches, transactions,
+ * the import/reverse use cases, the route registrar and exception handlers.
+ */
+final readonly class BankImportServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                BankAccountRepositoryInterface::class,
+                static fn (ContainerInterface $c): BankAccountRepositoryInterface => new PdoBankAccountRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                BankImportBatchRepositoryInterface::class,
+                static fn (ContainerInterface $c): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                BankTransactionRepositoryInterface::class,
+                static fn (ContainerInterface $c): BankTransactionRepositoryInterface => new PdoBankTransactionRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ImportBankCsvUseCaseInterface::class,
+                static fn (ContainerInterface $c): ImportBankCsvUseCaseInterface => new ImportBankCsvUseCase(
+                    ServiceResolver::get($c, BankAccountRepositoryInterface::class),
+                    ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    new BankCsvParser(),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ReverseBankImportBatchUseCaseInterface::class,
+                static fn (ContainerInterface $c): ReverseBankImportBatchUseCaseInterface => new ReverseBankImportBatchUseCase(
+                    ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                BankImportRouteRegistrar::class,
+                static fn (ContainerInterface $c): BankImportRouteRegistrar => new BankImportRouteRegistrar(
+                    new ImportBankCsvHandler(
+                        ServiceResolver::get($c, ImportBankCsvUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListBankImportBatchesHandler(
+                        ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ReverseBankImportBatchHandler(
+                        ServiceResolver::get($c, ReverseBankImportBatchUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListBankTransactionsHandler(
+                        ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListUnmatchedTransactionsHandler(
+                        ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetBankTransactionByIdHandler(
+                        ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                DuplicateBankImportExceptionHandler::class,
+                static fn (ContainerInterface $c): DuplicateBankImportExceptionHandler => new DuplicateBankImportExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankAccountNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): BankAccountNotFoundExceptionHandler => new BankAccountNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                InvalidBankCsvExceptionHandler::class,
+                static fn (ContainerInterface $c): InvalidBankCsvExceptionHandler => new InvalidBankCsvExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankTransactionNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): BankTransactionNotFoundExceptionHandler => new BankTransactionNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankImportBatchNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): BankImportBatchNotFoundExceptionHandler => new BankImportBatchNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankImportBatchAlreadyReversedExceptionHandler::class,
+                static fn (ContainerInterface $c): BankImportBatchAlreadyReversedExceptionHandler => new BankImportBatchAlreadyReversedExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankImportBatchHasMatchedLinesExceptionHandler::class,
+                static fn (ContainerInterface $c): BankImportBatchHasMatchedLinesExceptionHandler => new BankImportBatchHasMatchedLinesExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/src/BankImport/ListBankImportBatchesHandler.php
+++ b/src/BankImport/ListBankImportBatchesHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\BankImport;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,14 +24,14 @@ final readonly class ListBankImportBatchesHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 BankImportBatchResponse::toArray(...),
                 $this->batches->findByOrganization($organizationId, $page->limit, $page->offset),
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->batches->countByOrganization($organizationId),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->batches->countByOrganization($organizationId),
+        ))->toArray());
     }
 }

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\BankImport;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -47,14 +48,14 @@ final readonly class ListBankTransactionsHandler
             counterparty: $counterparty,
         );
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 BankTransactionResponse::toArray(...),
                 $this->transactions->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->transactions->countByOrganization($organizationId, $filter),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->transactions->countByOrganization($organizationId, $filter),
+        ))->toArray());
     }
 }

--- a/src/BankImport/ListUnmatchedTransactionsHandler.php
+++ b/src/BankImport/ListUnmatchedTransactionsHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\BankImport;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,14 +24,14 @@ final readonly class ListUnmatchedTransactionsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 BankTransactionResponse::toArray(...),
                 $this->transactions->findUnmatchedByOrganization($organizationId, $page->limit, $page->offset),
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->transactions->countUnmatchedByOrganization($organizationId),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->transactions->countUnmatchedByOrganization($organizationId),
+        ))->toArray());
     }
 }

--- a/src/BankImport/PdoBankAccountRepository.php
+++ b/src/BankImport/PdoBankAccountRepository.php
@@ -18,7 +18,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
 
     public function findById(int $id): ?BankAccount
     {
-        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE id = ?', [$id]);
+        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE id = ? AND is_deleted = 0', [$id]);
 
         return $row !== null ? $this->hydrate($row) : null;
     }
@@ -26,16 +26,21 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
     public function findByOrganization(int $organizationId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE organization_id = ? ORDER BY id ASC',
+            'SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC',
             [$organizationId],
         );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function deleteByOrganization(int $organizationId): void
+    public function deleteByOrganization(int $organizationId, string $deletedAt): void
     {
-        $this->query->execute('DELETE FROM bank_accounts WHERE organization_id = ?', [$organizationId]);
+        // Soft delete — bank accounts are referenced by import history and are
+        // never hard-deleted. `$deletedAt` comes from the use case's clock.
+        $this->query->execute(
+            'UPDATE bank_accounts SET is_deleted = 1, deleted_at = ? WHERE organization_id = ? AND is_deleted = 0',
+            [$deletedAt, $organizationId],
+        );
     }
 
     public function save(BankAccount $account): int

--- a/src/ClearSettings/ClearSettingsServiceProvider.php
+++ b/src/ClearSettings/ClearSettingsServiceProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires per-organization Clear settings (upstream config, dunning interval,
+ * bank-account profiles) and the upstream-connection test endpoint.
+ */
+final readonly class ClearSettingsServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ClearSettingsRepositoryInterface::class,
+                static fn (ContainerInterface $c): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    ServiceResolver::get($c, BankAccountRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                UpdateClearSettingsUseCaseInterface::class,
+                static fn (ContainerInterface $c): UpdateClearSettingsUseCaseInterface => new UpdateClearSettingsUseCase(
+                    ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
+                    ServiceResolver::get($c, BankAccountRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ClearSettingsRouteRegistrar::class,
+                static fn (ContainerInterface $c): ClearSettingsRouteRegistrar => new ClearSettingsRouteRegistrar(
+                    new GetClearSettingsHandler(
+                        ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new UpdateClearSettingsHandler(
+                        ServiceResolver::get($c, UpdateClearSettingsUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new TestUpstreamConnectionHandler(
+                        ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            );
+    }
+}

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -38,16 +38,30 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
 
     public function save(ClearSettings $settings): void
     {
-        $this->query->execute('DELETE FROM clear_settings WHERE organization_id = ?', [$settings->organizationId]);
-        $this->query->execute(
-            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days) '
-            . 'VALUES (?, ?, ?, ?)',
+        // Upsert without a destructive DELETE: update the existing row, and
+        // insert only when no row was affected (first save for the org).
+        $affected = $this->query->execute(
+            'UPDATE clear_settings SET upstream_base_url = ?, upstream_token_ref = ?, dunning_min_interval_days = ? '
+            . 'WHERE organization_id = ?',
             [
-                $settings->organizationId,
                 $settings->upstreamBaseUrl,
                 $settings->upstreamTokenRef,
                 $settings->dunningMinIntervalDays,
+                $settings->organizationId,
             ],
         );
+
+        if ($affected === 0) {
+            $this->query->execute(
+                'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days) '
+                . 'VALUES (?, ?, ?, ?)',
+                [
+                    $settings->organizationId,
+                    $settings->upstreamBaseUrl,
+                    $settings->upstreamTokenRef,
+                    $settings->dunningMinIntervalDays,
+                ],
+            );
+        }
     }
 }

--- a/src/ClearSettings/UpdateClearSettingsHandler.php
+++ b/src/ClearSettings/UpdateClearSettingsHandler.php
@@ -10,15 +10,13 @@ use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\AccountType;
 use NeneClear\BankImport\BankAccount;
-use NeneClear\BankImport\BankAccountRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 final readonly class UpdateClearSettingsHandler
 {
     public function __construct(
-        private ClearSettingsRepositoryInterface $settings,
-        private BankAccountRepositoryInterface $bankAccounts,
+        private UpdateClearSettingsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
     ) {
     }
@@ -67,20 +65,14 @@ final readonly class UpdateClearSettingsHandler
             );
         }
 
-        $this->bankAccounts->deleteByOrganization($organizationId);
-        foreach ($newAccounts as $account) {
-            $this->bankAccounts->save($account);
-        }
-
-        $this->settings->save(new ClearSettings(
+        $updated = $this->useCase->execute(new UpdateClearSettingsInput(
             organizationId: $organizationId,
             upstreamBaseUrl: $upstreamBaseUrl,
             upstreamTokenRef: $upstreamTokenRef,
             dunningMinIntervalDays: $dunningMinIntervalDays,
+            bankAccounts: $newAccounts,
+            actorUserId: AuthContext::userId($request),
         ));
-
-        $updated = $this->settings->findByOrganization($organizationId)
-            ?? new ClearSettings($organizationId, $upstreamBaseUrl, $upstreamTokenRef, $dunningMinIntervalDays);
 
         return $this->response->create(ClearSettingsResponse::toArray($updated));
     }

--- a/src/ClearSettings/UpdateClearSettingsInput.php
+++ b/src/ClearSettings/UpdateClearSettingsInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use NeneClear\BankImport\BankAccount;
+
+/**
+ * Validated, typed settings-update request handed from the handler to the
+ * use case. `$bankAccounts` are already parsed into domain objects.
+ */
+final readonly class UpdateClearSettingsInput
+{
+    /**
+     * @param list<BankAccount> $bankAccounts
+     */
+    public function __construct(
+        public int $organizationId,
+        public string $upstreamBaseUrl,
+        public string $upstreamTokenRef,
+        public int $dunningMinIntervalDays,
+        public array $bankAccounts,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/ClearSettings/UpdateClearSettingsUseCase.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCase.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+
+/**
+ * Applies an organization's Clear settings: replaces its registered bank
+ * accounts (soft-deleting the previous set) and upserts the upstream/dunning
+ * configuration. Records a `clear_settings_updated` audit event carrying the
+ * before/after configuration so every change is reconstructable.
+ */
+final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUseCaseInterface
+{
+    public function __construct(
+        private ClearSettingsRepositoryInterface $settings,
+        private BankAccountRepositoryInterface $bankAccounts,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(UpdateClearSettingsInput $input): ClearSettings
+    {
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $before = $this->settings->findByOrganization($input->organizationId);
+
+        // Replace the org's bank accounts: soft-delete the existing set, then
+        // insert the new profiles. Old rows stay for import-history references.
+        $this->bankAccounts->deleteByOrganization($input->organizationId, $now);
+        foreach ($input->bankAccounts as $account) {
+            $this->bankAccounts->save($account);
+        }
+
+        $this->settings->save(new ClearSettings(
+            organizationId: $input->organizationId,
+            upstreamBaseUrl: $input->upstreamBaseUrl,
+            upstreamTokenRef: $input->upstreamTokenRef,
+            dunningMinIntervalDays: $input->dunningMinIntervalDays,
+        ));
+
+        $updated = $this->settings->findByOrganization($input->organizationId)
+            ?? new ClearSettings(
+                $input->organizationId,
+                $input->upstreamBaseUrl,
+                $input->upstreamTokenRef,
+                $input->dunningMinIntervalDays,
+            );
+
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId,
+            eventType: 'clear_settings_updated',
+            actorUserId: $input->actorUserId,
+            occurredAt: $now,
+            payload: [
+                'before' => $before !== null ? self::snapshot($before) : null,
+                'after' => self::snapshot($updated),
+            ],
+        ));
+
+        return $updated;
+    }
+
+    /**
+     * Audit snapshot. `upstream_token_ref` is the env-var *name* (not the
+     * secret), so it is safe to record (compliance §15).
+     *
+     * @return array<string, mixed>
+     */
+    private static function snapshot(ClearSettings $settings): array
+    {
+        return [
+            'upstream_base_url' => $settings->upstreamBaseUrl,
+            'upstream_token_ref' => $settings->upstreamTokenRef,
+            'dunning_min_interval_days' => $settings->dunningMinIntervalDays,
+            'bank_account_numbers' => array_map(
+                static fn ($account): string => $account->accountNumber,
+                $settings->bankAccounts,
+            ),
+        ];
+    }
+}

--- a/src/ClearSettings/UpdateClearSettingsUseCaseInterface.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+interface UpdateClearSettingsUseCaseInterface
+{
+    public function execute(UpdateClearSettingsInput $input): ClearSettings;
+}

--- a/src/Dunning/DunningNoticeResponse.php
+++ b/src/Dunning/DunningNoticeResponse.php
@@ -18,7 +18,7 @@ final readonly class DunningNoticeResponse
             'invoice_number' => $notice->invoiceNumber,
             'client_id' => $notice->clientId,
             'recipient_email' => $notice->recipientEmail,
-            'outstanding_cents' => $notice->outstandingCents,
+            'outstanding_at_send_cents' => $notice->outstandingCents,
             'due_at' => $notice->dueAt,
             'channel' => $notice->channel,
             'template_version' => $notice->templateVersion,

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\I18n\MessageCatalog;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires dunning: notices, pauses, the send/pause/resume use cases, the route
+ * registrar and exception handlers. The mailer is bound at the infrastructure
+ * boundary (SMTP vs log-only depends on runtime config).
+ */
+final readonly class DunningServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DunningNoticeRepositoryInterface::class,
+                static fn (ContainerInterface $c): DunningNoticeRepositoryInterface => new PdoDunningNoticeRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                DunningPauseRepositoryInterface::class,
+                static fn (ContainerInterface $c): DunningPauseRepositoryInterface => new PdoDunningPauseRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                SendDunningUseCaseInterface::class,
+                static fn (ContainerInterface $c): SendDunningUseCaseInterface => new SendDunningUseCase(
+                    ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
+                    ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, DunningMailerInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                    ServiceResolver::get($c, MessageCatalog::class),
+                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                PauseDunningUseCase::class,
+                static fn (ContainerInterface $c): PauseDunningUseCase => new PauseDunningUseCase(
+                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ResumeDunningUseCase::class,
+                static fn (ContainerInterface $c): ResumeDunningUseCase => new ResumeDunningUseCase(
+                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                DunningRouteRegistrar::class,
+                static fn (ContainerInterface $c): DunningRouteRegistrar => new DunningRouteRegistrar(
+                    new SendDunningHandler(
+                        ServiceResolver::get($c, SendDunningUseCaseInterface::class),
+                        ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListDunningNoticesHandler(
+                        ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetDunningNoticeByIdHandler(
+                        ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new PauseDunningHandler(
+                        ServiceResolver::get($c, PauseDunningUseCase::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ResumeDunningHandler(
+                        ServiceResolver::get($c, ResumeDunningUseCase::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListDunningPausesHandler(
+                        ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                InvoiceAlreadyPaidExceptionHandler::class,
+                static fn (ContainerInterface $c): InvoiceAlreadyPaidExceptionHandler => new InvoiceAlreadyPaidExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                DunningTooFrequentExceptionHandler::class,
+                static fn (ContainerInterface $c): DunningTooFrequentExceptionHandler => new DunningTooFrequentExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                DunningNoticeNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): DunningNoticeNotFoundExceptionHandler => new DunningNoticeNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                DunningPausedExceptionHandler::class,
+                static fn (ContainerInterface $c): DunningPausedExceptionHandler => new DunningPausedExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/src/Dunning/ListDunningNoticesHandler.php
+++ b/src/Dunning/ListDunningNoticesHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,14 +24,14 @@ final readonly class ListDunningNoticesHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 DunningNoticeResponse::toArray(...),
                 $this->notices->findByOrganization($organizationId, $page->limit, $page->offset),
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->notices->countByOrganization($organizationId),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->notices->countByOrganization($organizationId),
+        ))->toArray());
     }
 }

--- a/src/Dunning/ListDunningPausesHandler.php
+++ b/src/Dunning/ListDunningPausesHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,8 +29,8 @@ final readonly class ListDunningPausesHandler
         $items = $this->pauses->findByOrganization($organizationId, $activeOnly, $limit, $offset);
         $total = $this->pauses->countByOrganization($organizationId, $activeOnly);
 
-        return $this->response->create([
-            'items' => array_map(static fn (DunningPause $p): array => [
+        return $this->response->create((new PaginationResponse(
+            items: array_map(static fn (DunningPause $p): array => [
                 'dunning_pause_id' => $p->id,
                 'invoice_id' => $p->invoiceId,
                 'paused_by' => $p->pausedBy,
@@ -39,9 +40,9 @@ final readonly class ListDunningPausesHandler
                 'unpaused_at' => $p->unpausedAt,
                 'is_active' => $p->isActive(),
             ], $items),
-            'limit' => $limit,
-            'offset' => $offset,
-            'total' => $total,
-        ]);
+            limit: $limit,
+            offset: $offset,
+            total: $total,
+        ))->toArray());
     }
 }

--- a/src/Dunning/PauseDunningUseCase.php
+++ b/src/Dunning/PauseDunningUseCase.php
@@ -41,7 +41,11 @@ final readonly class PauseDunningUseCase
             eventType: 'dunning_paused',
             actorUserId: $actorUserId,
             occurredAt: $now,
-            payload: ['invoice_id' => $invoiceId, 'reason' => $reason],
+            payload: [
+                'invoice_id' => $invoiceId,
+                'before' => ['is_paused' => false],
+                'after' => ['is_paused' => true, 'reason' => $reason],
+            ],
         ));
 
         return new DunningPause(

--- a/src/Dunning/ResumeDunningUseCase.php
+++ b/src/Dunning/ResumeDunningUseCase.php
@@ -28,7 +28,11 @@ final readonly class ResumeDunningUseCase
             eventType: 'dunning_resumed',
             actorUserId: $actorUserId,
             occurredAt: $now,
-            payload: ['invoice_id' => $invoiceId],
+            payload: [
+                'invoice_id' => $invoiceId,
+                'before' => ['is_paused' => true],
+                'after' => ['is_paused' => false],
+            ],
         ));
     }
 }

--- a/src/Export/ExportRouteRegistrar.php
+++ b/src/Export/ExportRouteRegistrar.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ExportRouteRegistrar
+{
+    public function __construct(
+        private ExportReconciliationsCsvHandler $reconciliationsHandler,
+        private ExportClientCreditsCsvHandler $clientCreditsHandler,
+        private ExportBankTransactionsCsvHandler $bankTransactionsHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $reconciliations = $this->reconciliationsHandler;
+        $clientCredits = $this->clientCreditsHandler;
+        $bankTransactions = $this->bankTransactionsHandler;
+
+        $router->get('/admin/export/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $reconciliations->handle($r));
+        $router->get('/admin/export/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $clientCredits->handle($r));
+        $router->get('/admin/export/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $bankTransactions->handle($r));
+    }
+}

--- a/src/Export/ExportServiceProvider.php
+++ b/src/Export/ExportServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
+use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+/**
+ * Wires the CSV export endpoints (reconciliations, client credits, bank
+ * transactions). Streams are built with the framework PSR-17 factories.
+ */
+final readonly class ExportServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            ExportRouteRegistrar::class,
+            static fn (ContainerInterface $c): ExportRouteRegistrar => new ExportRouteRegistrar(
+                new ExportReconciliationsCsvHandler(
+                    ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, ResponseFactoryInterface::class),
+                    ServiceResolver::get($c, StreamFactoryInterface::class),
+                ),
+                new ExportClientCreditsCsvHandler(
+                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, ResponseFactoryInterface::class),
+                    ServiceResolver::get($c, StreamFactoryInterface::class),
+                ),
+                new ExportBankTransactionsCsvHandler(
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, ResponseFactoryInterface::class),
+                    ServiceResolver::get($c, StreamFactoryInterface::class),
+                ),
+            ),
+        );
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -4,151 +4,52 @@ declare(strict_types=1);
 
 namespace NeneClear\Http;
 
-use Nene2\Auth\BearerTokenMiddleware;
+use LogicException;
+use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
-use NeneClear\Audit\PdoAuditEventRepository;
-use NeneClear\Auth\AuthRouteRegistrar;
-use NeneClear\Auth\Capability;
-use NeneClear\Auth\CapabilityMiddleware;
-use NeneClear\Auth\CapabilityRule;
-use NeneClear\Auth\GetCurrentUserHandler;
-use NeneClear\Auth\InvalidCredentialsExceptionHandler;
+use NeneClear\Auth\AuthServiceProvider;
 use NeneClear\Auth\JwtTokenService;
-use NeneClear\Auth\LoginHandler;
-use NeneClear\Auth\LoginUseCase;
-use NeneClear\Auth\PdoLoginThrottle;
-use NeneClear\Auth\TooManyLoginAttemptsExceptionHandler;
-use NeneClear\BankImport\BankAccountNotFoundExceptionHandler;
-use NeneClear\BankImport\BankCsvParser;
-use NeneClear\BankImport\BankImportBatchAlreadyReversedExceptionHandler;
-use NeneClear\BankImport\BankImportBatchHasMatchedLinesExceptionHandler;
-use NeneClear\BankImport\BankImportBatchNotFoundExceptionHandler;
-use NeneClear\BankImport\BankImportRouteRegistrar;
-use NeneClear\BankImport\BankTransactionNotFoundExceptionHandler;
-use NeneClear\BankImport\DuplicateBankImportExceptionHandler;
-use NeneClear\BankImport\GetBankTransactionByIdHandler;
-use NeneClear\BankImport\ImportBankCsvHandler;
-use NeneClear\BankImport\ImportBankCsvUseCase;
-use NeneClear\BankImport\InvalidBankCsvExceptionHandler;
-use NeneClear\BankImport\ListBankImportBatchesHandler;
-use NeneClear\BankImport\ListBankTransactionsHandler;
-use NeneClear\BankImport\ListUnmatchedTransactionsHandler;
-use NeneClear\BankImport\PdoBankAccountRepository;
-use NeneClear\BankImport\PdoBankImportBatchRepository;
-use NeneClear\BankImport\PdoBankTransactionRepository;
-use NeneClear\BankImport\ReverseBankImportBatchHandler;
-use NeneClear\BankImport\ReverseBankImportBatchUseCase;
-use NeneClear\ClearSettings\ClearSettingsRouteRegistrar;
-use NeneClear\ClearSettings\GetClearSettingsHandler;
-use NeneClear\ClearSettings\PdoClearSettingsRepository;
-use NeneClear\ClearSettings\TestUpstreamConnectionHandler;
-use NeneClear\ClearSettings\UpdateClearSettingsHandler;
-use NeneClear\Dunning\DunningNoticeNotFoundExceptionHandler;
-use NeneClear\Dunning\DunningPausedExceptionHandler;
-use NeneClear\Dunning\DunningRouteRegistrar;
-use NeneClear\Dunning\DunningTooFrequentExceptionHandler;
-use NeneClear\Dunning\GetDunningNoticeByIdHandler;
-use NeneClear\Dunning\InvoiceAlreadyPaidExceptionHandler;
-use NeneClear\Dunning\ListDunningNoticesHandler;
-use NeneClear\Dunning\ListDunningPausesHandler;
+use NeneClear\Auth\TokenIssuerInterface;
+use NeneClear\Dunning\DunningMailerInterface;
 use NeneClear\Dunning\LogOnlyDunningMailer;
-use NeneClear\Dunning\PauseDunningHandler;
-use NeneClear\Dunning\PauseDunningUseCase;
-use NeneClear\Dunning\PdoDunningNoticeRepository;
-use NeneClear\Dunning\PdoDunningPauseRepository;
-use NeneClear\Dunning\ResumeDunningHandler;
-use NeneClear\Dunning\ResumeDunningUseCase;
-use NeneClear\Dunning\SendDunningHandler;
-use NeneClear\Dunning\SendDunningUseCase;
 use NeneClear\Dunning\SmtpDunningMailer;
-use NeneClear\Export\ExportBankTransactionsCsvHandler;
-use NeneClear\Export\ExportClientCreditsCsvHandler;
-use NeneClear\Export\ExportReconciliationsCsvHandler;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamHttpClient;
-use NeneClear\InvoiceUpstream\ListUpstreamInvoicesHandler;
-use NeneClear\InvoiceUpstream\UpstreamClientNotFoundExceptionHandler;
-use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundExceptionHandler;
-use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableExceptionHandler;
-use NeneClear\Organization\CreateOrganizationHandler;
-use NeneClear\Organization\CreateOrganizationUseCase;
-use NeneClear\Organization\DeleteOrganizationHandler;
-use NeneClear\Organization\DeleteOrganizationUseCase;
-use NeneClear\Organization\GetOrganizationByIdHandler;
-use NeneClear\Organization\GetOrganizationByIdUseCase;
-use NeneClear\Organization\ListOrganizationsHandler;
-use NeneClear\Organization\ListOrganizationsUseCase;
-use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
-use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
-use NeneClear\Organization\OrganizationRouteRegistrar;
-use NeneClear\Organization\PdoOrganizationRepository;
-use NeneClear\Reconciliation\AllocationExceedsOutstandingExceptionHandler;
-use NeneClear\Reconciliation\ApplyCreditHandler;
-use NeneClear\Reconciliation\ApplyCreditUseCase;
-use NeneClear\Reconciliation\BankTransactionNotMatchableExceptionHandler;
-use NeneClear\Reconciliation\ClientCreditNotFoundExceptionHandler;
-use NeneClear\Reconciliation\ConfirmMatchHandler;
-use NeneClear\Reconciliation\ConfirmMatchUseCase;
-use NeneClear\Reconciliation\CreditExceedsRemainingExceptionHandler;
-use NeneClear\Reconciliation\GetReconciliationByIdHandler;
-use NeneClear\Reconciliation\ListClientCreditsHandler;
-use NeneClear\Reconciliation\ListReconciliationsHandler;
-use NeneClear\Reconciliation\PdoClientCreditRepository;
-use NeneClear\Reconciliation\PdoReconciliationRepository;
-use NeneClear\Reconciliation\ProposeMatchHandler;
-use NeneClear\Reconciliation\ProposeMatchUseCase;
-use NeneClear\Reconciliation\ReconciliationAlreadyReversedExceptionHandler;
-use NeneClear\Reconciliation\ReconciliationNotFoundExceptionHandler;
-use NeneClear\Reconciliation\ReconciliationRouteRegistrar;
-use NeneClear\Reconciliation\ReverseReconciliationHandler;
-use NeneClear\Reconciliation\ReverseReconciliationUseCase;
-use NeneClear\User\CreateUserHandler;
-use NeneClear\User\CreateUserUseCase;
-use NeneClear\User\DeleteUserHandler;
-use NeneClear\User\DeleteUserUseCase;
-use NeneClear\User\GetUserByIdHandler;
-use NeneClear\User\GetUserByIdUseCase;
-use NeneClear\User\ListUsersHandler;
-use NeneClear\User\ListUsersUseCase;
-use NeneClear\User\PdoUserRepository;
-use NeneClear\User\RoleNotAssignableExceptionHandler;
-use NeneClear\User\UpdateUserHandler;
-use NeneClear\User\UpdateUserUseCase;
-use NeneClear\User\UserAlreadyExistsExceptionHandler;
-use NeneClear\User\UserNotFoundExceptionHandler;
-use NeneClear\User\UserRouteRegistrar;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Builds the NeNe Clear HTTP application on top of the NENE2 runtime.
  *
+ * Wiring follows NENE2 `dependency-injection.md`: framework + config services
+ * are registered on a {@see ContainerBuilder} at this config boundary, and each
+ * domain is wired by its own {@see \Nene2\DependencyInjection\ServiceProviderInterface}
+ * via {@see ApplicationServiceProvider}. This factory only assembles the
+ * container and hands the resolved route registrars, exception handlers and
+ * auth middleware to {@see RuntimeApplicationFactory}.
+ *
  * The framework baseline pipeline (error handling, request id, security headers,
  * CORS, request size limit) and the built-in `/health` route are always present.
- *
  * Authenticated/admin routes are wired only when **both** a database query
- * executor and a JWT secret are provided. Without them the app still serves the
- * public/health surface, so `/health` never depends on a database. See
- * docs/development/nene2-compliance.md.
+ * executor and a JWT secret are provided, so `/health` never depends on a
+ * database. See docs/development/nene2-compliance.md.
  */
 final class ApplicationFactory
 {
-    /**
-     * Public paths that never require a bearer token.
-     *
-     * @var list<string>
-     */
-    private const array PUBLIC_PATHS = ['/', '/health', '/machine/health', '/admin/auth/login'];
-
     /**
      * @param list<string> $allowedOrigins CORS allowlist; empty disables CORS (set explicitly in production).
      */
@@ -168,172 +69,120 @@ final class ApplicationFactory
         string $invoiceBearerToken = '',
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
-        $json = new JsonResponseFactory($psr17, $psr17);
-        $rawProblemDetails = new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-clear.dev/problems/');
-        $problemDetails = new LocalizedProblemDetailsFactory(
-            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
-            $rawProblemDetails,
+
+        // Public/health-only surface: no database or JWT secret → no admin routes.
+        if ($query === null || $jwtSecret === null || $jwtSecret === '') {
+            return (new RuntimeApplicationFactory(
+                responseFactory: $psr17,
+                streamFactory: $psr17,
+                debug: $debug,
+                allowedOrigins: $allowedOrigins,
+            ))->create();
+        }
+
+        $container = self::buildContainer(
+            $query,
+            $jwtSecret,
+            $psr17,
+            self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
+            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
         );
 
-        $routeRegistrars = [];
-        $domainExceptionHandlers = [];
-        $authMiddleware = null;
+        $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
+        $exceptionHandlers = $container->get(ApplicationServiceProvider::EXCEPTION_HANDLERS);
+        $authMiddleware = $container->get(AuthServiceProvider::AUTH_MIDDLEWARE);
 
-        if ($query !== null && $jwtSecret !== null && $jwtSecret !== '') {
-            $jwt = new JwtTokenService($jwtSecret);
-            $users = new PdoUserRepository($query);
-            $organizations = new PdoOrganizationRepository($query);
-
-            $routeRegistrars[] = new AuthRouteRegistrar(
-                new LoginHandler(new LoginUseCase($users, $jwt), $json, new PdoLoginThrottle($query, new UtcClock())),
-                new GetCurrentUserHandler($users, $json, $problemDetails),
-            );
-            $routeRegistrars[] = new OrganizationRouteRegistrar(
-                new ListOrganizationsHandler(new ListOrganizationsUseCase($organizations), $json),
-                new CreateOrganizationHandler(new CreateOrganizationUseCase($organizations), $json),
-                new GetOrganizationByIdHandler(new GetOrganizationByIdUseCase($organizations), $json),
-                new DeleteOrganizationHandler(new DeleteOrganizationUseCase($organizations), $json),
-            );
-            $routeRegistrars[] = new UserRouteRegistrar(
-                new ListUsersHandler(new ListUsersUseCase($users), $json),
-                new CreateUserHandler(new CreateUserUseCase($users), $json),
-                new GetUserByIdHandler(new GetUserByIdUseCase($users), $json),
-                new UpdateUserHandler(new UpdateUserUseCase($users), $json),
-                new DeleteUserHandler(new DeleteUserUseCase($users), $json),
-            );
-
-            $audit = new PdoAuditEventRepository($query);
-            $bankAccounts = new PdoBankAccountRepository($query);
-            $batches = new PdoBankImportBatchRepository($query);
-            $transactions = new PdoBankTransactionRepository($query);
-            $clock = new UtcClock();
-            $importUseCase = new ImportBankCsvUseCase(
-                $bankAccounts,
-                $batches,
-                $transactions,
-                $audit,
-                new BankCsvParser(),
-                $clock,
-            );
-            $routeRegistrars[] = new BankImportRouteRegistrar(
-                new ImportBankCsvHandler($importUseCase, $json),
-                new ListBankImportBatchesHandler($batches, $json),
-                new ReverseBankImportBatchHandler(
-                    new ReverseBankImportBatchUseCase($batches, $transactions, $audit, $clock),
-                    $json,
-                ),
-                new ListBankTransactionsHandler($transactions, $json),
-                new ListUnmatchedTransactionsHandler($transactions, $json),
-                new GetBankTransactionByIdHandler($transactions, $json),
-            );
-
-            $upstream = $invoiceClient ?? (
-                $invoiceApiBaseUrl !== null && $invoiceApiBaseUrl !== '' && $invoiceBearerToken !== ''
-                    ? new InvoiceUpstreamHttpClient($invoiceApiBaseUrl, $invoiceBearerToken)
-                    : new FakeInvoiceUpstreamClient()
-            );
-            $clearSettings = new PdoClearSettingsRepository($query, $bankAccounts);
-            $routeRegistrars[] = new ClearSettingsRouteRegistrar(
-                new GetClearSettingsHandler($clearSettings, $json),
-                new UpdateClearSettingsHandler($clearSettings, $bankAccounts, $json),
-                new TestUpstreamConnectionHandler($upstream, $json),
-            );
-
-            $reconRepo = new PdoReconciliationRepository($query);
-            $creditRepo = new PdoClientCreditRepository($query);
-            $routeRegistrars[] = new ReconciliationRouteRegistrar(
-                new ProposeMatchHandler(new ProposeMatchUseCase($transactions, $upstream, $clock), $json),
-                new ConfirmMatchHandler(new ConfirmMatchUseCase($transactions, $reconRepo, $creditRepo, $upstream, $audit, $clock), $reconRepo, $json),
-                new ListReconciliationsHandler($reconRepo, $json),
-                new GetReconciliationByIdHandler($reconRepo, $json),
-                new ReverseReconciliationHandler(new ReverseReconciliationUseCase($reconRepo, $creditRepo, $transactions, $upstream, $audit, $clock), $reconRepo, $json),
-                new ListClientCreditsHandler($creditRepo, $json),
-                new ApplyCreditHandler(new ApplyCreditUseCase($creditRepo, $upstream, $audit), $json),
-            );
-
-            $routeRegistrars[] = static function (\Nene2\Routing\Router $router) use ($upstream, $json): void {
-                $handler = new ListUpstreamInvoicesHandler($upstream, $json);
-                $router->get('/admin/invoices', static fn (ServerRequestInterface $r): ResponseInterface => $handler->handle($r));
-            };
-
-            $routeRegistrars[] = static function (\Nene2\Routing\Router $router) use ($reconRepo, $creditRepo, $transactions, $psr17): void {
-                $reconExport = new ExportReconciliationsCsvHandler($reconRepo, $transactions, $psr17, $psr17);
-                $creditExport = new ExportClientCreditsCsvHandler($creditRepo, $psr17, $psr17);
-                $txExport = new ExportBankTransactionsCsvHandler($transactions, $psr17, $psr17);
-                $router->get('/admin/export/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $reconExport->handle($r));
-                $router->get('/admin/export/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $creditExport->handle($r));
-                $router->get('/admin/export/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $txExport->handle($r));
-            };
-
-            $domainExceptionHandlers[] = new InvalidCredentialsExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new TooManyLoginAttemptsExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new OrganizationNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new OrganizationAlreadyExistsExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new UserNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new UserAlreadyExistsExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new RoleNotAssignableExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new DuplicateBankImportExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankAccountNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new InvalidBankCsvExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankTransactionNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankImportBatchNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankImportBatchAlreadyReversedExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankImportBatchHasMatchedLinesExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new ReconciliationNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new ReconciliationAlreadyReversedExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new ClientCreditNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new CreditExceedsRemainingExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new AllocationExceedsOutstandingExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new BankTransactionNotMatchableExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new UpstreamInvoiceUnavailableExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new UpstreamInvoiceNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new UpstreamClientNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new InvoiceAlreadyPaidExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new DunningTooFrequentExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new DunningNoticeNotFoundExceptionHandler($problemDetails);
-            $domainExceptionHandlers[] = new DunningPausedExceptionHandler($problemDetails);
-
-            $mailer = $smtpHost !== null && $smtpHost !== ''
-                ? new SmtpDunningMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword)
-                : new LogOnlyDunningMailer();
-
-            $dunningNotices = new PdoDunningNoticeRepository($query);
-            $dunningPauses = new PdoDunningPauseRepository($query);
-            $routeRegistrars[] = new DunningRouteRegistrar(
-                new SendDunningHandler(new SendDunningUseCase($dunningNotices, $clearSettings, $upstream, $mailer, $audit, $clock, new MessageCatalog(dirname(__DIR__, 2) . '/lang'), $dunningPauses), $dunningNotices, $json),
-                new ListDunningNoticesHandler($dunningNotices, $json),
-                new GetDunningNoticeByIdHandler($dunningNotices, $json),
-                new PauseDunningHandler(new PauseDunningUseCase($dunningPauses, $audit, $clock), $json),
-                new ResumeDunningHandler(new ResumeDunningUseCase($dunningPauses, $audit, $clock), $json),
-                new ListDunningPausesHandler($dunningPauses, $json),
-            );
-
-            $authMiddleware = [
-                new BearerTokenMiddleware($rawProblemDetails, $jwt, excludedPaths: self::PUBLIC_PATHS),
-                new CapabilityMiddleware($problemDetails, [
-                    '/admin/organizations' => CapabilityRule::same(Capability::ManageOrganizations),
-                    '/admin/users' => CapabilityRule::same(Capability::ManageUsers),
-                    '/admin/bank-import-batches' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
-                    '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
-                    '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
-                    '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
-                    '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
-                    '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
-                    '/admin/invoices' => CapabilityRule::same(Capability::ViewReconciliation),
-                    '/admin/export' => CapabilityRule::same(Capability::ViewReconciliation),
-                    '/admin/dunning-pauses' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
-                ]),
-            ];
+        if (!is_array($routeRegistrars) || !is_array($exceptionHandlers) || !is_array($authMiddleware)) {
+            throw new LogicException('Application service aggregates are misconfigured.');
         }
+
+        /** @var list<callable(\Nene2\Routing\Router): void> $routeRegistrars */
+        /** @var list<DomainExceptionHandlerInterface> $exceptionHandlers */
+        /** @var list<MiddlewareInterface> $authMiddleware */
 
         return (new RuntimeApplicationFactory(
             responseFactory: $psr17,
             streamFactory: $psr17,
-            domainExceptionHandlers: $domainExceptionHandlers,
+            domainExceptionHandlers: $exceptionHandlers,
             routeRegistrars: $routeRegistrars,
             authMiddleware: $authMiddleware,
             debug: $debug,
             allowedOrigins: $allowedOrigins,
         ))->create();
+    }
+
+    /**
+     * Registers framework + config-derived services, then every domain provider.
+     */
+    private static function buildContainer(
+        DatabaseQueryExecutorInterface $query,
+        string $jwtSecret,
+        Psr17Factory $psr17,
+        InvoiceUpstreamClientInterface $invoiceClient,
+        DunningMailerInterface $mailer,
+    ): ContainerInterface {
+        $langDir = dirname(__DIR__, 2) . '/lang';
+
+        return (new ContainerBuilder())
+            ->set(Psr17Factory::class, static fn (ContainerInterface $c): Psr17Factory => $psr17)
+            ->set(ResponseFactoryInterface::class, static fn (ContainerInterface $c): ResponseFactoryInterface => $psr17)
+            ->set(StreamFactoryInterface::class, static fn (ContainerInterface $c): StreamFactoryInterface => $psr17)
+            ->set(JsonResponseFactory::class, static fn (ContainerInterface $c): JsonResponseFactory => new JsonResponseFactory($psr17, $psr17))
+            ->set(
+                ProblemDetailsResponseFactory::class,
+                static fn (ContainerInterface $c): ProblemDetailsResponseFactory => new ProblemDetailsResponseFactory(
+                    $psr17,
+                    $psr17,
+                    'https://nene-clear.dev/problems/',
+                ),
+            )
+            ->set(MessageCatalog::class, static fn (ContainerInterface $c): MessageCatalog => new MessageCatalog($langDir))
+            ->set(
+                LocalizedProblemDetailsFactory::class,
+                static fn (ContainerInterface $c): LocalizedProblemDetailsFactory => new LocalizedProblemDetailsFactory(
+                    ServiceResolver::get($c, MessageCatalog::class),
+                    ServiceResolver::get($c, ProblemDetailsResponseFactory::class),
+                ),
+            )
+            ->set(DatabaseQueryExecutorInterface::class, static fn (ContainerInterface $c): DatabaseQueryExecutorInterface => $query)
+            ->set(ClockInterface::class, static fn (ContainerInterface $c): ClockInterface => new UtcClock())
+            ->set(JwtTokenService::class, static fn (ContainerInterface $c): JwtTokenService => new JwtTokenService($jwtSecret))
+            ->set(TokenIssuerInterface::class, static fn (ContainerInterface $c): TokenIssuerInterface => ServiceResolver::get($c, JwtTokenService::class))
+            ->set(TokenVerifierInterface::class, static fn (ContainerInterface $c): TokenVerifierInterface => ServiceResolver::get($c, JwtTokenService::class))
+            ->set(InvoiceUpstreamClientInterface::class, static fn (ContainerInterface $c): InvoiceUpstreamClientInterface => $invoiceClient)
+            ->set(DunningMailerInterface::class, static fn (ContainerInterface $c): DunningMailerInterface => $mailer)
+            ->addProvider(new ApplicationServiceProvider())
+            ->build();
+    }
+
+    private static function resolveInvoiceClient(
+        ?InvoiceUpstreamClientInterface $override,
+        ?string $invoiceApiBaseUrl,
+        string $invoiceBearerToken,
+    ): InvoiceUpstreamClientInterface {
+        if ($override !== null) {
+            return $override;
+        }
+
+        if ($invoiceApiBaseUrl !== null && $invoiceApiBaseUrl !== '' && $invoiceBearerToken !== '') {
+            return new InvoiceUpstreamHttpClient($invoiceApiBaseUrl, $invoiceBearerToken);
+        }
+
+        return new FakeInvoiceUpstreamClient();
+    }
+
+    private static function resolveMailer(
+        ?string $smtpHost,
+        int $smtpPort,
+        string $smtpUsername,
+        string $smtpPassword,
+        string $smtpFromAddress,
+        string $smtpFromName,
+    ): DunningMailerInterface {
+        if ($smtpHost !== null && $smtpHost !== '') {
+            return new SmtpDunningMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword);
+        }
+
+        return new LogOnlyDunningMailer();
     }
 }

--- a/src/Http/ApplicationServiceProvider.php
+++ b/src/Http/ApplicationServiceProvider.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneClear\Audit\AuditRouteRegistrar;
+use NeneClear\Audit\AuditServiceProvider;
+use NeneClear\Auth\AuthRouteRegistrar;
+use NeneClear\Auth\AuthServiceProvider;
+use NeneClear\Auth\InvalidCredentialsExceptionHandler;
+use NeneClear\Auth\TooManyLoginAttemptsExceptionHandler;
+use NeneClear\BankImport\BankAccountNotFoundExceptionHandler;
+use NeneClear\BankImport\BankImportBatchAlreadyReversedExceptionHandler;
+use NeneClear\BankImport\BankImportBatchHasMatchedLinesExceptionHandler;
+use NeneClear\BankImport\BankImportBatchNotFoundExceptionHandler;
+use NeneClear\BankImport\BankImportRouteRegistrar;
+use NeneClear\BankImport\BankImportServiceProvider;
+use NeneClear\BankImport\BankTransactionNotFoundExceptionHandler;
+use NeneClear\BankImport\DuplicateBankImportExceptionHandler;
+use NeneClear\BankImport\InvalidBankCsvExceptionHandler;
+use NeneClear\ClearSettings\ClearSettingsRouteRegistrar;
+use NeneClear\ClearSettings\ClearSettingsServiceProvider;
+use NeneClear\Dunning\DunningNoticeNotFoundExceptionHandler;
+use NeneClear\Dunning\DunningPausedExceptionHandler;
+use NeneClear\Dunning\DunningRouteRegistrar;
+use NeneClear\Dunning\DunningServiceProvider;
+use NeneClear\Dunning\DunningTooFrequentExceptionHandler;
+use NeneClear\Dunning\InvoiceAlreadyPaidExceptionHandler;
+use NeneClear\Export\ExportRouteRegistrar;
+use NeneClear\Export\ExportServiceProvider;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamRouteRegistrar;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamServiceProvider;
+use NeneClear\InvoiceUpstream\UpstreamClientNotFoundExceptionHandler;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundExceptionHandler;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableExceptionHandler;
+use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
+use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
+use NeneClear\Organization\OrganizationRouteRegistrar;
+use NeneClear\Organization\OrganizationServiceProvider;
+use NeneClear\Reconciliation\AllocationExceedsOutstandingExceptionHandler;
+use NeneClear\Reconciliation\BankTransactionNotMatchableExceptionHandler;
+use NeneClear\Reconciliation\ClientCreditNotFoundExceptionHandler;
+use NeneClear\Reconciliation\CreditExceedsRemainingExceptionHandler;
+use NeneClear\Reconciliation\ReconciliationAlreadyReversedExceptionHandler;
+use NeneClear\Reconciliation\ReconciliationNotFoundExceptionHandler;
+use NeneClear\Reconciliation\ReconciliationRouteRegistrar;
+use NeneClear\Reconciliation\ReconciliationServiceProvider;
+use NeneClear\User\RoleNotAssignableExceptionHandler;
+use NeneClear\User\UserAlreadyExistsExceptionHandler;
+use NeneClear\User\UserNotFoundExceptionHandler;
+use NeneClear\User\UserRouteRegistrar;
+use NeneClear\User\UserServiceProvider;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Composition root: registers every domain service provider and exposes the
+ * aggregate route-registrar and exception-handler lists the HTTP runtime needs
+ * (mirrors NENE2's runtime/example provider pattern).
+ */
+final readonly class ApplicationServiceProvider implements ServiceProviderInterface
+{
+    /** Container key for the aggregated list of route registrar callables. */
+    public const string ROUTE_REGISTRARS = 'nene_clear.route_registrars';
+
+    /** Container key for the aggregated list of domain exception handlers. */
+    public const string EXCEPTION_HANDLERS = 'nene_clear.exception_handlers';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->addProvider(new AuditServiceProvider())
+            ->addProvider(new AuthServiceProvider())
+            ->addProvider(new OrganizationServiceProvider())
+            ->addProvider(new UserServiceProvider())
+            ->addProvider(new BankImportServiceProvider())
+            ->addProvider(new ClearSettingsServiceProvider())
+            ->addProvider(new ReconciliationServiceProvider())
+            ->addProvider(new InvoiceUpstreamServiceProvider())
+            ->addProvider(new ExportServiceProvider())
+            ->addProvider(new DunningServiceProvider());
+
+        $builder
+            ->set(self::ROUTE_REGISTRARS, static function (ContainerInterface $c): array {
+                /** @var list<callable(\Nene2\Routing\Router): void> $registrars */
+                $registrars = [
+                    ServiceResolver::get($c, AuthRouteRegistrar::class),
+                    ServiceResolver::get($c, OrganizationRouteRegistrar::class),
+                    ServiceResolver::get($c, UserRouteRegistrar::class),
+                    ServiceResolver::get($c, AuditRouteRegistrar::class),
+                    ServiceResolver::get($c, BankImportRouteRegistrar::class),
+                    ServiceResolver::get($c, ClearSettingsRouteRegistrar::class),
+                    ServiceResolver::get($c, ReconciliationRouteRegistrar::class),
+                    ServiceResolver::get($c, InvoiceUpstreamRouteRegistrar::class),
+                    ServiceResolver::get($c, ExportRouteRegistrar::class),
+                    ServiceResolver::get($c, DunningRouteRegistrar::class),
+                ];
+
+                return $registrars;
+            })
+            ->set(self::EXCEPTION_HANDLERS, static function (ContainerInterface $c): array {
+                /** @var list<\Nene2\Error\DomainExceptionHandlerInterface> $handlers */
+                $handlers = [
+                    ServiceResolver::get($c, InvalidCredentialsExceptionHandler::class),
+                    ServiceResolver::get($c, TooManyLoginAttemptsExceptionHandler::class),
+                    ServiceResolver::get($c, OrganizationNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, OrganizationAlreadyExistsExceptionHandler::class),
+                    ServiceResolver::get($c, UserNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, UserAlreadyExistsExceptionHandler::class),
+                    ServiceResolver::get($c, RoleNotAssignableExceptionHandler::class),
+                    ServiceResolver::get($c, DuplicateBankImportExceptionHandler::class),
+                    ServiceResolver::get($c, BankAccountNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, InvalidBankCsvExceptionHandler::class),
+                    ServiceResolver::get($c, BankTransactionNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, BankImportBatchNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, BankImportBatchAlreadyReversedExceptionHandler::class),
+                    ServiceResolver::get($c, BankImportBatchHasMatchedLinesExceptionHandler::class),
+                    ServiceResolver::get($c, ReconciliationNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, ReconciliationAlreadyReversedExceptionHandler::class),
+                    ServiceResolver::get($c, ClientCreditNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, CreditExceedsRemainingExceptionHandler::class),
+                    ServiceResolver::get($c, AllocationExceedsOutstandingExceptionHandler::class),
+                    ServiceResolver::get($c, BankTransactionNotMatchableExceptionHandler::class),
+                    ServiceResolver::get($c, UpstreamInvoiceUnavailableExceptionHandler::class),
+                    ServiceResolver::get($c, UpstreamInvoiceNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, UpstreamClientNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, InvoiceAlreadyPaidExceptionHandler::class),
+                    ServiceResolver::get($c, DunningTooFrequentExceptionHandler::class),
+                    ServiceResolver::get($c, DunningNoticeNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, DunningPausedExceptionHandler::class),
+                ];
+
+                return $handlers;
+            });
+    }
+}

--- a/src/Http/ServiceResolver.php
+++ b/src/Http/ServiceResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use LogicException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Type-safe accessor for PSR-11 container services used inside service
+ * providers (NENE2 `dependency-injection.md`).
+ *
+ * `ContainerInterface::get()` returns `mixed`; this narrows the result to the
+ * requested class/interface so provider factories stay strictly typed without
+ * repeating an `instanceof` guard at every call site. A misconfigured binding
+ * is a wiring defect, surfaced as a {@see LogicException}.
+ */
+final class ServiceResolver
+{
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $id
+     *
+     * @return T
+     */
+    public static function get(ContainerInterface $container, string $id): object
+    {
+        $service = $container->get($id);
+
+        if (!$service instanceof $id) {
+            throw new LogicException(sprintf('Service "%s" is misconfigured.', $id));
+        }
+
+        return $service;
+    }
+}

--- a/src/InvoiceUpstream/InvoiceUpstreamRouteRegistrar.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamRouteRegistrar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class InvoiceUpstreamRouteRegistrar
+{
+    public function __construct(
+        private ListUpstreamInvoicesHandler $listHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+
+        $router->get('/admin/invoices', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+    }
+}

--- a/src/InvoiceUpstream/InvoiceUpstreamServiceProvider.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the read-only Invoice upstream surface (listing invoices) and its
+ * degraded-mode exception handlers. The upstream client itself is bound at the
+ * infrastructure boundary because its selection depends on runtime config.
+ */
+final readonly class InvoiceUpstreamServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                InvoiceUpstreamRouteRegistrar::class,
+                static fn (ContainerInterface $c): InvoiceUpstreamRouteRegistrar => new InvoiceUpstreamRouteRegistrar(
+                    new ListUpstreamInvoicesHandler(
+                        ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                UpstreamInvoiceUnavailableExceptionHandler::class,
+                static fn (ContainerInterface $c): UpstreamInvoiceUnavailableExceptionHandler => new UpstreamInvoiceUnavailableExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                UpstreamInvoiceNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): UpstreamInvoiceNotFoundExceptionHandler => new UpstreamInvoiceNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                UpstreamClientNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): UpstreamClientNotFoundExceptionHandler => new UpstreamClientNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -39,7 +40,11 @@ final readonly class CreateOrganizationHandler
             throw new ValidationException($errors);
         }
 
-        $output = $this->useCase->execute(new CreateOrganizationInput(slug: $slug, name: $name));
+        $output = $this->useCase->execute(new CreateOrganizationInput(
+            slug: $slug,
+            name: $name,
+            actorUserId: AuthContext::userId($request),
+        ));
 
         return $this->response->create(
             ['organization_id' => $output->id, 'slug' => $output->slug, 'name' => $output->name],

--- a/src/Organization/CreateOrganizationInput.php
+++ b/src/Organization/CreateOrganizationInput.php
@@ -9,6 +9,7 @@ final readonly class CreateOrganizationInput
     public function __construct(
         public string $slug,
         public string $name,
+        public int $actorUserId,
     ) {
     }
 }

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace NeneClear\Organization;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
 final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -18,6 +24,22 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
         }
 
         $id = $this->organizations->save(new Organization(slug: $input->slug, name: $input->name));
+
+        // Audit: a tenant lifecycle event is scoped to the affected tenant, so it
+        // surfaces in that organization's own audit trail.
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $id,
+            eventType: 'organization_created',
+            actorUserId: $input->actorUserId,
+            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+            payload: [
+                'after' => [
+                    'organization_id' => $id,
+                    'slug' => $input->slug,
+                    'name' => $input->name,
+                ],
+            ],
+        ));
 
         return new CreateOrganizationOutput(id: $id, slug: $input->slug, name: $input->name);
     }

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Organization;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -22,7 +23,7 @@ final readonly class DeleteOrganizationHandler
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
 
-        $this->useCase->execute($id);
+        $this->useCase->execute($id, AuthContext::userId($request));
 
         return $this->response->createEmpty(204);
     }

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -4,19 +4,45 @@ declare(strict_types=1);
 
 namespace NeneClear\Organization;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
 final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
     public function __construct(
         private OrganizationRepositoryInterface $organizations,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
-    public function execute(int $id): void
+    public function execute(int $id, int $actorUserId): void
     {
-        if ($this->organizations->findById($id) === null) {
+        $organization = $this->organizations->findById($id);
+
+        if ($organization === null) {
             throw new OrganizationNotFoundException($id);
         }
 
-        $this->organizations->delete($id);
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $this->organizations->delete($id, $now);
+
+        // Audit: deletion carries the prior state (`before` only), scoped to the
+        // now-removed tenant. The audit event and the soft-delete row share one
+        // instant from the injected clock.
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $id,
+            eventType: 'organization_deleted',
+            actorUserId: $actorUserId,
+            occurredAt: $now,
+            payload: [
+                'before' => [
+                    'organization_id' => $id,
+                    'slug' => $organization->slug,
+                    'name' => $organization->name,
+                ],
+            ],
+        ));
     }
 }

--- a/src/Organization/DeleteOrganizationUseCaseInterface.php
+++ b/src/Organization/DeleteOrganizationUseCaseInterface.php
@@ -9,5 +9,5 @@ interface DeleteOrganizationUseCaseInterface
     /**
      * @throws OrganizationNotFoundException
      */
-    public function execute(int $id): void;
+    public function execute(int $id, int $actorUserId): void;
 }

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Organization;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -24,8 +25,8 @@ final readonly class ListOrganizationsHandler
         $page = PaginationQueryParser::parse($request, 50, 200);
         $output = $this->useCase->execute($page->limit, $page->offset);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 static fn (Organization $o): array => [
                     'organization_id' => $o->id,
                     'slug' => $o->slug,
@@ -33,9 +34,9 @@ final readonly class ListOrganizationsHandler
                 ],
                 $output->items,
             ),
-            'limit' => $output->limit,
-            'offset' => $output->offset,
-            'total' => $output->total,
-        ]);
+            limit: $output->limit,
+            offset: $output->offset,
+            total: $output->total,
+        ))->toArray());
     }
 }

--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -21,5 +21,5 @@ interface OrganizationRepositoryInterface
 
     public function save(Organization $organization): int;
 
-    public function delete(int $id): void;
+    public function delete(int $id, string $deletedAt): void;
 }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Organization;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the Organization (tenant) domain: repository, use cases, HTTP route
+ * registrar and domain exception handlers (NENE2 `dependency-injection.md`).
+ */
+final readonly class OrganizationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                OrganizationRepositoryInterface::class,
+                static fn (ContainerInterface $c): OrganizationRepositoryInterface => new PdoOrganizationRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ListOrganizationsUseCaseInterface::class,
+                static fn (ContainerInterface $c): ListOrganizationsUseCaseInterface => new ListOrganizationsUseCase(
+                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                GetOrganizationByIdUseCaseInterface::class,
+                static fn (ContainerInterface $c): GetOrganizationByIdUseCaseInterface => new GetOrganizationByIdUseCase(
+                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                CreateOrganizationUseCaseInterface::class,
+                static fn (ContainerInterface $c): CreateOrganizationUseCaseInterface => new CreateOrganizationUseCase(
+                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                DeleteOrganizationUseCaseInterface::class,
+                static fn (ContainerInterface $c): DeleteOrganizationUseCaseInterface => new DeleteOrganizationUseCase(
+                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                OrganizationRouteRegistrar::class,
+                static fn (ContainerInterface $c): OrganizationRouteRegistrar => new OrganizationRouteRegistrar(
+                    new ListOrganizationsHandler(
+                        ServiceResolver::get($c, ListOrganizationsUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new CreateOrganizationHandler(
+                        ServiceResolver::get($c, CreateOrganizationUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetOrganizationByIdHandler(
+                        ServiceResolver::get($c, GetOrganizationByIdUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new DeleteOrganizationHandler(
+                        ServiceResolver::get($c, DeleteOrganizationUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                OrganizationNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): OrganizationNotFoundExceptionHandler => new OrganizationNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                OrganizationAlreadyExistsExceptionHandler::class,
+                static fn (ContainerInterface $c): OrganizationAlreadyExistsExceptionHandler => new OrganizationAlreadyExistsExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
     public function findById(int $id): ?Organization
     {
         $row = $this->query->fetchOne(
-            'SELECT id, slug, name FROM organizations WHERE id = ?',
+            'SELECT id, slug, name FROM organizations WHERE id = ? AND is_deleted = 0',
             [$id],
         );
 
@@ -26,7 +26,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
     public function findBySlug(string $slug): ?Organization
     {
         $row = $this->query->fetchOne(
-            'SELECT id, slug, name FROM organizations WHERE slug = ?',
+            'SELECT id, slug, name FROM organizations WHERE slug = ? AND is_deleted = 0',
             [$slug],
         );
 
@@ -35,13 +35,13 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function existsBySlug(string $slug): bool
     {
-        return $this->query->fetchOne('SELECT 1 FROM organizations WHERE slug = ?', [$slug]) !== null;
+        return $this->query->fetchOne('SELECT 1 FROM organizations WHERE slug = ? AND is_deleted = 0', [$slug]) !== null;
     }
 
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, slug, name FROM organizations ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT id, slug, name FROM organizations WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
             [$limit, $offset],
         );
 
@@ -50,7 +50,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function countAll(): int
     {
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM organizations');
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM organizations WHERE is_deleted = 0');
 
         if ($row === null) {
             return 0;
@@ -78,9 +78,14 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         return $this->query->lastInsertId();
     }
 
-    public function delete(int $id): void
+    public function delete(int $id, string $deletedAt): void
     {
-        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
+        // Soft delete — auditable tenant history is never hard-deleted.
+        // `$deletedAt` comes from the use case's injected clock.
+        $this->query->execute(
+            'UPDATE organizations SET is_deleted = 1, deleted_at = ? WHERE id = ?',
+            [$deletedAt, $id],
+        );
     }
 
     /**

--- a/src/Reconciliation/ListClientCreditsHandler.php
+++ b/src/Reconciliation/ListClientCreditsHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Reconciliation;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,14 +24,14 @@ final readonly class ListClientCreditsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 ClientCreditResponse::toArray(...),
                 $this->clientCredits->findByOrganization($organizationId, $page->limit, $page->offset),
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->clientCredits->countByOrganization($organizationId),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->clientCredits->countByOrganization($organizationId),
+        ))->toArray());
     }
 }

--- a/src/Reconciliation/ListReconciliationsHandler.php
+++ b/src/Reconciliation/ListReconciliationsHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Reconciliation;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,14 +29,14 @@ final readonly class ListReconciliationsHandler
 
         $items = $this->reconciliations->findByOrganization($organizationId, $status, $page->limit, $page->offset);
 
-        return $this->response->create([
-            'items' => array_map(
+        return $this->response->create((new PaginationResponse(
+            items: array_map(
                 static fn (Reconciliation $r): array => ReconciliationResponse::toArray($r),
                 $items,
             ),
-            'limit' => $page->limit,
-            'offset' => $page->offset,
-            'total' => $this->reconciliations->countByOrganization($organizationId, $status),
-        ]);
+            limit: $page->limit,
+            offset: $page->offset,
+            total: $this->reconciliations->countByOrganization($organizationId, $status),
+        ))->toArray());
     }
 }

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires reconciliation (match proposal/confirmation/reversal) and client
+ * credit application, including allocation use cases and exception handlers.
+ */
+final readonly class ReconciliationServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ReconciliationRepositoryInterface::class,
+                static fn (ContainerInterface $c): ReconciliationRepositoryInterface => new PdoReconciliationRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ClientCreditRepositoryInterface::class,
+                static fn (ContainerInterface $c): ClientCreditRepositoryInterface => new PdoClientCreditRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ProposeMatchUseCaseInterface::class,
+                static fn (ContainerInterface $c): ProposeMatchUseCaseInterface => new ProposeMatchUseCase(
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ConfirmMatchUseCaseInterface::class,
+                static fn (ContainerInterface $c): ConfirmMatchUseCaseInterface => new ConfirmMatchUseCase(
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ReverseReconciliationUseCaseInterface::class,
+                static fn (ContainerInterface $c): ReverseReconciliationUseCaseInterface => new ReverseReconciliationUseCase(
+                    ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ApplyCreditUseCaseInterface::class,
+                static fn (ContainerInterface $c): ApplyCreditUseCaseInterface => new ApplyCreditUseCase(
+                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                ReconciliationRouteRegistrar::class,
+                static fn (ContainerInterface $c): ReconciliationRouteRegistrar => new ReconciliationRouteRegistrar(
+                    new ProposeMatchHandler(
+                        ServiceResolver::get($c, ProposeMatchUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ConfirmMatchHandler(
+                        ServiceResolver::get($c, ConfirmMatchUseCaseInterface::class),
+                        ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListReconciliationsHandler(
+                        ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetReconciliationByIdHandler(
+                        ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ReverseReconciliationHandler(
+                        ServiceResolver::get($c, ReverseReconciliationUseCaseInterface::class),
+                        ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ListClientCreditsHandler(
+                        ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ApplyCreditHandler(
+                        ServiceResolver::get($c, ApplyCreditUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                ReconciliationNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): ReconciliationNotFoundExceptionHandler => new ReconciliationNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                ReconciliationAlreadyReversedExceptionHandler::class,
+                static fn (ContainerInterface $c): ReconciliationAlreadyReversedExceptionHandler => new ReconciliationAlreadyReversedExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                ClientCreditNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): ClientCreditNotFoundExceptionHandler => new ClientCreditNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                CreditExceedsRemainingExceptionHandler::class,
+                static fn (ContainerInterface $c): CreditExceedsRemainingExceptionHandler => new CreditExceedsRemainingExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                AllocationExceedsOutstandingExceptionHandler::class,
+                static fn (ContainerInterface $c): AllocationExceedsOutstandingExceptionHandler => new AllocationExceedsOutstandingExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                BankTransactionNotMatchableExceptionHandler::class,
+                static fn (ContainerInterface $c): BankTransactionNotMatchableExceptionHandler => new BankTransactionNotMatchableExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/src/User/CreateUserHandler.php
+++ b/src/User/CreateUserHandler.php
@@ -49,6 +49,7 @@ final readonly class CreateUserHandler
             email: $email,
             role: $role,
             password: $password,
+            actorUserId: AuthContext::userId($request),
         ));
 
         return $this->response->create(UserResponse::toArray($user), 201, ['Location' => '/admin/users/' . $user->id]);

--- a/src/User/CreateUserInput.php
+++ b/src/User/CreateUserInput.php
@@ -13,6 +13,7 @@ final readonly class CreateUserInput
         public string $email,
         public Role $role,
         public ?string $password,
+        public int $actorUserId,
     ) {
     }
 }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
 use NeneClear\Auth\Role;
 
 final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -44,6 +49,24 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
         if ($created === null) {
             throw new UserNotFoundException($id);
         }
+
+        // Audit: account creation carries `after` only (no prior state). The
+        // password hash is never recorded — only who/what changed.
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $input->organizationId ?? 0,
+            eventType: 'user_created',
+            actorUserId: $input->actorUserId,
+            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+            payload: [
+                'after' => [
+                    'user_id' => $created->id,
+                    'email' => $created->email,
+                    'role' => $created->role->value,
+                    'status' => $created->status->value,
+                    'organization_id' => $created->organizationId,
+                ],
+            ],
+        ));
 
         return $created;
     }

--- a/src/User/DeleteUserHandler.php
+++ b/src/User/DeleteUserHandler.php
@@ -23,7 +23,7 @@ final readonly class DeleteUserHandler
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
 
-        $this->useCase->execute($id, AuthContext::organizationId($request));
+        $this->useCase->execute($id, AuthContext::organizationId($request), AuthContext::userId($request));
 
         return $this->response->createEmpty(204);
     }

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+
 final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
-    public function execute(int $id, ?int $callerOrganizationId): void
+    public function execute(int $id, ?int $callerOrganizationId, int $actorUserId): void
     {
         $user = $this->users->findById($id);
 
@@ -19,6 +25,25 @@ final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
             throw new UserNotFoundException($id);
         }
 
-        $this->users->delete($callerOrganizationId, $id);
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $this->users->delete($callerOrganizationId, $id, $now);
+
+        // Audit: deletion carries the prior state (`before` only) so the removed
+        // account's identity and privileges remain reconstructable.
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $user->organizationId ?? 0,
+            eventType: 'user_deleted',
+            actorUserId: $actorUserId,
+            occurredAt: $now,
+            payload: [
+                'before' => [
+                    'user_id' => $user->id,
+                    'email' => $user->email,
+                    'role' => $user->role->value,
+                    'status' => $user->status->value,
+                    'organization_id' => $user->organizationId,
+                ],
+            ],
+        ));
     }
 }

--- a/src/User/DeleteUserUseCaseInterface.php
+++ b/src/User/DeleteUserUseCaseInterface.php
@@ -9,5 +9,5 @@ interface DeleteUserUseCaseInterface
     /**
      * @throws UserNotFoundException
      */
-    public function execute(int $id, ?int $callerOrganizationId): void;
+    public function execute(int $id, ?int $callerOrganizationId, int $actorUserId): void;
 }

--- a/src/User/ListUsersHandler.php
+++ b/src/User/ListUsersHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\User;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
 use NeneClear\Auth\AuthContext;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,11 +24,11 @@ final readonly class ListUsersHandler
         $page = PaginationQueryParser::parse($request, 50, 200);
         $output = $this->useCase->execute(AuthContext::organizationId($request), $page->limit, $page->offset);
 
-        return $this->response->create([
-            'items' => array_map(UserResponse::toArray(...), $output->items),
-            'limit' => $output->limit,
-            'offset' => $output->offset,
-            'total' => $output->total,
-        ]);
+        return $this->response->create((new PaginationResponse(
+            items: array_map(UserResponse::toArray(...), $output->items),
+            limit: $output->limit,
+            offset: $output->offset,
+            total: $output->total,
+        ))->toArray());
     }
 }

--- a/src/User/PdoUserRepository.php
+++ b/src/User/PdoUserRepository.php
@@ -95,18 +95,20 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         return $this->query->lastInsertId();
     }
 
-    public function delete(?int $organizationId, int $id): void
+    public function delete(?int $organizationId, int $id, string $deletedAt): void
     {
         // Soft delete — financial/audit context never hard-deletes accounts.
+        // `$deletedAt` is supplied by the use case's injected clock so the row
+        // and its audit event share one instant (no wall-clock read here).
         if ($organizationId !== null) {
             $this->query->execute(
                 'UPDATE users SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
-                [date('Y-m-d H:i:s'), $id, $organizationId],
+                [$deletedAt, $id, $organizationId],
             );
         } else {
             $this->query->execute(
                 'UPDATE users SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id IS NULL',
-                [date('Y-m-d H:i:s'), $id],
+                [$deletedAt, $id],
             );
         }
     }

--- a/src/User/UpdateUserHandler.php
+++ b/src/User/UpdateUserHandler.php
@@ -50,6 +50,7 @@ final readonly class UpdateUserHandler
             callerOrganizationId: AuthContext::organizationId($request),
             role: $role,
             status: $status,
+            actorUserId: AuthContext::userId($request),
         ));
 
         return $this->response->create(UserResponse::toArray($user));

--- a/src/User/UpdateUserInput.php
+++ b/src/User/UpdateUserInput.php
@@ -13,6 +13,7 @@ final readonly class UpdateUserInput
         public ?int $callerOrganizationId,
         public ?Role $role,
         public ?UserStatus $status,
+        public int $actorUserId,
     ) {
     }
 }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
 use NeneClear\Auth\Role;
 
 final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 {
     public function __construct(
         private UserRepositoryInterface $users,
+        private AuditEventRepositoryInterface $auditEvents,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -37,6 +42,27 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
         );
 
         $this->users->save($updated);
+
+        // Audit: in-place change carries both the prior and the resulting role
+        // and status, so a role escalation or deactivation is fully reconstructable.
+        $this->auditEvents->record(new AuditEvent(
+            organizationId: $existing->organizationId ?? 0,
+            eventType: 'user_updated',
+            actorUserId: $input->actorUserId,
+            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+            payload: [
+                'user_id' => $existing->id,
+                'email' => $existing->email,
+                'before' => [
+                    'role' => $existing->role->value,
+                    'status' => $existing->status->value,
+                ],
+                'after' => [
+                    'role' => $updated->role->value,
+                    'status' => $updated->status->value,
+                ],
+            ],
+        ));
 
         return $updated;
     }

--- a/src/User/UserRepositoryInterface.php
+++ b/src/User/UserRepositoryInterface.php
@@ -21,5 +21,5 @@ interface UserRepositoryInterface
 
     public function save(User $user): int;
 
-    public function delete(?int $organizationId, int $id): void;
+    public function delete(?int $organizationId, int $id, string $deletedAt): void;
 }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the User (operator account) domain: repository, use cases, route
+ * registrar and domain exception handlers.
+ */
+final readonly class UserServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                UserRepositoryInterface::class,
+                static fn (ContainerInterface $c): UserRepositoryInterface => new PdoUserRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ListUsersUseCaseInterface::class,
+                static fn (ContainerInterface $c): ListUsersUseCaseInterface => new ListUsersUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                GetUserByIdUseCaseInterface::class,
+                static fn (ContainerInterface $c): GetUserByIdUseCaseInterface => new GetUserByIdUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                CreateUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): CreateUserUseCaseInterface => new CreateUserUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                UpdateUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): UpdateUserUseCaseInterface => new UpdateUserUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                DeleteUserUseCaseInterface::class,
+                static fn (ContainerInterface $c): DeleteUserUseCaseInterface => new DeleteUserUseCase(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                UserRouteRegistrar::class,
+                static fn (ContainerInterface $c): UserRouteRegistrar => new UserRouteRegistrar(
+                    new ListUsersHandler(
+                        ServiceResolver::get($c, ListUsersUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new CreateUserHandler(
+                        ServiceResolver::get($c, CreateUserUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetUserByIdHandler(
+                        ServiceResolver::get($c, GetUserByIdUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new UpdateUserHandler(
+                        ServiceResolver::get($c, UpdateUserUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new DeleteUserHandler(
+                        ServiceResolver::get($c, DeleteUserUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                UserNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): UserNotFoundExceptionHandler => new UserNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                UserAlreadyExistsExceptionHandler::class,
+                static fn (ContainerInterface $c): UserAlreadyExistsExceptionHandler => new UserAlreadyExistsExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                RoleNotAssignableExceptionHandler::class,
+                static fn (ContainerInterface $c): RoleNotAssignableExceptionHandler => new RoleNotAssignableExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/tests/Audit/InMemoryAuditEventRepository.php
+++ b/tests/Audit/InMemoryAuditEventRepository.php
@@ -14,8 +14,39 @@ final class InMemoryAuditEventRepository implements AuditEventRepositoryInterfac
 
     public function record(AuditEvent $event): int
     {
-        $this->events[] = $event;
+        $id = count($this->events) + 1;
+        $this->events[] = new AuditEvent(
+            organizationId: $event->organizationId,
+            eventType: $event->eventType,
+            actorUserId: $event->actorUserId,
+            occurredAt: $event->occurredAt,
+            payload: $event->payload,
+            id: $id,
+        );
 
-        return count($this->events);
+        return $id;
+    }
+
+    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
+    {
+        $matches = array_values(array_filter(
+            $this->events,
+            static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
+                && ($eventType === null || $e->eventType === $eventType),
+        ));
+
+        // Newest first, mirroring the SQL `ORDER BY id DESC`.
+        usort($matches, static fn (AuditEvent $a, AuditEvent $b): int => ($b->id ?? 0) <=> ($a->id ?? 0));
+
+        return array_slice($matches, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId, ?string $eventType): int
+    {
+        return count(array_filter(
+            $this->events,
+            static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
+                && ($eventType === null || $e->eventType === $eventType),
+        ));
     }
 }

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -9,6 +9,8 @@ use NeneClear\Auth\JwtTokenService;
 use NeneClear\Auth\LoginInput;
 use NeneClear\Auth\LoginUseCase;
 use NeneClear\Auth\Role;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use NeneClear\Tests\User\InMemoryUserRepository;
 use NeneClear\User\User;
 use NeneClear\User\UserStatus;
@@ -16,9 +18,21 @@ use PHPUnit\Framework\TestCase;
 
 final class LoginUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
     private function useCase(InMemoryUserRepository $users): LoginUseCase
     {
-        return new LoginUseCase($users, new JwtTokenService(secret: 'test-secret-test-secret-32chars!'));
+        return new LoginUseCase(
+            $users,
+            new JwtTokenService(secret: 'test-secret-test-secret-32chars!'),
+            $this->audit,
+            new FixedClock('2026-06-01T10:00:00+00:00'),
+        );
     }
 
     private function activeUser(string $password): User
@@ -72,5 +86,34 @@ final class LoginUseCaseTest extends TestCase
 
         $this->expectException(InvalidCredentialsException::class);
         $this->useCase($users)->execute(new LoginInput('invited@acme.example', 'correct horse'));
+    }
+
+    public function test_successful_login_is_audited(): void
+    {
+        $users = new InMemoryUserRepository([$this->activeUser('correct horse')]);
+        $this->useCase($users)->execute(new LoginInput('admin@acme.example', 'correct horse'));
+
+        self::assertCount(1, $this->audit->events);
+        self::assertSame('login_succeeded', $this->audit->events[0]->eventType);
+        self::assertSame('admin@acme.example', $this->audit->events[0]->payload['after']['email']);
+    }
+
+    public function test_failed_login_is_audited_without_leaking_password(): void
+    {
+        $users = new InMemoryUserRepository([$this->activeUser('correct horse')]);
+
+        try {
+            $this->useCase($users)->execute(new LoginInput('admin@acme.example', 'wrong-secret'));
+            self::fail('Expected InvalidCredentialsException');
+        } catch (InvalidCredentialsException) {
+            // expected
+        }
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('login_failed', $event->eventType);
+        self::assertSame(0, $event->actorUserId);
+        self::assertSame('invalid_credentials', $event->payload['after']['failure_reason']);
+        self::assertStringNotContainsStringIgnoringCase('wrong-secret', json_encode($event->payload, JSON_THROW_ON_ERROR));
     }
 }

--- a/tests/BankImport/InMemoryBankAccountRepository.php
+++ b/tests/BankImport/InMemoryBankAccountRepository.php
@@ -27,8 +27,10 @@ final class InMemoryBankAccountRepository implements BankAccountRepositoryInterf
         ));
     }
 
-    public function deleteByOrganization(int $organizationId): void
+    public function deleteByOrganization(int $organizationId, string $deletedAt): void
     {
+        // Soft delete: drop from the visible set, mirroring the `is_deleted = 0`
+        // read filter. The in-memory double only needs the observable effect.
         foreach ($this->byId as $id => $account) {
             if ($account->organizationId === $organizationId) {
                 unset($this->byId[$id]);

--- a/tests/Database/PdoOrganizationRepositoryTest.php
+++ b/tests/Database/PdoOrganizationRepositoryTest.php
@@ -59,7 +59,7 @@ final class PdoOrganizationRepositoryTest extends TestCase
         self::assertSame(2, $repo->countAll());
         self::assertCount(2, $repo->findAll(50, 0));
 
-        $repo->delete($second);
+        $repo->delete($second, '2026-01-01 00:00:00');
         self::assertSame(1, $repo->countAll());
         self::assertNull($repo->findById($second));
     }

--- a/tests/Database/PdoUserRepositoryTest.php
+++ b/tests/Database/PdoUserRepositoryTest.php
@@ -83,7 +83,7 @@ final class PdoUserRepositoryTest extends TestCase
         self::assertTrue($repo->existsByEmail('member@acme.example'));
         self::assertNotNull($repo->findByEmail('member@acme.example'));
 
-        $repo->delete(7, $id);
+        $repo->delete(7, $id, '2026-01-01 00:00:00');
 
         self::assertFalse($repo->existsByEmail('member@acme.example'));
         self::assertNull($repo->findById($id));

--- a/tests/Http/AuditHttpTest.php
+++ b/tests/Http/AuditHttpTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AuditHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-audit-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createLoginAttempts($query);
+        SchemaFixture::createAuditEvents($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin, 7));
+        $users->save($this->user('member@acme.example', Role::Member, 7));
+
+        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role, int $org): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: $org,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, mixed>|null $json
+     */
+    private function request(string $method, string $path, string $token, ?array $json = null): ResponseInterface
+    {
+        $request = $this->psr17->createServerRequest($method, $path)->withHeader('Authorization', 'Bearer ' . $token);
+        if ($json !== null) {
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->psr17->createStream((string) json_encode($json)));
+        }
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_admin_sees_mutations_with_before_and_after(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        // A mutating operation that must leave an audit trail.
+        $created = $this->request('POST', '/admin/users', $token, [
+            'email' => 'new@acme.example',
+            'role' => 'member',
+            'password' => 'a-strong-password',
+        ]);
+        self::assertSame(201, $created->getStatusCode());
+
+        $list = $this->request('GET', '/admin/audit-events', $token);
+        self::assertSame(200, $list->getStatusCode());
+        $body = $this->decode($list);
+
+        self::assertArrayHasKey('items', $body);
+        $types = array_column($body['items'], 'event_type');
+        self::assertContains('user_created', $types);
+        self::assertContains('login_succeeded', $types);
+
+        $userCreated = null;
+        foreach ($body['items'] as $item) {
+            if ($item['event_type'] === 'user_created') {
+                $userCreated = $item;
+                break;
+            }
+        }
+        self::assertNotNull($userCreated);
+        self::assertSame('new@acme.example', $userCreated['payload']['after']['email']);
+        // No password material ever reaches the audit trail.
+        self::assertStringNotContainsStringIgnoringCase('a-strong-password', (string) json_encode($userCreated));
+    }
+
+    public function test_event_type_filter_narrows_results(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $this->request('POST', '/admin/users', $token, [
+            'email' => 'new@acme.example',
+            'role' => 'member',
+            'password' => 'a-strong-password',
+        ]);
+
+        $body = $this->decode($this->request('GET', '/admin/audit-events?event_type=user_created', $token));
+        $types = array_unique(array_column($body['items'], 'event_type'));
+        self::assertSame(['user_created'], array_values($types));
+    }
+
+    public function test_member_lacks_capability_to_read_audit_trail(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+
+        $response = $this->request('GET', '/admin/audit-events', $token);
+        self::assertSame(403, $response->getStatusCode());
+    }
+}

--- a/tests/Http/AuthHttpTest.php
+++ b/tests/Http/AuthHttpTest.php
@@ -33,6 +33,7 @@ final class AuthHttpTest extends TestCase
         $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
         SchemaFixture::createUsers($this->query);
         SchemaFixture::createLoginAttempts($this->query);
+        SchemaFixture::createAuditEvents($this->query);
 
         (new PdoUserRepository($this->query))->save(new User(
             email: 'admin@acme.example',

--- a/tests/Http/OrganizationCrudHttpTest.php
+++ b/tests/Http/OrganizationCrudHttpTest.php
@@ -34,6 +34,7 @@ final class OrganizationCrudHttpTest extends TestCase
         SchemaFixture::createOrganizations($this->query);
         SchemaFixture::createUsers($this->query);
         SchemaFixture::createLoginAttempts($this->query);
+        SchemaFixture::createAuditEvents($this->query);
 
         $users = new PdoUserRepository($this->query);
         $users->save(new User(

--- a/tests/Http/UserCrudHttpTest.php
+++ b/tests/Http/UserCrudHttpTest.php
@@ -32,6 +32,7 @@ final class UserCrudHttpTest extends TestCase
         $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
+        SchemaFixture::createAuditEvents($query);
 
         $users = new PdoUserRepository($query);
         $users->save($this->user('admin@acme.example', Role::Admin, 7));

--- a/tests/Organization/CreateOrganizationUseCaseTest.php
+++ b/tests/Organization/CreateOrganizationUseCaseTest.php
@@ -8,16 +8,30 @@ use NeneClear\Organization\CreateOrganizationInput;
 use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\Organization;
 use NeneClear\Organization\OrganizationAlreadyExistsException;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class CreateOrganizationUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
+    private function useCase(InMemoryOrganizationRepository $repo): CreateOrganizationUseCase
+    {
+        return new CreateOrganizationUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+    }
+
     public function test_creates_organization_and_returns_output_with_id(): void
     {
         $repo = new InMemoryOrganizationRepository();
-        $useCase = new CreateOrganizationUseCase($repo);
+        $useCase = $this->useCase($repo);
 
-        $output = $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Co'));
+        $output = $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Co', actorUserId: 1));
 
         self::assertGreaterThan(0, $output->id);
         self::assertSame('acme', $output->slug);
@@ -25,13 +39,28 @@ final class CreateOrganizationUseCaseTest extends TestCase
         self::assertNotNull($repo->findBySlug('acme'));
     }
 
+    public function test_records_audit_event_scoped_to_new_tenant(): void
+    {
+        $repo = new InMemoryOrganizationRepository();
+        $useCase = $this->useCase($repo);
+
+        $output = $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Co', actorUserId: 1));
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('organization_created', $event->eventType);
+        self::assertSame($output->id, $event->organizationId);
+        self::assertSame(1, $event->actorUserId);
+        self::assertSame('acme', $event->payload['after']['slug']);
+    }
+
     public function test_rejects_duplicate_slug(): void
     {
         $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
-        $useCase = new CreateOrganizationUseCase($repo);
+        $useCase = $this->useCase($repo);
 
         $this->expectException(OrganizationAlreadyExistsException::class);
 
-        $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Again'));
+        $useCase->execute(new CreateOrganizationInput(slug: 'acme', name: 'Acme Again', actorUserId: 1));
     }
 }

--- a/tests/Organization/DeleteOrganizationUseCaseTest.php
+++ b/tests/Organization/DeleteOrganizationUseCaseTest.php
@@ -7,25 +7,54 @@ namespace NeneClear\Tests\Organization;
 use NeneClear\Organization\DeleteOrganizationUseCase;
 use NeneClear\Organization\Organization;
 use NeneClear\Organization\OrganizationNotFoundException;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class DeleteOrganizationUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
+    private function useCase(InMemoryOrganizationRepository $repo): DeleteOrganizationUseCase
+    {
+        return new DeleteOrganizationUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+    }
+
     public function test_deletes_existing_organization(): void
     {
         $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
-        $useCase = new DeleteOrganizationUseCase($repo);
+        $useCase = $this->useCase($repo);
 
-        $useCase->execute(1);
+        $useCase->execute(1, 1);
 
         self::assertNull($repo->findById(1));
     }
 
+    public function test_records_audit_event_with_prior_state(): void
+    {
+        $repo = new InMemoryOrganizationRepository([new Organization(slug: 'acme', name: 'Acme Co')]);
+        $useCase = $this->useCase($repo);
+
+        $useCase->execute(1, 1);
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('organization_deleted', $event->eventType);
+        self::assertSame(1, $event->organizationId);
+        self::assertSame('acme', $event->payload['before']['slug']);
+        self::assertSame('Acme Co', $event->payload['before']['name']);
+    }
+
     public function test_unknown_id_throws_not_found(): void
     {
-        $useCase = new DeleteOrganizationUseCase(new InMemoryOrganizationRepository());
+        $useCase = $this->useCase(new InMemoryOrganizationRepository());
 
         $this->expectException(OrganizationNotFoundException::class);
-        $useCase->execute(9999);
+        $useCase->execute(9999, 1);
     }
 }

--- a/tests/Organization/InMemoryOrganizationRepository.php
+++ b/tests/Organization/InMemoryOrganizationRepository.php
@@ -63,8 +63,11 @@ final class InMemoryOrganizationRepository implements OrganizationRepositoryInte
         return $id;
     }
 
-    public function delete(int $id): void
+    public function delete(int $id, string $deletedAt): void
     {
+        // Soft delete: drop from the visible set so reads no longer return it,
+        // mirroring the SQL `is_deleted = 0` filter. `$deletedAt` is recorded by
+        // the persistent adapter; the in-memory double only needs the effect.
         unset($this->byId[$id]);
     }
 }

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -19,6 +19,8 @@ final class SchemaFixture
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 slug TEXT NOT NULL UNIQUE,
                 name TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                deleted_at TEXT,
                 created_at TEXT,
                 updated_at TEXT
             )'
@@ -73,6 +75,8 @@ final class SchemaFixture
                 csv_amount_column INTEGER NOT NULL,
                 csv_counterparty_column INTEGER NOT NULL,
                 csv_header_rows INTEGER NOT NULL DEFAULT 1,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                deleted_at TEXT,
                 created_at TEXT,
                 updated_at TEXT
             )'

--- a/tests/User/CreateUserUseCaseTest.php
+++ b/tests/User/CreateUserUseCaseTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\CreateUserInput;
 use NeneClear\User\CreateUserUseCase;
 use NeneClear\User\User;
@@ -14,16 +16,28 @@ use PHPUnit\Framework\TestCase;
 
 final class CreateUserUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
+    private function useCase(InMemoryUserRepository $repo): CreateUserUseCase
+    {
+        return new CreateUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+    }
+
     public function test_with_password_creates_active_user(): void
     {
-        $repo = new InMemoryUserRepository();
-        $useCase = new CreateUserUseCase($repo);
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         $user = $useCase->execute(new CreateUserInput(
             organizationId: 7,
             email: 'member@acme.example',
             role: Role::Member,
             password: 'secret-pass',
+            actorUserId: 42,
         ));
 
         self::assertGreaterThan(0, $user->id);
@@ -34,16 +48,41 @@ final class CreateUserUseCaseTest extends TestCase
         self::assertTrue(password_verify('secret-pass', $user->passwordHash));
     }
 
+    public function test_records_audit_event_without_leaking_password(): void
+    {
+        $useCase = $this->useCase(new InMemoryUserRepository());
+
+        $useCase->execute(new CreateUserInput(
+            organizationId: 7,
+            email: 'member@acme.example',
+            role: Role::Member,
+            password: 'secret-pass',
+            actorUserId: 42,
+        ));
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('user_created', $event->eventType);
+        self::assertSame(42, $event->actorUserId);
+        self::assertSame(7, $event->organizationId);
+        self::assertSame('member@acme.example', $event->payload['after']['email']);
+        self::assertSame('active', $event->payload['after']['status']);
+        // The password / hash must never appear anywhere in the audit payload.
+        $encoded = json_encode($event->payload, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsStringIgnoringCase('secret-pass', $encoded);
+        self::assertStringNotContainsStringIgnoringCase('password', $encoded);
+    }
+
     public function test_without_password_creates_invited_user_with_unusable_hash(): void
     {
-        $repo = new InMemoryUserRepository();
-        $useCase = new CreateUserUseCase($repo);
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         $user = $useCase->execute(new CreateUserInput(
             organizationId: 7,
             email: 'invited@acme.example',
             role: Role::Viewer,
             password: null,
+            actorUserId: 42,
         ));
 
         self::assertSame(UserStatus::Invited, $user->status);
@@ -63,7 +102,7 @@ final class CreateUserUseCaseTest extends TestCase
                 organizationId: 7,
             ),
         ]);
-        $useCase = new CreateUserUseCase($repo);
+        $useCase = $this->useCase($repo);
 
         $this->expectException(UserAlreadyExistsException::class);
 
@@ -72,19 +111,20 @@ final class CreateUserUseCaseTest extends TestCase
             email: 'taken@acme.example',
             role: Role::Member,
             password: 'p',
+            actorUserId: 42,
         ));
     }
 
     public function test_superadmin_user_has_null_organization(): void
     {
-        $repo = new InMemoryUserRepository();
-        $useCase = new CreateUserUseCase($repo);
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         $user = $useCase->execute(new CreateUserInput(
             organizationId: null,
             email: 'root@platform.example',
             role: Role::Superadmin,
             password: 'p',
+            actorUserId: 1,
         ));
 
         self::assertNull($user->organizationId);
@@ -93,7 +133,7 @@ final class CreateUserUseCaseTest extends TestCase
 
     public function test_org_scoped_caller_cannot_mint_superadmin(): void
     {
-        $useCase = new CreateUserUseCase(new InMemoryUserRepository());
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         // An org-scoped admin (non-null org) assigning superadmin is privilege
         // escalation and must be rejected.
@@ -104,6 +144,7 @@ final class CreateUserUseCaseTest extends TestCase
             email: 'escalate@org.example',
             role: Role::Superadmin,
             password: 'p',
+            actorUserId: 42,
         ));
     }
 }

--- a/tests/User/DeleteUserUseCaseTest.php
+++ b/tests/User/DeleteUserUseCaseTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\DeleteUserUseCase;
 use NeneClear\User\User;
 use NeneClear\User\UserNotFoundException;
@@ -13,6 +15,18 @@ use PHPUnit\Framework\TestCase;
 
 final class DeleteUserUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
+    private function useCase(InMemoryUserRepository $repo): DeleteUserUseCase
+    {
+        return new DeleteUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+    }
+
     private function seedUser(int $orgId = 7): InMemoryUserRepository
     {
         return new InMemoryUserRepository([
@@ -30,34 +44,50 @@ final class DeleteUserUseCaseTest extends TestCase
     public function test_deletes_own_org_user(): void
     {
         $repo = $this->seedUser();
-        $useCase = new DeleteUserUseCase($repo);
+        $useCase = $this->useCase($repo);
 
-        $useCase->execute(1, 7);
+        $useCase->execute(1, 7, 42);
 
         self::assertNull($repo->findById(1));
+    }
+
+    public function test_records_audit_event_with_prior_state(): void
+    {
+        $repo = $this->seedUser();
+        $useCase = $this->useCase($repo);
+
+        $useCase->execute(1, 7, 42);
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('user_deleted', $event->eventType);
+        self::assertSame(42, $event->actorUserId);
+        self::assertSame('member@acme.example', $event->payload['before']['email']);
+        self::assertSame('member', $event->payload['before']['role']);
     }
 
     public function test_cross_tenant_delete_throws_not_found_and_keeps_user(): void
     {
         $repo = $this->seedUser(orgId: 7);
-        $useCase = new DeleteUserUseCase($repo);
+        $useCase = $this->useCase($repo);
 
         try {
-            $useCase->execute(1, 999);
+            $useCase->execute(1, 999, 42);
             self::fail('Expected UserNotFoundException');
         } catch (UserNotFoundException) {
             // User must still exist — a foreign tenant cannot delete it.
             self::assertNotNull($repo->findById(1));
         }
+
+        self::assertCount(0, $this->audit->events);
     }
 
     public function test_unknown_user_throws_not_found(): void
     {
-        $repo = new InMemoryUserRepository();
-        $useCase = new DeleteUserUseCase($repo);
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         $this->expectException(UserNotFoundException::class);
 
-        $useCase->execute(9999, 7);
+        $useCase->execute(9999, 7, 42);
     }
 }

--- a/tests/User/InMemoryUserRepository.php
+++ b/tests/User/InMemoryUserRepository.php
@@ -78,7 +78,7 @@ final class InMemoryUserRepository implements UserRepositoryInterface
         return $id;
     }
 
-    public function delete(?int $organizationId, int $id): void
+    public function delete(?int $organizationId, int $id, string $deletedAt): void
     {
         $user = $this->byId[$id] ?? null;
         if ($user !== null && $user->organizationId === $organizationId) {

--- a/tests/User/UpdateUserUseCaseTest.php
+++ b/tests/User/UpdateUserUseCaseTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
+use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\UpdateUserInput;
 use NeneClear\User\UpdateUserUseCase;
 use NeneClear\User\User;
@@ -14,6 +16,18 @@ use PHPUnit\Framework\TestCase;
 
 final class UpdateUserUseCaseTest extends TestCase
 {
+    private InMemoryAuditEventRepository $audit;
+
+    protected function setUp(): void
+    {
+        $this->audit = new InMemoryAuditEventRepository();
+    }
+
+    private function useCase(InMemoryUserRepository $repo): UpdateUserUseCase
+    {
+        return new UpdateUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+    }
+
     private function seedUser(int $orgId = 7): InMemoryUserRepository
     {
         return new InMemoryUserRepository([
@@ -30,14 +44,14 @@ final class UpdateUserUseCaseTest extends TestCase
 
     public function test_updates_role_and_status(): void
     {
-        $repo = $this->seedUser();
-        $useCase = new UpdateUserUseCase($repo);
+        $useCase = $this->useCase($this->seedUser());
 
         $updated = $useCase->execute(new UpdateUserInput(
             id: 1,
             callerOrganizationId: 7,
             role: Role::Admin,
             status: UserStatus::Active,
+            actorUserId: 42,
         ));
 
         self::assertSame(Role::Admin, $updated->role);
@@ -47,16 +61,38 @@ final class UpdateUserUseCaseTest extends TestCase
         self::assertSame('hash', $updated->passwordHash);
     }
 
+    public function test_records_audit_event_with_before_and_after(): void
+    {
+        $useCase = $this->useCase($this->seedUser());
+
+        $useCase->execute(new UpdateUserInput(
+            id: 1,
+            callerOrganizationId: 7,
+            role: Role::Admin,
+            status: UserStatus::Active,
+            actorUserId: 42,
+        ));
+
+        self::assertCount(1, $this->audit->events);
+        $event = $this->audit->events[0];
+        self::assertSame('user_updated', $event->eventType);
+        self::assertSame(42, $event->actorUserId);
+        self::assertSame('member', $event->payload['before']['role']);
+        self::assertSame('invited', $event->payload['before']['status']);
+        self::assertSame('admin', $event->payload['after']['role']);
+        self::assertSame('active', $event->payload['after']['status']);
+    }
+
     public function test_null_fields_preserve_existing_values(): void
     {
-        $repo = $this->seedUser();
-        $useCase = new UpdateUserUseCase($repo);
+        $useCase = $this->useCase($this->seedUser());
 
         $updated = $useCase->execute(new UpdateUserInput(
             id: 1,
             callerOrganizationId: 7,
             role: null,
             status: null,
+            actorUserId: 42,
         ));
 
         self::assertSame(Role::Member, $updated->role);
@@ -65,8 +101,7 @@ final class UpdateUserUseCaseTest extends TestCase
 
     public function test_cross_tenant_update_throws_not_found(): void
     {
-        $repo = $this->seedUser(orgId: 7);
-        $useCase = new UpdateUserUseCase($repo);
+        $useCase = $this->useCase($this->seedUser(orgId: 7));
 
         $this->expectException(UserNotFoundException::class);
 
@@ -75,13 +110,13 @@ final class UpdateUserUseCaseTest extends TestCase
             callerOrganizationId: 999,
             role: Role::Admin,
             status: null,
+            actorUserId: 42,
         ));
     }
 
     public function test_unknown_user_throws_not_found(): void
     {
-        $repo = new InMemoryUserRepository();
-        $useCase = new UpdateUserUseCase($repo);
+        $useCase = $this->useCase(new InMemoryUserRepository());
 
         $this->expectException(UserNotFoundException::class);
 
@@ -90,13 +125,13 @@ final class UpdateUserUseCaseTest extends TestCase
             callerOrganizationId: 7,
             role: Role::Admin,
             status: null,
+            actorUserId: 42,
         ));
     }
 
     public function test_cannot_promote_org_user_to_superadmin(): void
     {
-        $repo = $this->seedUser(orgId: 7);
-        $useCase = new UpdateUserUseCase($repo);
+        $useCase = $this->useCase($this->seedUser(orgId: 7));
 
         $this->expectException(\NeneClear\User\RoleNotAssignableException::class);
 
@@ -105,6 +140,7 @@ final class UpdateUserUseCaseTest extends TestCase
             callerOrganizationId: 7,
             role: Role::Superadmin,
             status: null,
+            actorUserId: 42,
         ));
     }
 }


### PR DESCRIPTION
Closes #109

Backend-only changes, split out of the design-system branch (#107) so they can be reviewed independently.

## What

**1. NENE2-compliant dependency injection (`nene2-compliance.md` §6)**
- Per-domain `ServiceProviderInterface` implementations (Audit, Auth, Organization, User, BankImport, ClearSettings, Reconciliation, InvoiceUpstream, Export, Dunning).
- `Http/ApplicationServiceProvider` aggregates them and exposes `ROUTE_REGISTRARS` / `EXCEPTION_HANDLERS`; `Auth/AuthServiceProvider` owns `AUTH_MIDDLEWARE`.
- `Http/ApplicationFactory` now assembles a PSR-11 container via `ContainerBuilder` instead of hand-wiring. `create()` signature is unchanged, so `public_html/index.php` and every HTTP test keep working untouched.
- `Http/ServiceResolver` — `class-string<T>` typed wrapper over the PSR-11 `get()`, removing repeated `instanceof` guards (PHPStan level 8 clean).

**2. No physical delete of business entities**
- `organizations` + `bank_accounts` get `is_deleted`/`deleted_at` (Phinx migrations + schema snapshots + test `SchemaFixture`); reads filter `is_deleted = 0`; `deleted_at` is sourced from the injected `ClockInterface` (never `date()`/`time()` in a repository).
- `clear_settings` now persists via UPDATE-or-INSERT (no `DELETE`).
- Only `login_attempts` keeps a hard delete — transient rate-limit counters, not auditable history (documented inline).

**3. Full audit coverage**
- Every state-changing use case records exactly one `AuditEvent`.
- Settings update moved out of the handler into `UpdateClearSettingsUseCase`, recording a new `clear_settings_updated` event (before/after). `event_type` registered in `docs/explanation/terminology.md` §2 before first use.

**4. Framework reuse**
- All list handlers use `Nene2\Http\PaginationResponse` instead of a hand-rolled envelope; user/org soft-delete clock injection.

## Verification
`composer check` green: PHPUnit 236 OK, PHPStan level 8 (310 files) no errors, php-cs-fixer clean.

Note: per CLAUDE.md, main is gated by Issue/PR review — this PR is for review, not direct merge. Please link the tracking Issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)