### PR TITLE
fix: realign E2E specs with refactored UI + close a11y gaps (#118)

### DIFF
--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -74,11 +74,11 @@ export function Pager({ offset, pageSize, total, onOffsetChange }: PagerProps) {
     <div className="tbl-foot">
       <span>{t('common.pagination.showing', { from: offset + 1, to: Math.min(offset + pageSize, total), total })}</span>
       <div className="pager">
-        <button onClick={() => onOffsetChange(Math.max(0, offset - pageSize))} disabled={current === 1}>
+        <button aria-label={t('common.pagination.prev')} onClick={() => onOffsetChange(Math.max(0, offset - pageSize))} disabled={current === 1}>
           <Icon name="chev-l" size="sm" />
         </button>
         <span className="cur">{current} / {totalPages}</span>
-        <button onClick={() => onOffsetChange(offset + pageSize)} disabled={current >= totalPages}>
+        <button aria-label={t('common.pagination.next')} onClick={() => onOffsetChange(offset + pageSize)} disabled={current >= totalPages}>
           <Icon name="chev-r" size="sm" />
         </button>
       </div>

--- a/frontend/src/components/ui/Kpi.tsx
+++ b/frontend/src/components/ui/Kpi.tsx
@@ -8,6 +8,8 @@ interface KpiProps {
   value: ReactNode
   sub?: ReactNode
   accent?: KpiAccent
+  /** Optional stable hook for tests (renders data-testid on the card). */
+  testId?: string
 }
 
 const accentClass: Record<KpiAccent, string> = {
@@ -17,9 +19,9 @@ const accentClass: Record<KpiAccent, string> = {
   bad: 'kpi badn',
 }
 
-export function Kpi({ icon, label, value, sub, accent = 'default' }: KpiProps) {
+export function Kpi({ icon, label, value, sub, accent = 'default', testId }: KpiProps) {
   return (
-    <div className={accentClass[accent]}>
+    <div className={accentClass[accent]} data-testid={testId}>
       <div className="kpi-top">
         <span className="kpi-ic">{icon}</span>
         {label}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -26,7 +26,7 @@ export function Modal({ open, onClose, title, sub, children, footer, size = 'def
 
   return (
     <div className="modal-scrim" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
-      <div className={modalClass}>
+      <div className={modalClass} role="dialog" aria-modal="true" aria-label={title}>
         <div className="modal-head">
           <div>
             <h3>{title}</h3>

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -53,6 +53,8 @@ export const en: Record<MessageKey, string> = {
   'common.checking': 'Checking…',
   'common.unitItems': '',
   'common.pagination.showing': '{{from}}–{{to}} of {{total}}',
+  'common.pagination.prev': 'Previous page',
+  'common.pagination.next': 'Next page',
 
   // ── Table headers ──
   'table.valueDate': 'Value date',
@@ -210,6 +212,7 @@ export const en: Record<MessageKey, string> = {
   'settings.connectionFail': 'Connection failed',
   'settings.section.dunning': 'Dunning policy',
   'settings.dunningInterval': 'Min. dunning interval (days)',
+  'settings.intervalError': 'The dunning interval must be at least 1 day.',
   'settings.section.banks': 'Bank accounts',
   'settings.addBankAccount': 'Add account',
   'settings.noBankAccounts': 'No bank accounts registered.',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -49,6 +49,8 @@ export const ja = {
   'common.checking': '確認中…',
   'common.unitItems': '件',
   'common.pagination.showing': '{{from}}〜{{to}} 件 / {{total}} 件',
+  'common.pagination.prev': '前のページ',
+  'common.pagination.next': '次のページ',
 
   // ── Table headers ──
   'table.valueDate': '入金日',
@@ -206,6 +208,7 @@ export const ja = {
   'settings.connectionFail': '接続失敗',
   'settings.section.dunning': '督促ポリシー',
   'settings.dunningInterval': '督促の最短間隔（日）',
+  'settings.intervalError': '督促間隔は1日以上で入力してください。',
   'settings.section.banks': '銀行口座',
   'settings.addBankAccount': '口座を追加',
   'settings.noBankAccounts': '銀行口座が登録されていません。',

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -29,6 +29,7 @@ export default function DashboardPage() {
       <KpiGrid style={{ marginBottom: 20 }}>
         <Kpi
           accent="accent"
+          testId="kpi-unmatched"
           icon={<Icon name="reconcile" />}
           label={t('dashboard.kpi.unmatched')}
           value={<>{unmatchedQ.isLoading ? '…' : unmatchedTotal}{unit && <small>{unit}</small>}</>}

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -129,7 +129,7 @@ function ReverseModal({ recon, onClose }: { recon: Reconciliation; onClose: () =
   })
   return (
     <Modal open onClose={onClose} title={t('reconciliation.confirmReverse')} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon name="refresh" size="sm" />{mut.isPending ? t('common.processing') : t('bankImport.reverse')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon name="refresh" size="sm" />{mut.isPending ? t('common.processing') : t('reconciliation.reverse')}</Button></>}
     >
       <div className="field"><label>{t('reconciliation.reversalReason')}</label><input className="inp" value={reason} onChange={e => setReason(e.target.value)} /></div>
       {mut.isError && <Notice variant="bad">{mut.error.message}</Notice>}

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -19,11 +19,23 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
   const [testResult, setTestResult] = useState<'ok' | 'fail' | null>(null)
   const [testing, setTesting] = useState(false)
   const [saved, setSaved] = useState(false)
+  const [intervalError, setIntervalError] = useState('')
 
   const saveMut = useMutation({
     mutationFn: () => updateClearSettings({ upstream_base_url: upstreamUrl, upstream_token_ref: upstreamToken, dunning_min_interval_days: dunningInterval, bank_accounts: accounts } as Partial<ClearSettings>),
     onSuccess: () => { void qc.invalidateQueries({ queryKey: ['clear-settings'] }); setSaved(true); setTimeout(() => setSaved(false), 3000) },
   })
+
+  // The dunning interval must be at least one day. Guard client-side so an
+  // invalid value never reaches the API (mirrors the upstream constraint).
+  function handleSave() {
+    if (!Number.isInteger(dunningInterval) || dunningInterval < 1) {
+      setIntervalError(t('settings.intervalError'))
+      return
+    }
+    setIntervalError('')
+    saveMut.mutate()
+  }
 
   async function handleTest() {
     setTestResult(null); setTesting(true)
@@ -58,7 +70,8 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
         <div className="form-row">
           <div className="field">
             <label>{t('settings.dunningInterval')}</label>
-            <input className="inp tnum" type="number" value={dunningInterval} style={{ width: 120 }} onChange={e => setDunningInterval(Number(e.target.value))} />
+            <input className="inp tnum" type="number" min={1} data-testid="dunning-interval" value={dunningInterval} style={{ width: 120 }} onChange={e => setDunningInterval(Number(e.target.value))} />
+            {intervalError && <span className="field-error" style={{ color: 'var(--bad)', fontSize: 12 }}>{intervalError}</span>}
           </div>
         </div>
       </div>
@@ -111,7 +124,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
           : <span />
         }
         {saveMut.isError && <Notice variant="bad">{saveMut.error.message}</Notice>}
-        <Button variant="primary" disabled={saveMut.isPending} onClick={() => saveMut.mutate()}>
+        <Button variant="primary" disabled={saveMut.isPending} onClick={handleSave}>
           <Icon name="check" />{saveMut.isPending ? t('common.saving') : t('settings.save')}
         </Button>
       </CardFoot>

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -172,6 +172,22 @@ export function dunningNotice(over: Record<string, unknown> = {}) {
   }
 }
 
+/** Eligible upstream invoice as surfaced on the dunning screen. */
+export function upstreamInvoice(over: Record<string, unknown> = {}) {
+  return {
+    invoice_id: 123,
+    invoice_number: 'INV-2026-009',
+    client_id: 45,
+    issued_at: '2026-03-31',
+    due_at: '2026-04-30',
+    total_cents: 110000,
+    outstanding_cents: 110000,
+    status: 'overdue',
+    currency: 'JPY',
+    ...over,
+  }
+}
+
 export function user(over: Record<string, unknown> = {}) {
   return {
     user_id: 1,

--- a/tests/e2e/specs/03-dashboard.spec.ts
+++ b/tests/e2e/specs/03-dashboard.spec.ts
@@ -16,7 +16,7 @@ test.describe('Dashboard', () => {
 
     await page.goto('/admin')
 
-    await expect(page.locator('p.text-4xl')).toContainText('7')
+    await expect(page.getByTestId('kpi-unmatched')).toContainText('7')
     await expect(page.getByText('INV-2026-009')).toBeVisible()
     await expect(page.getByText('¥1,100')).toBeVisible()
   })
@@ -29,7 +29,7 @@ test.describe('Dashboard', () => {
 
     await page.goto('/admin')
 
-    await expect(page.locator('p.text-4xl')).toContainText('0')
+    await expect(page.getByTestId('kpi-unmatched')).toContainText('0')
     await expect(page.getByText('データがありません。')).toBeVisible()
   })
 })

--- a/tests/e2e/specs/04-bank-transactions.spec.ts
+++ b/tests/e2e/specs/04-bank-transactions.spec.ts
@@ -33,8 +33,8 @@ test.describe('Bank transactions — list, filter, pagination boundaries', () =>
     await page.goto('/admin/bank-transactions')
 
     await expect(page.getByText('1 / 3')).toBeVisible()
-    await expect(page.getByRole('button', { name: '戻る' })).toBeDisabled()
-    await expect(page.getByRole('button', { name: '次へ' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: '前のページ' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '次のページ' })).toBeEnabled()
   })
 
   test('pagination: last page has Next disabled', async ({ page }) => {
@@ -49,12 +49,12 @@ test.describe('Bank transactions — list, filter, pagination boundaries', () =>
     })
 
     await page.goto('/admin/bank-transactions')
-    await page.getByRole('button', { name: '次へ' }).click() // → page 2
-    await page.getByRole('button', { name: '次へ' }).click() // → page 3 (last)
+    await page.getByRole('button', { name: '次のページ' }).click() // → page 2
+    await page.getByRole('button', { name: '次のページ' }).click() // → page 3 (last)
 
     await expect(page.getByText('3 / 3')).toBeVisible()
-    await expect(page.getByRole('button', { name: '次へ' })).toBeDisabled()
-    await expect(page.getByRole('button', { name: '戻る' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: '次のページ' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '前のページ' })).toBeEnabled()
   })
 
   test('no pagination controls when total fits one page', async ({ page }) => {
@@ -64,7 +64,7 @@ test.describe('Bank transactions — list, filter, pagination boundaries', () =>
 
     await page.goto('/admin/bank-transactions')
 
-    await expect(page.getByRole('button', { name: '次へ' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: '次のページ' })).toHaveCount(0)
   })
 
   test('status filter triggers a scoped query', async ({ page }) => {

--- a/tests/e2e/specs/05-bank-import.spec.ts
+++ b/tests/e2e/specs/05-bank-import.spec.ts
@@ -50,10 +50,11 @@ test.describe('Bank import — upload + reverse boundaries', () => {
     await page.goto('/admin/bank-import')
     await page.getByRole('button', { name: '取消' }).first().click()
 
-    const confirmBtn = page.locator('.fixed').getByRole('button', { name: '取消' })
+    const dialog = page.getByRole('dialog')
+    const confirmBtn = dialog.getByRole('button', { name: '取消' })
     await expect(confirmBtn).toBeDisabled()
 
-    await page.locator('.fixed input[type="text"]').fill('誤った取込のため')
+    await dialog.getByRole('textbox').fill('誤った取込のため')
     await expect(confirmBtn).toBeEnabled()
   })
 
@@ -64,11 +65,11 @@ test.describe('Bank import — upload + reverse boundaries', () => {
 
     await page.goto('/admin/bank-import')
     await page.getByRole('button', { name: '取消' }).first().click()
-    await page.locator('.fixed input[type="text"]').fill('誤った取込のため')
-    await page.locator('.fixed').getByRole('button', { name: '取消' }).click()
+    await page.getByRole('dialog').getByRole('textbox').fill('誤った取込のため')
+    await page.getByRole('dialog').getByRole('button', { name: '取消' }).click()
 
     // Dialog closes (reversal reason input disappears).
-    await expect(page.locator('.fixed input[type="text"]')).toHaveCount(0)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
   })
 
   test('reversed batch row shows no reverse button', async ({ page }) => {

--- a/tests/e2e/specs/06-reconciliation.spec.ts
+++ b/tests/e2e/specs/06-reconciliation.spec.ts
@@ -29,7 +29,7 @@ test.describe('Reconciliation — confirm + reverse boundaries', () => {
     await page.getByRole('button', { name: '消込を確定' }).first().click()
 
     // Fill the allocation (invoice id + amount in yen).
-    const modal = page.locator('.fixed')
+    const modal = page.getByRole('dialog')
     await modal.locator('input[type="number"]').nth(0).fill('1')
     await modal.locator('input[type="number"]').nth(1).fill('1100')
     await modal.getByRole('button', { name: '消込を確定' }).click()
@@ -47,12 +47,12 @@ test.describe('Reconciliation — confirm + reverse boundaries', () => {
 
     await page.goto('/admin/reconciliation')
     await page.getByRole('button', { name: '消込を確定' }).first().click()
-    const modal = page.locator('.fixed')
+    const modal = page.getByRole('dialog')
     await modal.locator('input[type="number"]').nth(0).fill('1')
     await modal.locator('input[type="number"]').nth(1).fill('1100')
     await modal.getByRole('button', { name: '消込を確定' }).click()
 
-    await expect(page.locator('.fixed')).toHaveCount(0)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
   })
 
   test('history: reverse button disabled until reason entered, then succeeds', async ({ page }) => {
@@ -65,13 +65,13 @@ test.describe('Reconciliation — confirm + reverse boundaries', () => {
     await page.getByRole('button', { name: '消込一覧' }).click()
     await page.getByRole('button', { name: '消込を取消' }).first().click()
 
-    const confirmBtn = page.locator('.fixed').getByRole('button', { name: '消込を取消' })
+    const confirmBtn = page.getByRole('dialog').getByRole('button', { name: '消込を取消' })
     await expect(confirmBtn).toBeDisabled()
-    await page.locator('.fixed input[type="text"]').fill('オペレーター誤操作')
+    await page.getByRole('dialog').getByRole('textbox').fill('オペレーター誤操作')
     await expect(confirmBtn).toBeEnabled()
     await confirmBtn.click()
 
-    await expect(page.locator('.fixed')).toHaveCount(0)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
   })
 
   test('reverse of an already-reversed match (409) shows the conflict', async ({ page }) => {
@@ -85,8 +85,8 @@ test.describe('Reconciliation — confirm + reverse boundaries', () => {
     await page.goto('/admin/reconciliation')
     await page.getByRole('button', { name: '消込一覧' }).click()
     await page.getByRole('button', { name: '消込を取消' }).first().click()
-    await page.locator('.fixed input[type="text"]').fill('二重取消')
-    await page.locator('.fixed').getByRole('button', { name: '消込を取消' }).click()
+    await page.getByRole('dialog').getByRole('textbox').fill('二重取消')
+    await page.getByRole('dialog').getByRole('button', { name: '消込を取消' }).click()
 
     await expect(page.getByText('この消込はすでに取り消されています。')).toBeVisible()
   })

--- a/tests/e2e/specs/07-dunning.spec.ts
+++ b/tests/e2e/specs/07-dunning.spec.ts
@@ -1,30 +1,30 @@
 import { test, expect } from '@playwright/test'
-import { apiRoute, json, problem, list, bypassLogin, dunningNotice } from '../fixtures/helpers'
+import { apiRoute, json, problem, list, bypassLogin, dunningNotice, upstreamInvoice } from '../fixtures/helpers'
 
+/**
+ * Dunning is driven by the eligible-invoices list: each overdue / partially
+ * paid invoice has a "送信" action that opens a confirm modal, and the POST is
+ * fired from inside that modal. There is no free-text invoice-id field.
+ */
 test.beforeEach(async ({ page }) => {
   await bypassLogin(page)
   await apiRoute(page, '**/admin/dunning-notices?**', (route) => json(route, 200, list([])))
+  await apiRoute(page, '**/admin/dunning-pauses?**', (route) => json(route, 200, list([])))
 })
 
 test.describe('Dunning — send boundaries', () => {
-  test('empty / zero invoice id shows client-side validation error', async ({ page }) => {
-    let posted = false
-    await apiRoute(page, '**/admin/dunning-notices', (route) => {
-      if (route.request().method() === 'POST') {
-        posted = true
-        return json(route, 201, dunningNotice())
-      }
-      return json(route, 200, list([]))
-    })
+  test('no eligible invoices shows the empty state', async ({ page }) => {
+    await apiRoute(page, '**/admin/invoices?**', (route) => json(route, 200, { items: [], total: 0 }))
 
     await page.goto('/admin/dunning')
-    await page.getByRole('button', { name: '督促を送信' }).click()
 
-    await expect(page.getByText('有効な請求書IDを入力してください')).toBeVisible()
-    expect(posted).toBe(false)
+    await expect(page.getByText('督促対象の請求書はありません')).toBeVisible()
   })
 
   test('invoice not eligible (422) surfaces the upstream error', async ({ page }) => {
+    await apiRoute(page, '**/admin/invoices?**', (route) =>
+      json(route, 200, { items: [upstreamInvoice({ invoice_id: 123 })], total: 1 }),
+    )
     await apiRoute(page, '**/admin/dunning-notices', (route) => {
       if (route.request().method() === 'POST') {
         return problem(route, 422, 'invoice-not-eligible-for-dunning', 'この請求書は支払済み、または残高がないため督促できません。')
@@ -33,13 +33,16 @@ test.describe('Dunning — send boundaries', () => {
     })
 
     await page.goto('/admin/dunning')
-    await page.locator('input[type="number"]').fill('123')
-    await page.getByRole('button', { name: '督促を送信' }).click()
+    await page.getByRole('button', { name: '督促を送信' }).first().click()
+    await page.getByRole('dialog').getByRole('button', { name: '督促を送信' }).click()
 
     await expect(page.getByText('この請求書は支払済み、または残高がないため督促できません。')).toBeVisible()
   })
 
   test('too frequent (422) surfaces the interval error', async ({ page }) => {
+    await apiRoute(page, '**/admin/invoices?**', (route) =>
+      json(route, 200, { items: [upstreamInvoice({ invoice_id: 123 })], total: 1 }),
+    )
     await apiRoute(page, '**/admin/dunning-notices', (route) => {
       if (route.request().method() === 'POST') {
         return problem(route, 422, 'dunning-too-frequent', '前回の督促から最短間隔が経過していません。', undefined, {
@@ -50,24 +53,37 @@ test.describe('Dunning — send boundaries', () => {
     })
 
     await page.goto('/admin/dunning')
-    await page.locator('input[type="number"]').fill('123')
-    await page.getByRole('button', { name: '督促を送信' }).click()
+    await page.getByRole('button', { name: '督促を送信' }).first().click()
+    await page.getByRole('dialog').getByRole('button', { name: '督促を送信' }).click()
 
     await expect(page.getByText('前回の督促から最短間隔が経過していません。')).toBeVisible()
   })
 
-  test('successful send shows the confirmation message', async ({ page }) => {
+  test('successful send closes the dialog and lists the notice in history', async ({ page }) => {
+    let sent = false
+    await apiRoute(page, '**/admin/invoices?**', (route) =>
+      json(route, 200, { items: [upstreamInvoice({ invoice_id: 123, invoice_number: 'INV-2026-009' })], total: 1 }),
+    )
+    // History reflects the send once the POST has happened (cache invalidation refetches).
+    await apiRoute(page, '**/admin/dunning-notices?**', (route) =>
+      json(route, 200, list(sent ? [dunningNotice({ invoice_number: 'INV-2026-009' })] : [])),
+    )
     await apiRoute(page, '**/admin/dunning-notices', (route) => {
       if (route.request().method() === 'POST') {
-        return json(route, 201, dunningNotice())
+        sent = true
+        return json(route, 201, dunningNotice({ invoice_number: 'INV-2026-009' }))
       }
       return json(route, 200, list([]))
     })
 
     await page.goto('/admin/dunning')
-    await page.locator('input[type="number"]').fill('123')
-    await page.getByRole('button', { name: '督促を送信' }).click()
+    await page.getByRole('button', { name: '督促を送信' }).first().click()
+    await page.getByRole('dialog').getByRole('button', { name: '督促を送信' }).click()
 
-    await expect(page.getByText('督促メールを送信しました。')).toBeVisible()
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    // The recipient email only appears in the history table, so it uniquely
+    // confirms the sent notice was listed (the invoice number also shows in the
+    // eligible-invoices table above).
+    await expect(page.getByText('accounts@acme.example')).toBeVisible()
   })
 })

--- a/tests/e2e/specs/08-settings.spec.ts
+++ b/tests/e2e/specs/08-settings.spec.ts
@@ -15,13 +15,14 @@ test.describe('Settings — dunning interval + connection test', () => {
   test('loads current settings and bank accounts', async ({ page }) => {
     await page.goto('/admin/settings')
 
-    await expect(page.locator('input[type="number"]')).toHaveValue('7')
-    await expect(page.getByText(/テスト銀行/)).toBeVisible()
+    await expect(page.getByTestId('dunning-interval')).toHaveValue('7')
+    // The bank name is now an editable field, so assert its value rather than text.
+    await expect(page.locator('.acct-card input').first()).toHaveValue('テスト銀行')
   })
 
   test('save shows the saved confirmation', async ({ page }) => {
     await page.goto('/admin/settings')
-    await page.locator('input[type="number"]').fill('14')
+    await page.getByTestId('dunning-interval').fill('14')
     await page.getByRole('button', { name: '保存' }).click()
 
     await expect(page.getByText('保存しました')).toBeVisible()
@@ -37,10 +38,10 @@ test.describe('Settings — dunning interval + connection test', () => {
     })
 
     await page.goto('/admin/settings')
-    await page.locator('input[type="number"]').fill('0')
+    await page.getByTestId('dunning-interval').fill('0')
     await page.getByRole('button', { name: '保存' }).click()
 
-    // zod min(1) blocks the request and shows a field error.
+    // The client guard (min 1) blocks the request and shows a field error.
     await page.waitForTimeout(300)
     expect(putCalled).toBe(false)
   })

--- a/tests/e2e/specs/09-users.spec.ts
+++ b/tests/e2e/specs/09-users.spec.ts
@@ -25,15 +25,18 @@ test.describe('Users — invite + delete boundaries', () => {
     await expect(page.getByText('招待中')).toBeVisible()
   })
 
-  test('invite with empty email shows client-side error', async ({ page }) => {
+  test('invite submit is disabled until an email is entered', async ({ page }) => {
     await apiRoute(page, '**/admin/users?**', (route) => json(route, 200, list([])))
 
     await page.goto('/admin/users')
     await page.getByRole('button', { name: 'ユーザーを招待' }).click()
-    // Submit the modal form without an email.
-    await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
 
-    await expect(page.getByText('メールアドレスを入力してください')).toBeVisible()
+    // The modal guards an empty email by disabling submit (no inline message).
+    const submit = page.getByRole('dialog').getByRole('button', { name: '招待を送信' })
+    await expect(submit).toBeDisabled()
+
+    await page.getByRole('dialog').getByRole('textbox').fill('new@acme.example')
+    await expect(submit).toBeEnabled()
   })
 
   test('invite duplicate email (409) surfaces the upstream error', async ({ page }) => {
@@ -47,8 +50,8 @@ test.describe('Users — invite + delete boundaries', () => {
 
     await page.goto('/admin/users')
     await page.getByRole('button', { name: 'ユーザーを招待' }).click()
-    await page.locator('.fixed input[type="email"]').fill('taken@acme.example')
-    await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
+    await page.getByRole('dialog').getByRole('textbox').fill('taken@acme.example')
+    await page.getByRole('dialog').getByRole('button', { name: '招待を送信' }).click()
 
     await expect(page.getByText('そのメールアドレスはすでに使用されています。')).toBeVisible()
   })
@@ -63,7 +66,7 @@ test.describe('Users — invite + delete boundaries', () => {
     await page.getByRole('button', { name: '削除' }).first().click()
 
     await expect(page.getByText('このユーザーを削除しますか？')).toBeVisible()
-    await page.locator('.fixed').getByRole('button', { name: '削除' }).click()
+    await page.getByRole('dialog').getByRole('button', { name: '削除' }).click()
 
     await expect(page.getByText('このユーザーを削除しますか？')).toHaveCount(0)
   })

--- a/tests/e2e/specs/11-scenario-reconcile.spec.ts
+++ b/tests/e2e/specs/11-scenario-reconcile.spec.ts
@@ -74,12 +74,12 @@ test('scenario: import → reconcile → reverse → logout keeps state consiste
   await navTo(page, '消込', /\/admin\/reconciliation/)
   await expect(page.getByText('カ）アクメ')).toBeVisible()
   await page.getByRole('button', { name: '消込を確定' }).first().click()
-  const modal = page.locator('.fixed')
+  const modal = page.getByRole('dialog')
   await modal.locator('input[type="number"]').nth(0).fill('1')
   await modal.locator('input[type="number"]').nth(1).fill('1100')
   await modal.getByRole('button', { name: '消込を確定' }).click()
   // Modal closes and the deposit leaves the unmatched list.
-  await expect(page.locator('.fixed')).toHaveCount(0)
+  await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('未消込の取引はありません')).toBeVisible()
 
   // ── 5. History shows the confirmed reconciliation ───────────────────────
@@ -88,9 +88,9 @@ test('scenario: import → reconcile → reverse → logout keeps state consiste
 
   // ── 6. Reverse it ───────────────────────────────────────────────────────
   await page.getByRole('button', { name: '消込を取消' }).first().click()
-  await page.locator('.fixed input[type="text"]').fill('誤った消込のため')
-  await page.locator('.fixed').getByRole('button', { name: '消込を取消' }).click()
-  await expect(page.locator('.fixed')).toHaveCount(0)
+  await page.getByRole('dialog').getByRole('textbox').fill('誤った消込のため')
+  await page.getByRole('dialog').getByRole('button', { name: '消込を取消' }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('取消済')).toBeVisible()
 
   // Back on the unmatched tab, the deposit is available again.

--- a/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
+++ b/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
@@ -1,16 +1,17 @@
 import { test, expect } from '@playwright/test'
 import {
-  apiRoute, json, problem, list, loginViaForm, navTo, logout, dunningNotice,
+  apiRoute, json, problem, list, loginViaForm, navTo, logout, dunningNotice, upstreamInvoice,
 } from '../fixtures/helpers'
 
 /**
  * Scenario 2 — Dunning with a mid-session locale switch.
  *
- * login → switch to EN → send dunning (ok) → send again (422 too-frequent) →
- * switch back to JA → history still shows the sent notice → logout.
+ * login → switch to EN → send dunning for an eligible invoice (ok) → send again
+ * (422 too-frequent) → switch back to JA → history still shows the sent notice →
+ * logout.
  *
- * Bug surface: locale switching mid-flow without losing form/list state,
- * error message rendering, and history refresh after a successful send.
+ * Bug surface: locale switching mid-flow without losing list/modal state, error
+ * message rendering, and history refresh after a successful send.
  */
 test('scenario: locale switch + dunning send + too-frequent + logout', async ({ page }) => {
   let notices: ReturnType<typeof dunningNotice>[] = []
@@ -19,6 +20,10 @@ test('scenario: locale switch + dunning send + too-frequent + logout', async ({ 
   await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
     json(route, 200, { items: [], total: 3, limit: 1, offset: 0 }),
   )
+  await apiRoute(page, '**/admin/invoices?**', (route) =>
+    json(route, 200, { items: [upstreamInvoice({ invoice_id: 123, invoice_number: 'INV-2026-123' })], total: 1 }),
+  )
+  await apiRoute(page, '**/admin/dunning-pauses?**', (route) => json(route, 200, list([])))
   await apiRoute(page, '**/admin/dunning-notices?**', (route) => json(route, 200, list(notices)))
   await apiRoute(page, '**/admin/dunning-notices', (route) => {
     if (route.request().method() === 'POST') {
@@ -44,23 +49,28 @@ test('scenario: locale switch + dunning send + too-frequent + logout', async ({ 
   await expect(page.getByRole('link', { name: 'Dunning' })).toBeVisible()
   await expect(page.locator('html')).toHaveAttribute('lang', 'en')
 
-  // ── 3. Navigate to dunning and send for invoice 123 ─────────────────────
+  // ── 3. Navigate to dunning and send for the eligible invoice ────────────
   await navTo(page, 'Dunning', /\/admin\/dunning/)
-  await page.locator('input[type="number"]').fill('123')
-  await page.getByRole('button', { name: 'Send dunning notice' }).click()
-  // Success confirmation (hardcoded JA) + history row appears.
-  await expect(page.getByText('督促メールを送信しました。')).toBeVisible()
-  await expect(page.getByText('INV-2026-123')).toBeVisible()
+  await page.getByRole('button', { name: 'Send dunning' }).first().click()
+  await page.getByRole('dialog').getByRole('button', { name: 'Send dunning' }).click()
+  // Modal closes and the sent notice appears in history (cache invalidation).
+  // The recipient email is unique to the history table (the invoice number also
+  // shows in the eligible-invoices list above).
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await expect(page.getByText('accounts@acme.example')).toBeVisible()
 
-  // ── 4. Send again → 422 too-frequent error ──────────────────────────────
-  await page.locator('input[type="number"]').fill('123')
-  await page.getByRole('button', { name: 'Send dunning notice' }).click()
+  // ── 4. Send again → 422 too-frequent error inside the modal ─────────────
+  await page.getByRole('button', { name: 'Send dunning' }).first().click()
+  await page.getByRole('dialog').getByRole('button', { name: 'Send dunning' }).click()
   await expect(page.getByText('前回の督促から最短間隔が経過していません。')).toBeVisible()
+  // Dismiss the modal (Escape is locale-independent).
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).toHaveCount(0)
 
   // ── 5. Switch back to JA — nav + history survive the locale flip ─────────
   await page.getByRole('button', { name: 'JA' }).click()
   await expect(page.getByRole('link', { name: '督促' })).toBeVisible()
-  await expect(page.getByText('INV-2026-123')).toBeVisible()
+  await expect(page.getByText('accounts@acme.example')).toBeVisible()
 
   // ── 6. Logout ───────────────────────────────────────────────────────────
   await logout(page)

--- a/tests/e2e/specs/13-scenario-users-session.spec.ts
+++ b/tests/e2e/specs/13-scenario-users-session.spec.ts
@@ -54,24 +54,24 @@ test('scenario: user admin → 409 → modal reset → delete → 401 expiry →
 
   // ── 2. Invite a user (success) → list grows ─────────────────────────────
   await page.getByRole('button', { name: 'ユーザーを招待' }).click()
-  await page.locator('.fixed input[type="email"]').fill('new@acme.example')
-  await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
-  await expect(page.locator('.fixed')).toHaveCount(0)
+  await page.getByRole('dialog').getByRole('textbox').fill('new@acme.example')
+  await page.getByRole('dialog').getByRole('button', { name: '招待を送信' }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('new@acme.example')).toBeVisible()
 
   // ── 3. Invite again → 409 shown inside the modal ────────────────────────
   await page.getByRole('button', { name: 'ユーザーを招待' }).click()
-  await page.locator('.fixed input[type="email"]').fill('dup@acme.example')
-  await page.locator('.fixed').getByRole('button', { name: 'ユーザーを招待' }).click()
+  await page.getByRole('dialog').getByRole('textbox').fill('dup@acme.example')
+  await page.getByRole('dialog').getByRole('button', { name: '招待を送信' }).click()
   await expect(page.getByText('そのメールアドレスはすでに使用されています。')).toBeVisible()
 
   // ── 4. Cancel, then reopen — the modal must be clean (no stale error) ────
-  await page.locator('.fixed').getByRole('button', { name: 'キャンセル' }).click()
-  await expect(page.locator('.fixed')).toHaveCount(0)
+  await page.getByRole('dialog').getByRole('button', { name: 'キャンセル' }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
   await page.getByRole('button', { name: 'ユーザーを招待' }).click()
   await expect(page.getByText('そのメールアドレスはすでに使用されています。')).toHaveCount(0)
-  await expect(page.locator('.fixed input[type="email"]')).toHaveValue('')
-  await page.locator('.fixed').getByRole('button', { name: 'キャンセル' }).click()
+  await expect(page.getByRole('dialog').getByRole('textbox')).toHaveValue('')
+  await page.getByRole('dialog').getByRole('button', { name: 'キャンセル' }).click()
 
   // ── 5. Delete a user → confirm → list shrinks ───────────────────────────
   await page
@@ -79,8 +79,8 @@ test('scenario: user admin → 409 → modal reset → delete → 401 expiry →
     .getByRole('button', { name: '削除' })
     .click()
   await expect(page.getByText('このユーザーを削除しますか？')).toBeVisible()
-  await page.locator('.fixed').getByRole('button', { name: '削除' }).click()
-  await expect(page.locator('.fixed')).toHaveCount(0)
+  await page.getByRole('dialog').getByRole('button', { name: '削除' }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('old@acme.example')).toHaveCount(0)
 
   // ── 6. Session expires → next data load bounces to /login ───────────────


### PR DESCRIPTION
Closes #118.

## What & why

The **E2E CI has been red since cc2261a (#91–#96)** and drifted further with #107 (design system) and #114 (Pager). **23 of 43 Playwright specs failed.** This was test debt, not an app bug — the specs still targeted the old markup (CSS classes, button labels, element structure). 01-login / 02-auth-guard / 10-locale kept passing, proving the SPA boots and login works.

This PR turns the suite green by (1) closing the small a11y/test-hook gaps in the components the refactors changed, and (2) updating the specs to use stable, semantic selectors.

## Production changes (a11y + stable hooks)

- **Pager** (`DataTable.tsx`): the prev/next buttons became icon-only with **no accessible name** — added `aria-label` (new `common.pagination.prev` / `.next` keys, ja + en). a11y fix + lets tests select by role.
- **Modal** (`Modal.tsx`): added `role="dialog"` + `aria-modal` + `aria-label` so screen readers and `getByRole('dialog')` both work.
- **Kpi** (`Kpi.tsx`): optional `testId`; the dashboard tags the unmatched-count KPI.
- **Settings** (`SettingsPage.tsx`): `data-testid` on the dunning-interval input, and **restored the `min(1)` client guard that #107 dropped** when it replaced react-hook-form+zod with `useState` — an interval of `0` was being silently posted.
- **Reconciliation** (`ReconciliationPage.tsx`): the reverse modal's confirm button reused the bank-import label `取消`; it now uses the domain label `消込を取消`.

## Spec changes

- Replaced `.fixed` / `p.text-4xl` / fragile button-label coupling with `getByRole('dialog')`, `getByTestId`, `getByRole`/`getByText`.
- **Rewrote the dunning specs (07, 12)** for the redesigned flow: eligible-invoices list + confirm modal (the old free-text invoice-id form is gone). Used the history-only recipient email to disambiguate from the eligible row.
- Rewrote the users empty-email test for the actual UX (submit disabled until a valid email, no inline message).
- Added an `upstreamInvoice` fixture.

## Verification

- `npm run check` (type-check + lint + 27 unit tests): pass
- Full Playwright suite: **43 passed, 0 failed**

## Follow-up (not in this PR)

The `e2e-ci.yml` workflow already runs on PRs to `main`. To prevent regressions, make **E2E CI a required status check** via branch protection (repo-admin).