### PR TITLE
feat: keyboard shortcuts + command palette

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { useTranslation } from '@/hooks/useTranslation'
 import { clearToken, isAdmin } from '@/api/client'
 import { Icon, LogoMark } from '@/components/ui'
+import { KeyboardShortcuts, openShortcutsOverlay } from '@/components/keyboard'
 import type { MessageKey } from '@/locales'
 
 type NavEntry = { to: string; labelKey: MessageKey; icon: string; end?: boolean; badge?: number; adminOnly?: boolean }
@@ -93,6 +94,14 @@ export default function AppShell() {
               <button className={locale === 'ja' ? 'on' : ''} onClick={() => switchLocale('ja')}>JA</button>
               <button className={locale === 'en' ? 'on' : ''} onClick={() => switchLocale('en')}>EN</button>
             </div>
+            <button
+              className="iconbtn"
+              title={t('shortcuts.open')}
+              aria-label={t('shortcuts.open')}
+              onClick={() => openShortcutsOverlay()}
+            >
+              <kbd className="kbd" aria-hidden="true">?</kbd>
+            </button>
             <span className="sep" />
             <button className="iconbtn" title={t('nav.logout')} onClick={handleLogout}>
               <Icon name="logout" />
@@ -105,6 +114,9 @@ export default function AppShell() {
           </div>
         </div>
       </div>
+
+      {/* Global keyboard dispatcher — mounted once, inside the authenticated shell. */}
+      <KeyboardShortcuts />
     </div>
   )
 }

