### PR TITLE
ci+docs: auto-close issues on rebase-merge to main (#115)

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,76 @@
+name: Close issues on merge
+
+# Safety net for the rebase-merge case: when a PR is brought onto `main` by rebase
+# it ends up `closed` (not `merged`), so GitHub's PR-based auto-close never fires and
+# the linked Issue is left open. This workflow scans the commits pushed to `main` for
+# closing keywords (Closes/Fixes/Resolves #NN) and closes the referenced Issues.
+# See docs/workflow.md -> "Closing Issues on Merge".
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  issues: write
+
+jobs:
+  close-referenced-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commits = context.payload.commits || [];
+            // Closing keywords per GitHub's spec; (#NN) link references are intentionally excluded.
+            const keyword = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const closed = new Set();
+
+            for (const commit of commits) {
+              const message = commit.message || '';
+              const sha = commit.id;
+              let match;
+              while ((match = keyword.exec(message)) !== null) {
+                const number = parseInt(match[1], 10);
+                if (closed.has(number)) continue;
+                closed.add(number);
+
+                let issue;
+                try {
+                  ({ data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: number,
+                  }));
+                } catch (e) {
+                  core.warning(`#${number}: not found (${e.status}); skipping`);
+                  continue;
+                }
+
+                // Never touch pull requests via the issues API.
+                if (issue.pull_request) {
+                  core.info(`#${number} is a pull request; skipping`);
+                  continue;
+                }
+                if (issue.state === 'closed') {
+                  core.info(`#${number} already closed; skipping`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body: `Closed automatically: resolved by ${sha} on \`main\`.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                core.info(`Closed #${number}`);
+              }
+            }

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -34,8 +34,26 @@ feat(reconciliation): add bank CSV import and confirm-match UseCase (#12)
 | --- | --- |
 | Normal work | Subject **must** include `(#issue)` |
 | Docs-only follow-up on same Issue | Reuse the same Issue number |
+| Work fully resolves an Issue | Add a closing keyword footer: `Closes #issue` |
 
 If you start editing without an Issue, **stop and create one first** — see `docs/workflow.md`.
+
+### Closing keyword vs. `(#issue)`
+
+The `(#issue)` reference in the subject only **links** the commit to the Issue — it does
+**not** close it. To close an Issue, add an explicit `Closes #NN` (or `Fixes` / `Resolves`)
+footer in the **commit body**:
+
+```text
+feat(dunning): dunning pause per invoice (#98)
+
+Closes #98
+```
+
+This matters because PRs are often brought onto `main` via **rebase**, in which case the PR
+is `closed` (not `merged`) and GitHub's PR-based auto-close never fires. A closing keyword in
+the commit message reaches `main` regardless, and the `close-issues.yml` workflow acts on it.
+See `docs/workflow.md` → "Closing Issues on Merge".
 
 ## Common Types
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -40,6 +40,25 @@ Every PR should include:
 
 Do not commit directly to `main`.
 
+## Closing Issues on Merge
+
+GitHub only auto-closes a linked Issue when the PR is **merged**. If a PR is brought
+onto `main` by **rebase** (the PR ends up `closed`, not `merged`), the `Closes #NN`
+auto-close never fires and the Issue is silently left open. This has already caused a
+backlog of "forgot to close" Issues.
+
+To prevent it:
+
+- Put a closing keyword (`Closes #NN` / `Fixes #NN` / `Resolves #NN`) in the **squash/merge
+  commit body**, not only in the PR description. Closing keywords in the commit message
+  reach `main` regardless of how the PR is integrated.
+- The `Close issues on merge` workflow (`.github/workflows/close-issues.yml`) scans every
+  commit pushed to `main` for these keywords and closes the referenced Issue. This is the
+  safety net for rebase-merged work.
+- Note: the conventional `(#NN)` reference in the subject is **not** a closing keyword and
+  will not close anything — it only links the commit to the Issue. Always add an explicit
+  closing keyword when the work fully resolves an Issue.
+
 ## Local Project Memory
 
 - `docs/roadmap.md`: long-lived direction and phases


### PR DESCRIPTION
## Purpose
Stop resolved Issues from being left open when PRs land on `main` via rebase. Fixes the root cause behind the 11 'forgot to close' Issues (#90–#98, #104, #105).

## Changes
- `.github/workflows/close-issues.yml`: on push to `main`, scan commits for closing keywords (`Closes/Fixes/Resolves #NN`) and close referenced open Issues. Skips PRs and already-closed issues; `(#NN)` link references are intentionally ignored.
- `docs/workflow.md`: new 'Closing Issues on Merge' section.
- `docs/development/commit-conventions.md`: closing-keyword vs `(#NN)` rule.

## Verification
- YAML validated (`yaml.safe_load`).

## Related
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)