### PR TITLE
feat(audit): adopt NeNe Invoice audit ideas — entity_type/id, AuditRecorder, presenter snapshots, read filters (#124)

### DIFF
--- a/database/migrations/20260606120000_add_entity_to_audit_events.php
+++ b/database/migrations/20260606120000_add_entity_to_audit_events.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Adds structured subject identification to the audit trail (Issue #124):
+ * `entity_type` (the kind of record changed) and `entity_id` (which one), so a
+ * single record's history is queryable. Mirrors nene-invoice ADR 0008 while
+ * keeping Clear's `audit_events` naming.
+ */
+final class AddEntityToAuditEvents extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('audit_events')
+            ->addColumn('entity_type', 'string', ['limit' => 64, 'null' => false, 'default' => '', 'after' => 'event_type'])
+            ->addColumn('entity_id', 'integer', ['null' => true, 'default' => null, 'after' => 'entity_type'])
+            ->addIndex(['entity_type', 'entity_id'])
+            ->update();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -121,6 +121,24 @@ Mutations that create a resource carry only `after`; deletions carry only
 `before`; in-place changes carry both. Payload keys reuse canonical field names
 (§3); booleans follow the `is_` rule (e.g. `is_paused`).
 
+### Audit entity types (`audit_events.entity_type`, exact strings)
+
+Each audit event also records the **subject record** it changed via
+`entity_type` + `entity_id` (Issue #124), so a single record's history is
+queryable. `entity_id` is null when there is no single subject (e.g. a failed
+login). New events MUST map to one of these registered `entity_type` values:
+
+| `entity_type` | `entity_id` is | Used by |
+| --- | --- | --- |
+| `bank_import_batch` | `bank_import_batch_id` | `bank_import`, `bank_import_batch_reversed` |
+| `payment_reconciliation` | `payment_reconciliation_id` | `reconciliation_confirmed`, `reconciliation_reversed` |
+| `client_credit` | `client_credit_id` | `client_credit_applied` |
+| `dunning_notice` | `dunning_notice_id` | `dunning_sent` |
+| `invoice` | upstream `invoice_id` | `dunning_paused`, `dunning_resumed` |
+| `user` | `user_id` (null on failed login) | `user_created/updated/deleted`, `login_succeeded`, `login_failed` |
+| `organization` | `organization_id` | `organization_created`, `organization_deleted` |
+| `clear_settings` | owning `organization_id` | `clear_settings_updated` |
+
 ---
 
 ## 3. Canonical field / column names (snake_case)
@@ -155,6 +173,8 @@ Mutations that create a resource carry only `after`; deletions carry only
 | Foreign keys (Clear-owned) | `bank_transaction_id`, `bank_import_batch_id`, `bank_account_id`, `payment_reconciliation_id`, `client_credit_id` | camelCase, abbreviations |
 | Actor / timestamps | `imported_by`, `imported_at`, `confirmed_by`, `confirmed_at`, `reversed_at`, `sent_by`, `sent_at`, `created_by`, `created_at` | `issue_date`, `paidAt`, `actor_id` (use role-specific names above) |
 | Audit event type | `event_type` | `type`, `action` |
+| Audit subject type | `entity_type` | `entity`, `target_type`, `resource` |
+| Audit subject id | `entity_id` | `target_id`, `resource_id` |
 | Audit actor / time | `actor_user_id`, `occurred_at` | `user_id`, `actor_id`, `created_at` (on audit rows) |
 | Login failure reason (audit) | `failure_reason` | `reason`, `error`, `code` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1154,6 +1154,17 @@ paths:
           description: Filter by exact event type (see terminology registry §audit event types).
           schema:
             type: string
+        - name: entity_type
+          in: query
+          description: Filter by subject record type (see terminology registry §audit entity types).
+          schema:
+            type: string
+        - name: entity_id
+          in: query
+          description: Filter by subject record id (use together with entity_type).
+          schema:
+            type: integer
+            format: int64
       responses:
         '200':
           description: A page of audit events.
@@ -1961,7 +1972,7 @@ components:
 
     AuditEvent:
       type: object
-      required: [audit_event_id, organization_id, event_type, occurred_at, payload]
+      required: [audit_event_id, organization_id, event_type, entity_type, occurred_at, payload]
       properties:
         audit_event_id:
           type: integer
@@ -1972,6 +1983,14 @@ components:
         event_type:
           type: string
           description: Exact event type string (see terminology registry §audit event types).
+        entity_type:
+          type: string
+          description: Subject record type (see terminology registry §audit entity types).
+        entity_id:
+          type: integer
+          format: int64
+          nullable: true
+          description: Subject record id; null when there is no single subject (e.g. failed login).
         actor_user_id:
           type: integer
           format: int64

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -144,6 +144,9 @@ export interface AuditEvent {
   audit_event_id: number
   organization_id: number
   event_type: AuditEventType
+  // Subject record the event changed (terminology §audit entity types).
+  entity_type: string
+  entity_id: number | null
   actor_user_id: number
   occurred_at: string
   payload: Record<string, unknown>

--- a/src/Audit/AuditEvent.php
+++ b/src/Audit/AuditEvent.php
@@ -6,6 +6,11 @@ namespace NeneClear\Audit;
 
 /**
  * Immutable audit record (compliance §6). Append-only; never updated or deleted.
+ *
+ * `entityType` / `entityId` identify the record the operation changed (ADR 0008
+ * in nene-invoice; adopted here keeping Clear's `audit_events` naming), so a
+ * single record's history is queryable. `entityId` is null when the subject has
+ * no single id (e.g. a failed login).
  */
 final readonly class AuditEvent
 {
@@ -15,6 +20,8 @@ final readonly class AuditEvent
     public function __construct(
         public int $organizationId,
         public string $eventType,
+        public string $entityType,
+        public ?int $entityId,
         public int $actorUserId,
         public string $occurredAt,
         public array $payload,

--- a/src/Audit/AuditEventRepositoryInterface.php
+++ b/src/Audit/AuditEventRepositoryInterface.php
@@ -9,12 +9,25 @@ interface AuditEventRepositoryInterface
     public function record(AuditEvent $event): int;
 
     /**
-     * Tenant-scoped, newest first. `$eventType` filters to a single
-     * `event_type` when non-null (see terminology §2 for the closed set).
+     * Tenant-scoped, newest first. Each non-null filter narrows the result:
+     * `$eventType` to a single `event_type` (terminology §2), `$entityType` /
+     * `$entityId` to a single subject record.
      *
      * @return list<AuditEvent>
      */
-    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array;
+    public function findByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+        int $limit,
+        int $offset,
+    ): array;
 
-    public function countByOrganization(int $organizationId, ?string $eventType): int;
+    public function countByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+    ): int;
 }

--- a/src/Audit/AuditEventResponse.php
+++ b/src/Audit/AuditEventResponse.php
@@ -15,6 +15,8 @@ final readonly class AuditEventResponse
             'audit_event_id' => $event->id,
             'organization_id' => $event->organizationId,
             'event_type' => $event->eventType,
+            'entity_type' => $event->entityType,
+            'entity_id' => $event->entityId,
             'actor_user_id' => $event->actorUserId,
             'occurred_at' => $event->occurredAt,
             'payload' => $event->payload,

--- a/src/Audit/AuditRecorder.php
+++ b/src/Audit/AuditRecorder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+final readonly class AuditRecorder implements AuditRecorderInterface
+{
+    public function __construct(
+        private AuditEventRepositoryInterface $repository,
+    ) {
+    }
+
+    public function record(
+        int $organizationId,
+        int $actorUserId,
+        string $occurredAt,
+        string $eventType,
+        string $entityType,
+        ?int $entityId,
+        array $payload,
+    ): int {
+        return $this->repository->record(new AuditEvent(
+            organizationId: $organizationId,
+            eventType: $eventType,
+            entityType: $entityType,
+            entityId: $entityId,
+            actorUserId: $actorUserId,
+            occurredAt: $occurredAt,
+            payload: $payload,
+        ));
+    }
+}

--- a/src/Audit/AuditRecorderInterface.php
+++ b/src/Audit/AuditRecorderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+/**
+ * Records one mutating operation in the audit trail (ADR 0008 in nene-invoice,
+ * adopted here). Use cases call this instead of building {@see AuditEvent}s by
+ * hand, so who/what/before/after recording stays uniform across domains.
+ *
+ * The recorder is built from the active transaction's executor, so the audit
+ * write commits or rolls back together with the business writes (Issue #122).
+ */
+interface AuditRecorderInterface
+{
+    /**
+     * @param string                $entityType subject record type (terminology §audit entity types)
+     * @param ?int                  $entityId   subject record id (null when there is no single id)
+     * @param array<string, mixed>  $payload    before/after snapshot (no secrets)
+     */
+    public function record(
+        int $organizationId,
+        int $actorUserId,
+        string $occurredAt,
+        string $eventType,
+        string $entityType,
+        ?int $entityId,
+        array $payload,
+    ): int;
+}

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -26,6 +26,14 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                     ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
                 ),
             )
+            // Non-transactional recorder (e.g. login auditing). Transactional use
+            // cases build their own recorder from the transaction executor instead.
+            ->set(
+                AuditRecorderInterface::class,
+                static fn (ContainerInterface $c): AuditRecorderInterface => new AuditRecorder(
+                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                ),
+            )
             ->set(
                 AuditRouteRegistrar::class,
                 static fn (ContainerInterface $c): AuditRouteRegistrar => new AuditRouteRegistrar(

--- a/src/Audit/ListAuditEventsHandler.php
+++ b/src/Audit/ListAuditEventsHandler.php
@@ -24,10 +24,18 @@ final readonly class ListAuditEventsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        $eventTypeParam = $request->getQueryParams()['event_type'] ?? null;
+        $query = $request->getQueryParams();
+
+        $eventTypeParam = $query['event_type'] ?? null;
         $eventType = is_string($eventTypeParam) && $eventTypeParam !== '' ? $eventTypeParam : null;
 
-        $items = $this->auditEvents->findByOrganization($organizationId, $eventType, $page->limit, $page->offset);
+        $entityTypeParam = $query['entity_type'] ?? null;
+        $entityType = is_string($entityTypeParam) && $entityTypeParam !== '' ? $entityTypeParam : null;
+
+        $entityIdParam = $query['entity_id'] ?? null;
+        $entityId = is_numeric($entityIdParam) ? (int) $entityIdParam : null;
+
+        $items = $this->auditEvents->findByOrganization($organizationId, $eventType, $entityType, $entityId, $page->limit, $page->offset);
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
@@ -36,7 +44,7 @@ final readonly class ListAuditEventsHandler
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->auditEvents->countByOrganization($organizationId, $eventType),
+            total: $this->auditEvents->countByOrganization($organizationId, $eventType, $entityType, $entityId),
         ))->toArray());
     }
 }

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -8,7 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final readonly class PdoAuditEventRepository implements AuditEventRepositoryInterface
 {
-    private const string COLUMNS = 'id, organization_id, event_type, actor_user_id, occurred_at, payload_json';
+    private const string COLUMNS = 'id, organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -18,11 +18,13 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
     public function record(AuditEvent $event): int
     {
         $this->query->execute(
-            'INSERT INTO audit_events (organization_id, event_type, actor_user_id, occurred_at, payload_json) '
-            . 'VALUES (?, ?, ?, ?, ?)',
+            'INSERT INTO audit_events (organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?)',
             [
                 $event->organizationId,
                 $event->eventType,
+                $event->entityType,
+                $event->entityId,
                 $event->actorUserId,
                 $event->occurredAt,
                 json_encode($event->payload, JSON_THROW_ON_ERROR),
@@ -32,32 +34,63 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
         return $this->query->lastInsertId();
     }
 
-    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
-    {
-        if ($eventType === null) {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE organization_id = ? '
-                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $limit, $offset],
-            );
-        } else {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE organization_id = ? AND event_type = ? '
-                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $eventType, $limit, $offset],
-            );
-        }
+    public function findByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+        int $limit,
+        int $offset,
+    ): array {
+        [$where, $params] = $this->filter($organizationId, $eventType, $entityType, $entityId);
+        $params[] = $limit;
+        $params[] = $offset;
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE ' . $where
+            . ' ORDER BY id DESC LIMIT ? OFFSET ?',
+            $params,
+        );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countByOrganization(int $organizationId, ?string $eventType): int
-    {
-        $row = $eventType === null
-            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE organization_id = ?', [$organizationId])
-            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE organization_id = ? AND event_type = ?', [$organizationId, $eventType]);
+    public function countByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+    ): int {
+        [$where, $params] = $this->filter($organizationId, $eventType, $entityType, $entityId);
+
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE ' . $where, $params);
 
         return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @return array{0: string, 1: list<string|int>}
+     */
+    private function filter(int $organizationId, ?string $eventType, ?string $entityType, ?int $entityId): array
+    {
+        $clauses = ['organization_id = ?'];
+        /** @var list<string|int> $params */
+        $params = [$organizationId];
+
+        if ($eventType !== null) {
+            $clauses[] = 'event_type = ?';
+            $params[] = $eventType;
+        }
+        if ($entityType !== null) {
+            $clauses[] = 'entity_type = ?';
+            $params[] = $entityType;
+        }
+        if ($entityId !== null) {
+            $clauses[] = 'entity_id = ?';
+            $params[] = $entityId;
+        }
+
+        return [implode(' AND ', $clauses), $params];
     }
 
     /**
@@ -71,6 +104,8 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
         return new AuditEvent(
             organizationId: (int) $row['organization_id'],
             eventType: (string) $row['event_type'],
+            entityType: (string) $row['entity_type'],
+            entityId: $row['entity_id'] !== null ? (int) $row['entity_id'] : null,
             actorUserId: (int) $row['actor_user_id'],
             occurredAt: (string) $row['occurred_at'],
             payload: $payload,

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -12,7 +12,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\User\UserRepositoryInterface;
@@ -51,7 +51,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): LoginUseCaseInterface => new LoginUseCase(
                     ServiceResolver::get($c, UserRepositoryInterface::class),
                     ServiceResolver::get($c, TokenIssuerInterface::class),
-                    ServiceResolver::get($c, AuditEventRepositoryInterface::class),
+                    ServiceResolver::get($c, AuditRecorderInterface::class),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/Auth/LoginUseCase.php
+++ b/src/Auth/LoginUseCase.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Auth;
 
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\User\UserRepositoryInterface;
 use NeneClear\User\UserStatus;
 
@@ -21,7 +20,7 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
     public function __construct(
         private UserRepositoryInterface $users,
         private TokenIssuerInterface $tokens,
-        private AuditEventRepositoryInterface $auditEvents,
+        private AuditRecorderInterface $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -38,34 +37,38 @@ final readonly class LoginUseCase implements LoginUseCaseInterface
             // not tenant-scoped (organization 0): recording the would-be org —
             // like recording the password — could leak whether the account
             // exists. Only the attempted email and a coarse reason are kept.
-            $this->auditEvents->record(new AuditEvent(
-                organizationId: 0,
-                eventType: 'login_failed',
-                actorUserId: 0,
-                occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-                payload: [
+            $this->auditRecorder->record(
+                0,
+                0,
+                $this->clock->now()->format('Y-m-d H:i:s'),
+                'login_failed',
+                'user',
+                null,
+                [
                     'after' => [
                         'email' => $input->email,
                         'failure_reason' => 'invalid_credentials',
                     ],
                 ],
-            ));
+            );
 
             throw new InvalidCredentialsException();
         }
 
-        $this->auditEvents->record(new AuditEvent(
-            organizationId: $user->organizationId ?? 0,
-            eventType: 'login_succeeded',
-            actorUserId: (int) $user->id,
-            occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-            payload: [
+        $this->auditRecorder->record(
+            $user->organizationId ?? 0,
+            (int) $user->id,
+            $this->clock->now()->format('Y-m-d H:i:s'),
+            'login_succeeded',
+            'user',
+            (int) $user->id,
+            [
                 'after' => [
                     'user_id' => (int) $user->id,
                     'email' => $user->email,
                 ],
             ],
-        ));
+        );
 
         return new LoginOutput(
             token: $this->tokens->issueForUser($user),

--- a/src/BankImport/BankImportServiceProvider.php
+++ b/src/BankImport/BankImportServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
@@ -50,7 +51,7 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
                     static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     new BankCsvParser(),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
@@ -61,7 +62,7 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/BankImport/ImportBankCsvUseCase.php
+++ b/src/BankImport/ImportBankCsvUseCase.php
@@ -8,8 +8,7 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterface
 {
@@ -17,14 +16,14 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
      * @param Closure(DatabaseQueryExecutorInterface): BankAccountRepositoryInterface $bankAccounts
      * @param Closure(DatabaseQueryExecutorInterface): BankImportBatchRepositoryInterface $batches
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $bankAccounts,
         private Closure $batches,
         private Closure $transactions,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private BankCsvParser $parser,
         private ClockInterface $clock,
     ) {
@@ -40,7 +39,7 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
                 $bankAccounts = ($this->bankAccounts)($tx);
                 $batches = ($this->batches)($tx);
                 $transactions = ($this->transactions)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 $account = $bankAccounts->findById($input->bankAccountId);
 
@@ -81,12 +80,14 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
                     ));
                 }
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'bank_import',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'bank_import',
+                    'bank_import_batch',
+                    $batchId,
+                    [
                         'after' => [
                             'bank_import_batch_id' => $batchId,
                             'file_hash' => $fileHash,
@@ -94,7 +95,7 @@ final readonly class ImportBankCsvUseCase implements ImportBankCsvUseCaseInterfa
                             'source_filename' => $input->sourceFilename,
                         ],
                     ],
-                ));
+                );
 
                 return new ImportBankCsvOutput(
                     bankImportBatchId: $batchId,

--- a/src/BankImport/ReverseBankImportBatchUseCase.php
+++ b/src/BankImport/ReverseBankImportBatchUseCase.php
@@ -8,21 +8,20 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportBatchUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): BankImportBatchRepositoryInterface $batches
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $batches,
         private Closure $transactions,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -35,7 +34,7 @@ final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportB
             function (DatabaseQueryExecutorInterface $tx) use ($input): ReverseBankImportBatchOutput {
                 $batches = ($this->batches)($tx);
                 $transactions = ($this->transactions)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 $batch = $batches->findById($input->batchId);
 
@@ -65,12 +64,14 @@ final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportB
                 $transactions->voidByBatchId($input->batchId);
                 $batches->reverseById($input->batchId, $now, $input->reversalReason);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'bank_import_batch_reversed',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'bank_import_batch_reversed',
+                    'bank_import_batch',
+                    $input->batchId,
+                    [
                         'bank_import_batch_id' => $input->batchId,
                         'before' => [
                             'status' => 'imported',
@@ -82,7 +83,7 @@ final readonly class ReverseBankImportBatchUseCase implements ReverseBankImportB
                             'rows_voided' => $unmatchedCount,
                         ],
                     ],
-                ));
+                );
 
                 return new ReverseBankImportBatchOutput(
                     batchId: $input->batchId,

--- a/src/ClearSettings/ClearSettingsServiceProvider.php
+++ b/src/ClearSettings/ClearSettingsServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\BankAccountRepositoryInterface;
 use NeneClear\BankImport\PdoBankAccountRepository;
@@ -40,7 +41,7 @@ final readonly class ClearSettingsServiceProvider implements ServiceProviderInte
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
                     static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/ClearSettings/UpdateClearSettingsUseCase.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCase.php
@@ -8,8 +8,7 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\BankImport\BankAccountRepositoryInterface;
 
 /**
@@ -23,13 +22,13 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
     /**
      * @param Closure(DatabaseQueryExecutorInterface): ClearSettingsRepositoryInterface $settings
      * @param Closure(DatabaseQueryExecutorInterface): BankAccountRepositoryInterface $bankAccounts
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $settings,
         private Closure $bankAccounts,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -45,7 +44,7 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
             function (DatabaseQueryExecutorInterface $ex) use ($input, $now): ClearSettings {
                 $settingsRepo = ($this->settings)($ex);
                 $bankAccounts = ($this->bankAccounts)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $before = $settingsRepo->findByOrganization($input->organizationId);
 
@@ -71,16 +70,18 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
                         $input->dunningMinIntervalDays,
                     );
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'clear_settings_updated',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'clear_settings_updated',
+                    'clear_settings',
+                    $input->organizationId,
+                    [
                         'before' => $before !== null ? self::snapshot($before) : null,
                         'after' => self::snapshot($updated),
                     ],
-                ));
+                );
 
                 return $updated;
             },

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
@@ -52,7 +53,7 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                     static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                     ServiceResolver::get($c, DunningMailerInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                     ServiceResolver::get($c, MessageCatalog::class),
                     static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
@@ -63,7 +64,7 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): PauseDunningUseCase => new PauseDunningUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -72,7 +73,7 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): ResumeDunningUseCase => new ResumeDunningUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/Dunning/PauseDunningUseCase.php
+++ b/src/Dunning/PauseDunningUseCase.php
@@ -8,19 +8,18 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class PauseDunningUseCase
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $pauses,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -33,7 +32,7 @@ final readonly class PauseDunningUseCase
         return $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $ex) use ($organizationId, $invoiceId, $actorUserId, $reason, $now): DunningPause {
                 $pauses = ($this->pauses)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $existing = $pauses->findActiveByInvoice($organizationId, $invoiceId);
                 if ($existing !== null) {
@@ -50,17 +49,19 @@ final readonly class PauseDunningUseCase
 
                 $id = $pauses->save($pause);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $organizationId,
-                    eventType: 'dunning_paused',
-                    actorUserId: $actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $organizationId,
+                    $actorUserId,
+                    $now,
+                    'dunning_paused',
+                    'invoice',
+                    $invoiceId,
+                    [
                         'invoice_id' => $invoiceId,
                         'before' => ['is_paused' => false],
                         'after' => ['is_paused' => true, 'reason' => $reason],
                     ],
-                ));
+                );
 
                 return new DunningPause(
                     organizationId: $pause->organizationId,

--- a/src/Dunning/ResumeDunningUseCase.php
+++ b/src/Dunning/ResumeDunningUseCase.php
@@ -8,19 +8,18 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class ResumeDunningUseCase
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $pauses,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -33,21 +32,23 @@ final readonly class ResumeDunningUseCase
         $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $ex) use ($organizationId, $invoiceId, $actorUserId, $now): void {
                 $pauses = ($this->pauses)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $pauses->resumeByInvoice($organizationId, $invoiceId, $actorUserId, $now);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $organizationId,
-                    eventType: 'dunning_resumed',
-                    actorUserId: $actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $organizationId,
+                    $actorUserId,
+                    $now,
+                    'dunning_resumed',
+                    'invoice',
+                    $invoiceId,
+                    [
                         'invoice_id' => $invoiceId,
                         'before' => ['is_paused' => true],
                         'after' => ['is_paused' => false],
                     ],
-                ));
+                );
             },
         );
     }

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -10,8 +10,7 @@ use DateTimeImmutable;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
 use NeneClear\I18n\Locale;
 use NeneClear\I18n\MessageCatalog;
@@ -26,7 +25,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
      * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads
      * @param Closure(DatabaseQueryExecutorInterface): DunningNoticeRepositoryInterface $notices
      * @param Closure(DatabaseQueryExecutorInterface): ClearSettingsRepositoryInterface $clearSettings
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      * @param ?Closure(DatabaseQueryExecutorInterface): DunningPauseRepositoryInterface $pauses
      */
     public function __construct(
@@ -36,7 +35,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
         private Closure $clearSettings,
         private InvoiceUpstreamClientInterface $invoiceClient,
         private DunningMailerInterface $mailer,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
         private MessageCatalog $catalog,
         private ?Closure $pauses = null,
@@ -107,16 +106,18 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
         $noticeId = $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $ex) use ($input, $invoice, $client, $notice, $nowStr, $lastNotice): int {
                 $notices = ($this->notices)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $noticeId = $notices->save($notice);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'dunning_sent',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $nowStr,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $nowStr,
+                    'dunning_sent',
+                    'dunning_notice',
+                    $noticeId,
+                    [
                         'dunning_notice_id' => $noticeId,
                         'invoice_id' => $input->invoiceId,
                         'before' => [
@@ -132,7 +133,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                             'template_version' => self::TEMPLATE_VERSION,
                         ],
                     ],
-                ));
+                );
 
                 return $noticeId;
             },

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -8,19 +8,18 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizations
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $organizations,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -33,7 +32,7 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
         return $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $tx) use ($input): CreateOrganizationOutput {
                 $organizations = ($this->organizations)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 if ($organizations->existsBySlug($input->slug)) {
                     throw new OrganizationAlreadyExistsException($input->slug);
@@ -43,19 +42,21 @@ final readonly class CreateOrganizationUseCase implements CreateOrganizationUseC
 
                 // Audit: a tenant lifecycle event is scoped to the affected tenant, so it
                 // surfaces in that organization's own audit trail.
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $id,
-                    eventType: 'organization_created',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-                    payload: [
+                $auditRecorder->record(
+                    $id,
+                    $input->actorUserId,
+                    $this->clock->now()->format('Y-m-d H:i:s'),
+                    'organization_created',
+                    'organization',
+                    $id,
+                    [
                         'after' => [
                             'organization_id' => $id,
                             'slug' => $input->slug,
                             'name' => $input->name,
                         ],
                     ],
-                ));
+                );
 
                 return new CreateOrganizationOutput(id: $id, slug: $input->slug, name: $input->name);
             },

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -8,19 +8,18 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): OrganizationRepositoryInterface $organizations
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $organizations,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -32,7 +31,7 @@ final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseC
         $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $tx) use ($id, $actorUserId): void {
                 $organizations = ($this->organizations)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 $organization = $organizations->findById($id);
 
@@ -45,19 +44,21 @@ final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseC
 
                 // Audit: deletion carries the prior state (`before` only), scoped to the
                 // now-removed tenant.
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $id,
-                    eventType: 'organization_deleted',
-                    actorUserId: $actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $id,
+                    $actorUserId,
+                    $now,
+                    'organization_deleted',
+                    'organization',
+                    $id,
+                    [
                         'before' => [
                             'organization_id' => $id,
                             'slug' => $organization->slug,
                             'name' => $organization->name,
                         ],
                     ],
-                ));
+                );
             },
         );
     }

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
@@ -48,7 +49,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 static fn (ContainerInterface $c): CreateOrganizationUseCaseInterface => new CreateOrganizationUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): OrganizationRepositoryInterface => new PdoOrganizationRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -57,7 +58,7 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 static fn (ContainerInterface $c): DeleteOrganizationUseCaseInterface => new DeleteOrganizationUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): OrganizationRepositoryInterface => new PdoOrganizationRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/src/Reconciliation/ApplyCreditUseCase.php
+++ b/src/Reconciliation/ApplyCreditUseCase.php
@@ -7,8 +7,7 @@ namespace NeneClear\Reconciliation;
 use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 
 final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
