### PR TITLE
fix(audit): make each mutating use case's writes + audit atomic (#122)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 use Dotenv\Dotenv;
 use Nene2\Config\DatabaseConfig;
-use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\Http\ResponseEmitter;
 use NeneClear\Http\ApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -27,9 +28,11 @@ $debug = $env('APP_DEBUG', 'false') === 'true';
 $jwtSecret = $env('NENE_CLEAR_JWT_SECRET') ?: null;
 
 // Resilient DB wiring: if the database is unconfigured or unreachable, the app
-// still boots and serves /health. Authenticated routes activate only when both
-// the executor and a JWT secret are available (see ApplicationFactory).
-$query = (static function () use ($env): ?DatabaseQueryExecutorInterface {
+// still boots and serves /health. Authenticated routes activate only when the
+// executor, the transaction manager, and a JWT secret are all available (see
+// ApplicationFactory). The executor and the transaction manager share one
+// connection factory so transactional() can open its own connection (Issue #122).
+$connectionFactory = (static function () use ($env): ?DatabaseConnectionFactoryInterface {
     try {
         $adapter = $env('DB_ADAPTER', 'sqlite');
         $config = $adapter === 'mysql'
@@ -46,11 +49,14 @@ $query = (static function () use ($env): ?DatabaseQueryExecutorInterface {
             )
             : DatabaseConfig::sqlite($env('DB_NAME') ?: dirname(__DIR__) . '/database/nene_clear.sqlite3');
 
-        return new PdoDatabaseQueryExecutor(new PdoConnectionFactory($config));
+        return new PdoConnectionFactory($config);
     } catch (\Throwable) {
         return null;
     }
 })();
+
+$query = $connectionFactory !== null ? new PdoDatabaseQueryExecutor($connectionFactory) : null;
+$transactionManager = $connectionFactory !== null ? new PdoDatabaseTransactionManager($connectionFactory) : null;
 
 $smtpHost = $env('SMTP_HOST') ?: null;
 $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
@@ -59,6 +65,7 @@ $application = ApplicationFactory::create(
     debug: $debug,
     allowedOrigins: [],
     query: $query,
+    transactionManager: $transactionManager,
     jwtSecret: $jwtSecret,
     smtpHost: $smtpHost,
     smtpPort: (int) $env('SMTP_PORT', '1025'),

--- a/src/BankImport/BankImportServiceProvider.php
+++ b/src/BankImport/BankImportServiceProvider.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Container\ContainerInterface;
@@ -44,10 +46,11 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
             ->set(
                 ImportBankCsvUseCaseInterface::class,
                 static fn (ContainerInterface $c): ImportBankCsvUseCaseInterface => new ImportBankCsvUseCase(
-                    ServiceResolver::get($c, BankAccountRepositoryInterface::class),
-                    ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
-                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     new BankCsvParser(),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
@@ -55,9 +58,10 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
             ->set(
                 ReverseBankImportBatchUseCaseInterface::class,
                 static fn (ContainerInterface $c): ReverseBankImportBatchUseCaseInterface => new ReverseBankImportBatchUseCase(
-                    ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
-                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/BankImport/ImportBankCsvUseCase.php
+++ b/src/BankImport/ImportBankCsvUseCase.php
@@ -4,17 +4,27 @@ declare(strict_types=1);
 
 namespace NeneClear\BankImport;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): BankAccountRepositoryInterface $bankAccounts
+     * @param Closure(DatabaseQueryExecutorInterface): BankImportBatchRepositoryInterface $batches
+     * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private BankAccountRepositoryInterface $bankAccounts,
-        private BankImportBatchRepositoryInterface $batches,
-        private BankTransactionRepositoryInterface $transactions,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $bankAccounts,
+        private Closure $batches,
+        private Closure $transactions,
+        private Closure $auditEvents,
         private BankCsvParser $parser,
         private ClockInterface $clock,
     ) {
@@ -22,64 +32,76 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
 
     public function execute(ImportBankCsvInput $input): ImportBankCsvOutput
     {
-        $account = $this->bankAccounts->findById($input->bankAccountId);
+        // The batch row, every transaction line, and the audit record commit (or
+        // roll back) as one unit, so a partially-imported batch or a batch without
+        // its audit event can never be persisted (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): ImportBankCsvOutput {
+                $bankAccounts = ($this->bankAccounts)($tx);
+                $batches = ($this->batches)($tx);
+                $transactions = ($this->transactions)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        if ($account === null || $account->organizationId !== $input->organizationId) {
-            throw new BankAccountNotFoundException($input->bankAccountId);
-        }
+                $account = $bankAccounts->findById($input->bankAccountId);
 
-        $fileHash = hash('sha256', $input->contents);
+                if ($account === null || $account->organizationId !== $input->organizationId) {
+                    throw new BankAccountNotFoundException($input->bankAccountId);
+                }
 
-        if ($this->batches->existsByFileHash($input->organizationId, $fileHash)) {
-            throw new DuplicateBankImportException($fileHash);
-        }
+                $fileHash = hash('sha256', $input->contents);
 
-        $lines = $this->parser->parse($input->contents, $account);
-        $now = $this->clock->now()->format('Y-m-d H:i:s');
+                if ($batches->existsByFileHash($input->organizationId, $fileHash)) {
+                    throw new DuplicateBankImportException($fileHash);
+                }
 
-        $batchId = $this->batches->save(new BankImportBatch(
-            organizationId: $input->organizationId,
-            bankAccountId: $input->bankAccountId,
-            fileHash: $fileHash,
-            sourceFilename: $input->sourceFilename,
-            rowCount: count($lines),
-            status: BankImportBatchStatus::Imported,
-            importedBy: $input->actorUserId,
-            importedAt: $now,
-        ));
+                $lines = $this->parser->parse($input->contents, $account);
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        foreach ($lines as $line) {
-            $this->transactions->save(new BankTransaction(
-                organizationId: $input->organizationId,
-                bankImportBatchId: $batchId,
-                bankAccountId: $input->bankAccountId,
-                valueDate: $line->valueDate,
-                amountCents: $line->amountCents,
-                counterpartyText: $line->counterpartyText,
-                lineKey: $line->lineKey,
-                status: BankTransactionStatus::Unmatched,
-            ));
-        }
+                $batchId = $batches->save(new BankImportBatch(
+                    organizationId: $input->organizationId,
+                    bankAccountId: $input->bankAccountId,
+                    fileHash: $fileHash,
+                    sourceFilename: $input->sourceFilename,
+                    rowCount: count($lines),
+                    status: BankImportBatchStatus::Imported,
+                    importedBy: $input->actorUserId,
+                    importedAt: $now,
+                ));
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'bank_import',
-            actorUserId: $input->actorUserId,
-            occurredAt: $now,
-            payload: [
-                'after' => [
-                    'bank_import_batch_id' => $batchId,
-                    'file_hash' => $fileHash,
-                    'row_count' => count($lines),
-                    'source_filename' => $input->sourceFilename,
-                ],
-            ],
-        ));
+                foreach ($lines as $line) {
+                    $transactions->save(new BankTransaction(
+                        organizationId: $input->organizationId,
+                        bankImportBatchId: $batchId,
+                        bankAccountId: $input->bankAccountId,
+                        valueDate: $line->valueDate,
+                        amountCents: $line->amountCents,
+                        counterpartyText: $line->counterpartyText,
+                        lineKey: $line->lineKey,
+                        status: BankTransactionStatus::Unmatched,
+                    ));
+                }
 
-        return new ImportBankCsvOutput(
-            bankImportBatchId: $batchId,
-            fileHash: $fileHash,
-            rowCount: count($lines),
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'bank_import',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'after' => [
+                            'bank_import_batch_id' => $batchId,
+                            'file_hash' => $fileHash,
+                            'row_count' => count($lines),
+                            'source_filename' => $input->sourceFilename,
+                        ],
+                    ],
+                ));
+
+                return new ImportBankCsvOutput(
+                    bankImportBatchId: $batchId,
+                    fileHash: $fileHash,
+                    rowCount: count($lines),
+                );
+            },
         );
     }
 }

--- a/src/BankImport/ReverseBankImportBatchUseCase.php
+++ b/src/BankImport/ReverseBankImportBatchUseCase.php
@@ -4,72 +4,91 @@ declare(strict_types=1);
 
 namespace NeneClear\BankImport;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportBatchUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): BankImportBatchRepositoryInterface $batches
+     * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private BankImportBatchRepositoryInterface $batches,
-        private BankTransactionRepositoryInterface $transactions,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $batches,
+        private Closure $transactions,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(ReverseBankImportBatchInput $input): ReverseBankImportBatchOutput
     {
-        $batch = $this->batches->findById($input->batchId);
+        // Voiding the lines, marking the batch reversed, and recording the audit
+        // event commit (or roll back) together (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): ReverseBankImportBatchOutput {
+                $batches = ($this->batches)($tx);
+                $transactions = ($this->transactions)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        if ($batch === null || $batch->organizationId !== $input->organizationId) {
-            throw new BankImportBatchNotFoundException($input->batchId);
-        }
+                $batch = $batches->findById($input->batchId);
 
-        if ($batch->status !== BankImportBatchStatus::Imported) {
-            throw new BankImportBatchAlreadyReversedException($input->batchId);
-        }
+                if ($batch === null || $batch->organizationId !== $input->organizationId) {
+                    throw new BankImportBatchNotFoundException($input->batchId);
+                }
 
-        $lines = $this->transactions->findByBatch($input->batchId);
+                if ($batch->status !== BankImportBatchStatus::Imported) {
+                    throw new BankImportBatchAlreadyReversedException($input->batchId);
+                }
 
-        foreach ($lines as $line) {
-            if ($line->status === BankTransactionStatus::Matched || $line->status === BankTransactionStatus::PartiallyMatched) {
-                throw new BankImportBatchHasMatchedLinesException($input->batchId);
-            }
-        }
+                $lines = $transactions->findByBatch($input->batchId);
 
-        $unmatchedCount = count(array_filter(
-            $lines,
-            static fn (BankTransaction $t): bool => $t->status === BankTransactionStatus::Unmatched,
-        ));
+                foreach ($lines as $line) {
+                    if ($line->status === BankTransactionStatus::Matched || $line->status === BankTransactionStatus::PartiallyMatched) {
+                        throw new BankImportBatchHasMatchedLinesException($input->batchId);
+                    }
+                }
 
-        $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $unmatchedCount = count(array_filter(
+                    $lines,
+                    static fn (BankTransaction $t): bool => $t->status === BankTransactionStatus::Unmatched,
+                ));
 
-        $this->transactions->voidByBatchId($input->batchId);
-        $this->batches->reverseById($input->batchId, $now, $input->reversalReason);
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'bank_import_batch_reversed',
-            actorUserId: $input->actorUserId,
-            occurredAt: $now,
-            payload: [
-                'bank_import_batch_id' => $input->batchId,
-                'before' => [
-                    'status' => 'imported',
-                    'row_count' => count($lines),
-                ],
-                'after' => [
-                    'status' => 'reversed',
-                    'reversal_reason' => $input->reversalReason,
-                    'rows_voided' => $unmatchedCount,
-                ],
-            ],
-        ));
+                $transactions->voidByBatchId($input->batchId);
+                $batches->reverseById($input->batchId, $now, $input->reversalReason);
 
