### PR TITLE
fix(frontend): dev で /admin/* リロード時に真っ白になる問題を修正 (#142)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,8 +28,27 @@ export default defineConfig(({ mode }) => {
       port: frontendPort,
       strictPort: true, // fail fast instead of silently bumping to next port
       // Dev only: forward API + health to the PHP backend.
+      //
+      // The SPA's client routes live under /admin/* — the same prefix as the
+      // API — so a plain proxy would also forward browser *document* reloads of
+      // e.g. /admin/reconciliation to PHP, which answers with the built
+      // index.html whose hashed asset URLs don't exist on the dev server → blank
+      // page. The `bypass` mirrors the prod SPA fallback in public_html/index.php:
+      // GET navigations that explicitly want text/html (and not application/json)
+      // are served the dev index.html so the SPA boots in place (and #135's
+      // expired-session login renders at the same URL). Real API calls
+      // (Accept: application/json) and CSV downloads (Accept: */*) still proxy.
       proxy: {
-        '/admin': { target, changeOrigin: true },
+        '/admin': {
+          target,
+          changeOrigin: true,
+          bypass(req) {
+            const accept = req.headers.accept ?? ''
+            if (req.method === 'GET' && accept.includes('text/html') && !accept.includes('application/json')) {
+              return '/index.html'
+            }
+          },
+        },
         '/health': { target, changeOrigin: true },
       },
     },


### PR DESCRIPTION
Closes #142

## Symptom

Open the admin SPA at a deep route (e.g. `/admin/reconciliation`), leave it open a while, then **reload** → blank white page. You had to manually trim the URL to `/` to reach the login screen. Expected (what #135 already does for live sessions): the same URL shows the login form in place, and logging back in returns you to that screen.

## Root cause — dev only

The SPA client routes live under `/admin/*`, the **same prefix as the API**. The Vite dev proxy forwarded *all* `/admin` requests — including browser document reloads — to PHP. The backend's SPA fallback returned the **production-built** `assets/index.html`, whose hashed asset URLs (`/assets/index-<hash>.js`) don't exist on the dev server; Vite answered those with `index.html` (text/html), the browser couldn't run HTML as a script, and the page stayed blank.

Production was already fine — `public_html/index.php` serves the built SPA for `Accept: text/html` navigations.

## Fix

A proxy `bypass` mirroring the prod `index.php` heuristic: `GET` document navigations (`Accept: text/html`, not `application/json`) are served the dev `index.html` so the SPA boots in place; real API calls (`application/json`) and CSV downloads (`*/*`) still proxy. Dev and prod now use the same Accept-header rule, and #135's in-place expired-session login finally runs on reload.

## Verification (curl against the running dev server)

| Request | Accept | Result |
| --- | --- | --- |
| `/admin/reconciliation` | `text/html` | dev shell → `/src/main.tsx` (was: stale built index → blank) |
| `/admin/auth/me` | `application/json` | proxied → 401 `problem+json` |
| `/admin/export/reconciliations` | `*/*` | proxied → 401 `problem+json` |

`npm run check`: type-check ✅, eslint ✅, 36 Vitest ✅. E2E unaffected (`vite preview` uses an empty proxy + history fallback). No backend change; no route restructuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)