### PR TITLE
feat(export): 督促CSVエクスポート追加 + 前受金エクスポートのボタン露出 (#144)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1195,6 +1195,28 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/export/dunning-notices:
+    get:
+      tags: [Export]
+      summary: Export dunning notices as CSV
+      description: >
+        UTF-8 BOM CSV; one row per dunning send record (operational/audit copy).
+        Columns reuse the dunning-notice response fields, incl.
+        `outstanding_at_send_cents`. Requires `view_reconciliation`.
+      operationId: exportDunningNotices
+      responses:
+        '200':
+          description: CSV file download.
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /admin/export/bank-transactions:
     get:
       tags: [Export]

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listClientCredits, applyClientCredit } from '@/api/endpoints'
+import { listClientCredits, applyClientCredit, downloadCsv } from '@/api/endpoints'
 import type { ClientCredit } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
@@ -102,7 +102,15 @@ export default function ClientCreditsPage() {
 
   return (
     <>
-      <PageHead title={t('clientCredit.title')} sub={t('clientCredit.subtitle')} />
+      <PageHead
+        title={t('clientCredit.title')}
+        sub={t('clientCredit.subtitle')}
+        actions={
+          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/client-credits', 'client-credits.csv')}>
+            <Icon name="export" />{t('export.csv')}
+          </Button>
+        }
+      />
 
       <FilterBar>
         <FilterField label={t('table.client')}>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listDunningNotices, sendDunningNotice, listUpstreamInvoices,
-  listDunningPauses, pauseDunningNotice, resumeDunningNotice,
+  listDunningPauses, pauseDunningNotice, resumeDunningNotice, downloadCsv,
 } from '@/api/endpoints'
 import type { UpstreamInvoice } from '@/types'
 import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
@@ -103,7 +103,15 @@ export default function DunningPage() {
 
   return (
     <>
-      <PageHead title={t('dunning.title')} sub={t('dunning.subtitle')} />
+      <PageHead
+        title={t('dunning.title')}
+        sub={t('dunning.subtitle')}
+        actions={
+          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/dunning-notices', 'dunning-notices.csv')}>
+            <Icon name="export" />{t('export.csv')}
+          </Button>
+        }
+      />
 
       {/* Pause banner */}
       {activePauses.size > 0 && (

--- a/src/Export/ExportDunningNoticesCsvHandler.php
+++ b/src/Export/ExportDunningNoticesCsvHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use NeneClear\Auth\AuthContext;
+use NeneClear\Dunning\DunningNoticeFilter;
+use NeneClear\Dunning\DunningNoticeRepositoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportDunningNoticesCsvHandler
+{
+    private const int BATCH = 1000;
+
+    public function __construct(
+        private DunningNoticeRepositoryInterface $notices,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $filter = new DunningNoticeFilter();
+        $rows = [];
+        $offset = 0;
+        do {
+            $batch = $this->notices->findByOrganization($organizationId, $filter, self::BATCH, $offset);
+            foreach ($batch as $notice) {
+                $rows[] = [
+                    $notice->id ?? '',
+                    $notice->invoiceId,
+                    $notice->invoiceNumber,
+                    $notice->clientId,
+                    $notice->recipientEmail,
+                    $notice->outstandingCents,
+                    $notice->dueAt,
+                    $notice->channel,
+                    $notice->templateVersion,
+                    $notice->sentBy,
+                    $notice->sentAt,
+                ];
+            }
+            $offset += self::BATCH;
+        } while (count($batch) === self::BATCH);
+
+        $csv = $this->buildCsv(
+            ['dunning_notice_id', 'invoice_id', 'invoice_number', 'client_id', 'recipient_email',
+                'outstanding_at_send_cents', 'due_at', 'channel', 'template_version', 'sent_by', 'sent_at'],
+            $rows,
+        );
+
+        return $this->csvResponse($csv, 'dunning-notices.csv');
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<list<mixed>> $rows
+     */
+    private function buildCsv(array $headers, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        fwrite($handle, "\xEF\xBB\xBF");
+        fputcsv($handle, $headers);
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
+        }
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        fclose($handle);
+
+        return $content !== false ? $content : '';
+    }
+
+    private function csvResponse(string $content, string $filename): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withBody($this->streamFactory->createStream($content));
+    }
+}

--- a/src/Export/ExportRouteRegistrar.php
+++ b/src/Export/ExportRouteRegistrar.php
@@ -14,6 +14,7 @@ final readonly class ExportRouteRegistrar
         private ExportReconciliationsCsvHandler $reconciliationsHandler,
         private ExportClientCreditsCsvHandler $clientCreditsHandler,
         private ExportBankTransactionsCsvHandler $bankTransactionsHandler,
+        private ExportDunningNoticesCsvHandler $dunningNoticesHandler,
     ) {
     }
 
@@ -22,9 +23,11 @@ final readonly class ExportRouteRegistrar
         $reconciliations = $this->reconciliationsHandler;
         $clientCredits = $this->clientCreditsHandler;
         $bankTransactions = $this->bankTransactionsHandler;
+        $dunningNotices = $this->dunningNoticesHandler;
 
         $router->get('/admin/export/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $reconciliations->handle($r));
         $router->get('/admin/export/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $clientCredits->handle($r));
         $router->get('/admin/export/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $bankTransactions->handle($r));
+        $router->get('/admin/export/dunning-notices', static fn (ServerRequestInterface $r): ResponseInterface => $dunningNotices->handle($r));
     }
 }

--- a/src/Export/ExportServiceProvider.php
+++ b/src/Export/ExportServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeneClear\Export;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Dunning\DunningNoticeRepositoryInterface;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
@@ -16,7 +17,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Wires the CSV export endpoints (reconciliations, client credits, bank
- * transactions). Streams are built with the framework PSR-17 factories.
+ * transactions, dunning notices). Streams are built with the framework PSR-17
+ * factories.
  */
 final readonly class ExportServiceProvider implements ServiceProviderInterface
 {
@@ -38,6 +40,11 @@ final readonly class ExportServiceProvider implements ServiceProviderInterface
                 ),
                 new ExportBankTransactionsCsvHandler(
                     ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, ResponseFactoryInterface::class),
+                    ServiceResolver::get($c, StreamFactoryInterface::class),
+                ),
+                new ExportDunningNoticesCsvHandler(
+                    ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
                 ),

--- a/tests/Http/ExportCsvHttpTest.php
+++ b/tests/Http/ExportCsvHttpTest.php
@@ -216,6 +216,52 @@ final class ExportCsvHttpTest extends TestCase
         self::assertStringContainsString('client_credit_id', $body);
     }
 
+    public function test_export_dunning_notices_returns_csv(): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: 1,
+            invoiceNumber: 'INV-001',
+            clientId: 100,
+            outstandingCents: 110000,
+            totalCents: 110000,
+            dueAt: '2026-04-30',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+        $this->invoiceClient->addClient(new InvoiceClientInfo(100, 'ACME', 'accounts@acme.example'));
+
+        $token = $this->tokenFor('admin@acme.example');
+        self::assertSame(201, $this->post($token, '/admin/dunning-notices', ['invoice_id' => 1])->getStatusCode());
+
+        $response = $this->get($token, '/admin/export/dunning-notices');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/csv', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('attachment', $response->getHeaderLine('Content-Disposition'));
+
+        $body = (string) $response->getBody();
+        self::assertStringStartsWith("\xEF\xBB\xBF", $body, 'Expected UTF-8 BOM');
+        self::assertStringContainsString('dunning_notice_id', $body);
+        // Canonical column name (terminology.md): outstanding_at_send_cents, not outstanding_cents.
+        self::assertStringContainsString('outstanding_at_send_cents', $body);
+        self::assertStringContainsString('INV-001', $body);
+        self::assertStringContainsString('accounts@acme.example', $body);
+    }
+
+    public function test_export_dunning_notices_empty_has_header_only(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->get($token, '/admin/export/dunning-notices');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        self::assertStringStartsWith("\xEF\xBB\xBF", $body);
+        self::assertStringContainsString('dunning_notice_id', $body);
+        $lines = array_filter(explode("\n", trim($body)));
+        self::assertCount(1, $lines, 'Expected header-only CSV when no notices exist');
+    }
+
     public function test_viewer_can_export(): void
     {
         $token = $this->tokenFor('viewer@acme.example');


### PR DESCRIPTION
Closes #144

## Why

CSV export coverage was inconsistent:

| Target | Backend | UI button |
| --- | --- | --- |
| Reconciliations | ✅ | ✅ |
| Bank transactions | ✅ | ✅ |
| Client credits (前受金) | ✅ | ❌ → **now ✅** |
| Dunning (督促) | ❌ → **now ✅** | ❌ → **now ✅** |

前受金 export already existed on the backend but was unreachable from the UI; 督促 had no export at all. This closes both gaps.

## Changes

**Dunning (督促) — new export**
- `ExportDunningNoticesCsvHandler` mirroring the client-credit handler (batched 1k, UTF-8 BOM, attachment), exporting all notices for the org
- Columns reuse the exact `DunningNoticeResponse` field names — notably the canonical **`outstanding_at_send_cents`** (per terminology.md), not `outstanding_cents`: `dunning_notice_id, invoice_id, invoice_number, client_id, recipient_email, outstanding_at_send_cents, due_at, channel, template_version, sent_by, sent_at`
- Registered as `GET /admin/export/dunning-notices` (already covered by the `/admin/export` → `view_reconciliation` capability prefix)
- OpenAPI path added

**Client credits (前受金) — quick win**
- CSV export button on `ClientCreditsPage`, wired to the existing endpoint

**Dunning page**
- CSV export button on `DunningPage`

**Tests**
- `ExportCsvHttpTest`: dunning export (populated → asserts BOM + `outstanding_at_send_cents` + INV-001) and header-only-when-empty

No new terminology — every CSV column already ships in `DunningNoticeResponse`.

## Compliance note

Reconciliation/client-credit exports are payment-ledger artifacts (電帳法 search reqs); the dunning export is an operational/audit copy of send records, not a tax ledger, so it reuses the existing column style and needs no tax-advisor sign-off. Final column confirmation can be left to operations.

## Checks
- `composer check`: 255 backend tests (6 skipped) ✅, PHPStan level 8 ✅, PHP-CS-Fixer ✅
- `npm run check`: type-check ✅, eslint ✅, 38 Vitest ✅
- Smoke: `GET /admin/export/dunning-notices` → 401 unauth (route registered, not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)