-        return new ReverseBankImportBatchOutput(
-            batchId: $input->batchId,
-            rowsVoided: $unmatchedCount,
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'bank_import_batch_reversed',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'bank_import_batch_id' => $input->batchId,
+                        'before' => [
+                            'status' => 'imported',
+                            'row_count' => count($lines),
+                        ],
+                        'after' => [
+                            'status' => 'reversed',
+                            'reversal_reason' => $input->reversalReason,
+                            'rows_voided' => $unmatchedCount,
+                        ],
+                    ],
+                ));
+
+                return new ReverseBankImportBatchOutput(
+                    batchId: $input->batchId,
+                    rowsVoided: $unmatchedCount,
+                );
+            },
         );
     }
 }

--- a/src/ClearSettings/ClearSettingsServiceProvider.php
+++ b/src/ClearSettings/ClearSettingsServiceProvider.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace NeneClear\ClearSettings;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\BankAccountRepositoryInterface;
+use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use Psr\Container\ContainerInterface;
@@ -34,9 +37,10 @@ final readonly class ClearSettingsServiceProvider implements ServiceProviderInte
             ->set(
                 UpdateClearSettingsUseCaseInterface::class,
                 static fn (ContainerInterface $c): UpdateClearSettingsUseCaseInterface => new UpdateClearSettingsUseCase(
-                    ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
-                    ServiceResolver::get($c, BankAccountRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/ClearSettings/UpdateClearSettingsUseCase.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\ClearSettings;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -17,10 +20,16 @@ use NeneClear\BankImport\BankAccountRepositoryInterface;
  */
 final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ClearSettingsRepositoryInterface $settings
+     * @param Closure(DatabaseQueryExecutorInterface): BankAccountRepositoryInterface $bankAccounts
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private ClearSettingsRepositoryInterface $settings,
-        private BankAccountRepositoryInterface $bankAccounts,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $settings,
+        private Closure $bankAccounts,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
@@ -28,42 +37,54 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
     public function execute(UpdateClearSettingsInput $input): ClearSettings
     {
         $now = $this->clock->now()->format('Y-m-d H:i:s');
-        $before = $this->settings->findByOrganization($input->organizationId);
 
-        // Replace the org's bank accounts: soft-delete the existing set, then
-        // insert the new profiles. Old rows stay for import-history references.
-        $this->bankAccounts->deleteByOrganization($input->organizationId, $now);
-        foreach ($input->bankAccounts as $account) {
-            $this->bankAccounts->save($account);
-        }
+        // The bank-account replacement, the settings upsert, and the audit record
+        // commit (or roll back) as one unit, so a half-applied settings change or a
+        // change without its audit event can never be persisted (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $now): ClearSettings {
+                $settingsRepo = ($this->settings)($ex);
+                $bankAccounts = ($this->bankAccounts)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $this->settings->save(new ClearSettings(
-            organizationId: $input->organizationId,
-            upstreamBaseUrl: $input->upstreamBaseUrl,
-            upstreamTokenRef: $input->upstreamTokenRef,
-            dunningMinIntervalDays: $input->dunningMinIntervalDays,
-        ));
+                $before = $settingsRepo->findByOrganization($input->organizationId);
 
-        $updated = $this->settings->findByOrganization($input->organizationId)
-            ?? new ClearSettings(
-                $input->organizationId,
-                $input->upstreamBaseUrl,
-                $input->upstreamTokenRef,
-                $input->dunningMinIntervalDays,
-            );
+                // Replace the org's bank accounts: soft-delete the existing set, then
+                // insert the new profiles. Old rows stay for import-history references.
+                $bankAccounts->deleteByOrganization($input->organizationId, $now);
+                foreach ($input->bankAccounts as $account) {
+                    $bankAccounts->save($account);
+                }
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'clear_settings_updated',
-            actorUserId: $input->actorUserId,
-            occurredAt: $now,
-            payload: [
-                'before' => $before !== null ? self::snapshot($before) : null,
-                'after' => self::snapshot($updated),
-            ],
-        ));
+                $settingsRepo->save(new ClearSettings(
+                    organizationId: $input->organizationId,
+                    upstreamBaseUrl: $input->upstreamBaseUrl,
+                    upstreamTokenRef: $input->upstreamTokenRef,
+                    dunningMinIntervalDays: $input->dunningMinIntervalDays,
+                ));
 
-        return $updated;
+                $updated = $settingsRepo->findByOrganization($input->organizationId)
+                    ?? new ClearSettings(
+                        $input->organizationId,
+                        $input->upstreamBaseUrl,
+                        $input->upstreamTokenRef,
+                        $input->dunningMinIntervalDays,
+                    );
+
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'clear_settings_updated',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'before' => $before !== null ? self::snapshot($before) : null,
+                        'after' => self::snapshot($updated),
+                    ],
+                ));
+
+                return $updated;
+            },
+        );
     }
 
     /**

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
+use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+use NeneClear\ClearSettings\PdoClearSettingsRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
@@ -42,29 +46,33 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
             ->set(
                 SendDunningUseCaseInterface::class,
                 static fn (ContainerInterface $c): SendDunningUseCaseInterface => new SendDunningUseCase(
-                    ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
-                    ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): DunningNoticeRepositoryInterface => new PdoDunningNoticeRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                     ServiceResolver::get($c, DunningMailerInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                     ServiceResolver::get($c, MessageCatalog::class),
-                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
                 ),
             )
             ->set(
                 PauseDunningUseCase::class,
                 static fn (ContainerInterface $c): PauseDunningUseCase => new PauseDunningUseCase(
-                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 ResumeDunningUseCase::class,
                 static fn (ContainerInterface $c): ResumeDunningUseCase => new ResumeDunningUseCase(
-                    ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/Dunning/PauseDunningUseCase.php
+++ b/src/Dunning/PauseDunningUseCase.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace NeneClear\Dunning;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class PauseDunningUseCase
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private DunningPauseRepositoryInterface $pauses,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $pauses,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
@@ -21,40 +29,48 @@ final readonly class PauseDunningUseCase
     {
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        $existing = $this->pauses->findActiveByInvoice($organizationId, $invoiceId);
-        if ($existing !== null) {
-            return $existing;
-        }
+        // The pause insert and its audit record commit (or roll back) together (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($organizationId, $invoiceId, $actorUserId, $reason, $now): DunningPause {
+                $pauses = ($this->pauses)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $pause = new DunningPause(
-            organizationId: $organizationId,
-            invoiceId: $invoiceId,
-            pausedBy: $actorUserId,
-            pausedAt: $now,
-            pausedReason: $reason,
-        );
+                $existing = $pauses->findActiveByInvoice($organizationId, $invoiceId);
+                if ($existing !== null) {
+                    return $existing;
+                }
 
-        $id = $this->pauses->save($pause);
+                $pause = new DunningPause(
+                    organizationId: $organizationId,
+                    invoiceId: $invoiceId,
+                    pausedBy: $actorUserId,
+                    pausedAt: $now,
+                    pausedReason: $reason,
+                );
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $organizationId,
-            eventType: 'dunning_paused',
-            actorUserId: $actorUserId,
-            occurredAt: $now,
-            payload: [
-                'invoice_id' => $invoiceId,
-                'before' => ['is_paused' => false],
-                'after' => ['is_paused' => true, 'reason' => $reason],
-            ],
-        ));
+                $id = $pauses->save($pause);
 
-        return new DunningPause(
-            organizationId: $pause->organizationId,
-            invoiceId: $pause->invoiceId,
-            pausedBy: $pause->pausedBy,
-            pausedAt: $pause->pausedAt,
-            pausedReason: $pause->pausedReason,
-            id: $id,
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $organizationId,
+                    eventType: 'dunning_paused',
+                    actorUserId: $actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'invoice_id' => $invoiceId,
+                        'before' => ['is_paused' => false],
+                        'after' => ['is_paused' => true, 'reason' => $reason],
+                    ],
+                ));
+
+                return new DunningPause(
+                    organizationId: $pause->organizationId,
+                    invoiceId: $pause->invoiceId,
+                    pausedBy: $pause->pausedBy,
+                    pausedAt: $pause->pausedAt,
+                    pausedReason: $pause->pausedReason,
+                    id: $id,
+                );
+            },
         );
     }
 }

--- a/src/Dunning/ResumeDunningUseCase.php
+++ b/src/Dunning/ResumeDunningUseCase.php
@@ -4,15 +4,23 @@ declare(strict_types=1);
 
 namespace NeneClear\Dunning;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class ResumeDunningUseCase
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private DunningPauseRepositoryInterface $pauses,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $pauses,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
@@ -21,18 +29,26 @@ final readonly class ResumeDunningUseCase
     {
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        $this->pauses->resumeByInvoice($organizationId, $invoiceId, $actorUserId, $now);
+        // The resume update and its audit record commit (or roll back) together (Issue #122).
+        $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($organizationId, $invoiceId, $actorUserId, $now): void {
+                $pauses = ($this->pauses)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $organizationId,
-            eventType: 'dunning_resumed',
-            actorUserId: $actorUserId,
-            occurredAt: $now,
-            payload: [
-                'invoice_id' => $invoiceId,
-                'before' => ['is_paused' => true],
-                'after' => ['is_paused' => false],
-            ],
-        ));
+                $pauses->resumeByInvoice($organizationId, $invoiceId, $actorUserId, $now);
+
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $organizationId,
+                    eventType: 'dunning_resumed',
+                    actorUserId: $actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'invoice_id' => $invoiceId,
+                        'before' => ['is_paused' => true],
+                        'after' => ['is_paused' => false],
+                    ],
+                ));
+            },
+        );
     }
 }

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace NeneClear\Dunning;
 
+use Closure;
 use DateInterval;
 use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -19,15 +22,24 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
     private const int DEFAULT_MIN_INTERVAL_DAYS = 7;
     private const string TEMPLATE_VERSION = '1.0';
 
+    /**
+     * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads
+     * @param Closure(DatabaseQueryExecutorInterface): DunningNoticeRepositoryInterface $notices
+     * @param Closure(DatabaseQueryExecutorInterface): ClearSettingsRepositoryInterface $clearSettings
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param ?Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
+     */
     public function __construct(
-        private DunningNoticeRepositoryInterface $notices,
-        private ClearSettingsRepositoryInterface $clearSettings,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private DatabaseQueryExecutorInterface $reader,
+        private Closure $notices,
+        private Closure $clearSettings,
         private InvoiceUpstreamClientInterface $invoiceClient,
         private DunningMailerInterface $mailer,
-        private AuditEventRepositoryInterface $auditEvents,
+        private Closure $auditEvents,
         private ClockInterface $clock,
         private MessageCatalog $catalog,
-        private ?DunningPauseRepositoryInterface $pauses = null,
+        private ?Closure $pauses = null,
     ) {
     }
 
