### PR TITLE
feat(reconciliation): 未消込タブに検索・ソート・ページャーを追加 (#140)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -586,11 +586,45 @@ paths:
     get:
       tags: [BankTransaction]
       summary: List unmatched bank transactions
-      description: Convenience filter for `status=unmatched` / `partially_matched`.
+      description: >
+        Convenience filter for `status=unmatched` / `partially_matched`,
+        searchable by transaction date, amount, and counterparty and sortable
+        (same query contract as `listBankTransactions`, minus `status`).
       operationId: listUnmatchedTransactions
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
+        - name: value_date_from
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: value_date_to
+          in: query
+          schema:
+            type: string
+            format: date
+        - name: amount_min_cents
+          in: query
+          schema:
+            type: integer
+            format: int64
+        - name: amount_max_cents
+          in: query
+          schema:
+            type: integer
+            format: int64
+        - name: counterparty
+          in: query
+          schema:
+            type: string
+        - name: sort_by
+          in: query
+          description: "Sort column: value_date | amount_cents | counterparty_text."
+          schema: { type: string }
+        - name: sort_dir
+          in: query
+          schema: { type: string, enum: [asc, desc] }
       responses:
         '200':
           description: A page of unmatched bank transactions.

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   login,
   listBankTransactions,
+  listUnmatchedTransactions,
   listReconciliations,
   confirmMatch,
   reverseReconciliation,
@@ -66,6 +67,37 @@ describe('endpoint request construction', () => {
     const url = calledUrl()
     expect(url).not.toContain('status=')
     expect(url).not.toContain('counterparty=')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=0')
+  })
+
+  it('listUnmatchedTransactions builds a filtered, sorted query string', async () => {
+    await listUnmatchedTransactions({
+      valueDateFrom: '2026-04-01',
+      amountMaxCents: 100000,
+      counterparty: 'ACME',
+      sortBy: 'amount_cents',
+      sortDir: 'asc',
+      limit: 20,
+      offset: 20,
+    })
+    const url = calledUrl()
+    expect(url).toContain('/admin/bank-transactions/unmatched?')
+    expect(url).toContain('value_date_from=2026-04-01')
+    expect(url).toContain('amount_max_cents=100000')
+    expect(url).toContain('counterparty=ACME')
+    expect(url).toContain('sort_by=amount_cents')
+    expect(url).toContain('sort_dir=asc')
+    expect(url).toContain('limit=20')
+    expect(url).toContain('offset=20')
+    expect(url).not.toContain('status=')
+  })
+
+  it('listUnmatchedTransactions omits unset filters but keeps pagination defaults', async () => {
+    await listUnmatchedTransactions({})
+    const url = calledUrl()
+    expect(url).not.toContain('counterparty=')
+    expect(url).not.toContain('sort_by=')
     expect(url).toContain('limit=50')
     expect(url).toContain('offset=0')
   })

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -121,8 +121,27 @@ export function listBankTransactions(filter: BankTransactionFilter, signal?: Abo
   return api.get<ListEnvelope<BankTransaction>>(`${BASE}/bank-transactions?${q}`, signal)
 }
 
-export function listUnmatchedTransactions(params: { limit?: number; offset?: number }, signal?: AbortSignal) {
+export interface UnmatchedQuery {
+  valueDateFrom?: string
+  valueDateTo?: string
+  amountMinCents?: number
+  amountMaxCents?: number
+  counterparty?: string
+  sortBy?: string
+  sortDir?: string
+  limit?: number
+  offset?: number
+}
+
+export function listUnmatchedTransactions(params: UnmatchedQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+  if (params.valueDateFrom) q.set('value_date_from', params.valueDateFrom)
+  if (params.valueDateTo) q.set('value_date_to', params.valueDateTo)
+  if (params.amountMinCents != null) q.set('amount_min_cents', String(params.amountMinCents))
+  if (params.amountMaxCents != null) q.set('amount_max_cents', String(params.amountMaxCents))
+  if (params.counterparty) q.set('counterparty', params.counterparty)
+  if (params.sortBy) q.set('sort_by', params.sortBy)
+  if (params.sortDir) q.set('sort_dir', params.sortDir)
   return api.get<ListEnvelope<BankTransaction>>(`${BASE}/bank-transactions/unmatched?${q}`, signal)
 }
 

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -145,11 +145,32 @@ export default function ReconciliationPage() {
   const [matchTarget, setMatchTarget] = useState<BankTransaction | null>(null)
   const [reverseTarget, setReverseTarget] = useState<Reconciliation | null>(null)
 
+  // Unmatched tab filter/sort/pager
+  const UPAGE = 50
+  const [uFrom, setUFrom] = useState('')
+  const [uTo, setUTo] = useState('')
+  const [uAmountMin, setUAmountMin] = useState('')
+  const [uAmountMax, setUAmountMax] = useState('')
+  const [uCounterparty, setUCounterparty] = useState('')
+  const [uApplied, setUApplied] = useState({ from: '', to: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
+  const [uSort, setUSort] = useState<SortState>({ by: 'value_date', dir: 'desc' })
   const unmatchedQ = useQuery({
-    queryKey: ['bank-transactions', 'unmatched', { limit: 50 }],
-    queryFn: ({ signal }) => listUnmatchedTransactions({ limit: 50 }, signal),
+    queryKey: ['bank-transactions', 'unmatched', uApplied, uSort],
+    queryFn: ({ signal }) => listUnmatchedTransactions({
+      valueDateFrom: uApplied.from ? uApplied.from.replace(/\//g, '-') : undefined,
+      valueDateTo: uApplied.to ? uApplied.to.replace(/\//g, '-') : undefined,
+      amountMinCents: uApplied.amountMin ? Math.round(Number(uApplied.amountMin) * 100) : undefined,
+      amountMaxCents: uApplied.amountMax ? Math.round(Number(uApplied.amountMax) * 100) : undefined,
+      counterparty: uApplied.counterparty || undefined,
+      sortBy: uSort.by, sortDir: uSort.dir, limit: UPAGE, offset: uApplied.offset,
+    }, signal),
     enabled: tab === 'unmatched',
   })
+  function uSearch() { setUApplied({ from: uFrom, to: uTo, amountMin: uAmountMin, amountMax: uAmountMax, counterparty: uCounterparty, offset: 0 }) }
+  function uClear() { setUFrom(''); setUTo(''); setUAmountMin(''); setUAmountMax(''); setUCounterparty(''); setUApplied({ from: '', to: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 }) }
+  function uOnSort(col: string) { setUSort(s => nextSort(s, col)); setUApplied(p => ({ ...p, offset: 0 })) }
+  const uTotal = unmatchedQ.data?.total ?? 0
+
   const HPAGE = 50
   const [hStatus, setHStatus] = useState('')
   const [hInvoice, setHInvoice] = useState('')
@@ -208,10 +229,43 @@ export default function ReconciliationPage() {
       />
 
       {tab === 'unmatched' && (
+        <>
+        <FilterBar>
+          <FilterField label={t('table.valueDate')}>
+            <div className="range-pair">
+              <DatePicker value={uFrom} onChange={setUFrom} />
+              <span className="tilde">〜</span>
+              <DatePicker value={uTo} onChange={setUTo} />
+            </div>
+          </FilterField>
+          <FilterField label={t('bankTransaction.amountFrom')}>
+            <input className="inp tnum" type="number" placeholder="0" style={{ width: 120 }} value={uAmountMin} onChange={e => setUAmountMin(e.target.value)} />
+          </FilterField>
+          <FilterField label={t('bankTransaction.amountTo')}>
+            <input className="inp tnum" type="number" placeholder="—" style={{ width: 120 }} value={uAmountMax} onChange={e => setUAmountMax(e.target.value)} />
+          </FilterField>
+          <FilterField label={t('table.counterparty')}>
+            <div className="inp-icon">
+              <Icon name="search" />
+              <input className="inp" data-kbd="search" placeholder={t('common.search')} style={{ paddingLeft: 32 }} value={uCounterparty} onChange={e => setUCounterparty(e.target.value)} />
+            </div>
+          </FilterField>
+          <div className="filter-actions">
+            <span className="filter-count">{t('filter.count', { n: uTotal })}</span>
+            <Button variant="ghost" size="sm" onClick={uClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
+            <Button variant="primary" size="sm" onClick={uSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          </div>
+        </FilterBar>
         <Card>
           <DataTable>
             <thead>
-              <tr><th>{t('table.valueDate')}</th><th>{t('table.amount')}</th><th>{t('table.counterparty')}</th><th>{t('table.matchCandidates')}</th><th /></tr>
+              <tr>
+                <SortableTh column="value_date" sort={uSort} onSort={uOnSort}>{t('table.valueDate')}</SortableTh>
+                <SortableTh column="amount_cents" sort={uSort} onSort={uOnSort}>{t('table.amount')}</SortableTh>
+                <SortableTh column="counterparty_text" sort={uSort} onSort={uOnSort}>{t('table.counterparty')}</SortableTh>
+                <th>{t('table.matchCandidates')}</th>
+                <th />
+              </tr>
             </thead>
             <tbody>
               <TableStateRow colSpan={5} loading={unmatchedQ.isLoading} empty={unmatchedQ.data?.items.length === 0} emptyKey="reconciliation.noUnmatched" />
@@ -230,7 +284,9 @@ export default function ReconciliationPage() {
               ))}
             </tbody>
           </DataTable>
+          <Pager offset={uApplied.offset} pageSize={UPAGE} total={uTotal} onOffsetChange={off => setUApplied(p => ({ ...p, offset: off }))} />
         </Card>
+        </>
       )}
 
       {tab === 'history' && (

--- a/src/BankImport/BankTransactionFilter.php
+++ b/src/BankImport/BankTransactionFilter.php
@@ -15,6 +15,7 @@ final readonly class BankTransactionFilter
         public ?string $counterparty = null,
         public string $sortColumn = 'value_date',
         public string $sortDirection = 'desc',
+        public bool $openForMatchingOnly = false,
     ) {
     }
 }

--- a/src/BankImport/BankTransactionRepositoryInterface.php
+++ b/src/BankImport/BankTransactionRepositoryInterface.php
@@ -26,12 +26,13 @@ interface BankTransactionRepositoryInterface
 
     /**
      * Lines still open for matching (unmatched or partially matched).
+     * The filter's {@see BankTransactionFilter::$openForMatchingOnly} must be set.
      *
      * @return list<BankTransaction>
      */
-    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array;
+    public function findUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array;
 
-    public function countUnmatchedByOrganization(int $organizationId): int;
+    public function countUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter): int;
 
     public function updateStatusById(int $organizationId, int $id, BankTransactionStatus $status): void;
 

--- a/src/BankImport/ListUnmatchedTransactionsHandler.php
+++ b/src/BankImport/ListUnmatchedTransactionsHandler.php
@@ -23,15 +23,41 @@ final readonly class ListUnmatchedTransactionsHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
+        $q = $request->getQueryParams();
+
+        $valueDateFrom = isset($q['value_date_from']) && is_string($q['value_date_from']) ? $q['value_date_from'] : null;
+        $valueDateTo = isset($q['value_date_to']) && is_string($q['value_date_to']) ? $q['value_date_to'] : null;
+
+        $amountMinParam = $q['amount_min_cents'] ?? null;
+        $amountMinCents = is_numeric($amountMinParam) ? (int) $amountMinParam : null;
+
+        $amountMaxParam = $q['amount_max_cents'] ?? null;
+        $amountMaxCents = is_numeric($amountMaxParam) ? (int) $amountMaxParam : null;
+
+        $counterparty = isset($q['counterparty']) && is_string($q['counterparty']) ? $q['counterparty'] : null;
+
+        $sortBy = isset($q['sort_by']) && is_string($q['sort_by']) && $q['sort_by'] !== '' ? $q['sort_by'] : 'value_date';
+        $sortDir = isset($q['sort_dir']) && is_string($q['sort_dir']) && $q['sort_dir'] !== '' ? $q['sort_dir'] : 'desc';
+
+        $filter = new BankTransactionFilter(
+            valueDateFrom: $valueDateFrom,
+            valueDateTo: $valueDateTo,
+            amountMinCents: $amountMinCents,
+            amountMaxCents: $amountMaxCents,
+            counterparty: $counterparty,
+            sortColumn: $sortBy,
+            sortDirection: $sortDir,
+            openForMatchingOnly: true,
+        );
 
         return $this->response->create((new PaginationResponse(
             items: array_map(
                 BankTransactionResponse::toArray(...),
-                $this->transactions->findUnmatchedByOrganization($organizationId, $page->limit, $page->offset),
+                $this->transactions->findUnmatchedByOrganization($organizationId, $filter, $page->limit, $page->offset),
             ),
             limit: $page->limit,
             offset: $page->offset,
-            total: $this->transactions->countUnmatchedByOrganization($organizationId),
+            total: $this->transactions->countUnmatchedByOrganization($organizationId, $filter),
         ))->toArray());
     }
 }

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -107,27 +107,25 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         return (int) ($row['c'] ?? 0);
     }
 
-    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array
     {
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE organization_id = ? AND status IN (?, ?) '
-            . 'ORDER BY value_date DESC, id DESC LIMIT ? OFFSET ?',
-            [$organizationId, BankTransactionStatus::Unmatched->value, BankTransactionStatus::PartiallyMatched->value, $limit, $offset],
+            'SELECT ' . self::COLUMNS . ' FROM bank_transactions WHERE ' . $where
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
+            [...$params, $limit, $offset],
         );
 
         return array_map($this->hydrate(...), $rows);
     }
 
-    public function countUnmatchedByOrganization(int $organizationId): int
+    public function countUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter): int
     {
+        [$where, $params] = $this->buildWhere($organizationId, $filter);
         $row = $this->query->fetchOne(
-            'SELECT COUNT(*) AS c FROM bank_transactions WHERE organization_id = ? AND status IN (?, ?)',
-            [$organizationId, BankTransactionStatus::Unmatched->value, BankTransactionStatus::PartiallyMatched->value],
+            'SELECT COUNT(*) AS c FROM bank_transactions WHERE ' . $where,
+            $params,
         );
-
-        if ($row === null) {
-            return 0;
-        }
 
         return (int) ($row['c'] ?? 0);
     }
@@ -156,7 +154,11 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
         $wheres = ['organization_id = ?'];
         $params = [$organizationId];
 
-        if ($filter->status !== null) {
+        if ($filter->openForMatchingOnly) {
+            $wheres[] = 'status IN (?, ?)';
+            $params[] = BankTransactionStatus::Unmatched->value;
+            $params[] = BankTransactionStatus::PartiallyMatched->value;
+        } elseif ($filter->status !== null) {
             $wheres[] = 'status = ?';
             $params[] = $filter->status->value;
         }

--- a/tests/BankImport/InMemoryBankTransactionRepository.php
+++ b/tests/BankImport/InMemoryBankTransactionRepository.php
@@ -72,23 +72,21 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
         ));
     }
 
