### PR TITLE
feat(bank-import, reconciliation, dunning): filter + sort on history tables — phase 3 (#130)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -413,6 +413,14 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - { name: source_filename, in: query, schema: { type: string } }
+        - { name: status, in: query, schema: { $ref: '#/components/schemas/BankImportBatchStatus' } }
+        - { name: row_count_min, in: query, schema: { type: integer } }
+        - { name: row_count_max, in: query, schema: { type: integer } }
+        - { name: imported_from, in: query, schema: { type: string, format: date } }
+        - { name: imported_to, in: query, schema: { type: string, format: date } }
+        - { name: sort_by, in: query, description: "id | source_filename | row_count | status | imported_at", schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: A page of import batches.
@@ -695,6 +703,12 @@ paths:
           in: query
           schema:
             $ref: '#/components/schemas/ReconciliationStatus'
+        - { name: bank_transaction_id, in: query, schema: { type: integer, format: int64 } }
+        - { name: invoice_id, in: query, description: Match reconciliations allocated to this invoice., schema: { type: integer, format: int64 } }
+        - { name: confirmed_from, in: query, schema: { type: string, format: date } }
+        - { name: confirmed_to, in: query, schema: { type: string, format: date } }
+        - { name: sort_by, in: query, description: "id | bank_transaction_id | status | confirmed_at", schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: A page of reconciliations.
@@ -934,6 +948,15 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - { name: invoice_number, in: query, schema: { type: string } }
+        - { name: recipient_email, in: query, schema: { type: string } }
+        - { name: outstanding_min_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: outstanding_max_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: sent_from, in: query, schema: { type: string, format: date } }
+        - { name: sent_to, in: query, schema: { type: string, format: date } }
+        - { name: sent_by, in: query, schema: { type: integer, format: int64 } }
+        - { name: sort_by, in: query, description: "invoice_number | recipient_email | outstanding_cents | sent_at | sent_by", schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: Paginated dunning notice list.

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -32,8 +32,29 @@ export function getCurrentUser(signal?: AbortSignal) {
 }
 
 // --- Bank import ---
-export function listBankImportBatches(params: { limit?: number; offset?: number }, signal?: AbortSignal) {
+export interface BankImportBatchQuery {
+  sourceFilename?: string
+  status?: string
+  rowCountMin?: number
+  rowCountMax?: number
+  importedFrom?: string
+  importedTo?: string
+  sortBy?: string
+  sortDir?: string
+  limit?: number
+  offset?: number
+}
+
+export function listBankImportBatches(params: BankImportBatchQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+  if (params.sourceFilename) q.set('source_filename', params.sourceFilename)
+  if (params.status) q.set('status', params.status)
+  if (params.rowCountMin != null) q.set('row_count_min', String(params.rowCountMin))
+  if (params.rowCountMax != null) q.set('row_count_max', String(params.rowCountMax))
+  if (params.importedFrom) q.set('imported_from', params.importedFrom)
+  if (params.importedTo) q.set('imported_to', params.importedTo)
+  if (params.sortBy) q.set('sort_by', params.sortBy)
+  if (params.sortDir) q.set('sort_dir', params.sortDir)
   return api.get<ListEnvelope<BankImportBatch>>(`${BASE}/bank-import-batches?${q}`, signal)
 }
 
@@ -106,9 +127,27 @@ export function listUnmatchedTransactions(params: { limit?: number; offset?: num
 }
 
 // --- Reconciliation ---
-export function listReconciliations(params: { status?: string; limit?: number; offset?: number }, signal?: AbortSignal) {
+export interface ReconciliationQuery {
+  status?: string
+  bankTransactionId?: string
+  invoiceId?: string
+  confirmedFrom?: string
+  confirmedTo?: string
+  sortBy?: string
+  sortDir?: string
+  limit?: number
+  offset?: number
+}
+
+export function listReconciliations(params: ReconciliationQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
   if (params.status) q.set('status', params.status)
+  if (params.bankTransactionId) q.set('bank_transaction_id', params.bankTransactionId)
+  if (params.invoiceId) q.set('invoice_id', params.invoiceId)
+  if (params.confirmedFrom) q.set('confirmed_from', params.confirmedFrom)
+  if (params.confirmedTo) q.set('confirmed_to', params.confirmedTo)
+  if (params.sortBy) q.set('sort_by', params.sortBy)
+  if (params.sortDir) q.set('sort_dir', params.sortDir)
   return api.get<ListEnvelope<Reconciliation>>(`${BASE}/reconciliations?${q}`, signal)
 }
 
@@ -186,8 +225,29 @@ export function listUpstreamInvoices(params: { status?: string }, signal?: Abort
 }
 
 // --- Dunning ---
-export function listDunningNotices(params: { limit?: number; offset?: number }, signal?: AbortSignal) {
+export interface DunningNoticeQuery {
+  invoiceNumber?: string
+  recipientEmail?: string
+  outstandingMinCents?: number
+  outstandingMaxCents?: number
+  sentFrom?: string
+  sentTo?: string
+  sortBy?: string
+  sortDir?: string
+  limit?: number
+  offset?: number
+}
+
+export function listDunningNotices(params: DunningNoticeQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+  if (params.invoiceNumber) q.set('invoice_number', params.invoiceNumber)
+  if (params.recipientEmail) q.set('recipient_email', params.recipientEmail)
+  if (params.outstandingMinCents != null) q.set('outstanding_min_cents', String(params.outstandingMinCents))
+  if (params.outstandingMaxCents != null) q.set('outstanding_max_cents', String(params.outstandingMaxCents))
+  if (params.sentFrom) q.set('sent_from', params.sentFrom)
+  if (params.sentTo) q.set('sent_to', params.sentTo)
+  if (params.sortBy) q.set('sort_by', params.sortBy)
+  if (params.sortDir) q.set('sort_dir', params.sortDir)
   return api.get<ListEnvelope<DunningNotice>>(`${BASE}/dunning-notices?${q}`, signal)
 }
 

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -2,8 +2,8 @@ import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listBankImportBatches, importBankCsv, reverseBankImportBatch, getClearSettings } from '@/api/endpoints'
 import type { BankImportBatch } from '@/types'
-import { Icon, StatusBadge, Button, Card, CardHead, CardBody, DataTable, TableStateRow, Notice, Modal, PageHead } from '@/components/ui'
-import type { StatusMeta } from '@/components/ui'
+import { Icon, StatusBadge, Button, Card, CardHead, CardBody, DataTable, TableStateRow, Notice, Modal, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
+import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { formatDate } from '@/utils/format'
 
@@ -54,8 +54,33 @@ export default function BankImportPage() {
   const [reverseTarget, setReverseTarget] = useState<BankImportBatch | null>(null)
   const [uploadMsg, setUploadMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
+  const PAGE = 50
+  const [fileName, setFileName] = useState('')
+  const [bStatus, setBStatus] = useState('')
+  const [rowMin, setRowMin] = useState('')
+  const [rowMax, setRowMax] = useState('')
+  const [impFrom, setImpFrom] = useState('')
+  const [impTo, setImpTo] = useState('')
+  const [applied, setApplied] = useState({ fileName: '', status: '', rowMin: '', rowMax: '', impFrom: '', impTo: '', offset: 0 })
+  const [sort, setSort] = useState<SortState>({ by: 'id', dir: 'desc' })
+
   const settingsQ = useQuery({ queryKey: ['clear-settings'], queryFn: ({ signal }) => getClearSettings(signal) })
-  const batchQ = useQuery({ queryKey: ['bank-import-batches'], queryFn: ({ signal }) => listBankImportBatches({ limit: 50 }, signal) })
+  const batchQ = useQuery({
+    queryKey: ['bank-import-batches', applied, sort],
+    queryFn: ({ signal }) => listBankImportBatches({
+      sourceFilename: applied.fileName || undefined,
+      status: applied.status || undefined,
+      rowCountMin: applied.rowMin ? Number(applied.rowMin) : undefined,
+      rowCountMax: applied.rowMax ? Number(applied.rowMax) : undefined,
+      importedFrom: applied.impFrom ? applied.impFrom.replace(/\//g, '-') : undefined,
+      importedTo: applied.impTo ? applied.impTo.replace(/\//g, '-') : undefined,
+      sortBy: sort.by, sortDir: sort.dir, limit: PAGE, offset: applied.offset,
+    }, signal),
+  })
+  function searchBatches() { setApplied({ fileName, status: bStatus, rowMin, rowMax, impFrom, impTo, offset: 0 }) }
+  function clearBatches() { setFileName(''); setBStatus(''); setRowMin(''); setRowMax(''); setImpFrom(''); setImpTo(''); setApplied({ fileName: '', status: '', rowMin: '', rowMax: '', impFrom: '', impTo: '', offset: 0 }) }
+  function onSortBatches(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
+  const batchTotal = batchQ.data?.total ?? 0
 
   const uploadMut = useMutation({
     mutationFn: ({ id, file }: { id: number; file: File }) => importBankCsv(id, file),
@@ -120,11 +145,53 @@ export default function BankImportPage() {
         </CardBody>
       </Card>
 
+      <FilterBar>
+        <FilterField label={t('table.fileName')}>
+          <div className="inp-icon">
+            <Icon name="search" />
+            <input className="inp" style={{ paddingLeft: 32, width: 160 }} placeholder={t('common.search')} value={fileName} onChange={e => setFileName(e.target.value)} />
+          </div>
+        </FilterField>
+        <FilterField label={t('table.status')}>
+          <select className="inp" value={bStatus} onChange={e => setBStatus(e.target.value)}>
+            <option value="">{t('filter.all')}</option>
+            <option value="imported">{t('bankImport.status.imported')}</option>
+            <option value="reversed">{t('bankImport.status.reversed')}</option>
+          </select>
+        </FilterField>
+        <FilterField label={t('table.rowCount')}>
+          <div className="range-pair">
+            <input className="inp tnum" type="number" value={rowMin} onChange={e => setRowMin(e.target.value)} />
+            <span className="tilde">〜</span>
+            <input className="inp tnum" type="number" value={rowMax} onChange={e => setRowMax(e.target.value)} />
+          </div>
+        </FilterField>
+        <FilterField label={t('table.importedAt')}>
+          <div className="range-pair">
+            <DatePicker value={impFrom} onChange={setImpFrom} />
+            <span className="tilde">〜</span>
+            <DatePicker value={impTo} onChange={setImpTo} />
+          </div>
+        </FilterField>
+        <div className="filter-actions">
+          <span className="filter-count">{t('filter.count', { n: batchTotal })}</span>
+          <Button variant="ghost" size="sm" onClick={clearBatches}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={searchBatches}><Icon name="search" size="sm" />{t('common.search')}</Button>
+        </div>
+      </FilterBar>
+
       <Card>
         <CardHead><h2><Icon name="clock" />{t('bankImport.batches')}</h2></CardHead>
         <DataTable>
           <thead>
-            <tr><th>{t('table.id')}</th><th>{t('table.fileName')}</th><th>{t('table.rowCount')}</th><th>{t('table.status')}</th><th>{t('table.importedAt')}</th><th /></tr>
+            <tr>
+              <SortableTh column="id" sort={sort} onSort={onSortBatches}>{t('table.id')}</SortableTh>
+              <SortableTh column="source_filename" sort={sort} onSort={onSortBatches}>{t('table.fileName')}</SortableTh>
+              <SortableTh column="row_count" sort={sort} onSort={onSortBatches}>{t('table.rowCount')}</SortableTh>
+              <SortableTh column="status" sort={sort} onSort={onSortBatches}>{t('table.status')}</SortableTh>
+              <SortableTh column="imported_at" sort={sort} onSort={onSortBatches}>{t('table.importedAt')}</SortableTh>
+              <th />
+            </tr>
           </thead>
           <tbody>
             <TableStateRow colSpan={6} loading={batchQ.isLoading} empty={batchQ.data?.items.length === 0} />
@@ -146,6 +213,7 @@ export default function BankImportPage() {
             ))}
           </tbody>
         </DataTable>
+        <Pager offset={applied.offset} pageSize={PAGE} total={batchTotal} onOffsetChange={off => setApplied(p => ({ ...p, offset: off }))} />
       </Card>
 
       {reverseTarget && <ReverseModal batch={reverseTarget} onClose={() => setReverseTarget(null)} />}

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -5,7 +5,8 @@ import {
   listDunningPauses, pauseDunningNotice, resumeDunningNotice,
 } from '@/api/endpoints'
 import type { UpstreamInvoice } from '@/types'
-import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead } from '@/components/ui'
+import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
+import type { SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { yen, formatDateTime, daysOverdue } from '@/utils/format'
 
@@ -61,7 +62,27 @@ export default function DunningPage() {
     queryKey: ['upstream-invoices', { status: 'issued,partially_paid,overdue' }],
     queryFn: ({ signal }) => listUpstreamInvoices({ status: 'issued,partially_paid,overdue' }, signal),
   })
-  const noticesQ = useQuery({ queryKey: ['dunning-notices'], queryFn: ({ signal }) => listDunningNotices({ limit: 50 }, signal) })
+  const HPAGE = 50
+  const [hInvoice, setHInvoice] = useState('')
+  const [hEmail, setHEmail] = useState('')
+  const [hFrom, setHFrom] = useState('')
+  const [hTo, setHTo] = useState('')
+  const [hApplied, setHApplied] = useState({ invoice: '', email: '', from: '', to: '', offset: 0 })
+  const [hSort, setHSort] = useState<SortState>({ by: 'sent_at', dir: 'desc' })
+  const noticesQ = useQuery({
+    queryKey: ['dunning-notices', hApplied, hSort],
+    queryFn: ({ signal }) => listDunningNotices({
+      invoiceNumber: hApplied.invoice || undefined,
+      recipientEmail: hApplied.email || undefined,
+      sentFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
+      sentTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
+      sortBy: hSort.by, sortDir: hSort.dir, limit: HPAGE, offset: hApplied.offset,
+    }, signal),
+  })
+  function hSearch() { setHApplied({ invoice: hInvoice, email: hEmail, from: hFrom, to: hTo, offset: 0 }) }
+  function hClear() { setHInvoice(''); setHEmail(''); setHFrom(''); setHTo(''); setHApplied({ invoice: '', email: '', from: '', to: '', offset: 0 }) }
+  function hOnSort(col: string) { setHSort(s => nextSort(s, col)); setHApplied(p => ({ ...p, offset: 0 })) }
+  const hTotal = noticesQ.data?.total ?? 0
   const pausesQ = useQuery({ queryKey: ['dunning-pauses', { active_only: true }], queryFn: ({ signal }) => listDunningPauses({ active_only: true, limit: 100 }, signal) })
 
   const resumeMut = useMutation({
@@ -141,11 +162,44 @@ export default function DunningPage() {
       </Card>
 
       {/* History */}
+      <FilterBar>
+        <FilterField label={t('table.invoiceNumber')}>
+          <div className="inp-icon">
+            <Icon name="search" />
+            <input className="inp" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
+          </div>
+        </FilterField>
+        <FilterField label={t('table.recipient')}>
+          <div className="inp-icon">
+            <Icon name="search" />
+            <input className="inp" style={{ paddingLeft: 32, width: 170 }} placeholder={t('common.search')} value={hEmail} onChange={e => setHEmail(e.target.value)} />
+          </div>
+        </FilterField>
+        <FilterField label={t('table.sentAt')}>
+          <div className="range-pair">
+            <DatePicker value={hFrom} onChange={setHFrom} />
+            <span className="tilde">〜</span>
+            <DatePicker value={hTo} onChange={setHTo} />
+          </div>
+        </FilterField>
+        <div className="filter-actions">
+          <span className="filter-count">{t('filter.count', { n: hTotal })}</span>
+          <Button variant="ghost" size="sm" onClick={hClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={hSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+        </div>
+      </FilterBar>
+
       <Card>
         <CardHead><h2><Icon name="clock" />{t('dunning.history')}</h2></CardHead>
         <DataTable>
           <thead>
-            <tr><th>{t('table.invoiceNumber')}</th><th>{t('table.recipient')}</th><th>{t('table.outstanding')}</th><th>{t('table.sentAt')}</th><th>{t('table.sender')}</th></tr>
+            <tr>
+              <SortableTh column="invoice_number" sort={hSort} onSort={hOnSort}>{t('table.invoiceNumber')}</SortableTh>
+              <SortableTh column="recipient_email" sort={hSort} onSort={hOnSort}>{t('table.recipient')}</SortableTh>
+              <SortableTh column="outstanding_cents" sort={hSort} onSort={hOnSort}>{t('table.outstanding')}</SortableTh>
+              <SortableTh column="sent_at" sort={hSort} onSort={hOnSort}>{t('table.sentAt')}</SortableTh>
+              <SortableTh column="sent_by" sort={hSort} onSort={hOnSort}>{t('table.sender')}</SortableTh>
+            </tr>
           </thead>
           <tbody>
             <TableStateRow colSpan={5} loading={noticesQ.isLoading} empty={noticesQ.data?.items.length === 0} />
@@ -160,6 +214,7 @@ export default function DunningPage() {
             ))}
           </tbody>
         </DataTable>
+        <Pager offset={hApplied.offset} pageSize={HPAGE} total={hTotal} onOffsetChange={off => setHApplied(p => ({ ...p, offset: off }))} />
       </Card>
 
       {sendTarget && <SendModal invoice={sendTarget} onClose={() => setSendTarget(null)} />}

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -6,7 +6,8 @@ import {
 } from '@/api/endpoints'
 import type { BankTransaction, Reconciliation, UpstreamInvoice } from '@/types'
 import type { AllocationInput } from '@/api/endpoints'
-import { Icon, Badge, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, Tabs, PageHead } from '@/components/ui'
+import { Icon, Badge, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, Tabs, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
+import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
 import { yen, formatDate } from '@/utils/format'
@@ -148,11 +149,28 @@ export default function ReconciliationPage() {
     queryFn: ({ signal }) => listUnmatchedTransactions({ limit: 50 }, signal),
     enabled: tab === 'unmatched',
   })
+  const HPAGE = 50
+  const [hStatus, setHStatus] = useState('')
+  const [hInvoice, setHInvoice] = useState('')
+  const [hFrom, setHFrom] = useState('')
+  const [hTo, setHTo] = useState('')
+  const [hApplied, setHApplied] = useState({ status: '', invoice: '', from: '', to: '', offset: 0 })
+  const [hSort, setHSort] = useState<SortState>({ by: 'id', dir: 'desc' })
   const reconciliationsQ = useQuery({
-    queryKey: ['reconciliations'],
-    queryFn: ({ signal }) => listReconciliations({ limit: 50 }, signal),
+    queryKey: ['reconciliations', hApplied, hSort],
+    queryFn: ({ signal }) => listReconciliations({
+      status: hApplied.status || undefined,
+      invoiceId: hApplied.invoice || undefined,
+      confirmedFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
+      confirmedTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
+      sortBy: hSort.by, sortDir: hSort.dir, limit: HPAGE, offset: hApplied.offset,
+    }, signal),
     enabled: tab === 'history',
   })
+  function hSearch() { setHApplied({ status: hStatus, invoice: hInvoice, from: hFrom, to: hTo, offset: 0 }) }
+  function hClear() { setHStatus(''); setHInvoice(''); setHFrom(''); setHTo(''); setHApplied({ status: '', invoice: '', from: '', to: '', offset: 0 }) }
+  function hOnSort(col: string) { setHSort(s => nextSort(s, col)); setHApplied(p => ({ ...p, offset: 0 })) }
+  const hTotal = reconciliationsQ.data?.total ?? 0
 
   return (
     <>
@@ -202,10 +220,41 @@ export default function ReconciliationPage() {
       )}
 
       {tab === 'history' && (
+        <>
+        <FilterBar>
+          <FilterField label={t('table.status')}>
+            <select className="inp" value={hStatus} onChange={e => setHStatus(e.target.value)}>
+              <option value="">{t('filter.all')}</option>
+              <option value="confirmed">{t('reconciliation.status.confirmed')}</option>
+              <option value="reversed">{t('reconciliation.status.reversed')}</option>
+            </select>
+          </FilterField>
+          <FilterField label={t('table.invoiceId')}>
+            <input className="inp tnum" type="number" placeholder="#" style={{ width: 110 }} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
+          </FilterField>
+          <FilterField label={t('table.confirmedAt')}>
+            <div className="range-pair">
+              <DatePicker value={hFrom} onChange={setHFrom} />
+              <span className="tilde">〜</span>
+              <DatePicker value={hTo} onChange={setHTo} />
+            </div>
+          </FilterField>
+          <div className="filter-actions">
+            <span className="filter-count">{t('filter.count', { n: hTotal })}</span>
+            <Button variant="ghost" size="sm" onClick={hClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
+            <Button variant="primary" size="sm" onClick={hSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          </div>
+        </FilterBar>
         <Card>
           <DataTable>
             <thead>
-              <tr><th>{t('table.id')}</th><th>{t('table.bankTxnId')}</th><th>{t('table.status')}</th><th>{t('table.confirmedAt')}</th><th /></tr>
+              <tr>
+                <SortableTh column="id" sort={hSort} onSort={hOnSort}>{t('table.id')}</SortableTh>
+                <SortableTh column="bank_transaction_id" sort={hSort} onSort={hOnSort}>{t('table.bankTxnId')}</SortableTh>
+                <SortableTh column="status" sort={hSort} onSort={hOnSort}>{t('table.status')}</SortableTh>
+                <SortableTh column="confirmed_at" sort={hSort} onSort={hOnSort}>{t('table.confirmedAt')}</SortableTh>
+                <th />
+              </tr>
             </thead>
             <tbody>
               <TableStateRow colSpan={5} loading={reconciliationsQ.isLoading} empty={reconciliationsQ.data?.items.length === 0} />
@@ -226,7 +275,9 @@ export default function ReconciliationPage() {
               ))}
             </tbody>
           </DataTable>
+          <Pager offset={hApplied.offset} pageSize={HPAGE} total={hTotal} onOffsetChange={off => setHApplied(p => ({ ...p, offset: off }))} />
         </Card>
+        </>
       )}
 
       {matchTarget && <ConfirmModal tx={matchTarget} onClose={() => setMatchTarget(null)} />}

--- a/src/BankImport/BankImportBatchFilter.php
+++ b/src/BankImport/BankImportBatchFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\BankImport;
+
+/**
+ * Server-side filter + sort for the bank-import-batch list (Issue #130). Every
+ * field is optional; null/empty means "no constraint". `sortColumn` is
+ * validated against a whitelist in the repository.
+ *
+ * `importedFrom` / `importedTo` are inclusive `YYYY-MM-DD` bounds on
+ * `DATE(imported_at)`.
+ */
+final readonly class BankImportBatchFilter
+{
+    public function __construct(
+        public ?string $sourceFilename = null,
+        public ?BankImportBatchStatus $status = null,
+        public ?int $rowCountMin = null,
+        public ?int $rowCountMax = null,
+        public ?string $importedFrom = null,
+        public ?string $importedTo = null,
+        public string $sortColumn = 'id',
+        public string $sortDirection = 'desc',
+    ) {
+    }
+}

--- a/src/BankImport/BankImportBatchRepositoryInterface.php
+++ b/src/BankImport/BankImportBatchRepositoryInterface.php
@@ -15,9 +15,9 @@ interface BankImportBatchRepositoryInterface
     /**
      * @return list<BankImportBatch>
      */
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findByOrganization(int $organizationId, BankImportBatchFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function countByOrganization(int $organizationId, BankImportBatchFilter $filter): int;
 
     public function reverseById(int $id, string $reversedAt, string $reversalReason): void;
 }

--- a/src/BankImport/ListBankImportBatchesHandler.php
+++ b/src/BankImport/ListBankImportBatchesHandler.php
@@ -23,15 +23,32 @@ final readonly class ListBankImportBatchesHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
+        $q = $request->getQueryParams();
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+
+        $statusParam = $q['status'] ?? null;
+        $status = is_string($statusParam) ? BankImportBatchStatus::tryFrom($statusParam) : null;
+
+        $filter = new BankImportBatchFilter(
+            sourceFilename: $str('source_filename'),
+            status: $status,
+            rowCountMin: $int('row_count_min'),
+            rowCountMax: $int('row_count_max'),
+            importedFrom: $str('imported_from'),
+            importedTo: $str('imported_to'),
+            sortColumn: $str('sort_by') ?? 'id',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
                 BankImportBatchResponse::toArray(...),
-                $this->batches->findByOrganization($organizationId, $page->limit, $page->offset),
+                $this->batches->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->batches->countByOrganization($organizationId),
+            total: $this->batches->countByOrganization($organizationId, $filter),
         ))->toArray());
     }
 }

--- a/src/BankImport/PdoBankImportBatchRepository.php
+++ b/src/BankImport/PdoBankImportBatchRepository.php
@@ -51,26 +51,83 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
         return $this->query->lastInsertId();
     }
 
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, BankImportBatchFilter $filter, int $limit, int $offset): array
     {
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $params[] = $limit;
+        $params[] = $offset;
+
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM bank_import_batches WHERE organization_id = ? '
-            . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            'SELECT ' . self::COLUMNS . ' FROM bank_import_batches WHERE ' . $where
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
+            $params,
         );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function countByOrganization(int $organizationId, BankImportBatchFilter $filter): int
     {
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_import_batches WHERE organization_id = ?', [$organizationId]);
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM bank_import_batches WHERE ' . $where, $params);
 
         if ($row === null) {
             return 0;
         }
 
         return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @return array{0: string, 1: list<string|int>}
+     */
+    private function whereClause(int $organizationId, BankImportBatchFilter $filter): array
+    {
+        $clauses = ['organization_id = ?'];
+        /** @var list<string|int> $params */
+        $params = [$organizationId];
+
+        if ($filter->sourceFilename !== null) {
+            $clauses[] = 'source_filename LIKE ?';
+            $params[] = '%' . $filter->sourceFilename . '%';
+        }
+        if ($filter->status !== null) {
+            $clauses[] = 'status = ?';
+            $params[] = $filter->status->value;
+        }
+        if ($filter->rowCountMin !== null) {
+            $clauses[] = 'row_count >= ?';
+            $params[] = $filter->rowCountMin;
+        }
+        if ($filter->rowCountMax !== null) {
+            $clauses[] = 'row_count <= ?';
+            $params[] = $filter->rowCountMax;
+        }
+        if ($filter->importedFrom !== null) {
+            $clauses[] = 'DATE(imported_at) >= ?';
+            $params[] = $filter->importedFrom;
+        }
+        if ($filter->importedTo !== null) {
+            $clauses[] = 'DATE(imported_at) <= ?';
+            $params[] = $filter->importedTo;
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    /** Whitelisted ORDER BY — column/direction mapped from a closed set. */
+    private static function orderBy(BankImportBatchFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'source_filename' => 'source_filename',
+            'row_count' => 'row_count',
+            'status' => 'status',
+            'imported_at' => 'imported_at',
+            default => 'id',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     public function reverseById(int $id, string $reversedAt, string $reversalReason): void

--- a/src/Dunning/DunningNoticeFilter.php
+++ b/src/Dunning/DunningNoticeFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * Server-side filter + sort for the dunning-notice history list (Issue #130).
+ * Every field is optional; null/empty means "no constraint". `sortColumn` is
+ * validated against a whitelist in the repository.
+ *
+ * `sentFrom` / `sentTo` are inclusive `YYYY-MM-DD` bounds on `DATE(sent_at)`.
+ */
+final readonly class DunningNoticeFilter
+{
+    public function __construct(
+        public ?string $invoiceNumber = null,
+        public ?string $recipientEmail = null,
+        public ?int $outstandingMinCents = null,
+        public ?int $outstandingMaxCents = null,
+        public ?string $sentFrom = null,
+        public ?string $sentTo = null,
+        public ?int $sentBy = null,
+        public string $sortColumn = 'sent_at',
+        public string $sortDirection = 'desc',
+    ) {
+    }
+}

--- a/src/Dunning/DunningNoticeRepositoryInterface.php
+++ b/src/Dunning/DunningNoticeRepositoryInterface.php
@@ -13,9 +13,9 @@ interface DunningNoticeRepositoryInterface
     /**
      * @return list<DunningNotice>
      */
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findByOrganization(int $organizationId, DunningNoticeFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId): int;
+    public function countByOrganization(int $organizationId, DunningNoticeFilter $filter): int;
 
     public function findLastByInvoice(int $organizationId, int $invoiceId): ?DunningNotice;
 }

--- a/src/Dunning/ListDunningNoticesHandler.php
+++ b/src/Dunning/ListDunningNoticesHandler.php
@@ -23,15 +23,30 @@ final readonly class ListDunningNoticesHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
+        $q = $request->getQueryParams();
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+
+        $filter = new DunningNoticeFilter(
+            invoiceNumber: $str('invoice_number'),
+            recipientEmail: $str('recipient_email'),
+            outstandingMinCents: $int('outstanding_min_cents'),
+            outstandingMaxCents: $int('outstanding_max_cents'),
+            sentFrom: $str('sent_from'),
+            sentTo: $str('sent_to'),
+            sentBy: $int('sent_by'),
+            sortColumn: $str('sort_by') ?? 'sent_at',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
                 DunningNoticeResponse::toArray(...),
-                $this->notices->findByOrganization($organizationId, $page->limit, $page->offset),
+                $this->notices->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->notices->countByOrganization($organizationId),
+            total: $this->notices->countByOrganization($organizationId, $filter),
         ))->toArray());
     }
 }

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -50,22 +50,83 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
         return $row !== null ? $this->hydrate($row) : null;
     }
 
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, DunningNoticeFilter $filter, int $limit, int $offset): array
     {
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $params[] = $limit;
+        $params[] = $offset;
+
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM dunning_notices WHERE organization_id = ? '
-            . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-            [$organizationId, $limit, $offset],
+            'SELECT ' . self::COLUMNS . ' FROM dunning_notices WHERE ' . $where
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
+            $params,
         );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function countByOrganization(int $organizationId, DunningNoticeFilter $filter): int
     {
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM dunning_notices WHERE organization_id = ?', [$organizationId]);
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM dunning_notices WHERE ' . $where, $params);
 
         return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @return array{0: string, 1: list<string|int>}
+     */
+    private function whereClause(int $organizationId, DunningNoticeFilter $filter): array
+    {
+        $clauses = ['organization_id = ?'];
+        /** @var list<string|int> $params */
+        $params = [$organizationId];
+
+        if ($filter->invoiceNumber !== null) {
+            $clauses[] = 'invoice_number LIKE ?';
+            $params[] = '%' . $filter->invoiceNumber . '%';
+        }
+        if ($filter->recipientEmail !== null) {
+            $clauses[] = 'recipient_email LIKE ?';
+            $params[] = '%' . $filter->recipientEmail . '%';
+        }
+        if ($filter->outstandingMinCents !== null) {
+            $clauses[] = 'outstanding_cents >= ?';
+            $params[] = $filter->outstandingMinCents;
+        }
+        if ($filter->outstandingMaxCents !== null) {
+            $clauses[] = 'outstanding_cents <= ?';
+            $params[] = $filter->outstandingMaxCents;
+        }
+        if ($filter->sentFrom !== null) {
+            $clauses[] = 'DATE(sent_at) >= ?';
+            $params[] = $filter->sentFrom;
+        }
+        if ($filter->sentTo !== null) {
+            $clauses[] = 'DATE(sent_at) <= ?';
+            $params[] = $filter->sentTo;
+        }
+        if ($filter->sentBy !== null) {
+            $clauses[] = 'sent_by = ?';
+            $params[] = $filter->sentBy;
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    /** Whitelisted ORDER BY — column/direction mapped from a closed set. */
+    private static function orderBy(DunningNoticeFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'invoice_number' => 'invoice_number',
+            'recipient_email' => 'recipient_email',
+            'outstanding_cents' => 'outstanding_cents',
+            'sent_by' => 'sent_by',
+            default => 'sent_at',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     public function findLastByInvoice(int $organizationId, int $invoiceId): ?DunningNotice

--- a/src/Export/ExportReconciliationsCsvHandler.php
+++ b/src/Export/ExportReconciliationsCsvHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Export;
 
 use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Reconciliation\ReconciliationFilter;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +32,7 @@ final readonly class ExportReconciliationsCsvHandler
         $rows = [];
         $offset = 0;
         do {
-            $batch = $this->reconciliations->findByOrganization($organizationId, null, self::BATCH, $offset);
+            $batch = $this->reconciliations->findByOrganization($organizationId, new ReconciliationFilter(), self::BATCH, $offset);
             foreach ($batch as $recon) {
                 $tx = $this->transactions->findById($organizationId, $recon->bankTransactionId);
 

--- a/src/Reconciliation/ListReconciliationsHandler.php
+++ b/src/Reconciliation/ListReconciliationsHandler.php
@@ -24,19 +24,31 @@ final readonly class ListReconciliationsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        $statusParam = $request->getQueryParams()['status'] ?? null;
+        $q = $request->getQueryParams();
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+
+        $statusParam = $q['status'] ?? null;
         $status = is_string($statusParam) ? ReconciliationStatus::tryFrom($statusParam) : null;
 
-        $items = $this->reconciliations->findByOrganization($organizationId, $status, $page->limit, $page->offset);
+        $filter = new ReconciliationFilter(
+            status: $status,
+            bankTransactionId: $int('bank_transaction_id'),
+            invoiceId: $int('invoice_id'),
+            confirmedFrom: $str('confirmed_from'),
+            confirmedTo: $str('confirmed_to'),
+            sortColumn: $str('sort_by') ?? 'id',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
                 static fn (Reconciliation $r): array => ReconciliationResponse::toArray($r),
-                $items,
+                $this->reconciliations->findByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->reconciliations->countByOrganization($organizationId, $status),
+            total: $this->reconciliations->countByOrganization($organizationId, $filter),
         ))->toArray());
     }
 }

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -29,32 +29,75 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
         return $row !== null ? $this->hydrateReconciliation($row) : null;
     }
 
-    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, ReconciliationFilter $filter, int $limit, int $offset): array
     {
-        if ($status === null) {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE organization_id = ? '
-                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $limit, $offset],
-            );
-        } else {
-            $rows = $this->query->fetchAll(
-                'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE organization_id = ? AND status = ? '
-                . 'ORDER BY id DESC LIMIT ? OFFSET ?',
-                [$organizationId, $status->value, $limit, $offset],
-            );
-        }
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $params[] = $limit;
+        $params[] = $offset;
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::RECON_COLUMNS . ' FROM payment_reconciliations WHERE ' . $where
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
+            $params,
+        );
 
         return array_map($this->hydrateReconciliation(...), $rows);
     }
 
-    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int
+    public function countByOrganization(int $organizationId, ReconciliationFilter $filter): int
     {
-        $row = $status === null
-            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM payment_reconciliations WHERE organization_id = ?', [$organizationId])
-            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM payment_reconciliations WHERE organization_id = ? AND status = ?', [$organizationId, $status->value]);
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM payment_reconciliations WHERE ' . $where, $params);
 
         return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * @return array{0: string, 1: list<string|int>}
+     */
+    private function whereClause(int $organizationId, ReconciliationFilter $filter): array
+    {
+        $clauses = ['organization_id = ?'];
+        /** @var list<string|int> $params */
+        $params = [$organizationId];
+
+        if ($filter->status !== null) {
+            $clauses[] = 'status = ?';
+            $params[] = $filter->status->value;
+        }
+        if ($filter->bankTransactionId !== null) {
+            $clauses[] = 'bank_transaction_id = ?';
+            $params[] = $filter->bankTransactionId;
+        }
+        if ($filter->invoiceId !== null) {
+            $clauses[] = 'EXISTS (SELECT 1 FROM reconciliation_allocations a '
+                . 'WHERE a.payment_reconciliation_id = payment_reconciliations.id AND a.invoice_id = ?)';
+            $params[] = $filter->invoiceId;
+        }
+        if ($filter->confirmedFrom !== null) {
+            $clauses[] = 'DATE(confirmed_at) >= ?';
+            $params[] = $filter->confirmedFrom;
+        }
+        if ($filter->confirmedTo !== null) {
+            $clauses[] = 'DATE(confirmed_at) <= ?';
+            $params[] = $filter->confirmedTo;
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    /** Whitelisted ORDER BY — column/direction mapped from a closed set. */
+    private static function orderBy(ReconciliationFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'bank_transaction_id' => 'bank_transaction_id',
+            'status' => 'status',
+            'confirmed_at' => 'confirmed_at',
+            default => 'id',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     public function findByIdempotencyKey(int $organizationId, string $key): ?Reconciliation

--- a/src/Reconciliation/ReconciliationFilter.php
+++ b/src/Reconciliation/ReconciliationFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Reconciliation;
+
+/**
+ * Server-side filter + sort for the reconciliation history list (Issue #130).
+ * Every field is optional; null/empty means "no constraint". `invoiceId` matches
+ * reconciliations that have an allocation to that invoice. `sortColumn` is
+ * validated against a whitelist in the repository.
+ *
+ * `confirmedFrom` / `confirmedTo` are inclusive `YYYY-MM-DD` bounds on
+ * `DATE(confirmed_at)`.
+ */
+final readonly class ReconciliationFilter
+{
+    public function __construct(
+        public ?ReconciliationStatus $status = null,
+        public ?int $bankTransactionId = null,
+        public ?int $invoiceId = null,
+        public ?string $confirmedFrom = null,
+        public ?string $confirmedTo = null,
+        public string $sortColumn = 'id',
+        public string $sortDirection = 'desc',
+    ) {
+    }
+}

--- a/src/Reconciliation/ReconciliationRepositoryInterface.php
+++ b/src/Reconciliation/ReconciliationRepositoryInterface.php
@@ -13,9 +13,9 @@ interface ReconciliationRepositoryInterface
     /**
      * @return list<Reconciliation>
      */
-    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array;
+    public function findByOrganization(int $organizationId, ReconciliationFilter $filter, int $limit, int $offset): array;
 
-    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int;
+    public function countByOrganization(int $organizationId, ReconciliationFilter $filter): int;
 
     public function save(Reconciliation $reconciliation): int;
 

--- a/tests/BankImport/InMemoryBankImportBatchRepository.php
+++ b/tests/BankImport/InMemoryBankImportBatchRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Tests\BankImport;
 
 use NeneClear\BankImport\BankImportBatch;
+use NeneClear\BankImport\BankImportBatchFilter;
 use NeneClear\BankImport\BankImportBatchRepositoryInterface;
 use NeneClear\BankImport\BankImportBatchStatus;
 
@@ -31,7 +32,7 @@ final class InMemoryBankImportBatchRepository implements BankImportBatchReposito
         return false;
     }
 
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, BankImportBatchFilter $filter, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
@@ -41,7 +42,7 @@ final class InMemoryBankImportBatchRepository implements BankImportBatchReposito
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function countByOrganization(int $organizationId, BankImportBatchFilter $filter): int
     {
         return count(array_filter(
             $this->byId,

--- a/tests/Database/PdoBankImportBatchRepositoryTest.php
+++ b/tests/Database/PdoBankImportBatchRepositoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\BankImport\BankImportBatch;
+use NeneClear\BankImport\BankImportBatchFilter;
+use NeneClear\BankImport\BankImportBatchStatus;
+use NeneClear\BankImport\PdoBankImportBatchRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoBankImportBatchRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoBankImportBatchRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-batch-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createBankImportBatches($this->query);
+        $this->repo = new PdoBankImportBatchRepository($this->query);
+
+        $this->seed('march.csv', 10, BankImportBatchStatus::Imported, '2026-03-10 09:00:00');
+        $this->seed('april.csv', 30, BankImportBatchStatus::Reversed, '2026-04-15 09:00:00');
+        $this->seed('april-2.csv', 20, BankImportBatchStatus::Imported, '2026-04-20 09:00:00');
+        $this->seed('other.csv', 5, BankImportBatchStatus::Imported, '2026-05-01 09:00:00', orgId: 99);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function seed(string $file, int $rows, BankImportBatchStatus $status, string $importedAt, int $orgId = 7): void
+    {
+        $this->repo->save(new BankImportBatch(
+            organizationId: $orgId,
+            bankAccountId: 1,
+            fileHash: bin2hex(random_bytes(6)),
+            sourceFilename: $file,
+            rowCount: $rows,
+            status: $status,
+            importedBy: 1,
+            importedAt: $importedAt,
+        ));
+    }
+
+    public function test_filename_status_and_rowcount_filters(): void
+    {
+        self::assertCount(2, $this->repo->findByOrganization(7, new BankImportBatchFilter(sourceFilename: 'april'), 50, 0));
+        self::assertCount(2, $this->repo->findByOrganization(7, new BankImportBatchFilter(status: BankImportBatchStatus::Imported), 50, 0));
+        self::assertCount(2, $this->repo->findByOrganization(7, new BankImportBatchFilter(rowCountMin: 20), 50, 0));
+        self::assertSame(2, $this->repo->countByOrganization(7, new BankImportBatchFilter(status: BankImportBatchStatus::Imported)));
+    }
+
+    public function test_imported_date_range(): void
+    {
+        $f = new BankImportBatchFilter(importedFrom: '2026-04-01', importedTo: '2026-04-30');
+        self::assertCount(2, $this->repo->findByOrganization(7, $f, 50, 0));
+    }
+
+    public function test_sort_by_row_count_ascending(): void
+    {
+        $rows = $this->repo->findByOrganization(7, new BankImportBatchFilter(sortColumn: 'row_count', sortDirection: 'asc'), 50, 0);
+        $counts = array_map(static fn (BankImportBatch $b): int => $b->rowCount, $rows);
+        self::assertSame([10, 20, 30], $counts);
+    }
+}

--- a/tests/Database/PdoDunningNoticeRepositoryTest.php
+++ b/tests/Database/PdoDunningNoticeRepositoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Dunning\DunningNotice;
+use NeneClear\Dunning\DunningNoticeFilter;
+use NeneClear\Dunning\PdoDunningNoticeRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDunningNoticeRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoDunningNoticeRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-dun-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createDunningNotices($this->query);
+        $this->repo = new PdoDunningNoticeRepository($this->query);
+
+        $this->seed('INV-001', 'a@acme.example', 110000, '2026-04-10 09:00:00', sentBy: 1);
+        $this->seed('INV-002', 'b@midori.example', 50000, '2026-04-20 09:00:00', sentBy: 2);
+        $this->seed('INV-003', 'a@acme.example', 220000, '2026-04-25 09:00:00', sentBy: 1);
+        $this->seed('INV-099', 'x@other.example', 9000, '2026-05-02 09:00:00', sentBy: 1, orgId: 99);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function seed(string $invoiceNumber, string $email, int $outstanding, string $sentAt, int $sentBy, int $orgId = 7): void
+    {
+        $this->repo->save(new DunningNotice(
+            organizationId: $orgId,
+            invoiceId: 1,
+            invoiceNumber: $invoiceNumber,
+            clientId: 45,
+            recipientEmail: $email,
+            outstandingCents: $outstanding,
+            dueAt: '2026-04-30',
+            channel: 'log',
+            templateVersion: '1.0',
+            sentBy: $sentBy,
+            sentAt: $sentAt,
+        ));
+    }
+
+    public function test_text_amount_and_actor_filters(): void
+    {
+        self::assertCount(1, $this->repo->findByOrganization(7, new DunningNoticeFilter(invoiceNumber: 'INV-002'), 50, 0));
+        self::assertCount(2, $this->repo->findByOrganization(7, new DunningNoticeFilter(recipientEmail: 'acme'), 50, 0));
+        self::assertCount(1, $this->repo->findByOrganization(7, new DunningNoticeFilter(outstandingMinCents: 200000), 50, 0));
+        self::assertCount(2, $this->repo->findByOrganization(7, new DunningNoticeFilter(sentBy: 1), 50, 0));
+    }
+
+    public function test_sent_date_range_and_sort(): void
+    {
+        $range = new DunningNoticeFilter(sentFrom: '2026-04-15', sentTo: '2026-04-30');
+        self::assertCount(2, $this->repo->findByOrganization(7, $range, 50, 0));
+
+        $rows = $this->repo->findByOrganization(7, new DunningNoticeFilter(sortColumn: 'outstanding_cents', sortDirection: 'asc'), 50, 0);
+        $amounts = array_map(static fn (DunningNotice $n): int => $n->outstandingCents, $rows);
+        self::assertSame([50000, 110000, 220000], $amounts);
+    }
+}

--- a/tests/Database/PdoReconciliationRepositoryTest.php
+++ b/tests/Database/PdoReconciliationRepositoryTest.php
@@ -12,6 +12,7 @@ use NeneClear\Reconciliation\PdoClientCreditRepository;
 use NeneClear\Reconciliation\PdoReconciliationRepository;
 use NeneClear\Reconciliation\Reconciliation;
 use NeneClear\Reconciliation\ReconciliationAllocation;
+use NeneClear\Reconciliation\ReconciliationFilter;
 use NeneClear\Reconciliation\ReconciliationStatus;
 use NeneClear\Tests\Support\SchemaFixture;
 use PHPUnit\Framework\TestCase;
@@ -128,11 +129,11 @@ final class PdoReconciliationRepositoryTest extends TestCase
         $id2 = $this->reconRepo->save($this->makeReconciliation(bankTxId: 2));
         $this->reconRepo->reverseById($id2, '2026-06-01 10:00:00', 'reason');
 
-        $confirmed = $this->reconRepo->findByOrganization(7, ReconciliationStatus::Confirmed, 50, 0);
+        $confirmed = $this->reconRepo->findByOrganization(7, new ReconciliationFilter(status: ReconciliationStatus::Confirmed), 50, 0);
         self::assertCount(1, $confirmed);
         self::assertSame($id1, $confirmed[0]->id);
 
-        self::assertSame(2, $this->reconRepo->countByOrganization(7, null));
+        self::assertSame(2, $this->reconRepo->countByOrganization(7, new ReconciliationFilter()));
     }
 
     public function test_client_credit_save_and_void(): void

--- a/tests/Dunning/InMemoryDunningNoticeRepository.php
+++ b/tests/Dunning/InMemoryDunningNoticeRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Tests\Dunning;
 
 use NeneClear\Dunning\DunningNotice;
+use NeneClear\Dunning\DunningNoticeFilter;
 use NeneClear\Dunning\DunningNoticeRepositoryInterface;
 
 final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryInterface
@@ -42,7 +43,7 @@ final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryIn
         return ($n !== null && $n->organizationId === $organizationId) ? $n : null;
     }
 
-    public function findByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, DunningNoticeFilter $filter, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
@@ -52,7 +53,7 @@ final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryIn
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId): int
+    public function countByOrganization(int $organizationId, DunningNoticeFilter $filter): int
     {
         return count(array_filter(
             $this->byId,

--- a/tests/Reconciliation/InMemoryReconciliationRepository.php
+++ b/tests/Reconciliation/InMemoryReconciliationRepository.php
@@ -6,6 +6,7 @@ namespace NeneClear\Tests\Reconciliation;
 
 use NeneClear\Reconciliation\Reconciliation;
 use NeneClear\Reconciliation\ReconciliationAllocation;
+use NeneClear\Reconciliation\ReconciliationFilter;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationStatus;
 
@@ -38,23 +39,23 @@ final class InMemoryReconciliationRepository implements ReconciliationRepository
         return null;
     }
 
-    public function findByOrganization(int $organizationId, ?ReconciliationStatus $status, int $limit, int $offset): array
+    public function findByOrganization(int $organizationId, ReconciliationFilter $filter, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
             static fn (Reconciliation $r): bool => $r->organizationId === $organizationId
-                && ($status === null || $r->status === $status),
+                && ($filter->status === null || $r->status === $filter->status),
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countByOrganization(int $organizationId, ?ReconciliationStatus $status): int
+    public function countByOrganization(int $organizationId, ReconciliationFilter $filter): int
     {
         return count(array_filter(
             $this->byId,
             static fn (Reconciliation $r): bool => $r->organizationId === $organizationId
-                && ($status === null || $r->status === $status),
+                && ($filter->status === null || $r->status === $filter->status),
         ));
     }
 

--- a/tests/e2e/specs/05-bank-import.spec.ts
+++ b/tests/e2e/specs/05-bank-import.spec.ts
@@ -29,7 +29,7 @@ test.describe('Bank import — upload + reverse boundaries', () => {
     await apiRoute(page, '**/admin/bank-import-batches?**', (route) => json(route, 200, list([])))
 
     await page.goto('/admin/bank-import')
-    await page.locator('select').selectOption('1')
+    await page.locator('form select').selectOption('1')
     await page.locator('input[type="file"]').setInputFiles({
       name: 'dup.csv',
       mimeType: 'text/csv',
@@ -79,7 +79,7 @@ test.describe('Bank import — upload + reverse boundaries', () => {
 
     await page.goto('/admin/bank-import')
 
-    await expect(page.getByText('取消済')).toBeVisible()
+    await expect(page.getByRole('table').getByText('取消済')).toBeVisible()
     await expect(page.getByRole('button', { name: '取消' })).toHaveCount(0)
   })
 })

--- a/tests/e2e/specs/06-reconciliation.spec.ts
+++ b/tests/e2e/specs/06-reconciliation.spec.ts
@@ -99,7 +99,7 @@ test.describe('Reconciliation — confirm + reverse boundaries', () => {
     await page.goto('/admin/reconciliation')
     await page.getByRole('button', { name: '消込一覧' }).click()
 
-    await expect(page.getByText('取消済')).toBeVisible()
+    await expect(page.getByRole('table').getByText('取消済')).toBeVisible()
     await expect(page.getByRole('button', { name: '消込を取消' })).toHaveCount(0)
   })
 })

--- a/tests/e2e/specs/11-scenario-reconcile.spec.ts
+++ b/tests/e2e/specs/11-scenario-reconcile.spec.ts
@@ -54,7 +54,7 @@ test('scenario: import → reconcile → reverse → logout keeps state consiste
   // ── 2. Import a bank CSV ────────────────────────────────────────────────
   await navTo(page, '銀行CSV取込', /\/admin\/bank-import/)
   await expect(page.getByText('データがありません。')).toBeVisible() // empty batch list
-  await page.locator('select').selectOption('1')
+  await page.locator('form select').selectOption('1')
   await page.locator('input[type="file"]').setInputFiles({
     name: 'april.csv',
     mimeType: 'text/csv',
@@ -84,14 +84,14 @@ test('scenario: import → reconcile → reverse → logout keeps state consiste
 
   // ── 5. History shows the confirmed reconciliation ───────────────────────
   await page.getByRole('button', { name: '消込一覧' }).click()
-  await expect(page.getByText('確定済')).toBeVisible()
+  await expect(page.getByRole('table').getByText('確定済')).toBeVisible()
 
   // ── 6. Reverse it ───────────────────────────────────────────────────────
   await page.getByRole('button', { name: '消込を取消' }).first().click()
   await page.getByRole('dialog').getByRole('textbox').fill('誤った消込のため')
   await page.getByRole('dialog').getByRole('button', { name: '消込を取消' }).click()
   await expect(page.getByRole('dialog')).toHaveCount(0)
-  await expect(page.getByText('取消済')).toBeVisible()
+  await expect(page.getByRole('table').getByText('取消済')).toBeVisible()
 
   // Back on the unmatched tab, the deposit is available again.
   await page.getByRole('button', { name: '未消込' }).click()


### PR DESCRIPTION
Completes the table-search rollout (design 04), server-side, reusing the Phase 1/2 foundation. Closes #130.

## Tables
- **bank-import (取込履歴):** `BankImportBatchFilter` — file name (LIKE), status, row-count range, imported-at range + sort (`id | source_filename | row_count | status | imported_at`).
- **reconciliation history (消込一覧):** `ReconciliationFilter` — status, bank_transaction_id, **invoice_id** (matches via an allocation `EXISTS`), confirmed-at range + sort.
- **dunning history (督促):** `DunningNoticeFilter` — invoice number (LIKE), recipient (LIKE), outstanding range, sent-at range, sent_by + sort.

Each: filter bar (text / select / number-range / date-range with the custom `DatePicker`) + match count + clear/search, sortable headers, pager — all server-side.

## Also
- Endpoints + OpenAPI params for the three lists.
- New `PdoBankImportBatchRepositoryTest`, `PdoDunningNoticeRepositoryTest`, and reconciliation coverage.
- E2E specs disambiguated where the new filter `<select>`/`<option>` collided with the upload-form select and table status badges.

## Verification
- Backend **252** (6 skipped; +5), PHPStan 8, CS clean; frontend **27**; E2E **43**.

## Note (dunning target table)
The dunning *eligible-invoices* table reads the Invoice upstream (contract filters by `status` only), so it intentionally has no server-side filter/sort here. If you want it filterable, that's a small client-side follow-up.