@@ -39,15 +51,15 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             throw new InvoiceAlreadyPaidException($input->invoiceId, $invoice->status);
         }
 
-        $pause = $this->pauses?->findActiveByInvoice($input->organizationId, $input->invoiceId);
+        $pause = ($this->pauses)?->__invoke($this->reader)->findActiveByInvoice($input->organizationId, $input->invoiceId);
         if ($pause !== null) {
             throw new DunningPausedException($input->invoiceId, $pause->pausedReason);
         }
 
-        $settings = $this->clearSettings->findByOrganization($input->organizationId);
+        $settings = ($this->clearSettings)($this->reader)->findByOrganization($input->organizationId);
         $minIntervalDays = $settings !== null ? $settings->dunningMinIntervalDays : self::DEFAULT_MIN_INTERVAL_DAYS;
 
-        $lastNotice = $this->notices->findLastByInvoice($input->organizationId, $input->invoiceId);
+        $lastNotice = ($this->notices)($this->reader)->findLastByInvoice($input->organizationId, $input->invoiceId);
         if ($lastNotice !== null) {
             $lastSentAt = new DateTimeImmutable($lastNotice->sentAt);
             $nextAllowed = $lastSentAt->add(new DateInterval('P' . $minIntervalDays . 'D'));
@@ -88,7 +100,43 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             sentAt: $nowStr,
         );
 
-        $noticeId = $this->notices->save($notice);
+        // Record the notice and its audit event atomically first (Issue #122), then
+        // send the email. The mailer is an external side effect kept OUTSIDE the
+        // transaction: recording before sending means a delivery failure leaves an
+        // honest "attempted" trail rather than an un-recordable already-sent email.
+        $noticeId = $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $invoice, $client, $notice, $nowStr, $lastNotice): int {
+                $notices = ($this->notices)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
+
+                $noticeId = $notices->save($notice);
+
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'dunning_sent',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $nowStr,
+                    payload: [
+                        'dunning_notice_id' => $noticeId,
+                        'invoice_id' => $input->invoiceId,
+                        'before' => [
+                            'invoice_status' => $invoice->status,
+                            'invoice_outstanding_cents' => $invoice->outstandingCents,
+                            'previous_dunning_sent_at' => $lastNotice?->sentAt,
+                        ],
+                        'after' => [
+                            'invoice_number' => $invoice->invoiceNumber,
+                            'recipient_email' => $client->recipientEmail,
+                            'outstanding_at_send_cents' => $invoice->outstandingCents,
+                            'channel' => $this->mailer->channel(),
+                            'template_version' => self::TEMPLATE_VERSION,
+                        ],
+                    ],
+                ));
+
+                return $noticeId;
+            },
+        );
 
         $this->mailer->send(new DunningMailPayload(
             to: $client->recipientEmail,
@@ -97,29 +145,6 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             organizationId: $input->organizationId,
             invoiceId: $input->invoiceId,
             dunningNoticeId: $noticeId,
-        ));
-
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'dunning_sent',
-            actorUserId: $input->actorUserId,
-            occurredAt: $nowStr,
-            payload: [
-                'dunning_notice_id' => $noticeId,
-                'invoice_id' => $input->invoiceId,
-                'before' => [
-                    'invoice_status' => $invoice->status,
-                    'invoice_outstanding_cents' => $invoice->outstandingCents,
-                    'previous_dunning_sent_at' => $lastNotice?->sentAt,
-                ],
-                'after' => [
-                    'invoice_number' => $invoice->invoiceNumber,
-                    'recipient_email' => $client->recipientEmail,
-                    'outstanding_at_send_cents' => $invoice->outstandingCents,
-                    'channel' => $this->mailer->channel(),
-                    'template_version' => self::TEMPLATE_VERSION,
-                ],
-            ],
         ));
 
         return new SendDunningOutput(dunningNoticeId: $noticeId);

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -7,6 +7,7 @@ namespace NeneClear\Http;
 use LogicException;
 use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -57,6 +58,7 @@ final class ApplicationFactory
         bool $debug = false,
         array $allowedOrigins = [],
         ?DatabaseQueryExecutorInterface $query = null,
+        ?DatabaseTransactionManagerInterface $transactionManager = null,
         ?string $jwtSecret = null,
         ?InvoiceUpstreamClientInterface $invoiceClient = null,
         ?string $smtpHost = null,
@@ -80,8 +82,15 @@ final class ApplicationFactory
             ))->create();
         }
 
+        // Admin routes mutate state, so they require a transaction manager to keep
+        // each use case's business writes + audit record atomic (see Issue #122).
+        if ($transactionManager === null) {
+            throw new LogicException('A DatabaseTransactionManagerInterface is required when the database is configured.');
+        }
+
         $container = self::buildContainer(
             $query,
+            $transactionManager,
             $jwtSecret,
             $psr17,
             self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
@@ -116,6 +125,7 @@ final class ApplicationFactory
      */
     private static function buildContainer(
         DatabaseQueryExecutorInterface $query,
+        DatabaseTransactionManagerInterface $transactionManager,
         string $jwtSecret,
         Psr17Factory $psr17,
         InvoiceUpstreamClientInterface $invoiceClient,
@@ -145,6 +155,7 @@ final class ApplicationFactory
                 ),
             )
             ->set(DatabaseQueryExecutorInterface::class, static fn (ContainerInterface $c): DatabaseQueryExecutorInterface => $query)
+            ->set(DatabaseTransactionManagerInterface::class, static fn (ContainerInterface $c): DatabaseTransactionManagerInterface => $transactionManager)
             ->set(ClockInterface::class, static fn (ContainerInterface $c): ClockInterface => new UtcClock())
             ->set(JwtTokenService::class, static fn (ContainerInterface $c): JwtTokenService => new JwtTokenService($jwtSecret))
             ->set(TokenIssuerInterface::class, static fn (ContainerInterface $c): TokenIssuerInterface => ServiceResolver::get($c, JwtTokenService::class))

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -4,43 +4,61 @@ declare(strict_types=1);
 
 namespace NeneClear\Organization;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizations
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private OrganizationRepositoryInterface $organizations,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $organizations,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(CreateOrganizationInput $input): CreateOrganizationOutput
     {
-        if ($this->organizations->existsBySlug($input->slug)) {
-            throw new OrganizationAlreadyExistsException($input->slug);
-        }
+        // The duplicate-slug check, the insert, and the audit record commit (or
+        // roll back) together so a change can never be persisted without its audit
+        // event (Issue #122). Repositories are built from the transaction executor.
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): CreateOrganizationOutput {
+                $organizations = ($this->organizations)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        $id = $this->organizations->save(new Organization(slug: $input->slug, name: $input->name));
+                if ($organizations->existsBySlug($input->slug)) {
+                    throw new OrganizationAlreadyExistsException($input->slug);
+                }
 
-        // Audit: a tenant lifecycle event is scoped to the affected tenant, so it
-        // surfaces in that organization's own audit trail.
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $id,
-            eventType: 'organization_created',
-            actorUserId: $input->actorUserId,
-            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-            payload: [
-                'after' => [
-                    'organization_id' => $id,
-                    'slug' => $input->slug,
-                    'name' => $input->name,
-                ],
-            ],
-        ));
+                $id = $organizations->save(new Organization(slug: $input->slug, name: $input->name));
 
-        return new CreateOrganizationOutput(id: $id, slug: $input->slug, name: $input->name);
+                // Audit: a tenant lifecycle event is scoped to the affected tenant, so it
+                // surfaces in that organization's own audit trail.
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $id,
+                    eventType: 'organization_created',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+                    payload: [
+                        'after' => [
+                            'organization_id' => $id,
+                            'slug' => $input->slug,
+                            'name' => $input->name,
+                        ],
+                    ],
+                ));
+
+                return new CreateOrganizationOutput(id: $id, slug: $input->slug, name: $input->name);
+            },
+        );
     }
 }

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -4,45 +4,61 @@ declare(strict_types=1);
 
 namespace NeneClear\Organization;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizations
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private OrganizationRepositoryInterface $organizations,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $organizations,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(int $id, int $actorUserId): void
     {
-        $organization = $this->organizations->findById($id);
+        // The soft-delete and its audit record share one transaction (and one
+        // instant from the injected clock), so neither can land without the other.
+        $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($id, $actorUserId): void {
+                $organizations = ($this->organizations)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        if ($organization === null) {
-            throw new OrganizationNotFoundException($id);
-        }
+                $organization = $organizations->findById($id);
 
-        $now = $this->clock->now()->format('Y-m-d H:i:s');
-        $this->organizations->delete($id, $now);
+                if ($organization === null) {
+                    throw new OrganizationNotFoundException($id);
+                }
 
-        // Audit: deletion carries the prior state (`before` only), scoped to the
-        // now-removed tenant. The audit event and the soft-delete row share one
-        // instant from the injected clock.
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $id,
-            eventType: 'organization_deleted',
-            actorUserId: $actorUserId,
-            occurredAt: $now,
-            payload: [
-                'before' => [
-                    'organization_id' => $id,
-                    'slug' => $organization->slug,
-                    'name' => $organization->name,
-                ],
-            ],
-        ));
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $organizations->delete($id, $now);
+
+                // Audit: deletion carries the prior state (`before` only), scoped to the
+                // now-removed tenant.
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $id,
+                    eventType: 'organization_deleted',
+                    actorUserId: $actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'before' => [
+                            'organization_id' => $id,
+                            'slug' => $organization->slug,
+                            'name' => $organization->name,
+                        ],
+                    ],
+                ));
+            },
+        );
     }
 }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace NeneClear\Organization;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Container\ContainerInterface;
