### PR TITLE
fix: show login in place on expired session, return to the same screen

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -142,17 +142,19 @@ describe('401 handling', () => {
     })
   })
 
-  it('clears the token and redirects to /login on 401', async () => {
+  it('clears the token on 401 (auth shell shows login in place — no hard redirect)', async () => {
     storeToken('expired-jwt')
     fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 401 }))
 
     await expect(api.get('/admin/x')).rejects.toBeInstanceOf(ApiError)
 
     expect(isAuthenticated()).toBe(false)
-    expect(window.location.href).toBe('/login')
+    // The token is cleared but the URL is left intact, so re-login returns the
+    // user to the same screen.
+    expect(window.location.href).toBe('')
   })
 
-  it('does NOT redirect on 401 from the login endpoint', async () => {
+  it('does NOT clear or redirect on 401 from the login endpoint', async () => {
     fetchMock.mockResolvedValue(
       mockResponse({
         ok: false,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,16 +16,65 @@ function getToken(): string | null {
   return sessionStorage.getItem(STORAGE_KEY)
 }
 
+// Reactive auth store: the token lives in sessionStorage (so it survives a
+// reload), but mutations also notify subscribers. The auth shell (RequireAuth)
+// subscribes via useSyncExternalStore, so storing a token reveals the app and
+// clearing it (logout or an expired 401) shows the login screen in place —
+// without a hard navigation that would blank the page and lose the route.
+const authListeners = new Set<() => void>()
+
+function notifyAuthChange(): void {
+  for (const listener of authListeners) listener()
+}
+
+/** Subscribe to token changes (for useSyncExternalStore in the auth shell). */
+export function subscribeAuthChange(listener: () => void): () => void {
+  authListeners.add(listener)
+  return () => {
+    authListeners.delete(listener)
+  }
+}
+
 export function storeToken(token: string): void {
   sessionStorage.setItem(STORAGE_KEY, token)
+  notifyAuthChange()
 }
 
 export function clearToken(): void {
   sessionStorage.removeItem(STORAGE_KEY)
+  notifyAuthChange()
 }
 
+/**
+ * Decodes a JWT payload (base64url). Returns null for tokens that are not a
+ * three-part JWT (e.g. E2E stub tokens) or that fail to decode.
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) return null
+
+  try {
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    b64 += '='.repeat((4 - (b64.length % 4)) % 4)
+    return JSON.parse(atob(b64)) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+/**
+ * True when there is a token AND, if it is a decodable JWT, it has not expired.
+ * Non-JWT stub tokens (no `exp`) are treated as valid. Pure — safe to use as a
+ * useSyncExternalStore snapshot (it never mutates state).
+ */
 export function isAuthenticated(): boolean {
-  return getToken() !== null
+  const token = getToken()
+  if (token === null) return false
+
+  const claims = decodeJwtPayload(token)
+  const exp = claims !== null && typeof claims.exp === 'number' ? claims.exp : null
+
+  return exp === null || exp * 1000 > Date.now()
 }
 
 /**
@@ -38,17 +87,8 @@ export function getUserRole(): string | null {
   const token = getToken()
   if (token === null) return null
 
-  const parts = token.split('.')
-  if (parts.length !== 3) return null
-
-  try {
-    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
-    b64 += '='.repeat((4 - (b64.length % 4)) % 4)
-    const claims = JSON.parse(atob(b64)) as { role?: unknown }
-    return typeof claims.role === 'string' ? claims.role : null
-  } catch {
-    return null
-  }
+  const claims = decodeJwtPayload(token)
+  return claims !== null && typeof claims.role === 'string' ? claims.role : null
 }
 
 /** Admin-tier roles (admin or the cross-tenant superadmin). */
@@ -81,12 +121,12 @@ async function request<T>(
     signal,
   })
 
-  // A 401 on a normal call means the session expired → clear and bounce to login.
-  // The login endpoint itself is excluded: its 401 is "wrong credentials" and
-  // must surface to the form, not trigger a redirect loop.
+  // A 401 on a normal call means the session expired → clear the token. The auth
+  // shell reacts to that and shows the login screen in place, at the current URL,
+  // so re-logging in returns the user to the same screen. The login endpoint is
+  // excluded: its 401 is "wrong credentials" and must surface to the form.
   if (res.status === 401 && !path.includes('/auth/login')) {
     clearToken()
-    window.location.href = '/login'
     throw new ApiError(401, { type: 'unauthorized', title: 'Unauthorized', status: 401 })
   }
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,5 +1,6 @@
+import { useSyncExternalStore } from 'react'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
-import { isAuthenticated, isAdmin } from '@/api/client'
+import { isAuthenticated, isAdmin, subscribeAuthChange } from '@/api/client'
 import AppShell from '@/components/AppShell'
 import LoginPage from '@/pages/login/LoginPage'
 import DashboardPage from '@/pages/dashboard/DashboardPage'
@@ -12,9 +13,17 @@ import SettingsPage from '@/pages/settings/SettingsPage'
 import UsersPage from '@/pages/users/UsersPage'
 import AuditLogPage from '@/pages/audit/AuditLogPage'
 
+/**
+ * Auth shell. Subscribes to the reactive token store so an expired/cleared
+ * session swaps the app for the login screen *in place* — same URL, no blank
+ * page, no hard redirect. Logging back in flips the store and reveals the route
+ * the user was on. (Honours the secure behaviour: the 401 handler clears the
+ * token; this just renders the consequence.)
+ */
 function RequireAuth({ children }: { children: React.ReactNode }) {
-  if (!isAuthenticated()) {
-    return <Navigate to="/login" replace />
+  const authed = useSyncExternalStore(subscribeAuthChange, isAuthenticated, isAuthenticated)
+  if (!authed) {
+    return <LoginPage />
   }
   return <>{children}</>
 }
@@ -28,10 +37,6 @@ function RequireAdmin({ children }: { children: React.ReactNode }) {
 }
 
 export const router = createBrowserRouter([
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
   {
     path: '/admin',
     element: (

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -43,8 +43,11 @@ export default function AppShell() {
   const adminNav = ADMIN_NAV.filter(item => !item.adminOnly || admin)
 
   function handleLogout() {
+    // Clearing the token flips the reactive auth store → the login screen
+    // renders in place. Reset the URL to the app root so the next login lands
+    // on the dashboard rather than whatever deep route we were on.
+    navigate('/admin', { replace: true })
     clearToken()
-    navigate('/login', { replace: true })
   }
 
   return (

--- a/frontend/src/pages/login/LoginPage.test.tsx
+++ b/frontend/src/pages/login/LoginPage.test.tsx
@@ -1,13 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-const navigateMock = vi.fn()
 const loginMock = vi.fn()
 const storeTokenMock = vi.fn()
-
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => navigateMock,
-}))
 
 vi.mock('@/api/endpoints', () => ({
   login: (email: string, password: string) => loginMock(email, password),
@@ -29,7 +24,6 @@ function fillAndSubmit(email: string, password: string) {
 
 describe('LoginPage', () => {
   beforeEach(() => {
-    navigateMock.mockReset()
     loginMock.mockReset()
     storeTokenMock.mockReset()
   })
@@ -41,7 +35,7 @@ describe('LoginPage', () => {
     expect(document.querySelector('input[name="password"]')).toBeInTheDocument()
   })
 
-  it('stores the token and navigates to /admin on success', async () => {
+  it('stores the token on success (the auth shell reveals the route in place)', async () => {
     loginMock.mockResolvedValue({ token: 'jwt-success' })
     render(<LoginPage />)
 
@@ -50,7 +44,6 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(loginMock).toHaveBeenCalledWith('admin@acme.example', 'secret-pass')
       expect(storeTokenMock).toHaveBeenCalledWith('jwt-success')
-      expect(navigateMock).toHaveBeenCalledWith('/admin', { replace: true })
     })
   })
 
@@ -68,7 +61,7 @@ describe('LoginPage', () => {
         screen.getByText('メールアドレスまたはパスワードが正しくありません。'),
       ).toBeInTheDocument()
     })
-    expect(navigateMock).not.toHaveBeenCalled()
+    expect(storeTokenMock).not.toHaveBeenCalled()
   })
 
   it('blocks submit and does not call the API when fields are empty', async () => {

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { login } from '@/api/endpoints'
 import { storeToken } from '@/api/client'
 import { Icon, Button, Notice, LogoMark } from '@/components/ui'
@@ -7,7 +6,6 @@ import { useTranslation } from '@/hooks/useTranslation'
 
 export default function LoginPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -19,8 +17,9 @@ export default function LoginPage() {
     setLoading(true)
     try {
       const { token } = await login(email, password)
+      // Storing the token flips the reactive auth store; the auth shell then
+      // reveals the route the user is on (no navigation needed).
       storeToken(token)
-      navigate('/admin', { replace: true })
     } catch {
       setError(t('login.error'))
     } finally {

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -41,11 +41,13 @@ export async function loginViaForm(
       user: { user_id: 1, email, role: opts.role ?? 'admin', organization_id: opts.orgId ?? 7 },
     }),
   )
-  await page.goto('/login')
+  await page.goto('/admin')
   await page.locator('input[name="email"]').fill(email)
   await page.locator('input[name="password"]').fill('admin1234')
   await page.getByRole('button').click()
-  await page.waitForURL(/\/admin$/)
+  // The auth shell renders the app in place once the token is stored; the
+  // logout button only exists inside the authenticated shell.
+  await page.getByRole('button', { name: 'ログアウト' }).waitFor()
 }
 
 /** Click a sidebar nav link by its visible label and wait for the route. */
@@ -54,10 +56,14 @@ export async function navTo(page: Page, label: string, urlRe: RegExp): Promise<v
   await page.waitForURL(urlRe)
 }
 
-/** Click the logout button and confirm we land on /login. */
+/**
+ * Click the logout button and confirm the session is gone. The token is cleared
+ * and the login screen renders in place (same URL) — so we wait for the login
+ * form, not a /login navigation.
+ */
 export async function logout(page: Page, label = 'ログアウト'): Promise<void> {
   await page.getByRole('button', { name: label }).click()
-  await page.waitForURL(/\/login/)
+  await page.locator('input[name="email"]').waitFor()
 }
 
 /**

--- a/tests/e2e/specs/01-login.spec.ts
+++ b/tests/e2e/specs/01-login.spec.ts
@@ -9,13 +9,14 @@ test.describe('Login', () => {
       return json(route, 200, { token: 'x', user: {} })
     })
 
-    await page.goto('/login')
+    await page.goto('/admin')
     await page.getByRole('button').click()
 
     // zod min(1) on email + password prevents the API call.
     await page.waitForTimeout(300)
     expect(loginCalled).toBe(false)
-    await expect(page).toHaveURL(/\/login/)
+    // Still on the login form (rendered in place by the auth shell).
+    await expect(page.locator('input[name="email"]')).toBeVisible()
   })
 
   test('shows error detail on wrong credentials (401) and stays on login', async ({ page }) => {
@@ -23,7 +24,7 @@ test.describe('Login', () => {
       problem(route, 401, 'invalid-credentials', '認証失敗', 'メールアドレスまたはパスワードが正しくありません。'),
     )
 
-    await page.goto('/login')
+    await page.goto('/admin')
     await page.locator('input[name="email"]').fill('admin@nene-clear.dev')
     await page.locator('input[name="password"]').fill('wrong-pass')
     await page.getByRole('button').click()
@@ -31,20 +32,20 @@ test.describe('Login', () => {
     await expect(
       page.getByText('メールアドレスまたはパスワードが正しくありません。'),
     ).toBeVisible()
-    await expect(page).toHaveURL(/\/login/)
-    // Token must not have been stored.
+    // The login form is still shown (in place); token must not have been stored.
+    await expect(page.locator('input[name="email"]')).toBeVisible()
     const token = await page.evaluate((k) => sessionStorage.getItem(k), TOKEN_KEY)
     expect(token).toBeNull()
   })
 
-  test('stores token and redirects to /admin on success', async ({ page }) => {
+  test('stores token and reveals the app in place on success', async ({ page }) => {
     await apiRoute(page, '**/admin/auth/login', (route) =>
       json(route, 200, {
         token: 'jwt-success',
         user: { user_id: 1, email: 'admin@nene-clear.dev', role: 'superadmin', organization_id: null },
       }),
     )
-    // Dashboard data after redirect.
+    // Dashboard data after the auth shell reveals the app.
     await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
       json(route, 200, { items: [], total: 0, limit: 1, offset: 0 }),
     )
@@ -52,11 +53,13 @@ test.describe('Login', () => {
       json(route, 200, { items: [], total: 0, limit: 5, offset: 0 }),
     )
 
-    await page.goto('/login')
+    await page.goto('/admin')
     await page.locator('input[name="email"]').fill('admin@nene-clear.dev')
     await page.locator('input[name="password"]').fill('admin1234')
     await page.getByRole('button').click()
 
+    // The authenticated shell appears in place at the same URL.
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
     await expect(page).toHaveURL(/\/admin$/)
     const token = await page.evaluate((k) => sessionStorage.getItem(k), TOKEN_KEY)
     expect(token).toBe('jwt-success')

--- a/tests/e2e/specs/02-auth-guard.spec.ts
+++ b/tests/e2e/specs/02-auth-guard.spec.ts
@@ -2,20 +2,22 @@ import { test, expect } from '@playwright/test'
 import { apiRoute, json, problem, bypassLogin } from '../fixtures/helpers'
 
 test.describe('Auth guard', () => {
-  test('unauthenticated access to /admin redirects to /login', async ({ page }) => {
+  test('unauthenticated access to /admin shows the login screen in place', async ({ page }) => {
     await page.goto('/admin')
-    await expect(page).toHaveURL(/\/login/)
+    // The auth shell renders the login form at the same URL (no redirect).
+    await expect(page.locator('input[name="email"]')).toBeVisible()
+    await expect(page).toHaveURL(/\/admin/)
   })
 
-  test('root path redirects into the app then to login when unauthenticated', async ({ page }) => {
+  test('root path lands in the app then shows login when unauthenticated', async ({ page }) => {
     await page.goto('/')
-    await expect(page).toHaveURL(/\/login/)
+    await expect(page.locator('input[name="email"]')).toBeVisible()
   })
 
-  test('expired session (401 mid-session) clears token and bounces to login', async ({ page }) => {
+  test('expired session (401 mid-session) clears token and shows login in place', async ({ page }) => {
     await bypassLogin(page)
 
-    // The dashboard's first data call returns 401 → global handler redirects.
+    // The dashboard's first data call returns 401 → global handler clears the token.
     await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
       problem(route, 401, 'unauthorized', 'Unauthorized'),
     )
@@ -25,8 +27,9 @@ test.describe('Auth guard', () => {
 
     await page.goto('/admin')
 
-    // The global 401 handler clears the token and redirects; the URL is the
-    // reliable signal (the harness re-injects the token on reload).
-    await expect(page).toHaveURL(/\/login/)
+    // The cleared token flips the auth shell to the login form, at the same URL,
+    // so re-login returns the user to this screen.
+    await expect(page.locator('input[name="email"]')).toBeVisible()
+    await expect(page).toHaveURL(/\/admin/)
   })
 })

--- a/tests/e2e/specs/11-scenario-reconcile.spec.ts
+++ b/tests/e2e/specs/11-scenario-reconcile.spec.ts
@@ -100,5 +100,6 @@ test('scenario: import → reconcile → reverse → logout keeps state consiste
   // ── 7. Logout and verify the session is gone ────────────────────────────
   await logout(page)
   await page.goto('/admin')
-  await expect(page).toHaveURL(/\/login/)
+  // Reloading with the token cleared lands on the login form (in place).
+  await expect(page.locator('input[name="email"]')).toBeVisible()
 })

--- a/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
+++ b/tests/e2e/specs/12-scenario-dunning-locale.spec.ts
@@ -75,5 +75,6 @@ test('scenario: locale switch + dunning send + too-frequent + logout', async ({ 
   // ── 6. Logout ───────────────────────────────────────────────────────────
   await logout(page)
   await page.goto('/admin')
-  await expect(page).toHaveURL(/\/login/)
+  // Reloading with the token cleared lands on the login form (in place).
+  await expect(page.locator('input[name="email"]')).toBeVisible()
 })

--- a/tests/e2e/specs/13-scenario-users-session.spec.ts
+++ b/tests/e2e/specs/13-scenario-users-session.spec.ts
@@ -8,7 +8,8 @@ import {
  *
  * login → users → invite (ok) → invite duplicate (409 in modal) → cancel →
  * reopen (modal must be clean, no stale error) → delete a user → session
- * expires mid-session (401) → bounced to login → re-login → back in.
+ * expires mid-session (401) → login shown in place → re-login → back on the
+ * same screen.
  *
  * Bug surface: modal state leakage between opens, cache invalidation on
  * invite/delete, and recovery from an expired session.
@@ -83,16 +84,18 @@ test('scenario: user admin → 409 → modal reset → delete → 401 expiry →
   await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByText('old@acme.example')).toHaveCount(0)
 
-  // ── 6. Session expires → next data load bounces to /login ───────────────
+  // ── 6. Session expires → next data load shows login in place (same URL) ──
   sessionValid = false
   await page.reload()
-  await expect(page).toHaveURL(/\/login/)
+  // Still on /admin/users, but the cleared token flips the shell to the login form.
+  await expect(page).toHaveURL(/\/admin\/users/)
+  await expect(page.locator('input[name="email"]')).toBeVisible()
 
-  // ── 7. Re-login succeeds ────────────────────────────────────────────────
+  // ── 7. Re-login returns to the same screen (the users page) ──────────────
   sessionValid = true
   await page.locator('input[name="email"]').fill('admin@nene-clear.dev')
   await page.locator('input[name="password"]').fill('admin1234')
   await page.getByRole('button').click()
-  await page.waitForURL(/\/admin$/)
-  await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible()
+  await expect(page).toHaveURL(/\/admin\/users/)
+  await expect(page.getByText('admin@acme.example')).toBeVisible()
 })


### PR DESCRIPTION
## Summary
Fixes the blank white screen when the admin SPA is left open until the JWT expires and the page is reloaded. The expired token was still in `sessionStorage`, so the route guard (token-present-only) let the page mount; the first data call 401'd and the handler did a hard `window.location` jump to `/login` that lost the route — forcing users to manually trim the URL down to root to reach login.

Adopts the **nene-invoice auth-shell model**, adapted to Clear's `sessionStorage` persistence: on an expired/cleared session the login screen now renders **in place at the same URL**, and re-logging in **returns the user to the screen they were on**. The secure behavior is unchanged — the token is still cleared on 401/expiry.

## Changes
- **`api/client.ts`** — reactive token store (`subscribeAuthChange`, notify on store/clear); `isAuthenticated()` is now JWT-`exp`-aware (non-JWT stub tokens stay valid); the 401 handler only clears the token (no hard redirect).
- **`app/router.tsx`** — `RequireAuth` subscribes via `useSyncExternalStore` and renders `<LoginPage/>` in place when unauthenticated; the standalone `/login` route is removed.
- **`pages/login/LoginPage.tsx`** — on success just stores the token; the shell reveals the underlying route.
- **`components/AppShell.tsx`** — logout clears the token and resets the URL to `/admin`.
- **E2E** — helpers + specs updated to assert the login form in place (same URL) rather than a `/login` navigation; scenario 13 now verifies re-login returns to the users page it expired on.

## Verification
- `npm run check` (tsc + eslint + vitest): green (27 tests)
- `npx playwright test`: green (43 tests)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)