@@ -16,14 +15,14 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
     /**
      * @param DatabaseQueryExecutorInterface $reader executor for pre-transaction reads (before upstream calls)
      * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private DatabaseQueryExecutorInterface $reader,
         private Closure $clientCredits,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
     ) {
     }
 
@@ -60,16 +59,18 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
         return $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $ex) use ($input, $credit): ApplyCreditOutput {
                 $clientCredits = ($this->clientCredits)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $updated = $clientCredits->applyAmount($input->organizationId, $input->creditId, $input->amountCents);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'client_credit_applied',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $credit->createdAt,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $credit->createdAt,
+                    'client_credit_applied',
+                    'client_credit',
+                    $input->creditId,
+                    [
                         'client_credit_id' => $input->creditId,
                         'invoice_id' => $input->invoiceId,
                         'amount_cents' => $input->amountCents,
@@ -82,7 +83,7 @@ final readonly class ApplyCreditUseCase implements ApplyCreditUseCaseInterface
                             'status' => $updated->status->value,
                         ],
                     ],
-                ));
+                );
 
                 return new ApplyCreditOutput(credit: $updated);
             },

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -8,8 +8,7 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\BankTransactionStatus;
@@ -22,7 +21,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
      * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
      * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
@@ -31,7 +30,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
         private Closure $reconciliations,
         private Closure $clientCredits,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -100,7 +99,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 $reconciliations = ($this->reconciliations)($ex);
                 $transactions = ($this->transactions)($ex);
                 $clientCredits = ($this->clientCredits)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $reconciliationId = $reconciliations->save(new Reconciliation(
                     organizationId: $input->organizationId,
@@ -149,12 +148,14 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                     ));
                 }
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'reconciliation_confirmed',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'reconciliation_confirmed',
+                    'payment_reconciliation',
+                    $reconciliationId,
+                    [
                         'before' => [
                             'bank_transaction_status' => $tx->status->value,
                             'bank_transaction_amount_cents' => $tx->amountCents,
@@ -181,7 +182,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                             ),
                         ],
                     ],
-                ));
+                );
 
                 return new ConfirmMatchOutput(reconciliationId: $reconciliationId);
             },

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\PdoBankTransactionRepository;
@@ -57,7 +58,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     static fn (DatabaseQueryExecutorInterface $tx): ReconciliationRepositoryInterface => new PdoReconciliationRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -70,7 +71,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -81,7 +82,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                 ),
             )
             ->set(

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -8,8 +8,7 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
@@ -21,7 +20,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
      * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
      * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
@@ -30,7 +29,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
         private Closure $clientCredits,
         private Closure $transactions,
         private InvoiceUpstreamClientInterface $invoiceClient,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -70,18 +69,20 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
                 $reconciliations = ($this->reconciliations)($ex);
                 $transactions = ($this->transactions)($ex);
                 $clientCredits = ($this->clientCredits)($ex);
-                $auditEvents = ($this->auditEvents)($ex);
+                $auditRecorder = ($this->auditRecorder)($ex);
 
                 $reconciliations->reverseById($input->reconciliationId, $now, $input->reversalReason);
                 $transactions->updateStatusById($input->organizationId, $reconciliation->bankTransactionId, BankTransactionStatus::Unmatched);
                 $clientCredits->voidByReconciliation($input->reconciliationId);
 
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId,
-                    eventType: 'reconciliation_reversed',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $now,
-                    payload: [
+                $auditRecorder->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'reconciliation_reversed',
+                    'payment_reconciliation',
+                    $input->reconciliationId,
+                    [
                         'payment_reconciliation_id' => $input->reconciliationId,
                         'before' => [
                             'status' => 'confirmed',
@@ -102,7 +103,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
                             'reversal_reason' => $input->reversalReason,
                         ],
                     ],
-                ));
+                );
 
                 return new ReverseReconciliationOutput(reconciliationId: $input->reconciliationId);
             },

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -8,20 +8,19 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Auth\Role;
 
 final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $users,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -45,7 +44,7 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
         return $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $tx) use ($input, $status, $hash): User {
                 $users = ($this->users)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 if ($users->existsByEmail($input->email)) {
                     throw new UserAlreadyExistsException($input->email);
@@ -66,22 +65,16 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
                 }
 
                 // Audit: account creation carries `after` only (no prior state). The
-                // password hash is never recorded — only who/what changed.
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $input->organizationId ?? 0,
-                    eventType: 'user_created',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-                    payload: [
-                        'after' => [
-                            'user_id' => $created->id,
-                            'email' => $created->email,
-                            'role' => $created->role->value,
-                            'status' => $created->status->value,
-                            'organization_id' => $created->organizationId,
-                        ],
-                    ],
-                ));
+                // snapshot reuses UserResponse, so the password hash is never recorded.
+                $auditRecorder->record(
+                    $input->organizationId ?? 0,
+                    $input->actorUserId,
+                    $this->clock->now()->format('Y-m-d H:i:s'),
+                    'user_created',
+                    'user',
+                    $created->id,
+                    ['after' => UserResponse::toArray($created)],
+                );
 
                 return $created;
             },

--- a/src/User/DeleteUserUseCase.php
+++ b/src/User/DeleteUserUseCase.php
@@ -8,19 +8,18 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 
 final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $users,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -32,7 +31,7 @@ final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
         $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $tx) use ($id, $callerOrganizationId, $actorUserId): void {
                 $users = ($this->users)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 $user = $users->findById($id);
 
@@ -45,21 +44,15 @@ final readonly class DeleteUserUseCase implements DeleteUserUseCaseInterface
 
                 // Audit: deletion carries the prior state (`before` only) so the removed
                 // account's identity and privileges remain reconstructable.
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $user->organizationId ?? 0,
-                    eventType: 'user_deleted',
-                    actorUserId: $actorUserId,
-                    occurredAt: $now,
-                    payload: [
-                        'before' => [
-                            'user_id' => $user->id,
-                            'email' => $user->email,
-                            'role' => $user->role->value,
-                            'status' => $user->status->value,
-                            'organization_id' => $user->organizationId,
-                        ],
-                    ],
-                ));
+                $auditRecorder->record(
+                    $user->organizationId ?? 0,
+                    $actorUserId,
+                    $now,
+                    'user_deleted',
+                    'user',
+                    $user->id,
+                    ['before' => UserResponse::toArray($user)],
+                );
             },
         );
     }

--- a/src/User/UpdateUserUseCase.php
+++ b/src/User/UpdateUserUseCase.php
@@ -8,20 +8,19 @@ use Closure;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Http\ClockInterface;
-use NeneClear\Audit\AuditEvent;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Auth\Role;
 
 final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 {
     /**
      * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
-     * @param Closure(DatabaseQueryExecutorInterface): AuditEventRepositoryInterface $auditEvents
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $users,
-        private Closure $auditEvents,
+        private Closure $auditRecorder,
         private ClockInterface $clock,
     ) {
     }
@@ -33,7 +32,7 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
         return $this->transactionManager->transactional(
             function (DatabaseQueryExecutorInterface $tx) use ($input): User {
                 $users = ($this->users)($tx);
-                $auditEvents = ($this->auditEvents)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
 
                 $existing = $users->findById($input->id);
 
@@ -60,12 +59,14 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
 
                 // Audit: in-place change carries both the prior and the resulting role
                 // and status, so a role escalation or deactivation is fully reconstructable.
-                $auditEvents->record(new AuditEvent(
-                    organizationId: $existing->organizationId ?? 0,
-                    eventType: 'user_updated',
-                    actorUserId: $input->actorUserId,
-                    occurredAt: $this->clock->now()->format('Y-m-d H:i:s'),
-                    payload: [
+                $auditRecorder->record(
+                    $existing->organizationId ?? 0,
+                    $input->actorUserId,
+                    $this->clock->now()->format('Y-m-d H:i:s'),
+                    'user_updated',
+                    'user',
+                    $existing->id,
+                    [
                         'user_id' => $existing->id,
                         'email' => $existing->email,
                         'before' => [
@@ -77,7 +78,7 @@ final readonly class UpdateUserUseCase implements UpdateUserUseCaseInterface
                             'status' => $updated->status->value,
                         ],
                     ],
-                ));
+                );
 
                 return $updated;
             },

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -10,7 +10,8 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Audit\AuditEventRepositoryInterface;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
@@ -48,7 +49,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): CreateUserUseCaseInterface => new CreateUserUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -57,7 +58,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): UpdateUserUseCaseInterface => new UpdateUserUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
@@ -66,7 +67,7 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $c): DeleteUserUseCaseInterface => new DeleteUserUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): AuditEventRepositoryInterface => new PdoAuditEventRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/tests/Audit/InMemoryAuditEventRepository.php
+++ b/tests/Audit/InMemoryAuditEventRepository.php
@@ -18,6 +18,8 @@ final class InMemoryAuditEventRepository implements AuditEventRepositoryInterfac
         $this->events[] = new AuditEvent(
             organizationId: $event->organizationId,
             eventType: $event->eventType,
+            entityType: $event->entityType,
+            entityId: $event->entityId,
             actorUserId: $event->actorUserId,
             occurredAt: $event->occurredAt,
             payload: $event->payload,
@@ -27,12 +29,20 @@ final class InMemoryAuditEventRepository implements AuditEventRepositoryInterfac
         return $id;
     }
 
-    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
-    {
+    public function findByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+        int $limit,
+        int $offset,
+    ): array {
         $matches = array_values(array_filter(
             $this->events,
             static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
-                && ($eventType === null || $e->eventType === $eventType),
+                && ($eventType === null || $e->eventType === $eventType)
+                && ($entityType === null || $e->entityType === $entityType)
+                && ($entityId === null || $e->entityId === $entityId),
         ));
 
         // Newest first, mirroring the SQL `ORDER BY id DESC`.
@@ -41,12 +51,18 @@ final class InMemoryAuditEventRepository implements AuditEventRepositoryInterfac
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId, ?string $eventType): int
-    {
+    public function countByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+    ): int {
         return count(array_filter(
             $this->events,
             static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
-                && ($eventType === null || $e->eventType === $eventType),
+                && ($eventType === null || $e->eventType === $eventType)
+                && ($entityType === null || $e->entityType === $entityType)
+                && ($entityId === null || $e->entityId === $entityId),
         ));
     }
 }

--- a/tests/Audit/ThrowingAuditEventRepository.php
+++ b/tests/Audit/ThrowingAuditEventRepository.php
@@ -22,13 +22,23 @@ final class ThrowingAuditEventRepository implements AuditEventRepositoryInterfac
         throw new RuntimeException('audit write failed (simulated)');
     }
 
-    public function findByOrganization(int $organizationId, ?string $eventType, int $limit, int $offset): array
-    {
+    public function findByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+        int $limit,
+        int $offset,
+    ): array {
         return [];
     }
 
-    public function countByOrganization(int $organizationId, ?string $eventType): int
-    {
+    public function countByOrganization(
+        int $organizationId,
+        ?string $eventType,
+        ?string $entityType,
+        ?int $entityId,
+    ): int {
         return 0;
     }
 }

--- a/tests/Auth/LoginUseCaseTest.php
+++ b/tests/Auth/LoginUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Auth;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Auth\InvalidCredentialsException;
 use NeneClear\Auth\JwtTokenService;
 use NeneClear\Auth\LoginInput;
@@ -30,7 +31,7 @@ final class LoginUseCaseTest extends TestCase
         return new LoginUseCase(
             $users,
             new JwtTokenService(secret: 'test-secret-test-secret-32chars!'),
-            $this->audit,
+            new AuditRecorder($this->audit),
             new FixedClock('2026-06-01T10:00:00+00:00'),
         );
     }

--- a/tests/BankImport/ImportBankCsvUseCaseTest.php
+++ b/tests/BankImport/ImportBankCsvUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\BankImport;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\BankImport\AccountType;
 use NeneClear\BankImport\BankAccount;
 use NeneClear\BankImport\BankAccountNotFoundException;
@@ -52,7 +53,7 @@ final class ImportBankCsvUseCaseTest extends TestCase
             fn () => $this->accounts,
             fn () => $this->batches,
             fn () => $this->transactions,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             new BankCsvParser(),
             new FixedClock(),
         );

--- a/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
+++ b/tests/BankImport/ReverseBankImportBatchUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\BankImport;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\BankImport\BankImportBatch;
 use NeneClear\BankImport\BankImportBatchAlreadyReversedException;
 use NeneClear\BankImport\BankImportBatchHasMatchedLinesException;
@@ -34,7 +35,7 @@ final class ReverseBankImportBatchUseCaseTest extends TestCase
             new FakeTransactionManager(),
             fn () => $this->batches,
             fn () => $this->transactions,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             new FixedClock(),
         );
     }

--- a/tests/Database/AuditAtomicityTest.php
+++ b/tests/Database/AuditAtomicityTest.php
@@ -6,6 +6,8 @@ namespace NeneClear\Tests\Database;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\BankImport\AccountType;
 use NeneClear\BankImport\BankAccount;
 use NeneClear\BankImport\BankAccountRepositoryInterface;
@@ -70,7 +72,7 @@ final class AuditAtomicityTest extends TestCase
             static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
             static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
             static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
-            static fn (DatabaseQueryExecutorInterface $tx): ThrowingAuditEventRepository => new ThrowingAuditEventRepository(),
+            static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new ThrowingAuditEventRepository()),
             new BankCsvParser(),
             new FixedClock(),
         );

--- a/tests/Database/ImportBankCsvPdoTest.php
+++ b/tests/Database/ImportBankCsvPdoTest.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\Database;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\BankImport\AccountType;
 use NeneClear\BankImport\BankAccount;
@@ -60,7 +61,7 @@ final class ImportBankCsvPdoTest extends TestCase
             fn () => $accounts,
             fn () => $batches,
             fn () => $transactions,
-            fn () => new PdoAuditEventRepository($this->query),
+            fn () => new AuditRecorder(new PdoAuditEventRepository($this->query)),
             new BankCsvParser(),
             new FixedClock(),
         );

--- a/tests/Dunning/PauseDunningUseCaseTest.php
+++ b/tests/Dunning/PauseDunningUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Dunning;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Dunning\PauseDunningUseCase;
 use NeneClear\Dunning\ResumeDunningUseCase;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
@@ -24,8 +25,8 @@ final class PauseDunningUseCaseTest extends TestCase
         $this->pauses = new InMemoryDunningPauseRepository();
         $this->audit = new InMemoryAuditEventRepository();
         $this->clock = new FixedClock('2026-06-01T10:00:00+00:00');
-        $this->pauseUseCase = new PauseDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => $this->audit, $this->clock);
-        $this->resumeUseCase = new ResumeDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => $this->audit, $this->clock);
+        $this->pauseUseCase = new PauseDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => new AuditRecorder($this->audit), $this->clock);
+        $this->resumeUseCase = new ResumeDunningUseCase(new FakeTransactionManager(), fn () => $this->pauses, fn () => new AuditRecorder($this->audit), $this->clock);
     }
 
     public function test_pause_creates_record_and_audit_event(): void

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Dunning;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\ClearSettings\ClearSettings;
 use NeneClear\Dunning\DunningTooFrequentException;
 use NeneClear\Dunning\InvoiceAlreadyPaidException;
@@ -43,7 +44,7 @@ final class SendDunningUseCaseTest extends TestCase
             fn () => $this->clearSettings,
             $this->invoiceClient,
             $this->mailer,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             new FixedClock('2026-05-31T09:00:00+00:00'),
             new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
         );

--- a/tests/Http/AuditHttpTest.php
+++ b/tests/Http/AuditHttpTest.php
@@ -145,6 +145,34 @@ final class AuditHttpTest extends TestCase
         self::assertSame(['user_created'], array_values($types));
     }
 
+    public function test_entity_type_is_recorded_and_filterable(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $created = $this->decode($this->request('POST', '/admin/users', $token, [
+            'email' => 'new@acme.example',
+            'role' => 'member',
+            'password' => 'a-strong-password',
+        ]));
+        $newUserId = $created['user_id'];
+
+        // The user_created event carries entity_type=user and entity_id=<new id>.
+        $body = $this->decode($this->request('GET', '/admin/audit-events?event_type=user_created', $token));
+        self::assertSame('user', $body['items'][0]['entity_type']);
+        self::assertSame($newUserId, $body['items'][0]['entity_id']);
+
+        // entity_type + entity_id narrow to that record's history only.
+        $filtered = $this->decode($this->request(
+            'GET',
+            "/admin/audit-events?entity_type=user&entity_id={$newUserId}",
+            $token,
+        ));
+        self::assertNotEmpty($filtered['items']);
+        foreach ($filtered['items'] as $item) {
+            self::assertSame('user', $item['entity_type']);
+            self::assertSame($newUserId, $item['entity_id']);
+        }
+    }
+
     public function test_member_lacks_capability_to_read_audit_trail(): void
     {
         $token = $this->tokenFor('member@acme.example');

--- a/tests/Organization/CreateOrganizationUseCaseTest.php
+++ b/tests/Organization/CreateOrganizationUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Organization;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Organization\CreateOrganizationInput;
 use NeneClear\Organization\CreateOrganizationUseCase;
 use NeneClear\Organization\Organization;
@@ -24,7 +25,7 @@ final class CreateOrganizationUseCaseTest extends TestCase
 
     private function useCase(InMemoryOrganizationRepository $repo): CreateOrganizationUseCase
     {
-        return new CreateOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new CreateOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_creates_organization_and_returns_output_with_id(): void

--- a/tests/Organization/DeleteOrganizationUseCaseTest.php
+++ b/tests/Organization/DeleteOrganizationUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Organization;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Organization\DeleteOrganizationUseCase;
 use NeneClear\Organization\Organization;
 use NeneClear\Organization\OrganizationNotFoundException;
@@ -23,7 +24,7 @@ final class DeleteOrganizationUseCaseTest extends TestCase
 
     private function useCase(InMemoryOrganizationRepository $repo): DeleteOrganizationUseCase
     {
-        return new DeleteOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new DeleteOrganizationUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_deletes_existing_organization(): void

--- a/tests/Reconciliation/ApplyCreditUseCaseTest.php
+++ b/tests/Reconciliation/ApplyCreditUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Reconciliation;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceItem;
 use NeneClear\Reconciliation\ApplyCreditInput;
@@ -34,7 +35,7 @@ final class ApplyCreditUseCaseTest extends TestCase
             new NullQueryExecutor(),
             fn () => $this->clientCredits,
             $this->invoiceClient,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
         );
     }
 

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Reconciliation;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionStatus;
@@ -46,7 +47,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
             fn () => $this->reconciliations,
             fn () => $this->clientCredits,
             $this->invoiceClient,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             new FixedClock(),
         );
     }

--- a/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
+++ b/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\Reconciliation;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
@@ -50,7 +51,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
             fn () => $this->reconciliations,
             fn () => $this->clientCredits,
             $this->invoiceClient,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             $clock,
         );
         $this->reverseUseCase = new ReverseReconciliationUseCase(
@@ -60,7 +61,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
             fn () => $this->clientCredits,
             fn () => $this->transactions,
             $this->invoiceClient,
-            fn () => $this->audit,
+            fn () => new AuditRecorder($this->audit),
             $clock,
         );
     }

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -130,6 +130,8 @@ final class SchemaFixture
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 organization_id INTEGER NOT NULL,
                 event_type TEXT NOT NULL,
+                entity_type TEXT NOT NULL DEFAULT \'\',
+                entity_id INTEGER,
                 actor_user_id INTEGER NOT NULL,
                 occurred_at TEXT NOT NULL,
                 payload_json TEXT NOT NULL

--- a/tests/User/CreateUserUseCaseTest.php
+++ b/tests/User/CreateUserUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\User;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
 use NeneClear\Tests\Support\FakeTransactionManager;
@@ -26,7 +27,7 @@ final class CreateUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): CreateUserUseCase
     {
-        return new CreateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new CreateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     public function test_with_password_creates_active_user(): void

--- a/tests/User/DeleteUserUseCaseTest.php
+++ b/tests/User/DeleteUserUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\User;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
 use NeneClear\Tests\Support\FakeTransactionManager;
@@ -25,7 +26,7 @@ final class DeleteUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): DeleteUserUseCase
     {
-        return new DeleteUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new DeleteUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     private function seedUser(int $orgId = 7): InMemoryUserRepository

--- a/tests/User/UpdateUserUseCaseTest.php
+++ b/tests/User/UpdateUserUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Tests\User;
 
+use NeneClear\Audit\AuditRecorder;
 use NeneClear\Auth\Role;
 use NeneClear\Tests\Audit\InMemoryAuditEventRepository;
 use NeneClear\Tests\Support\FakeTransactionManager;
@@ -26,7 +27,7 @@ final class UpdateUserUseCaseTest extends TestCase
 
     private function useCase(InMemoryUserRepository $repo): UpdateUserUseCase
     {
-        return new UpdateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => $this->audit, new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new UpdateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
     }
 
     private function seedUser(int $orgId = 7): InMemoryUserRepository


### PR DESCRIPTION
## Purpose
Adopt four audit-logging ideas from the sibling `nene-invoice` (ADR 0008) into Clear, **keeping Clear's binding naming** (`audit_events` / `event_type` / closed event-type set — no rename). Closes #124. Builds on the atomicity work in #122.

## Changes
1. **`entity_type` / `entity_id` columns** on `audit_events` (migration + `(entity_type, entity_id)` index; SchemaFixture mirrors it). Every event records its subject record, so a single record's history is queryable. `entity_type` values registered in `terminology.md` (§audit entity types).
2. **`AuditRecorder`** (`AuditRecorderInterface` + `AuditRecorder`) replaces hand-built `new AuditEvent(...)` at all 14 call sites. Built from the transaction executor, so the audit write stays atomic with the business writes (#122).
3. **Presenter-based snapshots**: `user_created` / `user_deleted` reuse `UserResponse` (password hash can never reach the trail); curated cross-entity diffs (reconciliation / dunning / bank-import) keep their intentional shape (partial application, as scoped).
4. **Read filters**: `GET /admin/audit-events` filters by `entity_type` / `entity_id` (alongside `event_type`); reflected in OpenAPI + the `AuditEvent` schema.

`LoginUseCase` records via the recorder too (`entity_type=user`; `entity_id` null on failed login). Frontend `AuditEvent` type gains `entity_type` / `entity_id`.

## Out of scope (as agreed)
- No rename of `audit_events`/`event_type`. No edits to `nene-invoice`. No `before_json`/`after_json` column split (Clear keeps single `payload`).

## Verification
- Spec/route parity preserved; OpenAPI YAML + `AuditEvent` schema updated.
- Backend **238** (6 skipped) incl. new `entity_type`/`entity_id` filter test and the #122 atomicity test; PHPStan level 8 clean; PHP-CS-Fixer clean.
- Frontend **27** (type-check + lint + Vitest).

## Migration note
`database/migrations/20260606120000_add_entity_to_audit_events.php` adds the columns (`entity_type` NOT NULL default '', `entity_id` nullable). Existing rows backfill to `''`/null; all new events set them.