@@ -44,16 +46,18 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
             ->set(
                 CreateOrganizationUseCaseInterface::class,
                 static fn (ContainerInterface $c): CreateOrganizationUseCaseInterface => new CreateOrganizationUseCase(
-                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): OrganizationRepositoryInterface => new PdoOrganizationRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 DeleteOrganizationUseCaseInterface::class,
                 static fn (ContainerInterface $c): DeleteOrganizationUseCaseInterface => new DeleteOrganizationUseCase(
-                    ServiceResolver::get($c, OrganizationRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): OrganizationRepositoryInterface => new PdoOrganizationRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/Reconciliation/ApplyCreditUseCase.php
+++ b/src/Reconciliation/ApplyCreditUseCase.php
@@ -4,22 +4,32 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 
 final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
 {
+    /**
+     * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads (before upstream calls)
+     * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private ClientCreditRepositoryInterface $clientCredits,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private DatabaseQueryExecutorInterface $reader,
+        private Closure $clientCredits,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private AuditEventRepositoryInterface $auditEvents,
+        private Closure $auditEvents,
     ) {
     }
 
     public function execute(ApplyCreditInput $input): ApplyCreditOutput
     {
-        $credit = $this->clientCredits->findById($input->organizationId, $input->creditId);
+        $credit = ($this->clientCredits)($this->reader)->findById($input->organizationId, $input->creditId);
 
         if ($credit === null) {
             throw new ClientCreditNotFoundException($input->creditId);
@@ -36,6 +46,8 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
         $externalRef = sprintf('clear:credit:%d:%d', $input->creditId, $input->invoiceId);
         $idempotencyKey = sprintf('clear:credit:apply:%d:%d', $input->creditId, $input->invoiceId);
 
+        // Upstream payment creation is an external side effect and runs OUTSIDE the
+        // database transaction; the credit update + audit below are atomic (Issue #122).
         $this->invoiceClient->createPayment(
             organizationId: $input->organizationId,
             invoiceId: $input->invoiceId,
@@ -45,28 +57,35 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
             idempotencyKey: $idempotencyKey,
         );
 
-        $updated = $this->clientCredits->applyAmount($input->organizationId, $input->creditId, $input->amountCents);
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $credit): ApplyCreditOutput {
+                $clientCredits = ($this->clientCredits)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'client_credit_applied',
-            actorUserId: $input->actorUserId,
-            occurredAt: $credit->createdAt,
-            payload: [
-                'client_credit_id' => $input->creditId,
-                'invoice_id' => $input->invoiceId,
-                'amount_cents' => $input->amountCents,
-                'before' => [
-                    'remaining_cents' => $credit->remainingCents,
-                    'status' => $credit->status->value,
-                ],
-                'after' => [
-                    'remaining_cents' => $updated->remainingCents,
-                    'status' => $updated->status->value,
-                ],
-            ],
-        ));
+                $updated = $clientCredits->applyAmount($input->organizationId, $input->creditId, $input->amountCents);
 
-        return new ApplyCreditOutput(credit: $updated);
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'client_credit_applied',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $credit->createdAt,
+                    payload: [
+                        'client_credit_id' => $input->creditId,
+                        'invoice_id' => $input->invoiceId,
+                        'amount_cents' => $input->amountCents,
+                        'before' => [
+                            'remaining_cents' => $credit->remainingCents,
+                            'status' => $credit->status->value,
+                        ],
+                        'after' => [
+                            'remaining_cents' => $updated->remainingCents,
+                            'status' => $updated->status->value,
+                        ],
+                    ],
+                ));
+
+                return new ApplyCreditOutput(credit: $updated);
+            },
+        );
     }
 }

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -14,12 +17,21 @@ use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 
 final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
 {
+    /**
+     * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads (before upstream calls)
+     * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
+     * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
+     * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private BankTransactionRepositoryInterface $transactions,
-        private ReconciliationRepositoryInterface $reconciliations,
-        private ClientCreditRepositoryInterface $clientCredits,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private DatabaseQueryExecutorInterface $reader,
+        private Closure $transactions,
+        private Closure $reconciliations,
+        private Closure $clientCredits,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private AuditEventRepositoryInterface $auditEvents,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
@@ -27,15 +39,16 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
     public function execute(ConfirmMatchInput $input): ConfirmMatchOutput
     {
         // Idempotency: if a key was provided and a reconciliation with that key already
-        // exists for this organization, return it without re-processing.
+        // exists for this organization, return it without re-processing (and without
+        // re-issuing upstream payments).
         if ($input->idempotencyKey !== null) {
-            $existing = $this->reconciliations->findByIdempotencyKey($input->organizationId, $input->idempotencyKey);
+            $existing = ($this->reconciliations)($this->reader)->findByIdempotencyKey($input->organizationId, $input->idempotencyKey);
             if ($existing !== null && $existing->id !== null) {
                 return new ConfirmMatchOutput(reconciliationId: $existing->id, idempotentReplay: true);
             }
         }
 
-        $tx = $this->transactions->findById($input->organizationId, $input->bankTransactionId);
+        $tx = ($this->transactions)($this->reader)->findById($input->organizationId, $input->bankTransactionId);
 
         if ($tx === null) {
             throw new BankTransactionNotFoundException($input->bankTransactionId);
@@ -47,7 +60,9 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
 
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        // Validate outstanding and call upstream for each allocation.
+        // Validate outstanding and call upstream for each allocation. Upstream payment
+        // creation is an external side effect and must happen OUTSIDE the database
+        // transaction (it cannot be rolled back); the local writes below are atomic.
         $paymentsCreated = [];
         foreach ($input->allocations as $allocation) {
             $invoice = $this->invoiceClient->getInvoice($input->organizationId, $allocation->invoiceId);
@@ -77,87 +92,99 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
             ];
         }
 
-        $reconciliationId = $this->reconciliations->save(new Reconciliation(
-            organizationId: $input->organizationId,
-            bankTransactionId: $input->bankTransactionId,
-            status: ReconciliationStatus::Confirmed,
-            confirmedBy: $input->actorUserId,
-            confirmedAt: $now,
-            reasonCode: $input->reasonCode,
-            idempotencyKey: $input->idempotencyKey,
-        ));
+        // Atomic local writes + audit: the reconciliation, its allocations, the bank
+        // transaction status, any overpayment credit, and the audit record commit (or
+        // roll back) together so a confirmed match can never lack its audit (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $tx, $now, $paymentsCreated): ConfirmMatchOutput {
+                $reconciliations = ($this->reconciliations)($ex);
+                $transactions = ($this->transactions)($ex);
+                $clientCredits = ($this->clientCredits)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $totalAllocated = 0;
-        foreach ($paymentsCreated as $entry) {
-            /** @var AllocationInput $allocation */
-            $allocation = $entry['allocation'];
-            $payment = $entry['payment'];
-            $externalRef = sprintf('clear:recon:%d:%d', $reconciliationId, $allocation->invoiceId);
+                $reconciliationId = $reconciliations->save(new Reconciliation(
+                    organizationId: $input->organizationId,
+                    bankTransactionId: $input->bankTransactionId,
+                    status: ReconciliationStatus::Confirmed,
+                    confirmedBy: $input->actorUserId,
+                    confirmedAt: $now,
+                    reasonCode: $input->reasonCode,
+                    idempotencyKey: $input->idempotencyKey,
+                ));
 
-            $this->reconciliations->saveAllocation(new ReconciliationAllocation(
-                organizationId: $input->organizationId,
-                reconciliationId: $reconciliationId,
-                invoiceId: $allocation->invoiceId,
-                amountCents: $allocation->amountCents,
-                paymentId: $payment->paymentId,
-                externalReference: $externalRef,
-            ));
+                $totalAllocated = 0;
+                foreach ($paymentsCreated as $entry) {
+                    /** @var AllocationInput $allocation */
+                    $allocation = $entry['allocation'];
+                    $payment = $entry['payment'];
+                    $externalRef = sprintf('clear:recon:%d:%d', $reconciliationId, $allocation->invoiceId);
 
-            $totalAllocated += $allocation->amountCents;
-        }
+                    $reconciliations->saveAllocation(new ReconciliationAllocation(
+                        organizationId: $input->organizationId,
+                        reconciliationId: $reconciliationId,
+                        invoiceId: $allocation->invoiceId,
+                        amountCents: $allocation->amountCents,
+                        paymentId: $payment->paymentId,
+                        externalReference: $externalRef,
+                    ));
 
-        $remainder = $tx->amountCents - $totalAllocated;
-        $newStatus = $remainder <= 0 ? BankTransactionStatus::Matched : BankTransactionStatus::PartiallyMatched;
-        $this->transactions->updateStatusById($input->organizationId, $input->bankTransactionId, $newStatus);
+                    $totalAllocated += $allocation->amountCents;
+                }
 
-        if ($remainder > 0) {
-            $this->clientCredits->save(new ClientCredit(
-                organizationId: $input->organizationId,
-                clientId: $paymentsCreated[0]['clientId'],
-                amountCents: $remainder,
-                remainingCents: $remainder,
-                status: ClientCreditStatus::Open,
-                sourceBankTransactionId: $input->bankTransactionId,
-                reconciliationId: $reconciliationId,
-                createdBy: $input->actorUserId,
-                createdAt: $now,
-            ));
-        }
+                $remainder = $tx->amountCents - $totalAllocated;
+                $newStatus = $remainder <= 0 ? BankTransactionStatus::Matched : BankTransactionStatus::PartiallyMatched;
+                $transactions->updateStatusById($input->organizationId, $input->bankTransactionId, $newStatus);
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'reconciliation_confirmed',
-            actorUserId: $input->actorUserId,
-            occurredAt: $now,
-            payload: [
-                'before' => [
-                    'bank_transaction_status' => $tx->status->value,
-                    'bank_transaction_amount_cents' => $tx->amountCents,
-                    'allocations' => array_map(
-                        static fn (array $e): array => [
-                            'invoice_id' => $e['allocation']->invoiceId,
-                            'invoice_outstanding_cents' => $e['invoiceOutstandingBefore'],
+                if ($remainder > 0) {
+                    $clientCredits->save(new ClientCredit(
+                        organizationId: $input->organizationId,
+                        clientId: $paymentsCreated[0]['clientId'],
+                        amountCents: $remainder,
+                        remainingCents: $remainder,
+                        status: ClientCreditStatus::Open,
+                        sourceBankTransactionId: $input->bankTransactionId,
+                        reconciliationId: $reconciliationId,
+                        createdBy: $input->actorUserId,
+                        createdAt: $now,
+                    ));
+                }
+
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'reconciliation_confirmed',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'before' => [
+                            'bank_transaction_status' => $tx->status->value,
+                            'bank_transaction_amount_cents' => $tx->amountCents,
+                            'allocations' => array_map(
+                                static fn (array $e): array => [
+                                    'invoice_id' => $e['allocation']->invoiceId,
+                                    'invoice_outstanding_cents' => $e['invoiceOutstandingBefore'],
+                                ],
+                                $paymentsCreated,
+                            ),
                         ],
-                        $paymentsCreated,
-                    ),
-                ],
-                'after' => [
-                    'payment_reconciliation_id' => $reconciliationId,
-                    'bank_transaction_status' => $newStatus->value,
-                    'total_allocated_cents' => $totalAllocated,
-                    'remainder_cents' => $remainder,
-                    'allocations' => array_map(
-                        static fn (array $e): array => [
-                            'invoice_id' => $e['allocation']->invoiceId,
-                            'amount_cents' => $e['allocation']->amountCents,
-                            'payment_id' => $e['payment']->paymentId,
+                        'after' => [
+                            'payment_reconciliation_id' => $reconciliationId,
+                            'bank_transaction_status' => $newStatus->value,
+                            'total_allocated_cents' => $totalAllocated,
+                            'remainder_cents' => $remainder,
+                            'allocations' => array_map(
+                                static fn (array $e): array => [
+                                    'invoice_id' => $e['allocation']->invoiceId,
+                                    'amount_cents' => $e['allocation']->amountCents,
+                                    'payment_id' => $e['payment']->paymentId,
+                                ],
+                                $paymentsCreated,
+                            ),
                         ],
-                        $paymentsCreated,
-                    ),
-                ],
-            ],
-        ));
+                    ],
+                ));
 