--- a/frontend/src/components/keyboard/CommandPalette.tsx
+++ b/frontend/src/components/keyboard/CommandPalette.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { MessageKey } from '@/locales'
+
+interface Command {
+  id: string
+  labelKey: MessageKey
+  path: string
+  combo: string[]
+}
+
+const COMMANDS: Command[] = [
+  { id: 'dashboard', labelKey: 'nav.dashboard', path: '/admin', combo: ['g', 'd'] },
+  { id: 'reconciliation', labelKey: 'nav.reconciliation', path: '/admin/reconciliation', combo: ['g', 'r'] },
+  { id: 'bankTransactions', labelKey: 'nav.bankTransactions', path: '/admin/bank-transactions', combo: ['g', 'b'] },
+  { id: 'bankImport', labelKey: 'nav.bankImport', path: '/admin/bank-import', combo: ['g', 'i'] },
+  { id: 'clientCredits', labelKey: 'nav.clientCredits', path: '/admin/client-credits', combo: ['g', 'c'] },
+  { id: 'dunning', labelKey: 'nav.dunning', path: '/admin/dunning', combo: ['g', 'n'] },
+  { id: 'users', labelKey: 'nav.users', path: '/admin/users', combo: ['g', 'u'] },
+  { id: 'settings', labelKey: 'nav.settings', path: '/admin/settings', combo: ['g', 's'] },
+  { id: 'audit', labelKey: 'nav.auditLog', path: '/admin/audit-log', combo: ['g', 'a'] },
+]
+
+export function CommandPalette({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const titleId = useId()
+  const [cursor, setCursor] = useState(0)
+  const cursorRef = useRef(0)
+
+  useEffect(() => {
+    cursorRef.current = cursor
+  }, [cursor])
+
+  useEffect(() => {
+    const run = (index: number): void => {
+      const cmd = COMMANDS[index]
+      if (cmd === undefined) return
+      onClose()
+      void navigate(cmd.path)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        e.preventDefault()
+        setCursor((c) => Math.min(c + 1, COMMANDS.length - 1))
+      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        setCursor((c) => Math.max(c - 1, 0))
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        run(cursorRef.current)
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [navigate, onClose])
+
+  useEffect(() => {
+    const el = document.querySelector(`[data-cmdp-row="${String(cursor)}"]`)
+    if (el instanceof HTMLElement && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest' })
+    }
+  }, [cursor])
+
+  return (
+    <div className="modal-dim">
+      <button type="button" aria-label={t('actions.close')} className="sc-backdrop" onClick={onClose} />
+      <div className="cmdp" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="cmdp-head" id={titleId}>
+          <b>{t('commandPalette.title')}</b>
+          <span>{t('commandPalette.titleEn')}</span>
+        </div>
+        <ul className="cmdp-list" role="listbox" aria-label={t('commandPalette.title')}>
+          {COMMANDS.map((cmd, i) => (
+            <li key={cmd.id}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={i === cursor}
+                data-cmdp-row={i}
+                className={`cmdp-row${i === cursor ? ' hl' : ''}`}
+                onMouseEnter={() => {
+                  setCursor(i)
+                }}
+                onClick={() => {
+                  onClose()
+                  void navigate(cmd.path)
+                }}
+              >
+                <span className="cmdp-label">{t(cmd.labelKey)}</span>
+                <span className="cmdp-keys">
+                  {cmd.combo.map((cap, index) => (
+                    <kbd key={`${cap}-${String(index)}`} className="kbd">
+                      {cap}
+                    </kbd>
+                  ))}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div className="cmdp-foot">{t('commandPalette.hint')}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/keyboard/KbdHint.tsx
+++ b/frontend/src/components/keyboard/KbdHint.tsx
@@ -1,0 +1,8 @@
+/** Decorative inline key hint, e.g. on a "New" button: <KbdHint k="n" />. */
+export function KbdHint({ k }: { k: string }) {
+  return (
+    <kbd className="kbd-hint" aria-hidden="true">
+      {k}
+    </kbd>
+  )
+}

--- a/frontend/src/components/keyboard/KeyboardShortcuts.test.tsx
+++ b/frontend/src/components/keyboard/KeyboardShortcuts.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { KeyboardShortcuts } from './KeyboardShortcuts'
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="loc">{location.pathname}</div>
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <input data-kbd="search" aria-label="search" />
+      <KeyboardShortcuts />
+      <Routes>
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+const loc = () => screen.getByTestId('loc').textContent
+
+describe('KeyboardShortcuts', () => {
+  beforeEach(() => {
+    document.body.focus()
+  })
+
+  it('g → d navigates to the dashboard', () => {
+    renderAt('/admin/reconciliation')
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'd' })
+    expect(loc()).toBe('/admin')
+  })
+
+  it('g → r navigates to reconciliation', () => {
+    renderAt('/admin')
+    fireEvent.keyDown(document, { key: 'g' })
+    fireEvent.keyDown(document, { key: 'r' })
+    expect(loc()).toBe('/admin/reconciliation')
+  })
+
+  it('? opens the cheat-sheet overlay and Esc closes it', () => {
+    renderAt('/admin')
+    fireEvent.keyDown(document, { key: '?' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('Ctrl+K opens the palette; j then Enter goes to the 2nd command', () => {
+    renderAt('/admin')
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    // Cursor starts at 0 (dashboard); j → 1 (reconciliation); Enter navigates.
+    fireEvent.keyDown(document, { key: 'j' })
+    fireEvent.keyDown(document, { key: 'Enter' })
+    expect(loc()).toBe('/admin/reconciliation')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('palette closes on Esc', () => {
+    renderAt('/admin')
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('Esc blurs a focused field, but not while composing (IME)', () => {
+    renderAt('/admin')
+    const input = screen.getByLabelText('search')
+    input.focus()
+    expect(document.activeElement).toBe(input)
+
+    // IME composition active → Esc must not steal the cancel.
+    fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+    expect(document.activeElement).toBe(input)
+
+    // Not composing → Esc blurs.
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(document.activeElement).not.toBe(input)
+  })
+
+  it('single keys are ignored while typing in a field', () => {
+    renderAt('/admin/reconciliation')
+    const input = screen.getByLabelText('search')
+    input.focus()
+    fireEvent.keyDown(input, { key: 'g' })
+    fireEvent.keyDown(input, { key: 'd' })
+    expect(loc()).toBe('/admin/reconciliation')
+  })
+
+  it('IME keydown (keyCode 229) does not start a g-sequence', () => {
+    renderAt('/admin/reconciliation')
+    fireEvent.keyDown(document, { key: 'g', keyCode: 229 })
+    fireEvent.keyDown(document, { key: 'd' })
+    expect(loc()).toBe('/admin/reconciliation')
+  })
+
+  it('u returns to the list from a detail view but not from a /new form', () => {
+    const { unmount } = renderAt('/admin/users/42')
+    fireEvent.keyDown(document, { key: 'u' })
+    expect(loc()).toBe('/admin/users')
+    unmount()
+
+    renderAt('/admin/users/new')
+    fireEvent.keyDown(document, { key: 'u' })
+    expect(loc()).toBe('/admin/users/new')
+  })
+})

--- a/frontend/src/components/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/components/keyboard/KeyboardShortcuts.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { CommandPalette } from './CommandPalette'
+import { SHOW_SHORTCUTS_EVENT } from './overlay-control'
+import { ShortcutsOverlay } from './ShortcutsOverlay'
+import { KBD_LIST_EVENT, type RowCursorAction } from './use-row-cursor'
+
+function emitListAction(action: RowCursorAction): void {
+  document.dispatchEvent(new CustomEvent(KBD_LIST_EVENT, { detail: { action } }))
+}
+
+const G_TIMEOUT_MS = 1200
+
+/** Layer 1 — g→key navigation targets (nene-clear routes). */
+const GOTO: Record<string, string> = {
+  d: '/admin',
+  r: '/admin/reconciliation',
+  b: '/admin/bank-transactions',
+  i: '/admin/bank-import',
+  c: '/admin/client-credits',
+  n: '/admin/dunning',
+  u: '/admin/users',
+  s: '/admin/settings',
+  a: '/admin/audit-log',
+}
+
+/**
+ * Layer 2 — `n` (new) per current list route. nene-clear has no create pages
+ * yet (all routes are flat lists), so this stays empty; `n` is a no-op until a
+ * create route exists.
+ */
+const NEW_ROUTE: Record<string, string> = {}
+
+/**
+ * Parent list roots for `u` (back to list, from detail views only). nene-clear
+ * has no detail routes yet, so `u` is effectively a no-op; kept for when detail
+ * pages land.
+ */
+const LIST_ROOTS = [
+  '/admin/reconciliation',
+  '/admin/bank-transactions',
+  '/admin/client-credits',
+  '/admin/dunning',
+  '/admin/users',
+  '/admin/audit-log',
+]
+
+/** Back to list only from a detail view — never from a /new or /edit form. */
+function parentListOf(path: string): string | null {
+  if (path.endsWith('/new') || path.endsWith('/edit')) return null
+  return LIST_ROOTS.find((root) => path.startsWith(`${root}/`)) ?? null
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    (target.isContentEditable || target.matches('input, textarea, select'))
+  )
+}
+
+/**
+ * Global keyboard dispatcher. Mount once inside the authenticated shell (never on
+ * login). Order of handling (A→E) is load-bearing — keep it.
+ */
+export function KeyboardShortcuts() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [overlayOpen, setOverlayOpen] = useState(false)
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const [pendingG, setPendingG] = useState(false)
+
+  const overlayRef = useRef(false)
+  const paletteRef = useRef(false)
+  const pendingRef = useRef(false)
+  const pathRef = useRef(location.pathname)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    overlayRef.current = overlayOpen
+  }, [overlayOpen])
+  useEffect(() => {
+    paletteRef.current = paletteOpen
+  }, [paletteOpen])
+  useEffect(() => {
+    const open = (): void => {
+      setOverlayOpen(true)
+    }
+    document.addEventListener(SHOW_SHORTCUTS_EVENT, open)
+    return () => {
+      document.removeEventListener(SHOW_SHORTCUTS_EVENT, open)
+    }
+  }, [])
+  useEffect(() => {
+    pendingRef.current = pendingG
+  }, [pendingG])
+  useEffect(() => {
+    pathRef.current = location.pathname
+  }, [location.pathname])
+
+  useEffect(() => {
+    const clearPending = (): void => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      pendingRef.current = false
+      setPendingG(false)
+    }
+
+    const onKeydown = (e: KeyboardEvent): void => {
+      // A — submit chord is always handled, even in fields / IME.
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        const form = e.target instanceof HTMLElement ? e.target.closest('form') : null
+        if (form !== null) {
+          e.preventDefault()
+          form.requestSubmit()
+        }
+        return
+      }
+
+      // ⌘K / Ctrl+K — toggle command palette (before the modifier guard; works in fields).
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        clearPending()
+        setOverlayOpen(false)
+        setPaletteOpen((open) => !open)
+        return
+      }
+
+      // Palette open → its own listener owns the keyboard.
+      if (paletteRef.current) return
+
+      if (e.key === 'Escape') {
+        if (overlayRef.current) setOverlayOpen(false)
+        else if (pendingRef.current) clearPending()
+        else if (!e.isComposing && isEditableTarget(e.target)) {
+          ;(e.target as HTMLElement).blur()
+        }
+        return
+      }
+
+      // B — IME / editable-field guard. (keyCode 229 = IME composition in flight.)
+      if (e.isComposing || e.keyCode === 229) return
+      if (isEditableTarget(e.target)) return
+
+      // C — modifier+single-key belongs to the OS/browser.
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+
+      if (e.key === '?') {
+        e.preventDefault()
+        clearPending()
+        setOverlayOpen((open) => !open)
+        return
+      }
+      if (overlayRef.current) return
+
+      // D — g-prefix sequence.
+      if (pendingRef.current) {
+        const dest = GOTO[e.key]
+        clearPending()
+        if (dest !== undefined) {
+          e.preventDefault()
+          void navigate(dest)
+        }
+        return
+      }
+      if (e.key === 'g') {
+        e.preventDefault()
+        pendingRef.current = true
+        setPendingG(true)
+        if (timerRef.current !== null) clearTimeout(timerRef.current)
+        timerRef.current = setTimeout(clearPending, G_TIMEOUT_MS)
+        return
+      }
+
+      // E — single-key actions.
+      if (e.key === '/') {
+        const target =
+          document.querySelector('[data-kbd="search"]') ??
+          document.querySelector(
+            'form input:not([type="hidden"]):not([type="checkbox"]):not([type="radio"]), form textarea, form select',
+          )
+        if (target instanceof HTMLElement) {
+          e.preventDefault()
+          target.focus()
+        }
+        return
+      }
+      if (e.key === 'n') {
+        const dest = NEW_ROUTE[pathRef.current]
+        if (dest !== undefined) {
+          e.preventDefault()
+          void navigate(dest)
+        }
+        return
+      }
+      if (e.key === 'u') {
+        const list = parentListOf(pathRef.current)
+        if (list !== null) {
+          e.preventDefault()
+          void navigate(list)
+        }
+        return
+      }
+      if (e.key === 'j' || e.key === 'k') {
+        e.preventDefault()
+        emitListAction(e.key === 'j' ? 'down' : 'up')
+        return
+      }
+      if (e.key === 'o') {
+        emitListAction('open')
+        return
+      }
+      if (e.key === 'Enter' && (e.target === document.body || e.target === null)) {
+        emitListAction('open')
+      }
+    }
+
+    document.addEventListener('keydown', onKeydown)
+    return () => {
+      document.removeEventListener('keydown', onKeydown)
+      if (timerRef.current !== null) clearTimeout(timerRef.current)
+    }
+  }, [navigate])
+
+  return (
+    <>
+      {pendingG && (
+        <div className="kbd-gind" role="status" aria-live="polite">
+          g…
+        </div>
+      )}
+      {overlayOpen && <ShortcutsOverlay onClose={() => setOverlayOpen(false)} />}
+      {paletteOpen && <CommandPalette onClose={() => setPaletteOpen(false)} />}
+    </>
+  )
+}

--- a/frontend/src/components/keyboard/ShortcutsOverlay.tsx
+++ b/frontend/src/components/keyboard/ShortcutsOverlay.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useId } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import { isMacPlatform } from './platform'
+import { MOD, SHORTCUT_GROUPS, type ShortcutCombo, type ShortcutGroup } from './shortcuts-data'
+
+export interface ShortcutsOverlayProps {
+  onClose: () => void
+}
+
+function capLabel(cap: string, mac: boolean): string {
+  if (cap === MOD) return mac ? '⌘' : 'Ctrl'
+  return cap
+}
+const isWide = (label: string): boolean => label.length > 1
+
+function Combo({ combo, mac }: { combo: ShortcutCombo; mac: boolean }) {
+  return (
+    <span className="sc-keys">
+      {combo.caps.map((cap, i) => {
+        const label = capLabel(cap, mac)
+        return (
+          <span key={`${cap}-${String(i)}`} className="sc-keycap-wrap">
+            {i > 0 && combo.join === 'then' && <span className="sc-join">→</span>}
+            {i > 0 && combo.join === 'plus' && <span className="sc-join">+</span>}
+            <kbd className={isWide(label) ? 'kbd wide' : 'kbd'}>{label}</kbd>
+          </span>
+        )
+      })}
+    </span>
+  )
+}
+
+function Group({ group, mac }: { group: ShortcutGroup; mac: boolean }) {
+  return (
+    <>
+      <div className="sc-grp">
+        {group.ja}
+        <span className="sc-grp-en"> · {group.en}</span>
+      </div>
+      {group.rows.map((row) => (
+        <div key={row.en} className="sc-row">
+          <span className="lbl">
+            {row.ja}
+            <small>{row.en}</small>
+          </span>
+          <span className="sc-keys-row">
+            {row.combos.map((combo, i) => (
+              <Combo key={i} combo={combo} mac={mac} />
+            ))}
+          </span>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export function ShortcutsOverlay({ onClose }: ShortcutsOverlayProps) {
+  const { t } = useTranslation()
+  const titleId = useId()
+  const mac = isMacPlatform()
+  const mid = Math.ceil(SHORTCUT_GROUPS.length / 2)
+  const columns = [SHORTCUT_GROUPS.slice(0, mid), SHORTCUT_GROUPS.slice(mid)]
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return (
+    <div className="modal-dim">
+      <button
+        type="button"
+        aria-label={t('actions.close')}
+        className="sc-backdrop"
+        onClick={onClose}
+      />
+      <div className="sc-modal" role="dialog" aria-modal="true" aria-labelledby={titleId}>
+        <div className="sc-head">
+          <span className="sc-title" id={titleId}>
+            <b>{t('shortcuts.title')}</b>
+            <span>{t('shortcuts.titleEn')}</span>
+          </span>
+          <button type="button" className="sc-x" onClick={onClose}>
+            <kbd className="kbd wide">Esc</kbd> {t('actions.close')}
+          </button>
+        </div>
+        <div className="sc-body">
+          {columns.map((groups, i) => (
+            <div key={i} className="sc-col">
+              {groups.map((group) => (
+                <Group key={group.en} group={group} mac={mac} />
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className="sc-foot">
+          <span>{t('shortcuts.footHint')}</span>
+          <span>{mac ? t('shortcuts.footModMac') : t('shortcuts.footModOther')}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/keyboard/index.ts
+++ b/frontend/src/components/keyboard/index.ts
@@ -1,0 +1,5 @@
+export { KeyboardShortcuts } from './KeyboardShortcuts'
+export { openShortcutsOverlay } from './overlay-control'
+export { KbdHint } from './KbdHint'
+export { isMacPlatform } from './platform'
+export { useRowCursor } from './use-row-cursor'

--- a/frontend/src/components/keyboard/overlay-control.ts
+++ b/frontend/src/components/keyboard/overlay-control.ts
@@ -1,0 +1,7 @@
+/** Event the sidebar button dispatches to open the `?` cheat-sheet overlay. */
+export const SHOW_SHORTCUTS_EVENT = 'kbd:show-shortcuts'
+
+/** Opens the cheat-sheet from outside the dispatcher (e.g. a sidebar button). */
+export function openShortcutsOverlay(): void {
+  document.dispatchEvent(new CustomEvent(SHOW_SHORTCUTS_EVENT))
+}

--- a/frontend/src/components/keyboard/platform.ts
+++ b/frontend/src/components/keyboard/platform.ts
@@ -1,0 +1,5 @@
+/** True on macOS-like platforms (⌘ vs Ctrl labelling only). */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent)
+}

--- a/frontend/src/components/keyboard/shortcuts-data.ts
+++ b/frontend/src/components/keyboard/shortcuts-data.ts
@@ -1,0 +1,75 @@
+export const MOD = 'mod'
+
+export interface ShortcutCombo {
+  caps: string[]
+  join: 'then' | 'plus' | 'none'
+}
+export interface ShortcutRow {
+  ja: string
+  en: string
+  combos: ShortcutCombo[]
+}
+export interface ShortcutGroup {
+  ja: string
+  en: string
+  rows: ShortcutRow[]
+}
+
+// Labels mirror the nene-clear nav terminology; the g 2nd keys match GOTO /
+// COMMANDS in KeyboardShortcuts.tsx / CommandPalette.tsx.
+export const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    ja: '画面遷移',
+    en: 'Navigation',
+    rows: [
+      { ja: 'ダッシュボード', en: 'Dashboard', combos: [{ caps: ['g', 'd'], join: 'then' }] },
+      { ja: '消込', en: 'Reconciliation', combos: [{ caps: ['g', 'r'], join: 'then' }] },
+      { ja: '銀行取引一覧', en: 'Bank transactions', combos: [{ caps: ['g', 'b'], join: 'then' }] },
+      { ja: '銀行CSV取込', en: 'Bank import', combos: [{ caps: ['g', 'i'], join: 'then' }] },
+      { ja: '前受金', en: 'Client credits', combos: [{ caps: ['g', 'c'], join: 'then' }] },
+      { ja: '督促', en: 'Dunning', combos: [{ caps: ['g', 'n'], join: 'then' }] },
+      { ja: 'ユーザー管理', en: 'Users', combos: [{ caps: ['g', 'u'], join: 'then' }] },
+      { ja: '設定', en: 'Settings', combos: [{ caps: ['g', 's'], join: 'then' }] },
+      { ja: '監査ログ', en: 'Audit log', combos: [{ caps: ['g', 'a'], join: 'then' }] },
+    ],
+  },
+  {
+    ja: 'リスト',
+    en: 'List',
+    rows: [
+      {
+        ja: '次 / 前の行',
+        en: 'Next / Prev row',
+        combos: [{ caps: ['j'], join: 'none' }, { caps: ['k'], join: 'none' }],
+      },
+      {
+        ja: '選択行を開く',
+        en: 'Open row',
+        combos: [{ caps: ['Enter'], join: 'none' }, { caps: ['o'], join: 'none' }],
+      },
+    ],
+  },
+  {
+    ja: 'アクション',
+    en: 'Actions',
+    rows: [
+      { ja: '検索へフォーカス', en: 'Focus search', combos: [{ caps: ['/'], join: 'none' }] },
+    ],
+  },
+  {
+    ja: 'フォーム',
+    en: 'Form',
+    rows: [
+      { ja: '確定 / 送信', en: 'Submit', combos: [{ caps: [MOD, 'Enter'], join: 'plus' }] },
+      { ja: '中断 / 閉じる', en: 'Cancel', combos: [{ caps: ['Esc'], join: 'none' }] },
+    ],
+  },
+  {
+    ja: '全般',
+    en: 'General',
+    rows: [
+      { ja: 'コマンドパレット', en: 'Command palette', combos: [{ caps: [MOD, 'K'], join: 'plus' }] },
+      { ja: 'ショートカット一覧', en: 'Show shortcuts', combos: [{ caps: ['?'], join: 'none' }] },
+    ],
+  },
+]

--- a/frontend/src/components/keyboard/use-row-cursor.ts
+++ b/frontend/src/components/keyboard/use-row-cursor.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react'
+
+export type RowCursorAction = 'down' | 'up' | 'open'
+
+/** Custom event the dispatcher emits for j / k / o / Enter. */
+export const KBD_LIST_EVENT = 'kbd:list'
+
+/**
+ * List row cursor (layer 4). A list opts in with its row count and an open
+ * handler; the global dispatcher emits `kbd:list`, and the cursored row gets
+ * `.is-cursor` (the caller renders it). Returns the active index, or -1 for none.
+ */
+export function useRowCursor(count: number, onOpen: (index: number) => void): number {
+  const [cursor, setCursor] = useState(-1)
+  const cursorRef = useRef(-1)
+  const onOpenRef = useRef(onOpen)
+
+  useEffect(() => {
+    cursorRef.current = cursor
+  }, [cursor])
+  useEffect(() => {
+    onOpenRef.current = onOpen
+  }, [onOpen])
+
+  // Keep the cursor in range when the row set shrinks (e.g. after filtering).
+  if (cursor >= count) setCursor(count - 1)
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const action = (event as CustomEvent<{ action: RowCursorAction }>).detail.action
+      if (action === 'down') setCursor((c) => Math.min(count - 1, c + 1))
+      else if (action === 'up') setCursor((c) => (c <= 0 ? 0 : c - 1))
+      else if (cursorRef.current >= 0) onOpenRef.current(cursorRef.current)
+    }
+    document.addEventListener(KBD_LIST_EVENT, handler)
+    return () => {
+      document.removeEventListener(KBD_LIST_EVENT, handler)
+    }
+  }, [count])
+
+  // Keep the cursored row visible (guard scrollIntoView for jsdom).
+  useEffect(() => {
+    if (cursor < 0) return
+    const el = document.querySelector(`[data-kbd-row="${String(cursor)}"]`)
+    if (el instanceof HTMLElement && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest' })
+    }
+  }, [cursor])
+
+  return cursor
+}

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -285,4 +285,16 @@ export const en: Record<MessageKey, string> = {
   'audit.event.organization_deleted': 'Organization deleted',
   'audit.event.login_succeeded': 'Login succeeded',
   'audit.event.login_failed': 'Login failed',
+
+  // ── Keyboard shortcuts / command palette ──
+  'shortcuts.title': 'Keyboard shortcuts',
+  'shortcuts.titleEn': 'Keyboard shortcuts',
+  'shortcuts.footHint': 'Press ? to reopen',
+  'shortcuts.footModMac': 'Modifier shown as ⌘ on macOS',
+  'shortcuts.footModOther': 'Modifier shown as Ctrl',
+  'shortcuts.open': 'Keyboard shortcuts (?)',
+  'commandPalette.title': 'Command palette',
+  'commandPalette.titleEn': 'Command palette',
+  'commandPalette.hint': 'Select with j / k or ↑ ↓, Enter to go',
+  'actions.close': 'Close',
 }

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -281,6 +281,18 @@ export const ja = {
   'audit.event.organization_deleted': '組織削除',
   'audit.event.login_succeeded': 'ログイン成功',
   'audit.event.login_failed': 'ログイン失敗',
+
+  // ── Keyboard shortcuts / command palette ──
+  'shortcuts.title': 'キーボードショートカット',
+  'shortcuts.titleEn': 'Keyboard shortcuts',
+  'shortcuts.footHint': '? で再表示',
+  'shortcuts.footModMac': '修飾キーは macOS で ⌘ と表示',
+  'shortcuts.footModOther': '修飾キーは Ctrl と表示',
+  'shortcuts.open': 'ショートカット一覧 (?)',
+  'commandPalette.title': 'コマンドパレット',
+  'commandPalette.titleEn': 'Command palette',
+  'commandPalette.hint': 'j / k・↑ ↓ で選択、Enter で移動',
+  'actions.close': '閉じる',
 } as const
 
 export type MessageKey = keyof typeof ja

--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -125,7 +125,7 @@ export default function AuditLogPage() {
           </select>
         </FilterField>
         <FilterField label={t('audit.table.actor')}>
-          <input className="inp tnum" type="number" placeholder="#" style={{ width: 110 }} value={actor} onChange={e => setActor(e.target.value)} />
+          <input className="inp tnum" data-kbd="search" type="number" placeholder="#" style={{ width: 110 }} value={actor} onChange={e => setActor(e.target.value)} />
         </FilterField>
         <FilterField label={t('audit.table.time')}>
           <div className="range-pair">

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -149,7 +149,7 @@ export default function BankImportPage() {
         <FilterField label={t('table.fileName')}>
           <div className="inp-icon">
             <Icon name="search" />
-            <input className="inp" style={{ paddingLeft: 32, width: 160 }} placeholder={t('common.search')} value={fileName} onChange={e => setFileName(e.target.value)} />
+            <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 160 }} placeholder={t('common.search')} value={fileName} onChange={e => setFileName(e.target.value)} />
           </div>
         </FilterField>
         <FilterField label={t('table.status')}>

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -87,7 +87,7 @@ export default function BankTransactionsPage() {
         <FilterField label={t('table.counterparty')}>
           <div className="inp-icon">
             <Icon name="search" />
-            <input className="inp" placeholder={t('common.search')} style={{ paddingLeft: 32 }} value={counterparty} onChange={e => setCounterparty(e.target.value)} />
+            <input className="inp" data-kbd="search" placeholder={t('common.search')} style={{ paddingLeft: 32 }} value={counterparty} onChange={e => setCounterparty(e.target.value)} />
           </div>
         </FilterField>
         <Button variant="primary" onClick={search}><Icon name="search" />{t('common.search')}</Button>

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -100,7 +100,7 @@ export default function ClientCreditsPage() {
         <FilterField label={t('table.client')}>
           <div className="inp-icon">
             <Icon name="search" />
-            <input className="inp" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={f.clientId} onChange={e => set('clientId')(e.target.value)} />
+            <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={f.clientId} onChange={e => set('clientId')(e.target.value)} />
           </div>
         </FilterField>
         <FilterField label={t('table.status')}>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -166,7 +166,7 @@ export default function DunningPage() {
         <FilterField label={t('table.invoiceNumber')}>
           <div className="inp-icon">
             <Icon name="search" />
-            <input className="inp" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
+            <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
           </div>
         </FilterField>
         <FilterField label={t('table.recipient')}>

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -230,7 +230,7 @@ export default function ReconciliationPage() {
             </select>
           </FilterField>
           <FilterField label={t('table.invoiceId')}>
-            <input className="inp tnum" type="number" placeholder="#" style={{ width: 110 }} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
+            <input className="inp tnum" data-kbd="search" type="number" placeholder="#" style={{ width: 110 }} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
           </FilterField>
           <FilterField label={t('table.confirmedAt')}>
             <div className="range-pair">

--- a/frontend/src/styles/design.css
+++ b/frontend/src/styles/design.css
@@ -628,3 +628,81 @@ th[aria-sort="descending"] .sort-ic::before{ content:"\2193"; }
 tr.filter-empty td{ text-align:center; color:var(--faint); padding:30px 14px !important;
   font-size:12.5px; background:var(--surface) !important; }
 tr.filter-empty:hover td{ background:var(--surface) !important; }
+
+/* ===== keyboard shortcuts: keycap ===== */
+.kbd {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 22px; height: 22px; padding: 0 7px;
+  font-family: var(--mono); font-size: 11.5px; font-weight: 600; line-height: 1;
+  color: var(--ink); background: var(--surface);
+  border: 1px solid var(--line-strong); border-bottom-width: 2px;
+  box-shadow: 0 1px 0 var(--line);
+}
+.kbd.wide { padding: 0 9px; }
+.kbd-hint {
+  display: inline-flex; align-items: center; justify-content: center;
+  height: 17px; min-width: 17px; padding: 0 5px;
+  font-family: var(--mono); font-size: 10px; font-weight: 600;
+  color: var(--muted); background: var(--surface-2);
+  border: 1px solid var(--line-strong); border-radius: 0;
+}
+
+/* g… prefix indicator */
+.kbd-gind {
+  position: fixed; left: 1.25rem; bottom: 1.25rem; z-index: 50;
+  display: inline-flex; align-items: center; padding: 0.375rem 0.625rem;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--surface); background: var(--ink);
+  box-shadow: var(--shadow-pop);
+}
+
+/* ===== modal backdrop (shared by overlay + palette) ===== */
+.modal-dim {
+  position: fixed; inset: 0; z-index: 60;
+  display: flex; align-items: center; justify-content: center; padding: 1rem;
+  background: color-mix(in srgb, var(--ink) 45%, transparent);
+}
+.sc-backdrop { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; background: transparent; cursor: default; }
+
+/* ===== ? cheat-sheet overlay ===== */
+.sc-modal {
+  position: relative; width: 720px; max-width: 100%; max-height: 90vh; overflow: auto;
+  background: var(--surface); border: 1px solid var(--line-strong); box-shadow: var(--shadow-pop);
+}
+.sc-head { display: flex; align-items: center; justify-content: space-between;
+  padding: 13px 18px; border-bottom: 1px solid var(--line); }
+.sc-title b { font-size: 14px; } .sc-title span { margin-left: 8px; font-size: 11px; color: var(--muted); }
+.sc-x { display: inline-flex; align-items: center; gap: 6px; border: 0; background: transparent;
+  color: var(--muted); font-size: 11.5px; cursor: pointer; }
+.sc-body { display: grid; grid-template-columns: 1fr 1fr; gap: 0 28px; padding: 14px 18px; }
+.sc-grp { margin: 10px 0 4px; font-size: 11px; color: var(--accent); font-weight: 600; }
+.sc-grp-en { color: var(--muted); font-weight: 400; }
+.sc-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 5px 0; }
+.sc-row .lbl { font-size: 12.5px; } .sc-row .lbl small { margin-left: 6px; color: var(--muted); font-size: 10.5px; }
+.sc-keys-row, .sc-keys, .sc-keycap-wrap { display: inline-flex; align-items: center; gap: 5px; }
+.sc-join { color: var(--muted); font-size: 11px; }
+.sc-foot { display: flex; gap: 18px; align-items: center; padding: 12px 18px;
+  border-top: 1px solid var(--line); background: var(--surface-2); font-size: 11.5px; color: var(--muted); }
+
+/* ===== command palette (⌘K) — angular to match nene-clear ===== */
+.cmdp {
+  position: relative; width: 460px; max-width: 100%; max-height: 80vh;
+  display: flex; flex-direction: column; overflow: hidden;
+  background: var(--surface); border: 1px solid var(--line-strong); box-shadow: var(--shadow-pop);
+}
+.cmdp-head { display: flex; align-items: baseline; gap: 8px; padding: 13px 16px 11px;
+  border-bottom: 1px solid var(--line); }
+.cmdp-head b { font-size: 13px; font-weight: 600; }
+.cmdp-head span { font-size: 11px; color: var(--muted); }
+.cmdp-list { overflow: auto; padding: 6px; margin: 0; list-style: none; }
+.cmdp-list li { margin: 0; }
+.cmdp-row { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  width: 100%; padding: 9px 11px; border: 0; background: transparent; color: var(--ink);
+  font-size: 13px; text-align: left; cursor: pointer; }
+.cmdp-row.hl { background: var(--navy-100); box-shadow: inset 3px 0 0 var(--accent); }
+.cmdp-keys { display: inline-flex; gap: 4px; }
+.cmdp-foot { padding: 10px 16px; border-top: 1px solid var(--line);
+  background: var(--surface-2); font-size: 11.5px; color: var(--muted); }
+
+/* ===== list row cursor (j/k highlight) ===== */
+tr.is-cursor, .is-cursor { background: var(--navy-100); box-shadow: inset 3px 0 0 var(--accent); }

--- a/tests/e2e/specs/14-keyboard.spec.ts
+++ b/tests/e2e/specs/14-keyboard.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin } from '../fixtures/helpers'
+
+/**
+ * Keyboard shortcuts + command palette, wired through the real AppShell mount.
+ * The dispatcher logic itself is unit-tested; this verifies the in-browser
+ * mounting, focus rules, and navigation end to end.
+ */
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) =>
+    json(route, 200, { items: [], total: 0, limit: 1, offset: 0 }),
+  )
+  await apiRoute(page, '**/admin/dunning-notices**', (route) => json(route, 200, list([])))
+  // Reconciliation list endpoints (g → r target) — keep noise down.
+  await apiRoute(page, '**/admin/reconciliations**', (route) => json(route, 200, list([])))
+  await apiRoute(page, '**/admin/bank-transactions**', (route) => json(route, 200, list([])))
+})
+
+test.describe('Keyboard shortcuts', () => {
+  test('? opens the cheat-sheet overlay; Esc closes it', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+    await page.keyboard.press('?')
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('キーボードショートカット')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+
+  test('g → r navigates to reconciliation', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+    await page.keyboard.press('g')
+    await page.keyboard.press('r')
+    await expect(page).toHaveURL(/\/admin\/reconciliation/)
+  })
+
+  test('Ctrl+K opens the palette; j then Enter navigates', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+    await page.keyboard.press('Control+k')
+    await expect(page.getByRole('listbox')).toBeVisible()
+
+    // Cursor starts at the first command (dashboard); j → reconciliation.
+    await page.keyboard.press('j')
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/\/admin\/reconciliation/)
+    await expect(page.getByRole('listbox')).toHaveCount(0)
+  })
+
+  test('/ focuses the list search field, not a navigation', async ({ page }) => {
+    await page.goto('/admin/bank-transactions')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+
+    await page.keyboard.press('/')
+    await expect(page.locator('[data-kbd="search"]')).toBeFocused()
+  })
+})


### PR DESCRIPTION
## Summary
Ports the **nene-invoice keyboard operation system** to the NeNe Clear admin SPA, adapted to Clear's conventions (navy design tokens, `--radius:0`, `useTranslation`, flat `/admin/*` routes).

What you get:
- **g → key navigation** (`g d` dashboard, `g r` reconciliation, `g b` bank transactions, `g i` import, `g c` client credits, `g n` dunning, `g u` users, `g s` settings, `g a` audit log) with a `g…` indicator.
- **Command palette** — `⌘/Ctrl+K`, navigate with `j/k`・`↑↓`, `Enter`/`Space` to go, `Esc` to close.
- **`?` cheat-sheet** overlay (also via a new topbar **?** button).
- **Form chords** — `⌘/Ctrl+Enter` submits the nearest `<form>` (works in fields/IME), `Esc` closes overlays / cancels the `g` prefix / blurs the focused field.
- **`/`** focuses the current list's search input.
- **List row cursor** infrastructure (`j/k/o/Enter`) via a decoupled `kbd:list` event + `useRowCursor`.

## Hardening (from the source's battle-tested rules)
- Single keys are suppressed while typing in `input/textarea/select/contenteditable`.
- IME guard: `isComposing` / `keyCode === 229` short-circuits the dispatcher.
- `⌘K` and `⌘Enter`/`Esc` are handled **before** the modifier guard so they work in fields; `Esc`-to-blur is skipped during IME composition.
- `scrollIntoView` is existence-checked (jsdom-safe).

## Adaptation notes
- `g`-map / `COMMANDS` / `SHORTCUT_GROUPS` track the real routes in `app/router.tsx`.
- Clear has no create/detail pages yet, so `n` (new) and `u` (back to list) are intentionally **no-ops** until those routes exist — the infra is in place.
- New i18n keys (`shortcuts.*`, `commandPalette.*`, `actions.close`) added to **both** ja and en.

## Files
New `src/components/keyboard/` (dispatcher, palette, overlay, data, hooks). Mount in `AppShell`. CSS appended to `design.css`. `data-kbd="search"` added to each list page's primary filter input.

## Verification
- `npm run check` (type-check + eslint + vitest): green — 36 tests incl. new `KeyboardShortcuts.test.tsx`.
- `npx playwright test`: green — 47 tests incl. new `specs/14-keyboard.spec.ts` (overlay, `g→r`, palette nav, `/` focus).

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)