### PR TITLE
feat: wire list row cursor (j/k + Enter/o) into all list pages

### DIFF
--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -5,6 +5,7 @@ import type { AuditEvent, AuditEventType } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead, DatePicker, SortableTh, nextSort } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { formatDateTime } from '@/utils/format'
 
 const PAGE = 20
@@ -111,6 +112,13 @@ export default function AuditLogPage() {
 
   const total = auditQ.data?.total ?? 0
 
+  // Row cursor (j/k); Enter/o toggles the cursored event's detail panel.
+  const rows = auditQ.data?.items ?? []
+  const cursor = useRowCursor(rows.length, (i) => {
+    const event = rows[i]
+    if (event) toggle(event.audit_event_id)
+  })
+
   return (
     <>
       <PageHead title={t('audit.title')} sub={t('audit.subtitle')} />
@@ -153,11 +161,11 @@ export default function AuditLogPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={4} loading={auditQ.isLoading} empty={auditQ.data?.items.length === 0} emptyKey="audit.empty" />
-            {auditQ.data?.items.map(event => {
+            {auditQ.data?.items.map((event, index) => {
               const isOpen = expanded.has(event.audit_event_id)
               return (
                 <Fragment key={event.audit_event_id}>
-                  <tr>
+                  <tr data-kbd-row={index} className={cursor === index ? 'is-cursor' : undefined}>
                     <td className="muted">{formatDateTime(event.occurred_at)}</td>
                     <td><StatusBadge map={EVENT_META} value={event.event_type} dot fallback={event.event_type} /></td>
                     <td>{actorLabel(event.actor_user_id)}</td>

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -5,6 +5,7 @@ import type { BankImportBatch } from '@/types'
 import { Icon, StatusBadge, Button, Card, CardHead, CardBody, DataTable, TableStateRow, Notice, Modal, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { formatDate } from '@/utils/format'
 
 const BATCH_STATUS: Record<BankImportBatch['status'], StatusMeta> = {
@@ -81,6 +82,13 @@ export default function BankImportPage() {
   function clearBatches() { setFileName(''); setBStatus(''); setRowMin(''); setRowMax(''); setImpFrom(''); setImpTo(''); setApplied({ fileName: '', status: '', rowMin: '', rowMax: '', impFrom: '', impTo: '', offset: 0 }) }
   function onSortBatches(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
   const batchTotal = batchQ.data?.total ?? 0
+
+  // Row cursor (j/k); Enter/o opens the reverse dialog for the cursored batch.
+  const batchRows = batchQ.data?.items ?? []
+  const cursor = useRowCursor(batchRows.length, (i) => {
+    const b = batchRows[i]
+    if (b && b.status === 'imported') setReverseTarget(b)
+  })
 
   const uploadMut = useMutation({
     mutationFn: ({ id, file }: { id: number; file: File }) => importBankCsv(id, file),
@@ -195,8 +203,8 @@ export default function BankImportPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={6} loading={batchQ.isLoading} empty={batchQ.data?.items.length === 0} />
-            {batchQ.data?.items.map(b => (
-              <tr key={b.bank_import_batch_id} className={b.status === 'reversed' ? 'dim' : ''}>
+            {batchQ.data?.items.map((b, index) => (
+              <tr key={b.bank_import_batch_id} data-kbd-row={index} className={[b.status === 'reversed' ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                 <td className="muted">{b.bank_import_batch_id}</td>
                 <td className="strong mono">{b.source_filename}</td>
                 <td className="num">{b.row_count}</td>

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -6,6 +6,7 @@ import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, Filte
 import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { yen } from '@/utils/format'
 
 const PAGE = 20
@@ -49,6 +50,10 @@ export default function BankTransactionsPage() {
   function onSort(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
 
   const total = txQ.data?.total ?? 0
+
+  // Read-only ledger: j/k move the row cursor; there is no per-row "open" action.
+  const rows = txQ.data?.items ?? []
+  const cursor = useRowCursor(rows.length, () => undefined)
 
   return (
     <>
@@ -105,8 +110,8 @@ export default function BankTransactionsPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={4} loading={txQ.isLoading} empty={txQ.data?.items.length === 0} />
-            {txQ.data?.items.map(tx => (
-              <tr key={tx.bank_transaction_id} className={tx.status === 'voided' ? 'dim' : ''}>
+            {txQ.data?.items.map((tx, index) => (
+              <tr key={tx.bank_transaction_id} data-kbd-row={index} className={[tx.status === 'voided' ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                 <td className="muted">{tx.value_date}</td>
                 <td className="num">{yen(tx.amount_cents)}</td>
                 <td className="strong">{tx.counterparty_text}</td>

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -5,6 +5,7 @@ import type { ClientCredit } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDate } from '@/utils/format'
 
 function ApplyModal({ credit, onClose }: { credit: ClientCredit; onClose: () => void }) {
@@ -92,6 +93,13 @@ export default function ClientCreditsPage() {
 
   const total = creditsQ.data?.total ?? 0
 
+  // Row cursor (j/k); Enter/o opens the apply dialog for the cursored credit.
+  const rows = creditsQ.data?.items ?? []
+  const cursor = useRowCursor(rows.length, (i) => {
+    const c = rows[i]
+    if (c && c.status === 'open') setApplyTarget(c)
+  })
+
   return (
     <>
       <PageHead title={t('clientCredit.title')} sub={t('clientCredit.subtitle')} />
@@ -154,8 +162,8 @@ export default function ClientCreditsPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={8} loading={creditsQ.isLoading} empty={creditsQ.data?.items.length === 0} emptyKey="filter.noMatch" />
-            {creditsQ.data?.items.map(c => (
-              <tr key={c.client_credit_id} className={c.status === 'voided' ? 'dim' : ''}>
+            {creditsQ.data?.items.map((c, index) => (
+              <tr key={c.client_credit_id} data-kbd-row={index} className={[c.status === 'voided' ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                 <td className="muted">{c.client_credit_id}</td>
                 <td className="strong">#{c.client_id}</td>
                 <td className="num">{yen(c.amount_cents)}</td>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -8,6 +8,7 @@ import type { UpstreamInvoice } from '@/types'
 import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDateTime, daysOverdue } from '@/utils/format'
 
 // ─── Send confirm modal ───
@@ -92,6 +93,14 @@ export default function DunningPage() {
 
   const activePauses = new Set((pausesQ.data?.items ?? []).map(p => p.invoice_id))
 
+  // Row cursor (j/k) targets the actionable "eligible invoices" list; Enter/o
+  // opens the send dialog for the cursored invoice (skipped when paused).
+  const eligibleRows = invoicesQ.data?.items ?? []
+  const cursor = useRowCursor(eligibleRows.length, (i) => {
+    const inv = eligibleRows[i]
+    if (inv && !activePauses.has(inv.invoice_id)) setSendTarget(inv)
+  })
+
   return (
     <>
       <PageHead title={t('dunning.title')} sub={t('dunning.subtitle')} />
@@ -130,12 +139,12 @@ export default function DunningPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={6} loading={invoicesQ.isLoading} empty={invoicesQ.data?.items.length === 0} emptyKey="dunning.noEligible" />
-            {invoicesQ.data?.items.map(inv => {
+            {invoicesQ.data?.items.map((inv, index) => {
               const paused = activePauses.has(inv.invoice_id)
               const elap = daysOverdue(inv.due_at)
               const daysNum = parseInt(elap)
               return (
-                <tr key={inv.invoice_id} className={paused ? 'dim' : ''}>
+                <tr key={inv.invoice_id} data-kbd-row={index} className={[paused ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                   <td className="strong mono">{inv.invoice_number}</td>
                   <td>
                     {inv.status === 'overdue' ? <Badge variant="bad" dot>{t('dunning.status.overdue')}</Badge> : <Badge variant="warn" dot>{t('dunning.status.partial')}</Badge>}

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -10,6 +10,7 @@ import { Icon, Badge, StatusBadge, Button, Card, DataTable, TableStateRow, Modal
 import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDate } from '@/utils/format'
 
 const RECON_STATUS: Record<Reconciliation['status'], StatusMeta> = {
@@ -172,6 +173,19 @@ export default function ReconciliationPage() {
   function hOnSort(col: string) { setHSort(s => nextSort(s, col)); setHApplied(p => ({ ...p, offset: 0 })) }
   const hTotal = reconciliationsQ.data?.total ?? 0
 
+  // Row cursor (j/k) for the active tab; Enter/o opens the row's primary action.
+  const unmatchedRows = unmatchedQ.data?.items ?? []
+  const historyRows = reconciliationsQ.data?.items ?? []
+  const cursor = useRowCursor(tab === 'unmatched' ? unmatchedRows.length : historyRows.length, (i) => {
+    if (tab === 'unmatched') {
+      const tx = unmatchedRows[i]
+      if (tx) setMatchTarget(tx)
+    } else {
+      const r = historyRows[i]
+      if (r && r.status === 'confirmed') setReverseTarget(r)
+    }
+  })
+
   return (
     <>
       <PageHead
@@ -201,8 +215,8 @@ export default function ReconciliationPage() {
             </thead>
             <tbody>
               <TableStateRow colSpan={5} loading={unmatchedQ.isLoading} empty={unmatchedQ.data?.items.length === 0} emptyKey="reconciliation.noUnmatched" />
-              {unmatchedQ.data?.items.map(tx => (
-                <tr key={tx.bank_transaction_id}>
+              {unmatchedQ.data?.items.map((tx, index) => (
+                <tr key={tx.bank_transaction_id} data-kbd-row={index} className={cursor === index ? 'is-cursor' : undefined}>
                   <td className="muted">{tx.value_date}</td>
                   <td className="num">{yen(tx.amount_cents)}</td>
                   <td className="strong">{tx.counterparty_text}</td>
@@ -258,8 +272,8 @@ export default function ReconciliationPage() {
             </thead>
             <tbody>
               <TableStateRow colSpan={5} loading={reconciliationsQ.isLoading} empty={reconciliationsQ.data?.items.length === 0} />
-              {reconciliationsQ.data?.items.map(r => (
-                <tr key={r.payment_reconciliation_id} className={r.status === 'reversed' ? 'dim' : ''}>
+              {reconciliationsQ.data?.items.map((r, index) => (
+                <tr key={r.payment_reconciliation_id} data-kbd-row={index} className={[r.status === 'reversed' ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                   <td className="muted">{r.payment_reconciliation_id}</td>
                   <td className="mono">#{r.bank_transaction_id}</td>
                   <td><StatusBadge map={RECON_STATUS} value={r.status} dot /></td>

--- a/frontend/src/pages/users/UsersPage.tsx
+++ b/frontend/src/pages/users/UsersPage.tsx
@@ -5,6 +5,7 @@ import type { User } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useRowCursor } from '@/components/keyboard'
 
 type Role = 'admin' | 'member' | 'viewer'
 
@@ -78,6 +79,13 @@ export default function UsersPage() {
 
   const usersQ = useQuery({ queryKey: ['users'], queryFn: ({ signal }) => listUsers({ limit: 100 }, signal) })
 
+  // Row cursor (j/k); Enter/o opens the delete confirmation for the cursored user.
+  const rows = usersQ.data?.items ?? []
+  const cursor = useRowCursor(rows.length, (i) => {
+    const u = rows[i]
+    if (u) setDeleteTarget(u)
+  })
+
   return (
     <>
       <PageHead
@@ -93,8 +101,8 @@ export default function UsersPage() {
           </thead>
           <tbody>
             <TableStateRow colSpan={5} loading={usersQ.isLoading} empty={usersQ.data?.items.length === 0} />
-            {usersQ.data?.items.map(u => (
-              <tr key={u.user_id}>
+            {usersQ.data?.items.map((u, index) => (
+              <tr key={u.user_id} data-kbd-row={index} className={cursor === index ? 'is-cursor' : undefined}>
                 <td className="strong">{u.email}</td>
                 <td><StatusBadge map={ROLE_MAP} value={u.role} /></td>
                 <td><StatusBadge map={STATUS_MAP} value={u.status} dot /></td>

--- a/tests/e2e/specs/14-keyboard.spec.ts
+++ b/tests/e2e/specs/14-keyboard.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { apiRoute, json, list, bypassLogin } from '../fixtures/helpers'
+import { apiRoute, json, list, user, bypassLogin } from '../fixtures/helpers'
 
 /**
  * Keyboard shortcuts + command palette, wired through the real AppShell mount.
@@ -60,5 +60,30 @@ test.describe('Keyboard shortcuts', () => {
 
     await page.keyboard.press('/')
     await expect(page.locator('[data-kbd="search"]')).toBeFocused()
+  })
+
+  test('list cursor: j highlights a row, Enter opens its action', async ({ page }) => {
+    await apiRoute(page, '**/admin/users?**', (route) =>
+      json(
+        route,
+        200,
+        list([
+          user({ user_id: 1, email: 'a@acme.example', role: 'admin', status: 'active' }),
+          user({ user_id: 2, email: 'b@acme.example', role: 'viewer', status: 'active' }),
+        ]),
+      ),
+    )
+    await page.goto('/admin/users')
+    await expect(page.getByText('a@acme.example')).toBeVisible()
+
+    // No cursor until j; then the first row is highlighted.
+    await expect(page.locator('tr.is-cursor')).toHaveCount(0)
+    await page.keyboard.press('j')
+    await expect(page.locator('tr.is-cursor')).toHaveCount(1)
+    await expect(page.getByRole('row', { name: /a@acme.example/ })).toHaveClass(/is-cursor/)
+
+    // Enter opens the cursored row's primary action (delete confirmation).
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('dialog')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
Follow-up to #136. The row-cursor infrastructure (`useRowCursor` + `kbd:list` dispatch) shipped but no list page opted in, so `j/k/o/Enter` were no-ops. This wires every list page's primary table into the cursor:

- **j / k** (and ↑/↓) move a visible row cursor (`.is-cursor`, `data-kbd-row`).
- **Enter / o** open the cursored row's primary action.

## Per-page "open" action
| Page | Open |
| --- | --- |
| Reconciliation | active tab — unmatched → confirm dialog; history → reverse (confirmed rows only) |
| Dunning | eligible invoices → send dialog (skipped when paused) |
| Client credits | open credits → apply dialog |
| Bank import | imported batches → reverse dialog |
| Users | delete confirmation |
| Audit log | toggle the row's detail panel |
| Bank transactions | read-only ledger — j/k cursor only, no row action |

One `useRowCursor` per page: the dispatcher broadcasts a single `kbd:list` event, so the primary/most-actionable table opts in (e.g. dunning's *eligible invoices*, not the read-only history).

## Verification
- `npm run check` (type-check + eslint + vitest): green — 36 tests.
- `npx playwright test`: green — 48 tests incl. a new row-cursor e2e case (j highlights a row, Enter opens its action).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)