-        return new ConfirmMatchOutput(reconciliationId: $reconciliationId);
+                return new ConfirmMatchOutput(reconciliationId: $reconciliationId);
+            },
+        );
     }
 }

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\BankImport\PdoBankTransactionRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
@@ -48,31 +51,37 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
             ->set(
                 ConfirmMatchUseCaseInterface::class,
                 static fn (ContainerInterface $c): ConfirmMatchUseCaseInterface => new ConfirmMatchUseCase(
-                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
-                    ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
-                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ReconciliationRepositoryInterface => new PdoReconciliationRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 ReverseReconciliationUseCaseInterface::class,
                 static fn (ContainerInterface $c): ReverseReconciliationUseCaseInterface => new ReverseReconciliationUseCase(
-                    ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
-                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
-                    ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ReconciliationRepositoryInterface => new PdoReconciliationRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 ApplyCreditUseCaseInterface::class,
                 static fn (ContainerInterface $c): ApplyCreditUseCaseInterface => new ApplyCreditUseCase(
-                    ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                 ),
             )
             ->set(

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -13,19 +16,28 @@ use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 
 final readonly class ReverseReconciliationUseCase implements ReverseReconciliationUseCaseInterface
 {
+    /**
+     * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads (before upstream calls)
+     * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
+     * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
+     * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private ReconciliationRepositoryInterface $reconciliations,
-        private ClientCreditRepositoryInterface $clientCredits,
-        private BankTransactionRepositoryInterface $transactions,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private DatabaseQueryExecutorInterface $reader,
+        private Closure $reconciliations,
+        private Closure $clientCredits,
+        private Closure $transactions,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private AuditEventRepositoryInterface $auditEvents,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(ReverseReconciliationInput $input): ReverseReconciliationOutput
     {
-        $reconciliation = $this->reconciliations->findById($input->organizationId, $input->reconciliationId);
+        $reconciliation = ($this->reconciliations)($this->reader)->findById($input->organizationId, $input->reconciliationId);
 
         if ($reconciliation === null) {
             throw new ReconciliationNotFoundException($input->reconciliationId);
@@ -35,9 +47,11 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
             throw new ReconciliationAlreadyReversedException($input->reconciliationId);
         }
 
-        $allocations = $this->reconciliations->findAllocationsByReconciliation($input->organizationId, $input->reconciliationId);
+        $allocations = ($this->reconciliations)($this->reader)->findAllocationsByReconciliation($input->organizationId, $input->reconciliationId);
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
+        // Upstream payment voids are external side effects and run OUTSIDE the
+        // database transaction; the local writes below are atomic (Issue #122).
         foreach ($allocations as $allocation) {
             if ($allocation->paymentId !== null) {
                 $idempotencyKey = sprintf('clear:recon:reverse:%d:%d', $input->reconciliationId, $allocation->invoiceId);
@@ -51,38 +65,47 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
             }
         }
 
-        $this->reconciliations->reverseById($input->reconciliationId, $now, $input->reversalReason);
-        $this->transactions->updateStatusById($input->organizationId, $reconciliation->bankTransactionId, BankTransactionStatus::Unmatched);
-        $this->clientCredits->voidByReconciliation($input->reconciliationId);
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $reconciliation, $allocations, $now): ReverseReconciliationOutput {
+                $reconciliations = ($this->reconciliations)($ex);
+                $transactions = ($this->transactions)($ex);
+                $clientCredits = ($this->clientCredits)($ex);
+                $auditEvents = ($this->auditEvents)($ex);
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId,
-            eventType: 'reconciliation_reversed',
-            actorUserId: $input->actorUserId,
-            occurredAt: $now,
-            payload: [
-                'payment_reconciliation_id' => $input->reconciliationId,
-                'before' => [
-                    'status' => 'confirmed',
-                    'bank_transaction_id' => $reconciliation->bankTransactionId,
-                    'confirmed_at' => $reconciliation->confirmedAt,
-                    'allocations' => array_map(
-                        static fn (ReconciliationAllocation $a): array => [
-                            'invoice_id' => $a->invoiceId,
-                            'amount_cents' => $a->amountCents,
-                            'payment_id' => $a->paymentId,
+                $reconciliations->reverseById($input->reconciliationId, $now, $input->reversalReason);
+                $transactions->updateStatusById($input->organizationId, $reconciliation->bankTransactionId, BankTransactionStatus::Unmatched);
+                $clientCredits->voidByReconciliation($input->reconciliationId);
+
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId,
+                    eventType: 'reconciliation_reversed',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'payment_reconciliation_id' => $input->reconciliationId,
+                        'before' => [
+                            'status' => 'confirmed',
+                            'bank_transaction_id' => $reconciliation->bankTransactionId,
+                            'confirmed_at' => $reconciliation->confirmedAt,
+                            'allocations' => array_map(
+                                static fn (ReconciliationAllocation $a): array => [
+                                    'invoice_id' => $a->invoiceId,
+                                    'amount_cents' => $a->amountCents,
+                                    'payment_id' => $a->paymentId,
+                                ],
+                                $allocations,
+                            ),
                         ],
-                        $allocations,
-                    ),
-                ],
-                'after' => [
-                    'status' => 'reversed',
-                    'bank_transaction_status' => 'unmatched',
-                    'reversal_reason' => $input->reversalReason,
-                ],
-            ],
-        ));
+                        'after' => [
+                            'status' => 'reversed',
+                            'bank_transaction_status' => 'unmatched',
+                            'reversal_reason' => $input->reversalReason,
+                        ],
+                    ],
+                ));
 
-        return new ReverseReconciliationOutput(reconciliationId: $input->reconciliationId);
+                return new ReverseReconciliationOutput(reconciliationId: $input->reconciliationId);
+            },
+        );
     }
 }

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -11,9 +14,14 @@ use NeneClear\Auth\Role;
 
 final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private UserRepositoryInterface $users,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $users,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
@@ -27,47 +35,56 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
             throw new RoleNotAssignableException($input->role->value);
         }
 
-        if ($this->users->existsByEmail($input->email)) {
-            throw new UserAlreadyExistsException($input->email);
-        }
-
         // With a password the account is active; without one it is invited and
         // cannot log in until a password is set (the hash is a random placeholder).
         $status = $input->password !== null ? UserStatus::Active : UserStatus::Invited;
         $hash = password_hash($input->password ?? bin2hex(random_bytes(16)), PASSWORD_BCRYPT);
 
-        $id = $this->users->save(new User(
-            email: $input->email,
-            role: $input->role,
-            status: $status,
-            passwordHash: $hash,
-            organizationId: $input->organizationId,
-        ));
+        // The uniqueness check, insert, and audit record commit (or roll back)
+        // together so a created account can never lack its audit event (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input, $status, $hash): User {
+                $users = ($this->users)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        $created = $this->users->findById($id);
+                if ($users->existsByEmail($input->email)) {
+                    throw new UserAlreadyExistsException($input->email);
+                }
 
-        if ($created === null) {
-            throw new UserNotFoundException($id);
-        }
+                $id = $users->save(new User(
+                    email: $input->email,
+                    role: $input->role,
+                    status: $status,
+                    passwordHash: $hash,
+                    organizationId: $input->organizationId,
+                ));
 
-        // Audit: account creation carries `after` only (no prior state). The
-        // password hash is never recorded — only who/what changed.
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $input->organizationId ?? 0,
-            eventType: 'user_created',
-            actorUserId: $input->actorUserId,
-            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-            payload: [
-                'after' => [
-                    'user_id' => $created->id,
-                    'email' => $created->email,
-                    'role' => $created->role->value,
-                    'status' => $created->status->value,
-                    'organization_id' => $created->organizationId,
-                ],
-            ],
-        ));
+                $created = $users->findById($id);
 
-        return $created;
+                if ($created === null) {
+                    throw new UserNotFoundException($id);
+                }
+
+                // Audit: account creation carries `after` only (no prior state). The
+                // password hash is never recorded — only who/what changed.
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $input->organizationId ?? 0,
+                    eventType: 'user_created',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+                    payload: [
+                        'after' => [
+                            'user_id' => $created->id,
+                            'email' => $created->email,
+                            'role' => $created->role->value,
+                            'status' => $created->status->value,
+                            'organization_id' => $created->organizationId,
+                        ],
+                    ],
+                ));
+
+                return $created;
+            },
+        );
     }
 }

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -4,46 +4,63 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private UserRepositoryInterface $users,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $users,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(int $id, ?int $callerOrganizationId, int $actorUserId): void
     {
-        $user = $this->users->findById($id);
+        // The soft-delete and its audit record share one transaction (and one
+        // instant from the injected clock), so neither can land without the other.
+        $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($id, $callerOrganizationId, $actorUserId): void {
+                $users = ($this->users)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        if ($user === null || $user->organizationId !== $callerOrganizationId) {
-            throw new UserNotFoundException($id);
-        }
+                $user = $users->findById($id);
 
-        $now = $this->clock->now()->format('Y-m-d H:i:s');
-        $this->users->delete($callerOrganizationId, $id, $now);
+                if ($user === null || $user->organizationId !== $callerOrganizationId) {
+                    throw new UserNotFoundException($id);
+                }
 
-        // Audit: deletion carries the prior state (`before` only) so the removed
-        // account's identity and privileges remain reconstructable.
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $user->organizationId ?? 0,
-            eventType: 'user_deleted',
-            actorUserId: $actorUserId,
-            occurredAt: $now,
-            payload: [
-                'before' => [
-                    'user_id' => $user->id,
-                    'email' => $user->email,
-                    'role' => $user->role->value,
-                    'status' => $user->status->value,
-                    'organization_id' => $user->organizationId,
-                ],
-            ],
-        ));
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $users->delete($callerOrganizationId, $id, $now);
+
+                // Audit: deletion carries the prior state (`before` only) so the removed
+                // account's identity and privileges remain reconstructable.
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $user->organizationId ?? 0,
+                    eventType: 'user_deleted',
+                    actorUserId: $actorUserId,
+                    occurredAt: $now,
+                    payload: [
+                        'before' => [
+                            'user_id' => $user->id,
+                            'email' => $user->email,
+                            'role' => $user->role->value,
+                            'status' => $user->status->value,
+                            'organization_id' => $user->organizationId,
+                        ],
+                    ],
+                ));
+            },
+        );
     }
 }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
 use NeneClear\Audit\AuditEvent;
 use NeneClear\Audit\AuditEventRepositoryInterface;
@@ -11,59 +14,73 @@ use NeneClear\Auth\Role;
 
 final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
+     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     */
     public function __construct(
-        private UserRepositoryInterface $users,
-        private AuditEventRepositoryInterface $auditEvents,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $users,
+        private Closure $auditEvents,
         private ClockInterface $clock,
     ) {
     }
 
     public function execute(UpdateUserInput $input): User
     {
-        $existing = $this->users->findById($input->id);
+        // The read, update, and audit record share one transaction so the recorded
+        // before/after always matches what was persisted (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): User {
+                $users = ($this->users)($tx);
+                $auditEvents = ($this->auditEvents)($tx);
 
-        if ($existing === null || $existing->organizationId !== $input->callerOrganizationId) {
-            throw new UserNotFoundException($input->id);
-        }
+                $existing = $users->findById($input->id);
 
-        // Privilege-escalation guard: an org-scoped user (non-null org) can never
-        // be promoted to the cross-tenant superadmin role.
-        if ($input->role === Role::Superadmin && $existing->organizationId !== null) {
-            throw new RoleNotAssignableException($input->role->value);
-        }
+                if ($existing === null || $existing->organizationId !== $input->callerOrganizationId) {
+                    throw new UserNotFoundException($input->id);
+                }
 
-        $updated = new User(
-            email: $existing->email,
-            role: $input->role ?? $existing->role,
-            status: $input->status ?? $existing->status,
-            passwordHash: $existing->passwordHash,
-            organizationId: $existing->organizationId,
-            id: $existing->id,
+                // Privilege-escalation guard: an org-scoped user (non-null org) can never
+                // be promoted to the cross-tenant superadmin role.
+                if ($input->role === Role::Superadmin && $existing->organizationId !== null) {
+                    throw new RoleNotAssignableException($input->role->value);
+                }
+
+                $updated = new User(
+                    email: $existing->email,
+                    role: $input->role ?? $existing->role,
+                    status: $input->status ?? $existing->status,
+                    passwordHash: $existing->passwordHash,
+                    organizationId: $existing->organizationId,
+                    id: $existing->id,
+                );
+
+                $users->save($updated);
+
+                // Audit: in-place change carries both the prior and the resulting role
+                // and status, so a role escalation or deactivation is fully reconstructable.
+                $auditEvents->record(new AuditEvent(
+                    organizationId: $existing->organizationId ?? 0,
+                    eventType: 'user_updated',
+                    actorUserId: $input->actorUserId,
+                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
+                    payload: [
+                        'user_id' => $existing->id,
+                        'email' => $existing->email,
+                        'before' => [
+                            'role' => $existing->role->value,
+                            'status' => $existing->status->value,
+                        ],
+                        'after' => [
+                            'role' => $updated->role->value,
+                            'status' => $updated->status->value,
+                        ],
+                    ],
+                ));
+
+                return $updated;
+            },
         );
-
-        $this->users->save($updated);
-
-        // Audit: in-place change carries both the prior and the resulting role
-        // and status, so a role escalation or deactivation is fully reconstructable.
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $existing->organizationId ?? 0,
-            eventType: 'user_updated',
-            actorUserId: $input->actorUserId,
-            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-            payload: [
-                'user_id' => $existing->id,
-                'email' => $existing->email,
-                'before' => [
-                    'role' => $existing->role->value,
-                    'status' => $existing->status->value,
-                ],
-                'after' => [
-                    'role' => $updated->role->value,
-                    'status' => $updated->status->value,
-                ],
-            ],
-        ));
-
-        return $updated;
     }
 }

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace NeneClear\User;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Container\ContainerInterface;
@@ -44,24 +46,27 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
             ->set(
                 CreateUserUseCaseInterface::class,
                 static fn (ContainerInterface $c): CreateUserUseCaseInterface => new CreateUserUseCase(
-                    ServiceResolver::get($c, UserRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 UpdateUserUseCaseInterface::class,
                 static fn (ContainerInterface $c): UpdateUserUseCaseInterface => new UpdateUserUseCase(
-                    ServiceResolver::get($c, UserRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(
                 DeleteUserUseCaseInterface::class,
                 static fn (ContainerInterface $c): DeleteUserUseCaseInterface => new DeleteUserUseCase(
-                    ServiceResolver::get($c, UserRepositoryInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/tests/Audit/ThrowingAuditEventRepository.php
+++ b/tests/Audit/ThrowingAuditEventRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Audit;
+
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventRepositoryInterface;
+use RuntimeException;
+
+/**
+ * Audit repository double whose {@see record()} always throws.
+ *
+ * Used to prove transactional atomicity: when the audit write fails, the
+ * surrounding `transactional()` must roll back the business writes too, so no
+ * state change is ever persisted without its audit event (Issue #122).
+ */
+final class ThrowingAuditEventRepository implements AuditEventRepositoryInterface
+{
+    public function record(AuditEvent $event): int
+    {
+        throw new RuntimeException('audit write failed (simulated)');
+    }
+
+    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
+    {
+        return [];
+    }
+
+    public function countByOrganization(int $organizationId, ?string $eventType): int
+    {
+        return 0;
+    }
+}

--- a/tests/BankImport/ImportBankCsvUseCaseTest.php
+++ b/tests/BankImport/ImportBankCsvUseCaseTest.php
@@ -12,6 +12,7 @@ use NeneClear\BankImport\DuplicateBankImportException;
 use NeneClear\BankImport\ImportBankCsvInput;
 use NeneClear\BankImport\ImportBankCsvUseCase;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -47,10 +48,11 @@ final class ImportBankCsvUseCaseTest extends TestCase
         $this->audit = new InMemoryAuditEventRepository();
 
         $this->useCase = new ImportBankCsvUseCase(
-            $this->accounts,
-            $this->batches,
-            $this->transactions,
-            $this->audit,
+            new FakeTransactionManager(),
+            fn () => $this->accounts,
+            fn () => $this->batches,
+            fn () => $this->transactions,
+            fn () => $this->audit,
             new BankCsvParser(),
             new FixedClock(),
         );

--- a/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
+++ b/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
@@ -14,6 +14,7 @@ use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\BankImport\ReverseBankImportBatchInput;
 use NeneClear\BankImport\ReverseBankImportBatchUseCase;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -30,9 +31,10 @@ final class ReverseBankImportBatchUseCaseTest extends TestCase
         $this->transactions = new InMemoryBankTransactionRepository();
         $this->audit = new InMemoryAuditEventRepository();
         $this->useCase = new ReverseBankImportBatchUseCase(
-            $this->batches,
-            $this->transactions,
-            $this->audit,
+            new FakeTransactionManager(),
+            fn () => $this->batches,
+            fn () => $this->transactions,
+            fn () => $this->audit,
             new FixedClock(),
         );
     }

--- a/tests/Database/AuditAtomicityTest.php
+++ b/tests/Database/AuditAtomicityTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\BankAccountRepositoryInterface;
+use NeneClear\BankImport\BankCsvParser;
+use NeneClear\BankImport\BankImportBatchRepositoryInterface;
+use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\BankImport\ImportBankCsvInput;
+use NeneClear\BankImport\ImportBankCsvUseCase;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\BankImport\PdoBankImportBatchRepository;
+use NeneClear\BankImport\PdoBankTransactionRepository;
+use NeneClear\Tests\Audit\ThrowingAuditEventRepository;
+use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Proves the audit atomicity guarantee (Issue #122): when the audit record fails
+ * mid-use-case, the framework transaction rolls back the business writes too, so
+ * a state change can never be persisted without its audit event.
+ *
+ * Uses the real PdoDatabaseTransactionManager (via DatabaseTestKit) over a file
+ * SQLite database and repositories built from the transaction's executor.
+ */
+final class AuditAtomicityTest extends TestCase
+{
+    private const string CSV = "date,deposit,withdrawal,memo\n2026/04/20,110000,,ACME\n2026/04/22,50000,,TARO\n";
+
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-atomicity-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
+
+        SchemaFixture::createBankAccounts($this->query);
+        SchemaFixture::createBankImportBatches($this->query);
+        SchemaFixture::createBankTransactions($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+
+        (new PdoBankAccountRepository($this->query))->save(new BankAccount(
+            organizationId: 7,
+            bankName: 'Test Bank',
+            bankBranch: 'Main',
+            accountType: AccountType::Ordinary,
+            accountNumber: '123',
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        ));
+
+        // Build every repository from the transaction's executor so the rollback
+        // actually undoes the writes; the audit repository always throws.
+        $this->useCase = new ImportBankCsvUseCase(
+            $kit->transactionManager,
+            static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
+            static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
+            static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
+            static fn (DatabaseQueryExecutorInterface $tx): ThrowingAuditEventRepository => new ThrowingAuditEventRepository(),
+            new BankCsvParser(),
+            new FixedClock(),
+        );
+    }
+
+    private ImportBankCsvUseCase $useCase;
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function test_failed_audit_rolls_back_the_business_writes(): void
+    {
+        try {
+            $this->useCase->execute(new ImportBankCsvInput(
+                organizationId: 7,
+                bankAccountId: 1,
+                contents: self::CSV,
+                sourceFilename: 'april.csv',
+                actorUserId: 42,
+            ));
+            self::fail('Expected the simulated audit failure to propagate.');
+        } catch (RuntimeException $e) {
+            self::assertSame('audit write failed (simulated)', $e->getMessage());
+        }
+
+        // The batch, its transactions, and the audit event must all be absent:
+        // the transaction rolled back as one unit.
+        self::assertSame(0, $this->rowCount('bank_import_batches'), 'batch must be rolled back');
+        self::assertSame(0, $this->rowCount('bank_transactions'), 'transactions must be rolled back');
+        self::assertSame(0, $this->rowCount('audit_events'), 'no audit event persisted');
+    }
+
+    private function rowCount(string $table): int
+    {
+        $row = $this->query->fetchOne("SELECT COUNT(*) AS n FROM {$table}");
+
+        return (int) ($row['n'] ?? 0);
+    }
+}

--- a/tests/Database/ImportBankCsvPdoTest.php
+++ b/tests/Database/ImportBankCsvPdoTest.php
@@ -15,6 +15,7 @@ use NeneClear\BankImport\ImportBankCsvUseCase;
 use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\BankImport\PdoBankImportBatchRepository;
 use NeneClear\BankImport\PdoBankTransactionRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use NeneClear\Tests\Support\SchemaFixture;
 use PHPUnit\Framework\TestCase;
@@ -55,10 +56,11 @@ final class ImportBankCsvPdoTest extends TestCase
         $transactions = new PdoBankTransactionRepository($this->query);
 
         $this->useCase = new ImportBankCsvUseCase(
-            $accounts,
-            $batches,
-            $transactions,
-            new PdoAuditEventRepository($this->query),
+            new FakeTransactionManager(),
+            fn () => $accounts,
+            fn () => $batches,
+            fn () => $transactions,
+            fn () => new PdoAuditEventRepository($this->query),
             new BankCsvParser(),
             new FixedClock(),
         );

--- a/tests/Dunning/PauseDunningUseCaseTest.php
+++ b/tests/Dunning/PauseDunningUseCaseTest.php
@@ -7,6 +7,7 @@ namespace NeneClear\Tests\Dunning;
 use NeneClear\Dunning\PauseDunningUseCase;
 use NeneClear\Dunning\ResumeDunningUseCase;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -23,8 +24,8 @@ final class PauseDunningUseCaseTest extends TestCase
         $this->pauses = new InMemoryDunningPauseRepository();
         $this->audit = new InMemoryAuditEventRepository();
         $this->clock = new FixedClock('2026-06-01T10:00:00+00:00');
-        $this->pauseUseCase = new PauseDunningUseCase($this->pauses, $this->audit, $this->clock);
-        $this->resumeUseCase = new ResumeDunningUseCase($this->pauses, $this->audit, $this->clock);
+        $this->pauseUseCase = new PauseDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => $this->audit, $this->clock);
+        $this->resumeUseCase = new ResumeDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => $this->audit, $this->clock);
     }
 
     public function test_pause_creates_record_and_audit_event(): void

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -15,7 +15,9 @@ use NeneClear\InvoiceUpstream\InvoiceClientInfo;
 use NeneClear\InvoiceUpstream\InvoiceItem;
 use NeneClear\InvoiceUpstream\UpstreamInvoiceNotFoundException;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\NullQueryExecutor;
 use PHPUnit\Framework\TestCase;
 
 final class SendDunningUseCaseTest extends TestCase
@@ -35,11 +37,13 @@ final class SendDunningUseCaseTest extends TestCase
         $this->mailer = new SpyDunningMailer();
         $this->audit = new InMemoryAuditEventRepository();
         $this->useCase = new SendDunningUseCase(
-            $this->notices,
-            $this->clearSettings,
+            new FakeTransactionManager(),
+            new NullQueryExecutor(),
+            fn () => $this->notices,
+            fn () => $this->clearSettings,
             $this->invoiceClient,
             $this->mailer,
-            $this->audit,
+            fn () => $this->audit,
             new FixedClock('2026-05-31T09:00:00+00:00'),
             new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
         );

--- a/tests/Http/AuditHttpTest.php
+++ b/tests/Http/AuditHttpTest.php
@@ -28,7 +28,8 @@ final class AuditHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-audit-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
         SchemaFixture::createAuditEvents($query);
@@ -37,7 +38,7 @@ final class AuditHttpTest extends TestCase
         $users->save($this->user('admin@acme.example', Role::Admin, 7));
         $users->save($this->user('member@acme.example', Role::Member, 7));
 
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/AuthHttpTest.php
+++ b/tests/Http/AuthHttpTest.php
@@ -30,7 +30,8 @@ final class AuthHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-auth-', true) . '.sqlite';
-        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
         SchemaFixture::createUsers($this->query);
         SchemaFixture::createLoginAttempts($this->query);
         SchemaFixture::createAuditEvents($this->query);
@@ -43,7 +44,7 @@ final class AuthHttpTest extends TestCase
             organizationId: 7,
         ));
 
-        $this->app = ApplicationFactory::create(query: $this->query, jwtSecret: self::SECRET);
+        $this->app = ApplicationFactory::create(query: $this->query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/BankImportHttpTest.php
+++ b/tests/Http/BankImportHttpTest.php
@@ -32,7 +32,8 @@ final class BankImportHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-bankhttp-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
         SchemaFixture::createBankAccounts($query);
@@ -58,7 +59,7 @@ final class BankImportHttpTest extends TestCase
             csvHeaderRows: 1,
         ));
 
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/ClearSettingsHttpTest.php
+++ b/tests/Http/ClearSettingsHttpTest.php
@@ -30,7 +30,8 @@ final class ClearSettingsHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-settings-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
 
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
@@ -43,7 +44,7 @@ final class ClearSettingsHttpTest extends TestCase
         $users->save($this->user('viewer@acme.example', Role::Viewer));
 
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/DunningHttpTest.php
+++ b/tests/Http/DunningHttpTest.php
@@ -32,7 +32,8 @@ final class DunningHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-dunning-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
 
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
@@ -48,7 +49,7 @@ final class DunningHttpTest extends TestCase
         $users->save($this->user('viewer@acme.example', Role::Viewer));
 
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/ExportCsvHttpTest.php
+++ b/tests/Http/ExportCsvHttpTest.php
@@ -36,7 +36,8 @@ final class ExportCsvHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-export-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
 
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
@@ -70,7 +71,7 @@ final class ExportCsvHttpTest extends TestCase
         ));
 
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/OrganizationCrudHttpTest.php
+++ b/tests/Http/OrganizationCrudHttpTest.php
@@ -30,7 +30,8 @@ final class OrganizationCrudHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-orgcrud-', true) . '.sqlite';
-        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
         SchemaFixture::createOrganizations($this->query);
         SchemaFixture::createUsers($this->query);
         SchemaFixture::createLoginAttempts($this->query);
