### PR TITLE
feat(bank-transactions, audit): column sort + audit filters/sort — phase 2 (#130)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -553,6 +553,13 @@ paths:
           in: query
           schema:
             type: string
+        - name: sort_by
+          in: query
+          description: "Sort column: value_date | amount_cents | counterparty_text | status."
+          schema: { type: string }
+        - name: sort_dir
+          in: query
+          schema: { type: string, enum: [asc, desc] }
       responses:
         '200':
           description: A page of bank transactions.
@@ -1192,6 +1199,24 @@ paths:
           schema:
             type: integer
             format: int64
+        - name: actor_user_id
+          in: query
+          schema: { type: integer, format: int64 }
+        - name: occurred_from
+          in: query
+          description: Inclusive lower bound on occurred_at (YYYY-MM-DD).
+          schema: { type: string, format: date }
+        - name: occurred_to
+          in: query
+          description: Inclusive upper bound on occurred_at (YYYY-MM-DD).
+          schema: { type: string, format: date }
+        - name: sort_by
+          in: query
+          description: "Sort column: occurred_at | event_type | entity_type | actor_user_id."
+          schema: { type: string }
+        - name: sort_dir
+          in: query
+          schema: { type: string, enum: [asc, desc] }
       responses:
         '200':
           description: A page of audit events.

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -79,6 +79,8 @@ export interface BankTransactionFilter {
   amount_min_cents?: number
   amount_max_cents?: number
   counterparty?: string
+  sortBy?: string
+  sortDir?: string
   limit?: number
   offset?: number
 }
@@ -91,6 +93,8 @@ export function listBankTransactions(filter: BankTransactionFilter, signal?: Abo
   if (filter.amount_min_cents != null) q.set('amount_min_cents', String(filter.amount_min_cents))
   if (filter.amount_max_cents != null) q.set('amount_max_cents', String(filter.amount_max_cents))
   if (filter.counterparty) q.set('counterparty', filter.counterparty)
+  if (filter.sortBy) q.set('sort_by', filter.sortBy)
+  if (filter.sortDir) q.set('sort_dir', filter.sortDir)
   q.set('limit', String(filter.limit ?? 50))
   q.set('offset', String(filter.offset ?? 0))
   return api.get<ListEnvelope<BankTransaction>>(`${BASE}/bank-transactions?${q}`, signal)
@@ -188,9 +192,25 @@ export function listDunningNotices(params: { limit?: number; offset?: number }, 
 }
 
 // --- Audit trail (admin) ---
-export function listAuditEvents(params: { eventType?: string; limit?: number; offset?: number }, signal?: AbortSignal) {
+export interface AuditQuery {
+  eventType?: string
+  actorUserId?: string
+  occurredFrom?: string
+  occurredTo?: string
+  sortBy?: string
+  sortDir?: string
+  limit?: number
+  offset?: number
+}
+
+export function listAuditEvents(params: AuditQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
   if (params.eventType) q.set('event_type', params.eventType)
+  if (params.actorUserId) q.set('actor_user_id', params.actorUserId)
+  if (params.occurredFrom) q.set('occurred_from', params.occurredFrom)
+  if (params.occurredTo) q.set('occurred_to', params.occurredTo)
+  if (params.sortBy) q.set('sort_by', params.sortBy)
+  if (params.sortDir) q.set('sort_dir', params.sortDir)
   return api.get<ListEnvelope<AuditEvent>>(`${BASE}/audit-events?${q}`, signal)
 }
 

--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -2,8 +2,8 @@ import { Fragment, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listAuditEvents } from '@/api/endpoints'
 import type { AuditEvent, AuditEventType } from '@/types'
-import { StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead } from '@/components/ui'
-import type { StatusMeta } from '@/components/ui'
+import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead, DatePicker, SortableTh, nextSort } from '@/components/ui'
+import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { formatDateTime } from '@/utils/format'
 
@@ -68,20 +68,31 @@ function EventDetail({ event }: { event: AuditEvent }) {
 export default function AuditLogPage() {
   const { t } = useTranslation()
   const [eventType, setEventType] = useState('')
-  const [applied, setApplied] = useState<{ eventType: string; offset: number }>({ eventType: '', offset: 0 })
+  const [actor, setActor] = useState('')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [applied, setApplied] = useState<{ eventType: string; actor: string; from: string; to: string; offset: number }>({ eventType: '', actor: '', from: '', to: '', offset: 0 })
+  const [sort, setSort] = useState<SortState>({ by: 'occurred_at', dir: 'desc' })
   const [expanded, setExpanded] = useState<ReadonlySet<number>>(new Set())
 
   const auditQ = useQuery({
-    queryKey: ['audit-events', applied],
+    queryKey: ['audit-events', applied, sort],
     queryFn: ({ signal }) => listAuditEvents({
       eventType: applied.eventType || undefined,
+      actorUserId: applied.actor || undefined,
+      occurredFrom: applied.from ? applied.from.replace(/\//g, '-') : undefined,
+      occurredTo: applied.to ? applied.to.replace(/\//g, '-') : undefined,
+      sortBy: sort.by,
+      sortDir: sort.dir,
       limit: PAGE,
       offset: applied.offset,
     }, signal),
   })
 
-  function search() { setApplied({ eventType, offset: 0 }) }
+  function search() { setApplied({ eventType, actor, from, to, offset: 0 }) }
+  function clear() { setEventType(''); setActor(''); setFrom(''); setTo(''); setApplied({ eventType: '', actor: '', from: '', to: '', offset: 0 }) }
   function goPage(off: number) { setApplied(p => ({ ...p, offset: off })) }
+  function onSort(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
 
   function toggle(id: number) {
     setExpanded(prev => {
@@ -113,16 +124,30 @@ export default function AuditLogPage() {
             ))}
           </select>
         </FilterField>
-        <Button variant="primary" onClick={search}>{t('common.search')}</Button>
+        <FilterField label={t('audit.table.actor')}>
+          <input className="inp tnum" type="number" placeholder="#" style={{ width: 110 }} value={actor} onChange={e => setActor(e.target.value)} />
+        </FilterField>
+        <FilterField label={t('audit.table.time')}>
+          <div className="range-pair">
+            <DatePicker value={from} onChange={setFrom} />
+            <span className="tilde">〜</span>
+            <DatePicker value={to} onChange={setTo} />
+          </div>
+        </FilterField>
+        <div className="filter-actions">
+          <span className="filter-count">{t('filter.count', { n: total })}</span>
+          <Button variant="ghost" size="sm" onClick={clear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={search}><Icon name="search" size="sm" />{t('common.search')}</Button>
+        </div>
       </FilterBar>
 
       <Card>
         <DataTable>
           <thead>
             <tr>
-              <th>{t('audit.table.time')}</th>
-              <th>{t('audit.table.event')}</th>
-              <th>{t('audit.table.actor')}</th>
+              <SortableTh column="occurred_at" sort={sort} onSort={onSort}>{t('audit.table.time')}</SortableTh>
+              <SortableTh column="event_type" sort={sort} onSort={onSort}>{t('audit.table.event')}</SortableTh>
+              <SortableTh column="actor_user_id" sort={sort} onSort={onSort}>{t('audit.table.actor')}</SortableTh>
               <th>{t('audit.table.detail')}</th>
             </tr>
           </thead>

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listBankTransactions, downloadCsv } from '@/api/endpoints'
 import type { BankTransaction } from '@/types'
-import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead } from '@/components/ui'
+import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead, SortableTh, nextSort } from '@/components/ui'
+import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { yen } from '@/utils/format'
@@ -27,9 +28,10 @@ export default function BankTransactionsPage() {
   const [amountMax, setAmountMax] = useState('')
   const [counterparty, setCounterparty] = useState('')
   const [applied, setApplied] = useState<AppliedFilter>({ status: '', dateFrom: '', dateTo: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
+  const [sort, setSort] = useState<SortState>({ by: 'value_date', dir: 'desc' })
 
   const txQ = useQuery({
-    queryKey: ['bank-transactions', applied],
+    queryKey: ['bank-transactions', applied, sort],
     queryFn: ({ signal }) => listBankTransactions({
       status: applied.status || undefined,
       value_date_from: applied.dateFrom || undefined,
@@ -37,12 +39,14 @@ export default function BankTransactionsPage() {
       amount_min_cents: applied.amountMin ? Math.round(Number(applied.amountMin) * 100) : undefined,
       amount_max_cents: applied.amountMax ? Math.round(Number(applied.amountMax) * 100) : undefined,
       counterparty: applied.counterparty || undefined,
+      sortBy: sort.by, sortDir: sort.dir,
       limit: PAGE, offset: applied.offset,
     }, signal),
   })
 
   function search() { setApplied({ status, dateFrom, dateTo, amountMin, amountMax, counterparty, offset: 0 }) }
   function goPage(off: number) { setApplied(p => ({ ...p, offset: off })) }
+  function onSort(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
 
   const total = txQ.data?.total ?? 0
 
@@ -92,7 +96,12 @@ export default function BankTransactionsPage() {
       <Card>
         <DataTable>
           <thead>
-            <tr><th>{t('table.valueDate')}</th><th>{t('table.amount')}</th><th>{t('table.counterparty')}</th><th>{t('table.status')}</th></tr>
+            <tr>
+              <SortableTh column="value_date" sort={sort} onSort={onSort}>{t('table.valueDate')}</SortableTh>
+              <SortableTh column="amount_cents" sort={sort} onSort={onSort}>{t('table.amount')}</SortableTh>
+              <SortableTh column="counterparty_text" sort={sort} onSort={onSort}>{t('table.counterparty')}</SortableTh>
+              <SortableTh column="status" sort={sort} onSort={onSort}>{t('table.status')}</SortableTh>
+            </tr>
           </thead>
           <tbody>
             <TableStateRow colSpan={4} loading={txQ.isLoading} empty={txQ.data?.items.length === 0} />

--- a/src/Audit/AuditEventFilter.php
+++ b/src/Audit/AuditEventFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Audit;
+
+/**
+ * Server-side filter + sort for the audit-event list (Issue #130). Every field
+ * is optional; null/empty means "no constraint". `sortColumn` is validated
+ * against a whitelist in the repository.
+ *
+ * `occurredFrom` / `occurredTo` are inclusive `YYYY-MM-DD` bounds on
+ * `DATE(occurred_at)`.
+ */
+final readonly class AuditEventFilter
+{
+    public function __construct(
+        public ?string $eventType = null,
+        public ?string $entityType = null,
+        public ?int $entityId = null,
+        public ?int $actorUserId = null,
+        public ?string $occurredFrom = null,
+        public ?string $occurredTo = null,
+        public string $sortColumn = 'occurred_at',
+        public string $sortDirection = 'desc',
+    ) {
+    }
+}

--- a/src/Audit/AuditEventRepositoryInterface.php
+++ b/src/Audit/AuditEventRepositoryInterface.php
@@ -9,25 +9,11 @@ interface AuditEventRepositoryInterface
     public function record(AuditEvent $event): int;
 
     /**
-     * Tenant-scoped, newest first. Each non-null filter narrows the result:
-     * `$eventType` to a single `event_type` (terminology §2), `$entityType` /
-     * `$entityId` to a single subject record.
+     * Tenant-scoped. Filtered + sorted via {@see AuditEventFilter}.
      *
      * @return list<AuditEvent>
      */
-    public function findByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-        int $limit,
-        int $offset,
-    ): array;
+    public function findByOrganization(int $organizationId, AuditEventFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-    ): int;
+    public function countByOrganization(int $organizationId, AuditEventFilter $filter): int;
 }

--- a/src/Audit/ListAuditEventsHandler.php
+++ b/src/Audit/ListAuditEventsHandler.php
@@ -24,27 +24,29 @@ final readonly class ListAuditEventsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        $query = $request->getQueryParams();
+        $q = $request->getQueryParams();
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
 
-        $eventTypeParam = $query['event_type'] ?? null;
-        $eventType = is_string($eventTypeParam) && $eventTypeParam !== '' ? $eventTypeParam : null;
-
-        $entityTypeParam = $query['entity_type'] ?? null;
-        $entityType = is_string($entityTypeParam) && $entityTypeParam !== '' ? $entityTypeParam : null;
-
-        $entityIdParam = $query['entity_id'] ?? null;
-        $entityId = is_numeric($entityIdParam) ? (int) $entityIdParam : null;
-
-        $items = $this->auditEvents->findByOrganization($organizationId, $eventType, $entityType, $entityId, $page->limit, $page->offset);
+        $filter = new AuditEventFilter(
+            eventType: $str('event_type'),
+            entityType: $str('entity_type'),
+            entityId: $int('entity_id'),
+            actorUserId: $int('actor_user_id'),
+            occurredFrom: $str('occurred_from'),
+            occurredTo: $str('occurred_to'),
+            sortColumn: $str('sort_by') ?? 'occurred_at',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
                 static fn (AuditEvent $e): array => AuditEventResponse::toArray($e),
-                $items,
+                $this->auditEvents->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->auditEvents->countByOrganization($organizationId, $eventType, $entityType, $entityId),
+            total: $this->auditEvents->countByOrganization($organizationId, $filter),
         ))->toArray());
     }
 }

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -34,34 +34,24 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
         return $this->query->lastInsertId();
     }
 
-    public function findByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-        int $limit,
-        int $offset,
-    ): array {
-        [$where, $params] = $this->filter($organizationId, $eventType, $entityType, $entityId);
+    public function findByOrganization(int $organizationId, AuditEventFilter $filter, int $limit, int $offset): array
+    {
+        [$where, $params] = $this->filter($organizationId, $filter);
         $params[] = $limit;
         $params[] = $offset;
 
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM audit_events WHERE ' . $where
-            . ' ORDER BY id DESC LIMIT ? OFFSET ?',
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
             $params,
         );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-    ): int {
-        [$where, $params] = $this->filter($organizationId, $eventType, $entityType, $entityId);
+    public function countByOrganization(int $organizationId, AuditEventFilter $filter): int
+    {
+        [$where, $params] = $this->filter($organizationId, $filter);
 
         $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM audit_events WHERE ' . $where, $params);
 
@@ -71,26 +61,52 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
     /**
      * @return array{0: string, 1: list<string|int>}
      */
-    private function filter(int $organizationId, ?string $eventType, ?string $entityType, ?int $entityId): array
+    private function filter(int $organizationId, AuditEventFilter $filter): array
     {
         $clauses = ['organization_id = ?'];
         /** @var list<string|int> $params */
         $params = [$organizationId];
 
-        if ($eventType !== null) {
+        if ($filter->eventType !== null) {
             $clauses[] = 'event_type = ?';
-            $params[] = $eventType;
+            $params[] = $filter->eventType;
         }
-        if ($entityType !== null) {
+        if ($filter->entityType !== null) {
             $clauses[] = 'entity_type = ?';
-            $params[] = $entityType;
+            $params[] = $filter->entityType;
         }
-        if ($entityId !== null) {
+        if ($filter->entityId !== null) {
             $clauses[] = 'entity_id = ?';
-            $params[] = $entityId;
+            $params[] = $filter->entityId;
+        }
+        if ($filter->actorUserId !== null) {
+            $clauses[] = 'actor_user_id = ?';
+            $params[] = $filter->actorUserId;
+        }
+        if ($filter->occurredFrom !== null) {
+            $clauses[] = 'DATE(occurred_at) >= ?';
+            $params[] = $filter->occurredFrom;
+        }
+        if ($filter->occurredTo !== null) {
+            $clauses[] = 'DATE(occurred_at) <= ?';
+            $params[] = $filter->occurredTo;
         }
 
         return [implode(' AND ', $clauses), $params];
+    }
+
+    /** Whitelisted ORDER BY — column/direction mapped from a closed set. */
+    private static function orderBy(AuditEventFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'event_type' => 'event_type',
+            'entity_type' => 'entity_type',
+            'actor_user_id' => 'actor_user_id',
+            default => 'occurred_at',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     /**

--- a/src/BankImport/BankTransactionFilter.php
+++ b/src/BankImport/BankTransactionFilter.php
@@ -13,6 +13,8 @@ final readonly class BankTransactionFilter
         public ?int $amountMinCents = null,
         public ?int $amountMaxCents = null,
         public ?string $counterparty = null,
+        public string $sortColumn = 'value_date',
+        public string $sortDirection = 'desc',
     ) {
     }
 }

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -39,6 +39,9 @@ final readonly class ListBankTransactionsHandler
 
         $counterparty = isset($q['counterparty']) && is_string($q['counterparty']) ? $q['counterparty'] : null;
 
+        $sortBy = isset($q['sort_by']) && is_string($q['sort_by']) && $q['sort_by'] !== '' ? $q['sort_by'] : 'value_date';
+        $sortDir = isset($q['sort_dir']) && is_string($q['sort_dir']) && $q['sort_dir'] !== '' ? $q['sort_dir'] : 'desc';
+
         $filter = new BankTransactionFilter(
             status: $status,
             valueDateFrom: $valueDateFrom,
@@ -46,6 +49,8 @@ final readonly class ListBankTransactionsHandler
             amountMinCents: $amountMinCents,
             amountMaxCents: $amountMaxCents,
             counterparty: $counterparty,
+            sortColumn: $sortBy,
+            sortDirection: $sortDir,
         );
 
         return $this->response->create((new PaginationResponse(

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -75,11 +75,25 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         [$where, $params] = $this->buildWhere($organizationId, $filter);
         $rows = $this->query->fetchAll(
             'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE ' . $where
-            . ' ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
             [...$params, $limit, $offset],
         );
 
         return array_map($this->hydrate(...), $rows);
+    }
+
+    /** Whitelisted ORDER BY — column/direction mapped from a closed set. */
+    private static function orderBy(BankTransactionFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'amount_cents' => 'amount_cents',
+            'counterparty_text' => 'counterparty_text',
+            'status' => 'status',
+            default => 'value_date',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     public function countByOrganization(int $organizationId, BankTransactionFilter $filter): int

--- a/tests/Audit/InMemoryAuditEventRepository.php
+++ b/tests/Audit/InMemoryAuditEventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Tests\Audit;
 
 use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventFilter;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 
 final class InMemoryAuditEventRepository implements AuditEventRepositoryInterface
@@ -29,40 +30,66 @@ final class InMemoryAuditEventRepository implements AuditEventRepositoryInterfac
         return $id;
     }
 
-    public function findByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-        int $limit,
-        int $offset,
-    ): array {
+    public function findByOrganization(int $organizationId, AuditEventFilter $filter, int $limit, int $offset): array
+    {
         $matches = array_values(array_filter(
             $this->events,
-            static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
-                && ($eventType === null || $e->eventType === $eventType)
-                && ($entityType === null || $e->entityType === $entityType)
-                && ($entityId === null || $e->entityId === $entityId),
+            fn (AuditEvent $e): bool => $this->matches($e, $organizationId, $filter),
         ));
 
-        // Newest first, mirroring the SQL `ORDER BY id DESC`.
-        usort($matches, static fn (AuditEvent $a, AuditEvent $b): int => ($b->id ?? 0) <=> ($a->id ?? 0));
+        $asc = strtolower($filter->sortDirection) === 'asc';
+        usort($matches, function (AuditEvent $a, AuditEvent $b) use ($filter, $asc): int {
+            $r = $this->sortKey($a, $filter->sortColumn) <=> $this->sortKey($b, $filter->sortColumn);
+            $r = $asc ? $r : -$r;
+            return $r !== 0 ? $r : (($b->id ?? 0) <=> ($a->id ?? 0));
+        });
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-    ): int {
+    public function countByOrganization(int $organizationId, AuditEventFilter $filter): int
+    {
         return count(array_filter(
             $this->events,
-            static fn (AuditEvent $e): bool => $e->organizationId === $organizationId
-                && ($eventType === null || $e->eventType === $eventType)
-                && ($entityType === null || $e->entityType === $entityType)
-                && ($entityId === null || $e->entityId === $entityId),
+            fn (AuditEvent $e): bool => $this->matches($e, $organizationId, $filter),
         ));
+    }
+
+    private function matches(AuditEvent $e, int $organizationId, AuditEventFilter $f): bool
+    {
+        if ($e->organizationId !== $organizationId) {
+            return false;
+        }
+        if ($f->eventType !== null && $e->eventType !== $f->eventType) {
+            return false;
+        }
+        if ($f->entityType !== null && $e->entityType !== $f->entityType) {
+            return false;
+        }
+        if ($f->entityId !== null && $e->entityId !== $f->entityId) {
+            return false;
+        }
+        if ($f->actorUserId !== null && $e->actorUserId !== $f->actorUserId) {
+            return false;
+        }
+        $date = substr($e->occurredAt, 0, 10);
+        if ($f->occurredFrom !== null && $date < $f->occurredFrom) {
+            return false;
+        }
+        if ($f->occurredTo !== null && $date > $f->occurredTo) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function sortKey(AuditEvent $e, string $column): int|string
+    {
+        return match ($column) {
+            'event_type' => $e->eventType,
+            'entity_type' => $e->entityType,
+            'actor_user_id' => $e->actorUserId,
+            default => $e->occurredAt,
+        };
     }
 }

--- a/tests/Audit/ThrowingAuditEventRepository.php
+++ b/tests/Audit/ThrowingAuditEventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Tests\Audit;
 
 use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventFilter;
 use NeneClear\Audit\AuditEventRepositoryInterface;
 use RuntimeException;
 
@@ -22,23 +23,13 @@ final class ThrowingAuditEventRepository implements AuditEventRepositoryInterfac
         throw new RuntimeException('audit write failed (simulated)');
     }
 
-    public function findByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-        int $limit,
-        int $offset,
-    ): array {
+    public function findByOrganization(int $organizationId, AuditEventFilter $filter, int $limit, int $offset): array
+    {
         return [];
     }
 
-    public function countByOrganization(
-        int $organizationId,
-        ?string $eventType,
-        ?string $entityType,
-        ?int $entityId,
-    ): int {
+    public function countByOrganization(int $organizationId, AuditEventFilter $filter): int
+    {
         return 0;
     }
 }

--- a/tests/Database/PdoAuditEventRepositoryTest.php
+++ b/tests/Database/PdoAuditEventRepositoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Audit\AuditEvent;
+use NeneClear\Audit\AuditEventFilter;
+use NeneClear\Audit\PdoAuditEventRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoAuditEventRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoAuditEventRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-audit-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createAuditEvents($this->query);
+        $this->repo = new PdoAuditEventRepository($this->query);
+
+        $this->seed('user_created', 'user', 10, actor: 1, at: '2026-04-10 09:00:00');
+        $this->seed('reconciliation_confirmed', 'payment_reconciliation', 5, actor: 2, at: '2026-04-20 12:00:00');
+        $this->seed('login_failed', 'user', null, actor: 0, at: '2026-04-25 23:00:00');
+        $this->seed('user_created', 'user', 11, actor: 1, at: '2026-05-02 09:00:00', orgId: 99);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function seed(string $eventType, string $entityType, ?int $entityId, int $actor, string $at, int $orgId = 7): void
+    {
+        $this->repo->record(new AuditEvent(
+            organizationId: $orgId,
+            eventType: $eventType,
+            entityType: $entityType,
+            entityId: $entityId,
+            actorUserId: $actor,
+            occurredAt: $at,
+            payload: ['after' => ['x' => 1]],
+        ));
+    }
+
+    public function test_tenant_scoping_and_no_filter(): void
+    {
+        self::assertCount(3, $this->repo->findByOrganization(7, new AuditEventFilter(), 50, 0));
+        self::assertSame(3, $this->repo->countByOrganization(7, new AuditEventFilter()));
+    }
+
+    public function test_event_type_actor_and_date_filters(): void
+    {
+        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(eventType: 'user_created'), 50, 0));
+        // actor 1 has two events but one belongs to org 99 → only one is in org 7.
+        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(actorUserId: 1), 50, 0));
+
+        $range = new AuditEventFilter(occurredFrom: '2026-04-15', occurredTo: '2026-04-30');
+        self::assertCount(2, $this->repo->findByOrganization(7, $range, 50, 0)); // 04-20 and 04-25
+    }
+
+    public function test_sort_by_occurred_at_ascending(): void
+    {
+        $rows = $this->repo->findByOrganization(7, new AuditEventFilter(sortColumn: 'occurred_at', sortDirection: 'asc'), 50, 0);
+        $times = array_map(static fn (AuditEvent $e): string => $e->occurredAt, $rows);
+        self::assertSame(['2026-04-10 09:00:00', '2026-04-20 12:00:00', '2026-04-25 23:00:00'], $times);
+    }
+}

--- a/tests/Database/PdoBankTransactionRepositoryTest.php
+++ b/tests/Database/PdoBankTransactionRepositoryTest.php
@@ -159,4 +159,18 @@ final class PdoBankTransactionRepositoryTest extends TestCase
         $matched = $this->repo->findById(7, $matchedId);
         self::assertSame(BankTransactionStatus::Matched, $matched?->status);
     }
+
+    public function test_sort_by_amount_ascending(): void
+    {
+        $this->tx(amountCents: 30000);
+        $this->tx(amountCents: 10000);
+        $this->tx(amountCents: 20000);
+
+        $filter = new BankTransactionFilter(sortColumn: 'amount_cents', sortDirection: 'asc');
+        $amounts = array_map(
+            static fn ($t): int => $t->amountCents,
+            $this->repo->findByOrganization(7, $filter, 50, 0),
+        );
+        self::assertSame([10000, 20000, 30000], $amounts);
+    }
 }


### PR DESCRIPTION
Continues the table-search rollout (design 04), server-side, building on Phase 1 (#131). Refs #130.

## bank-transactions
- Adds **column sort** (it already had the filter bar): `value_date | amount_cents | counterparty_text | status` via `BankTransactionFilter.sortColumn` + whitelisted `ORDER BY`; sortable headers on the page.

## audit-log
- Introduces an **`AuditEventFilter` VO** (replaces the ad-hoc param list) and adds **`actor_user_id` + `occurred_at` date-range** filters and **column sort** (`occurred_at | event_type | actor_user_id`), server-side.
- Page gains actor / date-range filter fields, match count, clear, and sortable headers.

## Also
- OpenAPI params for both; new `PdoAuditEventRepositoryTest` (filter+sort) + a bank-transaction sort test.

## Verification
- Backend **247** (6 skipped; +4), PHPStan 8, CS clean; frontend **27**; E2E **43**.

## Remaining (next, tracked in #130)
取込履歴 (bank-import-batches), 消込一覧 (reconciliation history), 督促 (dunning notices). The dunning *target* table reads upstream invoices (contract filters by `status` only) → client-side there.