### PR TITLE
feat(frontend): rename 操作履歴 → 監査ログ + admin-only audit log (#126)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -28,6 +28,35 @@ export function isAuthenticated(): boolean {
   return getToken() !== null
 }
 
+/**
+ * The current user's role, decoded from the stored JWT's `role` claim. This is
+ * for UI gating only — the backend capability checks remain the source of truth.
+ * Returns null when there is no token or it is not a decodable JWT (e.g. a test
+ * stub token).
+ */
+export function getUserRole(): string | null {
+  const token = getToken()
+  if (token === null) return null
+
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+
+  try {
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    b64 += '='.repeat((4 - (b64.length % 4)) % 4)
+    const claims = JSON.parse(atob(b64)) as { role?: unknown }
+    return typeof claims.role === 'string' ? claims.role : null
+  } catch {
+    return null
+  }
+}
+
+/** Admin-tier roles (admin or the cross-tenant superadmin). */
+export function isAdmin(): boolean {
+  const role = getUserRole()
+  return role === 'admin' || role === 'superadmin'
+}
+
 async function request<T>(
   method: string,
   path: string,

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom'
-import { isAuthenticated } from '@/api/client'
+import { isAuthenticated, isAdmin } from '@/api/client'
 import AppShell from '@/components/AppShell'
 import LoginPage from '@/pages/login/LoginPage'
 import DashboardPage from '@/pages/dashboard/DashboardPage'
@@ -15,6 +15,14 @@ import AuditLogPage from '@/pages/audit/AuditLogPage'
 function RequireAuth({ children }: { children: React.ReactNode }) {
   if (!isAuthenticated()) {
     return <Navigate to="/login" replace />
+  }
+  return <>{children}</>
+}
+
+/** Administrators-only routes (e.g. the audit log). Non-admins are sent home. */
+function RequireAdmin({ children }: { children: React.ReactNode }) {
+  if (!isAdmin()) {
+    return <Navigate to="/admin" replace />
   }
   return <>{children}</>
 }
@@ -40,7 +48,7 @@ export const router = createBrowserRouter([
       { path: 'dunning', element: <DunningPage /> },
       { path: 'settings', element: <SettingsPage /> },
       { path: 'users', element: <UsersPage /> },
-      { path: 'audit-log', element: <AuditLogPage /> },
+      { path: 'audit-log', element: <RequireAdmin><AuditLogPage /></RequireAdmin> },
     ],
   },
   {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,10 +1,12 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { useTranslation } from '@/hooks/useTranslation'
-import { clearToken } from '@/api/client'
+import { clearToken, isAdmin } from '@/api/client'
 import { Icon, LogoMark } from '@/components/ui'
 import type { MessageKey } from '@/locales'
 
-const NAV: Array<{ to: string; labelKey: MessageKey; icon: string; end?: boolean; badge?: number }> = [
+type NavEntry = { to: string; labelKey: MessageKey; icon: string; end?: boolean; badge?: number; adminOnly?: boolean }
+
+const NAV: NavEntry[] = [
   { to: '/admin', labelKey: 'nav.dashboard', icon: 'grid', end: true },
   { to: '/admin/bank-import', labelKey: 'nav.bankImport', icon: 'import' },
   { to: '/admin/bank-transactions', labelKey: 'bankTransaction.title', icon: 'table' },
@@ -13,10 +15,11 @@ const NAV: Array<{ to: string; labelKey: MessageKey; icon: string; end?: boolean
   { to: '/admin/dunning', labelKey: 'nav.dunning', icon: 'bell' },
 ]
 
-const ADMIN_NAV: Array<{ to: string; labelKey: MessageKey; icon: string }> = [
+const ADMIN_NAV: NavEntry[] = [
   { to: '/admin/settings', labelKey: 'nav.settings', icon: 'gear' },
   { to: '/admin/users', labelKey: 'nav.users', icon: 'users' },
-  { to: '/admin/audit-log', labelKey: 'nav.auditLog', icon: 'clock' },
+  // The audit log is administrators-only (backend gates it behind manage_users).
+  { to: '/admin/audit-log', labelKey: 'nav.auditLog', icon: 'clock', adminOnly: true },
 ]
 
 function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; label: string; badge?: number; end?: boolean }) {
@@ -36,6 +39,8 @@ function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; la
 export default function AppShell() {
   const { t, locale, switchLocale } = useTranslation()
   const navigate = useNavigate()
+  const admin = isAdmin()
+  const adminNav = ADMIN_NAV.filter(item => !item.adminOnly || admin)
 
   function handleLogout() {
     clearToken()
@@ -58,7 +63,7 @@ export default function AppShell() {
             <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} badge={item.badge} end={item.end} />
           ))}
           <div className="side-sect">{t('nav.section.admin')}</div>
-          {ADMIN_NAV.map(item => (
+          {adminNav.map(item => (
             <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} />
           ))}
         </nav>

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -20,7 +20,7 @@ export const en: Record<MessageKey, string> = {
   'nav.dunning': 'Dunning',
   'nav.settings': 'Settings',
   'nav.users': 'Users',
-  'nav.auditLog': 'Audit Log',
+  'nav.auditLog': 'Audit logs',
   'nav.logout': 'Sign out',
 
   // ── Login ──
@@ -251,7 +251,7 @@ export const en: Record<MessageKey, string> = {
   'users.status.invited': 'Invited',
 
   // ── Audit log (operation history) ──
-  'audit.title': 'Audit Log',
+  'audit.title': 'Audit logs',
   'audit.subtitle': 'An audit trail recording who changed what, when, and how (before/after) for every operation.',
   'audit.filter.event': 'Event type',
   'audit.filter.all': 'All operations',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -16,7 +16,7 @@ export const ja = {
   'nav.dunning': '督促',
   'nav.settings': '設定',
   'nav.users': 'ユーザー管理',
-  'nav.auditLog': '操作履歴',
+  'nav.auditLog': '監査ログ',
   'nav.logout': 'ログアウト',
 
   // ── Login ──
@@ -247,7 +247,7 @@ export const ja = {
   'users.status.invited': '招待中',
 
   // ── Audit log (operation history) ──
-  'audit.title': '操作履歴',
+  'audit.title': '監査ログ',
   'audit.subtitle': 'すべての操作について、誰が・いつ・何を・どう変えたか（変更前後）を追跡する監査ログです。',
   'audit.filter.event': 'イベント種別',
   'audit.filter.all': 'すべての操作',


### PR DESCRIPTION
## Purpose
Align the audit feature's name across the NeNe series and restrict it to administrators in the UI. Closes #126.

## Changes
- **Naming (matches `nene-invoice`):** side-menu + page title now read **監査ログ** (ja) / **Audit logs** (en) — was 操作履歴 / "Audit Log".
- **Admin-only view:** the backend already gates `GET /admin/audit-events` behind `manage_users` (admin + superadmin). The UI now matches:
  - `getUserRole()` / `isAdmin()` decode the `role` claim from the stored JWT (UI gating only; server stays the source of truth).
  - the 監査ログ side-menu item is hidden from non-admins.
  - `/admin/audit-log` is wrapped in `RequireAdmin` (non-admins are redirected home).

## Out of scope
- No backend capability change (audit is already admin-only).
- Other admin nav items (users/settings) unchanged.

## Verification
- Frontend **27** (type-check + lint + Vitest); **E2E 43** — all green.
- Backend untouched (no PHP changes).