@@ -52,7 +53,7 @@ final class OrganizationCrudHttpTest extends TestCase
             organizationId: 1,
         ));
 
-        $this->app = ApplicationFactory::create(query: $this->query, jwtSecret: self::SECRET);
+        $this->app = ApplicationFactory::create(query: $this->query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/ReconciliationHttpTest.php
+++ b/tests/Http/ReconciliationHttpTest.php
@@ -35,7 +35,8 @@ final class ReconciliationHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-recon-http-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
 
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
@@ -66,7 +67,7 @@ final class ReconciliationHttpTest extends TestCase
         ));
 
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Http/UserCrudHttpTest.php
+++ b/tests/Http/UserCrudHttpTest.php
@@ -29,7 +29,8 @@ final class UserCrudHttpTest extends TestCase
     protected function setUp(): void
     {
         $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-usercrud-', true) . '.sqlite';
-        $query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
         SchemaFixture::createUsers($query);
         SchemaFixture::createLoginAttempts($query);
         SchemaFixture::createAuditEvents($query);
@@ -39,7 +40,7 @@ final class UserCrudHttpTest extends TestCase
         $users->save($this->user('member@acme.example', Role::Member, 7));
         $this->crossTenantUserId = $users->save($this->user('other@org8.example', Role::Member, 8));
 
-        $this->app = ApplicationFactory::create(query: $query, jwtSecret: self::SECRET);
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
         $this->psr17 = new Psr17Factory();
     }
 