-    public function findUnmatchedByOrganization(int $organizationId, int $limit, int $offset): array
+    public function findUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter, int $limit, int $offset): array
     {
         $matches = array_values(array_filter(
             $this->byId,
-            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
-                && in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true),
+            fn (BankTransaction $t): bool => $this->matchesFilter($t, $organizationId, $filter),
         ));
 
         return array_slice($matches, $offset, $limit);
     }
 
-    public function countUnmatchedByOrganization(int $organizationId): int
+    public function countUnmatchedByOrganization(int $organizationId, BankTransactionFilter $filter): int
     {
         return count(array_filter(
             $this->byId,
-            static fn (BankTransaction $t): bool => $t->organizationId === $organizationId
-                && in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true),
+            fn (BankTransaction $t): bool => $this->matchesFilter($t, $organizationId, $filter),
         ));
     }
 
@@ -136,7 +134,11 @@ final class InMemoryBankTransactionRepository implements BankTransactionReposito
         if ($t->organizationId !== $organizationId) {
             return false;
         }
-        if ($filter->status !== null && $t->status !== $filter->status) {
+        if ($filter->openForMatchingOnly
+            && ! in_array($t->status, [BankTransactionStatus::Unmatched, BankTransactionStatus::PartiallyMatched], true)) {
+            return false;
+        }
+        if (! $filter->openForMatchingOnly && $filter->status !== null && $t->status !== $filter->status) {
             return false;
         }
         if ($filter->valueDateFrom !== null && $t->valueDate < $filter->valueDateFrom) {

--- a/tests/Http/BankImportHttpTest.php
+++ b/tests/Http/BankImportHttpTest.php
@@ -134,6 +134,32 @@ final class BankImportHttpTest extends TestCase
         self::assertSame(2, $this->decode($this->get($token, '/admin/bank-transactions/unmatched'))['total'] ?? null);
     }
 
+    public function test_unmatched_supports_filter_sort_and_pagination(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $this->upload($token, self::CSV);
+
+        // Counterparty search narrows to a single open line.
+        $byCounterparty = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?counterparty=ACME'));
+        self::assertSame(1, $byCounterparty['total'] ?? null);
+        self::assertSame('ACME', $byCounterparty['items'][0]['counterparty_text'] ?? null);
+
+        // Amount range filter (TARO 50,000 < ACME 110,000).
+        $byAmount = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?amount_max_cents=100000'));
+        self::assertSame(1, $byAmount['total'] ?? null);
+        self::assertSame(50000, $byAmount['items'][0]['amount_cents'] ?? null);
+
+        // Sort by amount ascending → smallest (TARO 50,000) first.
+        $sorted = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?sort_by=amount_cents&sort_dir=asc'));
+        self::assertSame(2, $sorted['total'] ?? null);
+        self::assertSame('TARO', $sorted['items'][0]['counterparty_text'] ?? null);
+
+        // Pagination: total reflects the full open set, page returns one row.
+        $paged = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?limit=1&offset=0'));
+        self::assertSame(2, $paged['total'] ?? null);
+        self::assertCount(1, $paged['items'] ?? []);
+    }
+
     public function test_duplicate_upload_is_blocked(): void
     {
         $token = $this->tokenFor('admin@acme.example');


### PR DESCRIPTION
Closes #140

## What

The reconciliation page's **未消込 (unmatched) tab** — the default landing view — had **no search, no sort, and no pager** (hardcoded `limit:50`). Only the history tab had them. This brings the unmatched tab to parity with the bank-transactions list, which shows the same kind of data.

| | before | after |
| --- | --- | --- |
| 未消込タブ | ページャー/検索/ソート 無し | ✅ 全部あり |

## Changes

**Backend**
- `BankTransactionFilter`: add `openForMatchingOnly`; reuse `buildWhere`/`orderBy`
- `findUnmatchedByOrganization` / `countUnmatchedByOrganization` now take a `BankTransactionFilter` (interface + Pdo + in-memory repos)
- `ListUnmatchedTransactionsHandler` parses `value_date_from/to`, `amount_min/max_cents`, `counterparty`, `sort_by`, `sort_dir` (status is fixed to the open set)

**OpenAPI**
- Same query params added to `/admin/bank-transactions/unmatched`

**Frontend**
- `FilterBar` (date range / amount range / counterparty) + `SortableTh` (value_date / amount_cents / counterparty_text) + `Pager` on the unmatched tab
- `listUnmatchedTransactions` extended with the filter/sort params

**Tests**
- HTTP test: unmatched filter / sort / pagination
- Vitest: `listUnmatchedTransactions` query-string construction

No new terminology — reuses already-registered query params.

## Checks
- `composer check`: 253 backend tests (6 skipped contract tests) ✅, PHPStan level 8 ✅, PHP-CS-Fixer ✅
- `npm run check`: type-check ✅, eslint ✅, 38 Vitest ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)