### PR TITLE
fix: realign OpenAPI with routes + refresh stale docs (#120)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,6 @@ Entry point for AI agents working on **NeNe Clear** (private repo `nene-clear`).
 
 ## Framework
 
-[NENE2](https://github.com/hideyukiMORI/NENE2) via Composer when runtime lands.
+[NENE2](https://github.com/hideyukiMORI/NENE2) — wired via Composer as a local
+path dependency (`../NENE2`, `hideyukimori/nene2: @dev`). Runtime is live: PSR-15
+HTTP stack, DI via per-domain `ServiceProvider` + `ServiceResolver`, PHP 8.4.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Operators who need both install **two sibling apps** connected via HTTP.
 - React + TypeScript admin UI (`frontend/`), Japanese + English.
 - Invoice upstream HTTP client + contract tests (activate by setting
   `NENE_INVOICE_API_BASE_URL` / `NENE_INVOICE_BEARER_TOKEN`).
-- Tests: 208 backend (PHPUnit, PHPStan level 8), 27 frontend (Vitest),
+- Tests: 236 backend (PHPUnit, 6 skipped; PHPStan level 8), 27 frontend (Vitest),
   43 browser E2E (Playwright). CI runs all three on every push/PR.
 - Login throttling; security assessment in
   [`docs/security/assessment-2026-05.md`](./docs/security/assessment-2026-05.md).
@@ -65,18 +65,18 @@ Next: Phase 3 (Tier A shared-hosting installer / release ZIP) and Phase 4
 ## Quickstart (local development)
 
 ```bash
-# 1. Infrastructure (MySQL 8.4 on :3310, Mailpit on :1025 / web UI :8025)
+# 1. Infrastructure (MySQL 8.4 on :3383, Mailpit SMTP :1383 / web UI :8383)
 docker compose up -d
 cp .env.example .env            # adjust DB_*, NENE_CLEAR_JWT_SECRET as needed
 
 # 2. Backend (PHP 8.4). NENE2 is a local path dependency (../NENE2).
 composer install
 composer migrations:migrate     # apply schema
-php -S localhost:8080 -t public_html/    # or your preferred SAPI
+php -S localhost:8384 -t public_html/    # or your preferred SAPI (NENE_CLEAR_PORT=8384)
 
 # 3. Frontend admin UI (Node 22)
 npm --prefix frontend install
-npm --prefix frontend run dev   # Vite dev server on :5380, proxies /admin → backend
+npm --prefix frontend run dev   # Vite dev server on :5383, proxies /admin → backend
 
 # Quality gates
 composer check                  # PHPUnit + PHPStan level 8 + PHP-CS-Fixer

--- a/docs/development/phase-1-reconciliation-design.md
+++ b/docs/development/phase-1-reconciliation-design.md
@@ -215,13 +215,13 @@ enforced by `CapabilityMiddleware`.
 | `testUpstreamConnection` | POST `/admin/clear-settings/test-upstream` | `manage_clear_settings` | pings Invoice API |
 | `importBankCsv` | POST `/admin/bank-import-batches` | `manage_reconciliation` | multipart CSV + `bank_account_id` |
 | `listBankImportBatches` | GET `/admin/bank-import-batches` | `view_reconciliation` | |
-| `getBankImportBatchById` | GET `/admin/bank-import-batches/{id}` | `view_reconciliation` | |
+| ~~`getBankImportBatchById`~~ | ~~GET `/admin/bank-import-batches/{id}`~~ | — | dropped (YAGNI; never implemented, removed from registry/OpenAPI) |
 | `reverseBankImportBatch` | POST `/admin/bank-import-batches/{id}/reverse` | `manage_reconciliation` | voids lines, audited |
 | `listBankTransactions` | GET `/admin/bank-transactions` | `view_reconciliation` | filter by status/date/amount/counterparty (search req.) |
 | `listUnmatchedTransactions` | GET `/admin/bank-transactions/unmatched` | `view_reconciliation` | |
 | `getBankTransactionById` | GET `/admin/bank-transactions/{id}` | `view_reconciliation` | |
 | `listUpstreamInvoices` | GET `/admin/upstream/invoices` | `view_reconciliation` | read proxy to Invoice |
-| `getUpstreamInvoiceById` | GET `/admin/upstream/invoices/{id}` | `view_reconciliation` | |
+| ~~`getUpstreamInvoiceById`~~ | ~~GET `/admin/upstream/invoices/{id}`~~ | — | dropped (YAGNI; never implemented, removed from registry/OpenAPI) |
 | `proposeMatch` | POST `/admin/reconciliations/propose` | `view_reconciliation` | returns suggestions; **no write** |
 | `confirmMatch` | POST `/admin/reconciliations` | `manage_reconciliation` | human confirm → upstream write |
 | `reverseReconciliation` | POST `/admin/reconciliations/{id}/reverse` | `manage_reconciliation` | |

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -217,9 +217,9 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `getClearSettings`, `updateClearSettings`, `testUpstreamConnection` | Clear settings (admin) |
-| `importBankCsv`, `listBankImportBatches`, `getBankImportBatchById`, `reverseBankImportBatch` | Bank import |
+| `importBankCsv`, `listBankImportBatches`, `reverseBankImportBatch` | Bank import |
 | `listBankTransactions`, `listUnmatchedTransactions`, `getBankTransactionById` | Bank transaction |
-| `listUpstreamInvoices`, `getUpstreamInvoiceById` | Invoice upstream (read-only) |
+| `listUpstreamInvoices` | Invoice upstream (read-only) |
 | `proposeMatch`, `confirmMatch`, `reverseReconciliation`, `listReconciliations`, `getReconciliationById` | Reconciliation |
 | `listClientCredits`, `applyClientCredit` | Client credit |
 | `listDunningNotices`, `getDunningNoticeById`, `sendDunningNotice` | Dunning |

--- a/docs/integrations/mcp-tools.md
+++ b/docs/integrations/mcp-tools.md
@@ -32,8 +32,8 @@ and Clear's [`nene2-compliance.md`](../development/nene2-compliance.md) §12.
 ## Read tools (in the catalog)
 
 `getHealth`, `listUnmatchedTransactions`, `listBankTransactions`,
-`getBankTransactionById`, `listBankImportBatches`, `getBankImportBatchById`,
-`listUpstreamInvoices`, `getUpstreamInvoiceById`, `proposeMatch`,
+`getBankTransactionById`, `listBankImportBatches`,
+`listUpstreamInvoices`, `proposeMatch`,
 `listReconciliations`, `getReconciliationById`, `listClientCredits`.
 
 All except `getHealth` require the configured operator bearer credential and the

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -81,20 +81,6 @@
       "responseSchemaRef": "#/components/schemas/BankImportBatchListResponse"
     },
     {
-      "name": "getBankImportBatchById",
-      "title": "Get Bank Import Batch",
-      "description": "Read a single bank CSV import batch by id.",
-      "safety": "read",
-      "source": { "type": "openapi", "operationId": "getBankImportBatchById", "method": "GET", "path": "/admin/bank-import-batches/{id}" },
-      "inputSchema": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["id"],
-        "properties": { "id": { "type": "integer", "format": "int64" } }
-      },
-      "responseSchemaRef": "#/components/schemas/BankImportBatch"
-    },
-    {
       "name": "listUpstreamInvoices",
       "title": "List Upstream Invoices",
       "description": "List open/overdue invoices with outstanding balances from the NeNe Invoice upstream (read-only proxy).",
@@ -104,29 +90,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "status": { "type": "string", "enum": ["issued", "partially_paid", "paid"] },
-          "overdue": { "type": "boolean" },
-          "client_id": { "type": "integer", "format": "int64" },
-          "outstanding_gt": { "type": "integer", "format": "int64" },
-          "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
-          "offset": { "type": "integer", "minimum": 0 }
+          "status": { "type": "string", "description": "Comma-separated statuses, e.g. issued,partially_paid,overdue" }
         }
       },
       "responseSchemaRef": "#/components/schemas/UpstreamInvoiceListResponse"
-    },
-    {
-      "name": "getUpstreamInvoiceById",
-      "title": "Get Upstream Invoice",
-      "description": "Read a single upstream invoice by id (read-only proxy).",
-      "safety": "read",
-      "source": { "type": "openapi", "operationId": "getUpstreamInvoiceById", "method": "GET", "path": "/admin/upstream/invoices/{id}" },
-      "inputSchema": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["id"],
-        "properties": { "id": { "type": "integer", "format": "int64" } }
-      },
-      "responseSchemaRef": "#/components/schemas/UpstreamInvoice"
     },
     {
       "name": "proposeMatch",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5,9 +5,9 @@ info:
   description: >
     NeNe Clear — payment reconciliation and dunning (入金消込・督促管理).
     This file is the source of truth for Clear's public JSON API contract.
-    Phase 1 scope: multi-tenant auth/RBAC, clear settings, bank CSV import,
+    Covered: multi-tenant auth/RBAC, clear settings, bank CSV import,
     read-only Invoice upstream proxy, reconciliation (propose/confirm/reverse),
-    and client credit. Dunning is Phase 2 and is not in this file yet.
+    client credit, dunning (notices + per-invoice pause/resume), and CSV export.
     NeNe Clear does NOT issue invoices or compute tax — invoice figures are read
     from the NeNe Invoice upstream (see docs/integrations/invoice-upstream-contract.md).
     Conventions follow NENE2 (docs/development/nene2-compliance.md): RFC 9457
@@ -15,8 +15,8 @@ info:
     items/limit/offset list envelope. Identifiers are governed by
     docs/explanation/terminology.md.
 servers:
-  - url: http://localhost:8080
-    description: Local Docker development server
+  - url: http://localhost:8384
+    description: Local development server (NENE_CLEAR_PORT=8384)
 security:
   - bearerAuth: []
 tags:
@@ -44,6 +44,8 @@ tags:
     description: Overdue reminders — send, history, pause/resume per invoice.
   - name: Export
     description: CSV export for accounting software handoff (税理士 review gate applies).
+  - name: Audit
+    description: Immutable audit trail (admin, read-only).
 
 paths:
   /health:
@@ -478,29 +480,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /admin/bank-import-batches/{id}:
-    parameters:
-      - $ref: '#/components/parameters/IdPath'
-    get:
-      tags: [BankImport]
-      summary: Get import batch by id
-      operationId: getBankImportBatchById
-      responses:
-        '200':
-          description: The import batch.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BankImportBatch'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
   /admin/bank-import-batches/{id}/reverse:
     parameters:
       - $ref: '#/components/parameters/IdPath'
@@ -644,29 +623,14 @@ paths:
         recomputes these figures.
       operationId: listUpstreamInvoices
       parameters:
-        - $ref: '#/components/parameters/Limit'
-        - $ref: '#/components/parameters/Offset'
         - name: status
           in: query
+          description: "Comma-separated statuses, e.g. `issued,partially_paid,overdue`. Omitted = all open statuses."
           schema:
-            $ref: '#/components/schemas/UpstreamInvoiceStatus'
-        - name: overdue
-          in: query
-          schema:
-            type: boolean
-        - name: client_id
-          in: query
-          schema:
-            type: integer
-            format: int64
-        - name: outstanding_gt
-          in: query
-          schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         '200':
-          description: A page of upstream invoices.
+          description: List of upstream invoices (read proxy; not paginated).
           content:
             application/json:
               schema:
@@ -675,42 +639,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '503':
-          $ref: '#/components/responses/UpstreamUnavailable'
-        '500':
-          $ref: '#/components/responses/InternalServerError'
-
-  /admin/upstream/invoices/{id}:
-    parameters:
-      - $ref: '#/components/parameters/IdPath'
-    get:
-      tags: [UpstreamInvoice]
-      summary: Get upstream invoice by id (read proxy)
-      operationId: getUpstreamInvoiceById
-      responses:
-        '200':
-          description: The upstream invoice.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpstreamInvoice'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          description: Invoice not found upstream.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
-              examples:
-                notFound:
-                  value:
-                    type: https://nene-clear.dev/problems/upstream-invoice-not-found
-                    title: Upstream Invoice Not Found
-                    status: 404
-                    detail: The referenced invoice was not found upstream.
         '503':
           $ref: '#/components/responses/UpstreamUnavailable'
         '500':
@@ -963,42 +891,6 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /admin/invoices:
-    get:
-      tags: [UpstreamInvoice]
-      summary: List upstream invoices
-      description: >
-        Proxy to NeNe Invoice — returns open/overdue invoices for the operator's
-        organization. Used by the reconciliation and dunning UIs. Requires
-        `view_reconciliation`.
-      operationId: listInvoices
-      parameters:
-        - name: status
-          in: query
-          description: "Comma-separated statuses, e.g. `issued,partially_paid,overdue`"
-          schema:
-            type: string
-      responses:
-        '200':
-          description: List of upstream invoices.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  items:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/UpstreamInvoice'
-                  total:
-                    type: integer
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '503':
-          $ref: '#/components/responses/UpstreamUnavailable'
-
   /admin/dunning-notices:
     get:
       tags: [Dunning]
@@ -1244,6 +1136,37 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /admin/audit-events:
+    get:
+      tags: [Audit]
+      summary: List audit events
+      description: >
+        Immutable audit trail for the operator's organization, newest first.
+        Records every state change (reconciliation, dunning, settings, user/role)
+        with before/after snapshots. Read-only. Requires `manage_users`.
+      operationId: listAuditEvents
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: event_type
+          in: query
+          description: Filter by exact event type (see terminology registry §audit event types).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A page of audit events.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEventListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
 components:
   securitySchemes:
@@ -1773,16 +1696,12 @@ components:
           enum: [JPY]
     UpstreamInvoiceListResponse:
       type: object
-      required: [items, limit, offset, total]
+      required: [items, total]
       properties:
         items:
           type: array
           items:
             $ref: '#/components/schemas/UpstreamInvoice'
-        limit:
-          type: integer
-        offset:
-          type: integer
         total:
           type: integer
 
@@ -2033,6 +1952,46 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DunningNotice'
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+
+    AuditEvent:
+      type: object
+      required: [audit_event_id, organization_id, event_type, occurred_at, payload]
+      properties:
+        audit_event_id:
+          type: integer
+          format: int64
+        organization_id:
+          type: integer
+          format: int64
+        event_type:
+          type: string
+          description: Exact event type string (see terminology registry §audit event types).
+        actor_user_id:
+          type: integer
+          format: int64
+          nullable: true
+        occurred_at:
+          type: string
+          format: date-time
+        payload:
+          type: object
+          description: Event detail, including before/after snapshots for state changes.
+          additionalProperties: true
+
+    AuditEventListResponse:
+      type: object
+      required: [items, limit, offset, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditEvent'
         limit:
           type: integer
         offset:

--- a/docs/security/assessment-2026-05.md
+++ b/docs/security/assessment-2026-05.md
@@ -104,10 +104,10 @@ deploy could not migrate past this point. **Fix:** added `'null' => false`.
 ## Reproduce
 
 ```bash
-docker compose up -d                       # MySQL on :3310
-DB_ADAPTER=mysql DB_HOST=127.0.0.1 DB_PORT=3310 DB_NAME=nene_clear \
+docker compose up -d                       # MySQL on :3383
+DB_ADAPTER=mysql DB_HOST=127.0.0.1 DB_PORT=3383 DB_NAME=nene_clear \
   DB_USER=nene_clear DB_PASSWORD=nene_clear composer migrations:migrate -- --no-interaction
-DB_HOST=127.0.0.1 DB_PORT=3310 php tests/security/seed.php
+DB_HOST=127.0.0.1 DB_PORT=3383 php tests/security/seed.php
 php -S localhost:8082 sec-router.php &     # MySQL-backed instance
 bash tests/security/probe.sh               # round 1
 bash tests/security/probe2.sh              # round 2 (deeper vectors)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-05-31
+Last updated: 2026-06-06
 
 ## Status
 
@@ -8,18 +8,19 @@ Last updated: 2026-05-31
 **Phase 2 — Complete** (Admin UI + dunning; ja/en; professional review gate obtained).
 **Infrastructure — Complete** (docker-compose + Mailpit; SmtpDunningMailer; InvoiceUpstreamHttpClient; login throttle).
 **Security — Assessed** (2-round multi-tenant pentest; 4 findings fixed incl. one critical privilege escalation; `docs/security/assessment-2026-05.md`).
+**Post-Phase-2 hardening — Merged** (PR #99–#118): bug fixes, 6 frontend gap closures, CSV export, per-invoice dunning pause, `template_version`, OpenAPI Dunning/Export spec, NENE2-compliant DI + soft-delete + full audit trail, admin audit-log page, shared `StatusBadge`/`Pager`, ClaudeDesign design system, E2E realign + a11y.
 **nene-invoice upstream — Their side implemented (PR #141); Clear client + contract tests ready. Real connection (set env vars) still pending.**
-**Bug fixes + feature gap closure — 12 issues (PR #99–#103) filed and addressed (open PRs, not yet merged).**
 
 ### Tests / quality gates
 
 | Layer | Count | Tool |
 | --- | --- | --- |
-| Backend | 208 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
+| Backend | 236 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
 | Frontend unit | 27 | Vitest |
 | Browser E2E | 43 | Playwright (API mocked) |
 
-CI: GitHub Actions — `backend-ci`, `frontend-ci`, `e2e-ci` run on push/PR to main.
+CI: GitHub Actions — `backend-ci`, `frontend-ci`, `e2e-ci` run on push/PR to main;
+`close-issues` auto-closes linked Issues on rebase-merge to main.
 6 skipped backend tests = Invoice contract tests that auto-activate once
 `NENE_INVOICE_API_BASE_URL` + `NENE_INVOICE_BEARER_TOKEN` are set.
 
@@ -28,26 +29,34 @@ CI: GitHub Actions — `backend-ci`, `frontend-ci`, `e2e-ci` run on push/PR to m
 | Domain | Endpoints | Auth |
 | --- | --- | --- |
 | Auth | `POST /admin/auth/login` (throttled), `GET /admin/auth/me` | JWT |
-| Organization | CRUD `/admin/organizations` | `manage_organizations` |
-| User | CRUD `/admin/users` | `manage_users` |
+| Organization | `GET/POST /admin/organizations`, `GET/DELETE /admin/organizations/{id}` | `manage_organizations` |
+| User | `GET/POST /admin/users`, `GET/PUT/DELETE /admin/users/{id}` | `manage_users` |
 | ClearSettings | `GET/PUT /admin/clear-settings`, `POST /admin/clear-settings/test-upstream` | `manage_clear_settings` |
 | Bank import | `POST /admin/bank-import-batches` (CSV), `GET` list, `POST /{id}/reverse` | `view_reconciliation` / `manage_reconciliation` |
 | Bank transactions | `GET /admin/bank-transactions` (filters), `GET /{id}`, `GET /unmatched` | `view_reconciliation` |
-| Reconciliation | `POST /propose`, `POST /admin/reconciliations` (confirm), `GET` list/by-id, `POST /{id}/reverse` | `view_reconciliation` / `manage_reconciliation` |
+| Invoice upstream | `GET /admin/upstream/invoices` (read-only proxy) | `view_reconciliation` |
+| Reconciliation | `POST /admin/reconciliations/propose`, `POST /admin/reconciliations` (confirm), `GET` list/by-id, `POST /{id}/reverse` | `view_reconciliation` / `manage_reconciliation` |
 | Client credits | `GET /admin/client-credits`, `POST /{id}/apply` | `view_reconciliation` / `manage_reconciliation` |
 | Dunning | `POST /admin/dunning-notices`, `GET` list/by-id | `send_dunning` / `view_reconciliation` |
+| Dunning pause | `GET/POST /admin/dunning-pauses`, `POST /{invoiceId}/resume` | `send_dunning` / `view_reconciliation` |
+| Export (CSV) | `GET /admin/export/{reconciliations,client-credits,bank-transactions}` | `view_reconciliation` |
+| Audit log | `GET /admin/audit-events` | `manage_users` |
 | Admin UI | React SPA (`frontend/`), served from `public_html/assets/` | JWT (session storage) |
 
 ## Infrastructure
 
+Fixed local ports (see `CLAUDE.md`; do **not** revert to framework defaults).
+
 | Component | Status | Notes |
 | --- | --- | --- |
-| Docker | ✅ `docker-compose.yml` | MySQL 8.4 (port 3310) + Mailpit (SMTP 1025, web UI 8025) |
+| Docker | ✅ `docker-compose.yml` | MySQL 8.4 (host port 3383) + Mailpit (SMTP 1383, web UI 8383) |
+| PHP backend | ✅ | `NENE_CLEAR_PORT=8384` |
+| Vite dev server | ✅ | `NENE_CLEAR_FRONTEND_PORT=5383` |
 | SMTP mailer | ✅ `SmtpDunningMailer` | Activated when `SMTP_HOST` set; falls back to `LogOnlyDunningMailer`; credentials passed via EsmtpTransport (not DSN) |
 | Invoice upstream | ✅ `InvoiceUpstreamHttpClient` | Activated when `NENE_INVOICE_API_BASE_URL` + `NENE_INVOICE_BEARER_TOKEN` set; falls back to `FakeInvoiceUpstreamClient` |
 | Login throttle | ✅ `PdoLoginThrottle` | 5 failures / 15 min per email+IP → 15 min lock (HTTP 429) |
 | Contract tests | ✅ 6 tests (auto-skip) | Run against real Invoice API by setting env vars |
-| CI | ✅ GitHub Actions | backend / frontend / e2e workflows |
+| CI | ✅ GitHub Actions | backend / frontend / e2e / close-issues workflows |
 
 ## Open risks
 
@@ -56,38 +65,24 @@ CI: GitHub Actions — `backend-ci`, `frontend-ci`, `e2e-ci` run on push/PR to m
    `NENE_INVOICE_BEARER_TOKEN` against a live Invoice instance and run the
    contract suite to confirm the integration end-to-end.
 
-## Open PRs (pending review + merge)
-
-| PR | Description |
-| --- | --- |
-| #99 | fix: 3 bugs — overdue dunning eligibility, ClientCredit clientId, channel recording |
-| #100 | feat: template_version on DunningNotice (migration + entity + UseCase) |
-| #101 | feat: 6 frontend gaps — proposeMatch UI, dunning invoice browser, client credits page, amount filter, settings bank/upstream |
-| #102 | feat: CSV export endpoints (reconciliations / client-credits / bank-transactions) |
-| #103 | feat: dunning pause per invoice (dunning_pauses table + UseCase + UI) |
-
-All PRs pass `composer check` (208 tests, PHPStan level 8) and `npm run check` (27 unit tests).
-Note: PRs are independent branches from main; they will have merge conflicts with each other — merge sequentially.
-
 ## Next steps
 
-1. **Merge PRs #99–#103** — sequential merge (order above). Resolve conflicts per NENE2 architecture rules.
-2. **Activate real Invoice upstream** — set env vars, run contract tests live.
-3. **Dunning template customization** — operator-editable templates per org
+1. **Activate real Invoice upstream** — set env vars, run contract tests live.
+2. **Dunning template customization** — operator-editable templates per org
    (currently a single hardcoded `lang/ja.php` template).
-4. **CSV export — tax advisor sign-off** — review column set per compliance §9 before calling it production-ready.
-5. **Phase 3 — Tier A shared hosting** — web installer, release ZIP, two-app
+3. **CSV export — tax advisor sign-off** — review column set per compliance §9 before calling it production-ready.
+4. **Phase 3 — Tier A shared hosting** — web installer, release ZIP, two-app
    (Invoice + Clear) operator setup guide.
-6. **Phase 4 — Ecosystem** — MCP tools (`listUnmatchedTransactions`,
+5. **Phase 4 — Ecosystem** — MCP tools (`listUnmatchedTransactions`,
    `proposeMatch`, `sendDunningNotice`).
 
-## Recently completed (this cycle)
+## Recently completed
 
+- Post-Phase-2 hardening merged to main (PR #99–#118): see Status above.
 - i18n message catalog (ja/en), multi-tenant SQL scoping, audit before/after
   snapshots, reconciliation idempotency, operator guide (電子帳簿保存法 §3.4).
 - Admin UI (login, dashboard, bank import, transactions, reconciliation,
-  dunning, settings, users) with full test coverage.
+  dunning, client credits, settings, users, audit log) with full test coverage.
 - Security hardening: login rate limiting, role-assignment privilege-escalation
   guard, SMTP credential handling, upstream error masking.
-- CI pipelines + this status refresh.
-- Bug fixes + feature gap closure: 12 issues identified and resolved in PRs #99–#103.
+- CI pipelines (backend / frontend / e2e / auto-close-issues).

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -153,7 +153,7 @@ export function applyClientCredit(creditId: number, invoiceId: number, amountCen
 export function listUpstreamInvoices(params: { status?: string }, signal?: AbortSignal) {
   const q = new URLSearchParams()
   if (params.status) q.set('status', params.status)
-  return api.get<{ items: UpstreamInvoice[]; total: number }>(`${BASE}/invoices?${q}`, signal)
+  return api.get<{ items: UpstreamInvoice[]; total: number }>(`${BASE}/upstream/invoices?${q}`, signal)
 }
 
 // --- Dunning ---

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -105,7 +105,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                             '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                             '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
-                            '/admin/invoices' => CapabilityRule::same(Capability::ViewReconciliation),
+                            '/admin/upstream/invoices' => CapabilityRule::same(Capability::ViewReconciliation),
                             '/admin/export' => CapabilityRule::same(Capability::ViewReconciliation),
                             '/admin/dunning-pauses' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
                         ],

--- a/src/InvoiceUpstream/InvoiceUpstreamRouteRegistrar.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamRouteRegistrar.php
@@ -19,6 +19,6 @@ final readonly class InvoiceUpstreamRouteRegistrar
     {
         $listHandler = $this->listHandler;
 
-        $router->get('/admin/invoices', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+        $router->get('/admin/upstream/invoices', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
     }
 }

--- a/tests/e2e/specs/07-dunning.spec.ts
+++ b/tests/e2e/specs/07-dunning.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Dunning — send boundaries', () => {
   test('no eligible invoices shows the empty state', async ({ page }) => {
-    await apiRoute(page, '**/admin/invoices?**', (route) => json(route, 200, { items: [], total: 0 }))
+    await apiRoute(page, '**/admin/upstream/invoices?**', (route) => json(route, 200, { items: [], total: 0 }))
 
     await page.goto('/admin/dunning')
 
@@ -22,7 +22,7 @@ test.describe('Dunning — send boundaries', () => {
   })
 
   test('invoice not eligible (422) surfaces the upstream error', async ({ page }) => {
-    await apiRoute(page, '**/admin/invoices?**', (route) =>
+    await apiRoute(page, '**/admin/upstream/invoices?**', (route) =>
       json(route, 200, { items: [upstreamInvoice({ invoice_id: 123 })], total: 1 }),
     )
     await apiRoute(page, '**/admin/dunning-notices', (route) => {
@@ -40,7 +40,7 @@ test.describe('Dunning — send boundaries', () => {
   })
 
   test('too frequent (422) surfaces the interval error', async ({ page }) => {
-    await apiRoute(page, '**/admin/invoices?**', (route) =>
+    await apiRoute(page, '**/admin/upstream/invoices?**', (route) =>
       json(route, 200, { items: [upstreamInvoice({ invoice_id: 123 })], total: 1 }),
     )
     await apiRoute(page, '**/admin/dunning-notices', (route) => {
@@ -61,7 +61,7 @@ test.describe('Dunning — send boundaries', () => {
 
   test('successful send closes the dialog and lists the notice in history', async ({ page }) => {
     let sent = false
-    await apiRoute(page, '**/admin/invoices?**', (route) =>
+    await apiRoute(page, '**/admin/upstream/invoices?**', (route) =>
       json(route, 200, { items: [upstreamInvoice({ invoice_id: 123, invoice_number: 'INV-2026-009' })], total: 1 }),
     )
     // History reflects the send once the POST has happened (cache invalidation refetches).

--- a/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
+++ b/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
@@ -20,7 +20,7 @@ test('scenario: locale switch + dunning send + too-frequent + logout', async ({ 
   await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
     json(route, 200, { items: [], total: 3, limit: 1, offset: 0 }),
   )
-  await apiRoute(page, '**/admin/invoices?**', (route) =>
+  await apiRoute(page, '**/admin/upstream/invoices?**', (route) =>
     json(route, 200, { items: [upstreamInvoice({ invoice_id: 123, invoice_number: 'INV-2026-123' })], total: 1 }),
   )
   await apiRoute(page, '**/admin/dunning-pauses?**', (route) => json(route, 200, list([])))


### PR DESCRIPTION
## Purpose
Close the spec↔implementation drift surfaced by a full audit of the binding terminology registry vs `openapi.yaml` vs registered routes vs frontend/tests, and refresh stale figures across living docs. Closes #120.

## Change summary
**API contract**
- Rename upstream-invoice proxy route `/admin/invoices` → canonical `/admin/upstream/invoices` (operationId `listUpstreamInvoices`; handler class was already `ListUpstreamInvoicesHandler`). Updated capability prefix, frontend client, E2E mocks.
- Rewrite the OpenAPI `listUpstreamInvoices` block to the **implemented** simple shape (`status` filter → `{items,total}`); delete the duplicate `/admin/invoices` (`listInvoices`, unregistered) block.
- Add implemented **`listAuditEvents`** (`GET /admin/audit-events`) to OpenAPI: path + `AuditEvent`/`AuditEventListResponse` schemas + `Audit` tag.
- **Deprecate** registered-but-unbuilt `getUpstreamInvoiceById` + `getBankImportBatchById` — removed from OpenAPI, terminology registry, and MCP catalog (`tools.json`, `mcp-tools.md`). Marked dropped in the Phase-1 design doc.

**Doc freshness**
- Fixed local ports → scheme (MySQL 3383 / Mailpit 1383·8383 / backend 8384 / Vite 5383) in README, current.md, openapi server, security assessment.
- Backend test count 208 → 236 (6 skipped).
- `current.md` rebuilt: dropped the merged "Open PRs #99–#103" section, refreshed endpoint table + status to today.
- OpenAPI description (was "Dunning is Phase 2, not in this file yet") and AGENTS.md ("runtime when it lands") corrected to reality.

## Verification
- **Spec ↔ route parity:** `/admin` spec paths == registered routes, zero diff both directions.
- Backend **236** (6 skipped), PHPStan level 8 clean, PHP-CS-Fixer clean.
- Frontend **27** (type-check + lint + Vitest).
- Affected E2E **5 passed** (`07-dunning`, `12-scenario-dunning-locale`) with the renamed path.
- `openapi.yaml` parses; `tools.json` valid JSON; no dangling refs.

## Remaining follow-up
- Real Invoice upstream connection still unexercised (set env vars + run contract suite) — tracked in `current.md`.