--- a/tests/Organization/CreateOrganizationUseCaseTest.php
+++ b/tests/Organization/CreateOrganizationUseCaseTest.php
@@ -9,6 +9,7 @@ use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\Organization;
 use NeneClear\Organization\OrganizationAlreadyExistsException;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +24,7 @@ final class CreateOrganizationUseCaseTest extends TestCase
 
     private function useCase(InMemoryOrganizationRepository $repo): CreateOrganizationUseCase
     {
-        return new CreateOrganizationUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new CreateOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_creates_organization_and_returns_output_with_id(): void

--- a/tests/Organization/DeleteOrganizationUseCaseTest.php
+++ b/tests/Organization/DeleteOrganizationUseCaseTest.php
@@ -8,6 +8,7 @@ use NeneClear\Organization\DeleteOrganizationUseCase;
 use NeneClear\Organization\Organization;
 use NeneClear\Organization\OrganizationNotFoundException;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +23,7 @@ final class DeleteOrganizationUseCaseTest extends TestCase
 
     private function useCase(InMemoryOrganizationRepository $repo): DeleteOrganizationUseCase
     {
-        return new DeleteOrganizationUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new DeleteOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_deletes_existing_organization(): void

--- a/tests/Reconciliation/ApplyCreditUseCaseTest.php
+++ b/tests/Reconciliation/ApplyCreditUseCaseTest.php
@@ -13,6 +13,8 @@ use NeneClear\Reconciliation\ClientCreditNotFoundException;
 use NeneClear\Reconciliation\ClientCreditStatus;
 use NeneClear\Reconciliation\CreditExceedsRemainingException;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
+use NeneClear\Tests\Support\NullQueryExecutor;
 use PHPUnit\Framework\TestCase;
 
 final class ApplyCreditUseCaseTest extends TestCase
@@ -28,9 +30,11 @@ final class ApplyCreditUseCaseTest extends TestCase
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
         $this->audit = new InMemoryAuditEventRepository();
         $this->useCase = new ApplyCreditUseCase(
-            $this->clientCredits,
+            new FakeTransactionManager(),
+            new NullQueryExecutor(),
+            fn () => $this->clientCredits,
             $this->invoiceClient,
-            $this->audit,
+            fn () => $this->audit,
         );
     }
 

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -18,7 +18,9 @@ use NeneClear\Reconciliation\ConfirmMatchUseCase;
 use NeneClear\Reconciliation\ReconciliationStatus;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
 use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\NullQueryExecutor;
 use PHPUnit\Framework\TestCase;
 
 final class ConfirmMatchUseCaseTest extends TestCase
@@ -38,11 +40,13 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
         $this->audit = new InMemoryAuditEventRepository();
         $this->useCase = new ConfirmMatchUseCase(
-            $this->transactions,
-            $this->reconciliations,
-            $this->clientCredits,
+            new FakeTransactionManager(),
+            new NullQueryExecutor(),
+            fn () => $this->transactions,
+            fn () => $this->reconciliations,
+            fn () => $this->clientCredits,
             $this->invoiceClient,
-            $this->audit,
+            fn () => $this->audit,
             new FixedClock(),
         );
     }

--- a/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
+++ b/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
@@ -19,7 +19,9 @@ use NeneClear\Reconciliation\ReverseReconciliationInput;
 use NeneClear\Reconciliation\ReverseReconciliationUseCase;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
 use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\NullQueryExecutor;
 use PHPUnit\Framework\TestCase;
 
 final class ReverseReconciliationUseCaseTest extends TestCase
@@ -42,19 +44,23 @@ final class ReverseReconciliationUseCaseTest extends TestCase
 
         $clock = new FixedClock();
         $this->confirmUseCase = new ConfirmMatchUseCase(
-            $this->transactions,
-            $this->reconciliations,
-            $this->clientCredits,
+            new FakeTransactionManager(),
+            new NullQueryExecutor(),
+            fn () => $this->transactions,
+            fn () => $this->reconciliations,
+            fn () => $this->clientCredits,
             $this->invoiceClient,
-            $this->audit,
+            fn () => $this->audit,
             $clock,
         );
         $this->reverseUseCase = new ReverseReconciliationUseCase(
-            $this->reconciliations,
-            $this->clientCredits,
-            $this->transactions,
+            new FakeTransactionManager(),
+            new NullQueryExecutor(),
+            fn () => $this->reconciliations,
+            fn () => $this->clientCredits,
+            fn () => $this->transactions,
             $this->invoiceClient,
-            $this->audit,
+            fn () => $this->audit,
             $clock,
         );
     }

--- a/tests/Support/FakeTransactionManager.php
+++ b/tests/Support/FakeTransactionManager.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Support;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+/**
+ * Transaction manager double for unit tests.
+ *
+ * Runs the unit of work inline (no real transaction) and passes the supplied
+ * executor to the callback. Unit-test use cases build their repositories from
+ * in-memory doubles that ignore the executor, so a {@see NullQueryExecutor} is
+ * passed by default. Atomicity (real rollback) is covered by integration tests
+ * that use the framework's PdoDatabaseTransactionManager.
+ */
+final readonly class FakeTransactionManager implements DatabaseTransactionManagerInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $executor = new NullQueryExecutor(),
+    ) {
+    }
+
+    public function transactional(callable $callback): mixed
+    {
+        return $callback($this->executor);
+    }
+}

--- a/tests/Support/NullQueryExecutor.php
+++ b/tests/Support/NullQueryExecutor.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Support;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * A query executor that throws on every call.
+ *
+ * Used by {@see FakeTransactionManager} for unit tests whose repository factories
+ * ignore the executor (they return in-memory doubles). If a unit test ever reaches
+ * a real SQL call through this executor, that is a wiring mistake and should fail
+ * loudly rather than hit a database.
+ *
+ * @phpstan-import-type SqlParameters from DatabaseQueryExecutorInterface
+ * @phpstan-import-type SqlRow from DatabaseQueryExecutorInterface
+ */
+final class NullQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    public function execute(string $sql, array $parameters = []): int
+    {
+        throw new LogicException('NullQueryExecutor cannot run SQL; unit-test repository factories must ignore the executor.');
+    }
+
+    public function insert(string $sql, array $parameters = []): int
+    {
+        throw new LogicException('NullQueryExecutor cannot run SQL; unit-test repository factories must ignore the executor.');
+    }
+
+    public function lastInsertId(): int
+    {
+        throw new LogicException('NullQueryExecutor cannot run SQL; unit-test repository factories must ignore the executor.');
+    }
+
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        throw new LogicException('NullQueryExecutor cannot run SQL; unit-test repository factories must ignore the executor.');
+    }
+
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        throw new LogicException('NullQueryExecutor cannot run SQL; unit-test repository factories must ignore the executor.');
+    }
+}

--- a/tests/User/CreateUserUseCaseTest.php
+++ b/tests/User/CreateUserUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\CreateUserInput;
 use NeneClear\User\CreateUserUseCase;
@@ -25,7 +26,7 @@ final class CreateUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): CreateUserUseCase
     {
-        return new CreateUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new CreateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_with_password_creates_active_user(): void

--- a/tests/User/DeleteUserUseCaseTest.php
+++ b/tests/User/DeleteUserUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\DeleteUserUseCase;
 use NeneClear\User\User;
@@ -24,7 +25,7 @@ final class DeleteUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): DeleteUserUseCase
     {
-        return new DeleteUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new DeleteUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     private function seedUser(int $orgId = 7): InMemoryUserRepository

--- a/tests/User/UpdateUserUseCaseTest.php
+++ b/tests/User/UpdateUserUseCaseTest.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\User;
 
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
+use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\UpdateUserInput;
 use NeneClear\User\UpdateUserUseCase;
@@ -25,7 +26,7 @@ final class UpdateUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): UpdateUserUseCase
     {
-        return new UpdateUserUseCase($repo, $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new UpdateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     private function seedUser(int $orgId = 7): InMemoryUserRepository


### PR DESCRIPTION
## Purpose
Close the audit **atomicity** gap: every mutating use case recorded its `AuditEvent` as a separate, autocommitted statement *after* the business writes, so a failure in between could leave a committed change with **no audit record** (and multi-write use cases half-applied). This also deviated from `nene2-compliance.md` §(169/239), which mandates transactions via `DatabaseTransactionManagerInterface`. Closes #122.

## Change summary
- **DI:** wire `DatabaseTransactionManagerInterface` through `ApplicationFactory` (+ guard: required when the DB is configured) and `public_html/index.php` (executor and transaction manager share one connection factory).
- **13 use cases** refactored to build repositories from the transaction executor and wrap **DB writes + audit** in `transactional()` (all-or-nothing): Organization Create/Delete · User Create/Update/Delete · BankImport Import/Reverse · Reconciliation Confirm/Reverse/ApplyCredit · Dunning Send/Pause/Resume · ClearSettings Update.
- **External side effects stay outside the transaction:** Invoice upstream `createPayment`/`voidPayment` run *before* the transactional block; the dunning email is sent *after* the notice + audit commit (record-then-send, so a delivery failure leaves an honest "attempted" trail rather than an un-recordable already-sent email).
- **6 ServiceProviders** updated to inject the transaction manager + repository factories (`Closure(DatabaseQueryExecutorInterface): XRepositoryInterface`).

## Tests
- New doubles: `FakeTransactionManager` (runs the unit of work inline) + `NullQueryExecutor`.
- Adapted the 13 use-case unit tests and 9 HTTP tests (pass `DatabaseTestKit`'s `transactionManager`).
- **New `AuditAtomicityTest`**: with the real `PdoDatabaseTransactionManager`, a forced audit-write failure rolls back the business writes — asserts the batch, its transactions, and the audit event are all absent.

## Verification
- Backend **237** (6 skipped), PHPStan level 8 clean, PHP-CS-Fixer clean.
- Frontend **27** (type-check + lint + Vitest). Backend-only change; no HTTP contract change, so E2E is unaffected (CI confirms).

## Notes / follow-up
- `LoginUseCase` (login_succeeded/failed) is append-only auth logging, not a business mutation, and is intentionally left as-is.
- The record-then-send ordering for dunning means a post-commit SMTP failure surfaces as a 500 while the notice/audit are recorded; delivery retry is out of scope here.