### PR TITLE
feat(users): 招待→メール送信→パスワード設定→ログインの導線を実装 (#146)

### DIFF
--- a/database/migrations/20260607120000_create_user_invitations_table.php
+++ b/database/migrations/20260607120000_create_user_invitations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUserInvitationsTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('user_invitations')
+            ->addColumn('organization_id', 'integer', ['null' => true, 'default' => null])
+            ->addColumn('user_id', 'integer', ['null' => false])
+            ->addColumn('token_hash', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('expires_at', 'datetime', ['null' => false])
+            ->addColumn('accepted_at', 'datetime', ['null' => true, 'default' => null])
+            ->addColumn('created_at', 'datetime', ['null' => true, 'default' => null])
+            ->addIndex(['token_hash'], ['unique' => true, 'name' => 'uq_user_invitations_token_hash'])
+            ->addIndex(['user_id'], ['name' => 'idx_user_invitations_user'])
+            ->create();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -55,6 +55,7 @@ domain folders are **PascalCase singular**.
 | --- | --- | --- | --- |
 | Tenant | `Organization` | `organizations` | `organization_id` |
 | Operator account | `User` | `users` | `user_id` |
+| Operator onboarding token | `UserInvitation` | `user_invitations` | `user_invitation_id` |
 | Clear settings (singleton per org) | `ClearSettings` (entity); `Settings` (folder) | `clear_settings` | — (one per `organization_id`) |
 | Registered company bank account + CSV profile | `BankAccount` | `bank_accounts` | `bank_account_id` |
 | Bank CSV import batch | `BankImportBatch` | `bank_import_batches` | `bank_import_batch_id` |
@@ -108,7 +109,8 @@ follows `{entity}_{past-tense-verb}` in lowercase snake_case.
 | `dunning_sent` | Dunning notice sent | `before` + `after` |
 | `dunning_paused` | Dunning paused for an invoice | `before` + `after` |
 | `dunning_resumed` | Dunning resumed for an invoice | `before` + `after` |
-| `user_created` | Operator account created | `after` |
+| `user_created` | Operator account created (invited or active) | `after` |
+| `invitation_accepted` | Invitee set their password → account activated | `before` + `after` |
 | `user_updated` | Operator role/status changed | `before` + `after` |
 | `user_deleted` | Operator account deleted | `before` |
 | `organization_created` | Tenant created | `after` |
@@ -135,7 +137,7 @@ login). New events MUST map to one of these registered `entity_type` values:
 | `client_credit` | `client_credit_id` | `client_credit_applied` |
 | `dunning_notice` | `dunning_notice_id` | `dunning_sent` |
 | `invoice` | upstream `invoice_id` | `dunning_paused`, `dunning_resumed` |
-| `user` | `user_id` (null on failed login) | `user_created/updated/deleted`, `login_succeeded`, `login_failed` |
+| `user` | `user_id` (null on failed login) | `user_created/updated/deleted`, `invitation_accepted`, `login_succeeded`, `login_failed` |
 | `organization` | `organization_id` | `organization_created`, `organization_deleted` |
 | `clear_settings` | owning `organization_id` | `clear_settings_updated` |
 
@@ -149,6 +151,8 @@ login). New events MUST map to one of these registered `entity_type` values:
 | Organization slug | `slug` | `org_slug`, `code` |
 | User role | `role` (values in §2) | `user_role`, `permission` |
 | User credential | `password_hash` | `password`, `pass_hash` |
+| Invitation token (hashed at rest) | `token_hash` (SHA-256 hex) | `token`, `invite_token`, `secret` |
+| Invitation expiry / consumption | `expires_at`, `accepted_at` | `expiry`, `used_at`, `consumed_at` |
 | Soft-delete flag / time | `is_deleted`, `deleted_at` | `deleted`, `is_del` |
 | Bank transaction amount | `amount_cents` | `deposit_cents`, `value_cents` |
 | Bank value date | `value_date` (date type) | `transaction_date`, `valued_at`, `paid_at` (on the bank line) |
@@ -203,6 +207,8 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `organization-already-exists` | Create rejected — slug already taken |
 | `user-not-found` | User id not found |
 | `user-already-exists` | Create rejected — email already taken |
+| `invitation-invalid` | Invitation token not found, already accepted, or malformed (no enumeration of which) |
+| `invitation-expired` | Invitation token past its `expires_at` |
 | `bank-account-not-found` | Bank account id not found / not in caller's org |
 | `bank-import-batch-not-found` | Import batch id not found |
 | `bank-transaction-not-found` | Bank transaction id not found |
@@ -233,7 +239,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | operationId | Resource |
 | --- | --- |
 | `getHealth` | System |
-| `login`, `getCurrentUser` | Auth |
+| `login`, `getCurrentUser`, `getInvitation`, `acceptInvitation` | Auth |
 | `listOrganizations`, `getOrganizationById`, `createOrganization`, `deleteOrganization` | Organization (superadmin) |
 | `listUsers`, `getUserById`, `createUser`, `updateUser`, `deleteUser` | User (admin) |
 | `getClearSettings`, `updateClearSettings`, `testUpstreamConnection` | Clear settings (admin) |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -136,6 +136,67 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /admin/auth/invitation:
+    get:
+      tags: [Auth]
+      summary: Validate an invitation token
+      description: >
+        Public (no session). Validates the raw token from the invitation e-mail
+        link and returns the invitee's e-mail so the accept-invite page can show
+        who is being onboarded.
+      operationId: getInvitation
+      parameters:
+        - name: token
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: The invitation is valid.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email: { type: string, format: email }
+                required: [email]
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          description: Invitation token expired (`invitation-expired`).
+
+  /admin/auth/invitation/accept:
+    post:
+      tags: [Auth]
+      summary: Accept an invitation and set a password
+      description: >
+        Public (no session). Consumes the invitation token, sets the invitee's
+        password and activates the account. The caller then logs in normally.
+      operationId: acceptInvitation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token: { type: string }
+                password: { type: string, minLength: 8 }
+              required: [token, password]
+      responses:
+        '200':
+          description: The account is now active.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          description: Invitation token expired (`invitation-expired`).
+        '422':
+          $ref: '#/components/responses/ValidationError'
+
   /admin/organizations:
     get:
       tags: [Organization]

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1195,6 +1195,28 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /admin/export/dunning-notices:
+    get:
+      tags: [Export]
+      summary: Export dunning notices as CSV
+      description: >
+        UTF-8 BOM CSV; one row per dunning send record (operational/audit copy).
+        Columns reuse the dunning-notice response fields, incl.
+        `outstanding_at_send_cents`. Requires `view_reconciliation`.
+      operationId: exportDunningNotices
+      responses:
+        '200':
+          description: CSV file download.
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /admin/export/bank-transactions:
     get:
       tags: [Export]

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -31,6 +31,15 @@ export function getCurrentUser(signal?: AbortSignal) {
   return api.get<User>(`${BASE}/auth/me`, signal)
 }
 
+// --- Invitation onboarding (public; the invitee has no session yet) ---
+export function getInvitation(token: string, signal?: AbortSignal) {
+  return api.get<{ email: string }>(`${BASE}/auth/invitation?token=${encodeURIComponent(token)}`, signal)
+}
+
+export function acceptInvitation(token: string, password: string) {
+  return api.post<User>(`${BASE}/auth/invitation/accept`, { token, password })
+}
+
 // --- Bank import ---
 export interface BankImportBatchQuery {
   sourceFilename?: string

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { isAuthenticated, isAdmin, subscribeAuthChange } from '@/api/client'
 import AppShell from '@/components/AppShell'
 import LoginPage from '@/pages/login/LoginPage'
+import AcceptInvitePage from '@/pages/accept-invite/AcceptInvitePage'
 import DashboardPage from '@/pages/dashboard/DashboardPage'
 import BankImportPage from '@/pages/bank-import/BankImportPage'
 import BankTransactionsPage from '@/pages/bank-transactions/BankTransactionsPage'
@@ -55,6 +56,12 @@ export const router = createBrowserRouter([
       { path: 'users', element: <UsersPage /> },
       { path: 'audit-log', element: <RequireAdmin><AuditLogPage /></RequireAdmin> },
     ],
+  },
+  {
+    // Public onboarding route reached from the invitation e-mail link. It lives
+    // outside RequireAuth so an invitee with no session can set their password.
+    path: '/accept-invite',
+    element: <AcceptInvitePage />,
   },
   {
     path: '/',

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -253,6 +253,23 @@ export const en: Record<MessageKey, string> = {
   'users.status.active': 'Active',
   'users.status.invited': 'Invited',
 
+  // ── Accept invitation (onboarding) ──
+  'acceptInvite.pitchTitle': 'Activate your account',
+  'acceptInvite.pitchBody': 'Set a password to start signing in to NeNe Clear.',
+  'acceptInvite.title': 'Set your password',
+  'acceptInvite.subtitle': 'Set a password for {email}.',
+  'acceptInvite.password': 'Password (at least 8 characters)',
+  'acceptInvite.passwordConfirm': 'Confirm password',
+  'acceptInvite.submit': 'Set password and activate account',
+  'acceptInvite.loading': 'Checking your invitation…',
+  'acceptInvite.tooShort': 'Password must be at least 8 characters.',
+  'acceptInvite.mismatch': 'Passwords do not match.',
+  'acceptInvite.invalid': 'This invitation link is invalid or has already been used. Ask an administrator to send a new one.',
+  'acceptInvite.expired': 'This invitation link has expired. Ask an administrator to send a new one.',
+  'acceptInvite.failed': 'Could not set your password. Please try again later.',
+  'acceptInvite.success': 'Your account is now active. Please sign in.',
+  'acceptInvite.toLogin': 'Go to sign in',
+
   // ── Audit log (operation history) ──
   'audit.title': 'Audit logs',
   'audit.subtitle': 'An audit trail recording who changed what, when, and how (before/after) for every operation.',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -249,6 +249,23 @@ export const ja = {
   'users.status.active': '有効',
   'users.status.invited': '招待中',
 
+  // ── Accept invitation (onboarding) ──
+  'acceptInvite.pitchTitle': 'アカウントを有効化',
+  'acceptInvite.pitchBody': 'パスワードを設定すると、NeNe Clear にログインできるようになります。',
+  'acceptInvite.title': 'パスワードの設定',
+  'acceptInvite.subtitle': '{email} のパスワードを設定してください。',
+  'acceptInvite.password': 'パスワード（8文字以上）',
+  'acceptInvite.passwordConfirm': 'パスワード（確認）',
+  'acceptInvite.submit': 'パスワードを設定してアカウントを有効化',
+  'acceptInvite.loading': '招待を確認しています…',
+  'acceptInvite.tooShort': 'パスワードは8文字以上で設定してください。',
+  'acceptInvite.mismatch': 'パスワードが一致しません。',
+  'acceptInvite.invalid': 'この招待リンクは無効か、すでに使用されています。管理者に再送を依頼してください。',
+  'acceptInvite.expired': 'この招待リンクは有効期限が切れています。管理者に再送を依頼してください。',
+  'acceptInvite.failed': '設定に失敗しました。時間をおいて再度お試しください。',
+  'acceptInvite.success': 'アカウントを有効化しました。ログインしてください。',
+  'acceptInvite.toLogin': 'ログインへ進む',
+
   // ── Audit log (operation history) ──
   'audit.title': '監査ログ',
   'audit.subtitle': 'すべての操作について、誰が・いつ・何を・どう変えたか（変更前後）を追跡する監査ログです。',

--- a/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
+++ b/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { getInvitation, acceptInvitation } from '@/api/endpoints'
+import { ApiError } from '@/api/client'
+import { Icon, Button, Notice, LogoMark } from '@/components/ui'
+import { useTranslation } from '@/hooks/useTranslation'
+
+const MIN_PASSWORD = 8
+
+/**
+ * Public onboarding page reached from the invitation e-mail link
+ * (`/accept-invite?token=…`). It validates the token, lets the invitee choose a
+ * password, activates the account, then sends them to the login screen.
+ */
+export default function AcceptInvitePage() {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const token = params.get('token') ?? ''
+
+  const [status, setStatus] = useState<'loading' | 'ready' | 'invalid' | 'expired'>(() => token === '' ? 'invalid' : 'loading')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState('')
+  const [done, setDone] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (token === '') return
+    const controller = new AbortController()
+    getInvitation(token, controller.signal)
+      .then(({ email }) => { setEmail(email); setStatus('ready') })
+      .catch(err => {
+        if (controller.signal.aborted) return
+        setStatus(err instanceof ApiError && err.status === 410 ? 'expired' : 'invalid')
+      })
+    return () => controller.abort()
+  }, [token])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (password.length < MIN_PASSWORD) { setError(t('acceptInvite.tooShort')); return }
+    if (password !== confirm) { setError(t('acceptInvite.mismatch')); return }
+    setSubmitting(true)
+    try {
+      await acceptInvitation(token, password)
+      setDone(true)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 410) setStatus('expired')
+      else if (err instanceof ApiError && err.status === 404) setStatus('invalid')
+      else setError(t('acceptInvite.failed'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="login">
+      <div className="login-aside">
+        <div className="login-grid" />
+        <div className="brand">
+          <LogoMark height={36} className="logo-mark" />
+          <b>NeNe Clear</b>
+        </div>
+        <div className="pitch">
+          <h2>{t('acceptInvite.pitchTitle')}</h2>
+          <p>{t('acceptInvite.pitchBody')}</p>
+        </div>
+      </div>
+
+      <div className="login-main">
+        <div className="login-card">
+          <div className="lh">
+            <h1>{t('acceptInvite.title')}</h1>
+            {status === 'ready' && <p>{t('acceptInvite.subtitle', { email })}</p>}
+          </div>
+
+          {status === 'loading' && <p className="muted">{t('acceptInvite.loading')}</p>}
+
+          {status === 'invalid' && <Notice variant="bad">{t('acceptInvite.invalid')}</Notice>}
+          {status === 'expired' && <Notice variant="bad">{t('acceptInvite.expired')}</Notice>}
+
+          {status === 'ready' && done && (
+            <>
+              <Notice variant="ok">{t('acceptInvite.success')}</Notice>
+              <Button variant="primary" style={{ justifyContent: 'center', padding: '11px', marginTop: 16, width: '100%' }} onClick={() => navigate('/admin')}>
+                <Icon name="login" />{t('acceptInvite.toLogin')}
+              </Button>
+            </>
+          )}
+
+          {status === 'ready' && !done && (
+            <form className="stack" onSubmit={handleSubmit}>
+              <div className="field">
+                <label>{t('acceptInvite.password')}</label>
+                <div className="inp-icon">
+                  <Icon name="lock" />
+                  <input
+                    className="inp" type="password" name="password"
+                    value={password} onChange={e => setPassword(e.target.value)}
+                    autoComplete="new-password" required minLength={MIN_PASSWORD}
+                  />
+                </div>
+              </div>
+              <div className="field">
+                <label>{t('acceptInvite.passwordConfirm')}</label>
+                <div className="inp-icon">
+                  <Icon name="lock" />
+                  <input
+                    className="inp" type="password" name="password_confirm"
+                    value={confirm} onChange={e => setConfirm(e.target.value)}
+                    autoComplete="new-password" required minLength={MIN_PASSWORD}
+                  />
+                </div>
+              </div>
+              <Button variant="primary" type="submit" disabled={submitting} style={{ justifyContent: 'center', padding: '11px' }}>
+                <Icon name="check" />{submitting ? t('common.processing') : t('acceptInvite.submit')}
+              </Button>
+              {error && <Notice variant="bad">{error}</Notice>}
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listClientCredits, applyClientCredit } from '@/api/endpoints'
+import { listClientCredits, applyClientCredit, downloadCsv } from '@/api/endpoints'
 import type { ClientCredit } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
@@ -102,7 +102,15 @@ export default function ClientCreditsPage() {
 
   return (
     <>
-      <PageHead title={t('clientCredit.title')} sub={t('clientCredit.subtitle')} />
+      <PageHead
+        title={t('clientCredit.title')}
+        sub={t('clientCredit.subtitle')}
+        actions={
+          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/client-credits', 'client-credits.csv')}>
+            <Icon name="export" />{t('export.csv')}
+          </Button>
+        }
+      />
 
       <FilterBar>
         <FilterField label={t('table.client')}>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listDunningNotices, sendDunningNotice, listUpstreamInvoices,
-  listDunningPauses, pauseDunningNotice, resumeDunningNotice,
+  listDunningPauses, pauseDunningNotice, resumeDunningNotice, downloadCsv,
 } from '@/api/endpoints'
 import type { UpstreamInvoice } from '@/types'
 import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
@@ -103,7 +103,15 @@ export default function DunningPage() {
 
   return (
     <>
-      <PageHead title={t('dunning.title')} sub={t('dunning.subtitle')} />
+      <PageHead
+        title={t('dunning.title')}
+        sub={t('dunning.subtitle')}
+        actions={
+          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/dunning-notices', 'dunning-notices.csv')}>
+            <Icon name="export" />{t('export.csv')}
+          </Button>
+        }
+      />
 
       {/* Pause banner */}
       {activePauses.size > 0 && (

--- a/lang/en.php
+++ b/lang/en.php
@@ -46,6 +46,12 @@ return [
     'problem.user-already-exists.title'  => 'User Already Exists',
     'problem.user-already-exists.detail' => 'A user with that email already exists.',
 
+    'problem.invitation-invalid.title'  => 'Invitation Invalid',
+    'problem.invitation-invalid.detail' => 'This invitation link is invalid or has already been used.',
+
+    'problem.invitation-expired.title'  => 'Invitation Expired',
+    'problem.invitation-expired.detail' => 'This invitation link has expired. Ask an administrator to send a new one.',
+
     'problem.bank-account-not-found.title'  => 'Bank Account Not Found',
     'problem.bank-account-not-found.detail' => 'The requested bank account was not found.',
 

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -46,6 +46,12 @@ return [
     'problem.user-already-exists.title'  => 'ユーザーが既に存在します',
     'problem.user-already-exists.detail' => 'そのメールアドレスはすでに使用されています。',
 
+    'problem.invitation-invalid.title'  => '招待が無効です',
+    'problem.invitation-invalid.detail' => 'この招待リンクは無効か、すでに使用されています。',
+
+    'problem.invitation-expired.title'  => '招待の有効期限が切れています',
+    'problem.invitation-expired.detail' => 'この招待リンクは有効期限が切れています。管理者に再送を依頼してください。',
+
     'problem.bank-account-not-found.title'  => '銀行口座が見つかりません',
     'problem.bank-account-not-found.detail' => '指定された銀行口座は存在しません。',
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -75,6 +75,9 @@ $application = ApplicationFactory::create(
     smtpFromName: $env('SMTP_FROM_NAME', 'NeNe Clear'),
     invoiceApiBaseUrl: $invoiceApiBaseUrl,
     invoiceBearerToken: $env('NENE_INVOICE_BEARER_TOKEN'),
+    // Absolute base for invitation e-mail links. Same-origin in production; the
+    // dev frontend (Vite) runs on a separate port, so default to it locally.
+    appBaseUrl: $env('NENE_CLEAR_APP_URL', 'http://localhost:5383'),
 );
 
 $psr17 = new Psr17Factory();

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -34,7 +34,11 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
      *
      * @var list<string>
      */
-    private const array PUBLIC_PATHS = ['/', '/health', '/machine/health', '/admin/auth/login'];
+    private const array PUBLIC_PATHS = [
+        '/', '/health', '/machine/health', '/admin/auth/login',
+        // Invitee has no session yet; the invitation token is the credential.
+        '/admin/auth/invitation', '/admin/auth/invitation/accept',
+    ];
 
     public function register(ContainerBuilder $builder): void
     {

--- a/src/Export/ExportDunningNoticesCsvHandler.php
+++ b/src/Export/ExportDunningNoticesCsvHandler.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Export;
+
+use NeneClear\Auth\AuthContext;
+use NeneClear\Dunning\DunningNoticeFilter;
+use NeneClear\Dunning\DunningNoticeRepositoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final readonly class ExportDunningNoticesCsvHandler
+{
+    private const int BATCH = 1000;
+
+    public function __construct(
+        private DunningNoticeRepositoryInterface $notices,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request) ?? 0;
+
+        $filter = new DunningNoticeFilter();
+        $rows = [];
+        $offset = 0;
+        do {
+            $batch = $this->notices->findByOrganization($organizationId, $filter, self::BATCH, $offset);
+            foreach ($batch as $notice) {
+                $rows[] = [
+                    $notice->id ?? '',
+                    $notice->invoiceId,
+                    $notice->invoiceNumber,
+                    $notice->clientId,
+                    $notice->recipientEmail,
+                    $notice->outstandingCents,
+                    $notice->dueAt,
+                    $notice->channel,
+                    $notice->templateVersion,
+                    $notice->sentBy,
+                    $notice->sentAt,
+                ];
+            }
+            $offset += self::BATCH;
+        } while (count($batch) === self::BATCH);
+
+        $csv = $this->buildCsv(
+            ['dunning_notice_id', 'invoice_id', 'invoice_number', 'client_id', 'recipient_email',
+                'outstanding_at_send_cents', 'due_at', 'channel', 'template_version', 'sent_by', 'sent_at'],
+            $rows,
+        );
+
+        return $this->csvResponse($csv, 'dunning-notices.csv');
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<list<mixed>> $rows
+     */
+    private function buildCsv(array $headers, array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+        assert($handle !== false);
+        fwrite($handle, "\xEF\xBB\xBF");
+        fputcsv($handle, $headers);
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
+        }
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        fclose($handle);
+
+        return $content !== false ? $content : '';
+    }
+
+    private function csvResponse(string $content, string $filename): ResponseInterface
+    {
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/csv; charset=UTF-8')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"')
+            ->withBody($this->streamFactory->createStream($content));
+    }
+}

--- a/src/Export/ExportRouteRegistrar.php
+++ b/src/Export/ExportRouteRegistrar.php
@@ -14,6 +14,7 @@ final readonly class ExportRouteRegistrar
         private ExportReconciliationsCsvHandler $reconciliationsHandler,
         private ExportClientCreditsCsvHandler $clientCreditsHandler,
         private ExportBankTransactionsCsvHandler $bankTransactionsHandler,
+        private ExportDunningNoticesCsvHandler $dunningNoticesHandler,
     ) {
     }
 
@@ -22,9 +23,11 @@ final readonly class ExportRouteRegistrar
         $reconciliations = $this->reconciliationsHandler;
         $clientCredits = $this->clientCreditsHandler;
         $bankTransactions = $this->bankTransactionsHandler;
+        $dunningNotices = $this->dunningNoticesHandler;
 
         $router->get('/admin/export/reconciliations', static fn (ServerRequestInterface $r): ResponseInterface => $reconciliations->handle($r));
         $router->get('/admin/export/client-credits', static fn (ServerRequestInterface $r): ResponseInterface => $clientCredits->handle($r));
         $router->get('/admin/export/bank-transactions', static fn (ServerRequestInterface $r): ResponseInterface => $bankTransactions->handle($r));
+        $router->get('/admin/export/dunning-notices', static fn (ServerRequestInterface $r): ResponseInterface => $dunningNotices->handle($r));
     }
 }

--- a/src/Export/ExportServiceProvider.php
+++ b/src/Export/ExportServiceProvider.php
@@ -7,6 +7,7 @@ namespace NeneClear\Export;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Dunning\DunningNoticeRepositoryInterface;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
@@ -16,7 +17,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Wires the CSV export endpoints (reconciliations, client credits, bank
- * transactions). Streams are built with the framework PSR-17 factories.
+ * transactions, dunning notices). Streams are built with the framework PSR-17
+ * factories.
  */
 final readonly class ExportServiceProvider implements ServiceProviderInterface
 {
@@ -38,6 +40,11 @@ final readonly class ExportServiceProvider implements ServiceProviderInterface
                 ),
                 new ExportBankTransactionsCsvHandler(
                     ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
+                    ServiceResolver::get($c, ResponseFactoryInterface::class),
+                    ServiceResolver::get($c, StreamFactoryInterface::class),
+                ),
+                new ExportDunningNoticesCsvHandler(
+                    ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
                 ),

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -26,6 +26,10 @@ use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamHttpClient;
+use NeneClear\User\InvitationLinkBuilder;
+use NeneClear\User\InvitationMailerInterface;
+use NeneClear\User\LogOnlyInvitationMailer;
+use NeneClear\User\SmtpInvitationMailer;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -69,6 +73,8 @@ final class ApplicationFactory
         string $smtpFromName = 'NeNe Clear',
         ?string $invoiceApiBaseUrl = null,
         string $invoiceBearerToken = '',
+        string $appBaseUrl = '',
+        ?InvitationMailerInterface $invitationMailer = null,
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
 
@@ -95,6 +101,8 @@ final class ApplicationFactory
             $psr17,
             self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
             self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            $appBaseUrl,
         );
 
         $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
@@ -130,6 +138,8 @@ final class ApplicationFactory
         Psr17Factory $psr17,
         InvoiceUpstreamClientInterface $invoiceClient,
         DunningMailerInterface $mailer,
+        InvitationMailerInterface $invitationMailer,
+        string $appBaseUrl,
     ): ContainerInterface {
         $langDir = dirname(__DIR__, 2) . '/lang';
 
@@ -162,6 +172,8 @@ final class ApplicationFactory
             ->set(TokenVerifierInterface::class, static fn (ContainerInterface $c): TokenVerifierInterface => ServiceResolver::get($c, JwtTokenService::class))
             ->set(InvoiceUpstreamClientInterface::class, static fn (ContainerInterface $c): InvoiceUpstreamClientInterface => $invoiceClient)
             ->set(DunningMailerInterface::class, static fn (ContainerInterface $c): DunningMailerInterface => $mailer)
+            ->set(InvitationMailerInterface::class, static fn (ContainerInterface $c): InvitationMailerInterface => $invitationMailer)
+            ->set(InvitationLinkBuilder::class, static fn (ContainerInterface $c): InvitationLinkBuilder => new InvitationLinkBuilder($appBaseUrl))
             ->addProvider(new ApplicationServiceProvider())
             ->build();
     }
@@ -195,5 +207,20 @@ final class ApplicationFactory
         }
 
         return new LogOnlyDunningMailer();
+    }
+
+    private static function resolveInvitationMailer(
+        ?string $smtpHost,
+        int $smtpPort,
+        string $smtpUsername,
+        string $smtpPassword,
+        string $smtpFromAddress,
+        string $smtpFromName,
+    ): InvitationMailerInterface {
+        if ($smtpHost !== null && $smtpHost !== '') {
+            return new SmtpInvitationMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword);
+        }
+
+        return new LogOnlyInvitationMailer();
     }
 }

--- a/src/Http/ApplicationServiceProvider.php
+++ b/src/Http/ApplicationServiceProvider.php
@@ -48,6 +48,9 @@ use NeneClear\Reconciliation\ReconciliationAlreadyReversedExceptionHandler;
 use NeneClear\Reconciliation\ReconciliationNotFoundExceptionHandler;
 use NeneClear\Reconciliation\ReconciliationRouteRegistrar;
 use NeneClear\Reconciliation\ReconciliationServiceProvider;
+use NeneClear\User\InvitationExpiredExceptionHandler;
+use NeneClear\User\InvitationInvalidExceptionHandler;
+use NeneClear\User\InvitationRouteRegistrar;
 use NeneClear\User\RoleNotAssignableExceptionHandler;
 use NeneClear\User\UserAlreadyExistsExceptionHandler;
 use NeneClear\User\UserNotFoundExceptionHandler;
@@ -89,6 +92,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, AuthRouteRegistrar::class),
                     ServiceResolver::get($c, OrganizationRouteRegistrar::class),
                     ServiceResolver::get($c, UserRouteRegistrar::class),
+                    ServiceResolver::get($c, InvitationRouteRegistrar::class),
                     ServiceResolver::get($c, AuditRouteRegistrar::class),
                     ServiceResolver::get($c, BankImportRouteRegistrar::class),
                     ServiceResolver::get($c, ClearSettingsRouteRegistrar::class),
@@ -109,6 +113,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, OrganizationAlreadyExistsExceptionHandler::class),
                     ServiceResolver::get($c, UserNotFoundExceptionHandler::class),
                     ServiceResolver::get($c, UserAlreadyExistsExceptionHandler::class),
+                    ServiceResolver::get($c, InvitationInvalidExceptionHandler::class),
+                    ServiceResolver::get($c, InvitationExpiredExceptionHandler::class),
                     ServiceResolver::get($c, RoleNotAssignableExceptionHandler::class),
                     ServiceResolver::get($c, DuplicateBankImportExceptionHandler::class),
                     ServiceResolver::get($c, BankAccountNotFoundExceptionHandler::class),

--- a/src/User/AcceptInvitationHandler.php
+++ b/src/User/AcceptInvitationHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Public endpoint: consumes an invitation token and sets the invitee's
+ * password, activating the account. The caller then logs in normally.
+ */
+final readonly class AcceptInvitationHandler
+{
+    private const int MIN_PASSWORD_LENGTH = 8;
+
+    public function __construct(
+        private AcceptInvitationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $token = is_string($body['token'] ?? null) ? (string) $body['token'] : '';
+        $password = is_string($body['password'] ?? null) ? (string) $body['password'] : '';
+
+        $errors = [];
+        if ($token === '') {
+            $errors[] = new ValidationError('token', 'A token is required.', 'required');
+        }
+        if (mb_strlen($password) < self::MIN_PASSWORD_LENGTH) {
+            $errors[] = new ValidationError('password', 'Password must be at least 8 characters.', 'too_short');
+        }
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $user = $this->useCase->execute(new AcceptInvitationInput($token, $password));
+
+        return $this->response->create(UserResponse::toArray($user));
+    }
+}

--- a/src/User/AcceptInvitationInput.php
+++ b/src/User/AcceptInvitationInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class AcceptInvitationInput
+{
+    public function __construct(
+        public string $rawToken,
+        public string $password,
+    ) {
+    }
+}

--- a/src/User/AcceptInvitationUseCase.php
+++ b/src/User/AcceptInvitationUseCase.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditRecorderInterface;
+
+final readonly class AcceptInvitationUseCase implements AcceptInvitationUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
+     * @param Closure(DatabaseQueryExecutorInterface): UserInvitationRepositoryInterface $invitations
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $users,
+        private Closure $invitations,
+        private Closure $auditRecorder,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(AcceptInvitationInput $input): User
+    {
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $hash = password_hash($input->password, PASSWORD_BCRYPT);
+
+        // Token validation, password set, invitation consumption, and the audit
+        // record commit (or roll back) together. Re-checking inside the
+        // transaction also closes a double-accept race.
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input, $now, $hash): User {
+                $invitations = ($this->invitations)($tx);
+                $users = ($this->users)($tx);
+                $auditRecorder = ($this->auditRecorder)($tx);
+
+                $invitation = $invitations->findByTokenHash(InvitationToken::hash($input->rawToken));
+                if ($invitation === null || $invitation->acceptedAt !== null) {
+                    throw new InvitationInvalidException();
+                }
+                if ($invitation->expiresAt < $now) {
+                    throw new InvitationExpiredException();
+                }
+
+                $existing = $users->findById($invitation->userId);
+                if ($existing === null) {
+                    throw new InvitationInvalidException();
+                }
+
+                $activated = new User(
+                    email: $existing->email,
+                    role: $existing->role,
+                    status: UserStatus::Active,
+                    passwordHash: $hash,
+                    organizationId: $existing->organizationId,
+                    id: $existing->id,
+                );
+                $users->save($activated);
+                $invitations->markAccepted($invitation->id ?? 0, $now);
+
+                // Audit: in-place activation carries before + after. UserResponse
+                // never exposes the password hash. The actor is the invitee
+                // themselves (the only party holding the token).
+                $auditRecorder->record(
+                    $existing->organizationId ?? 0,
+                    $existing->id ?? 0,
+                    $now,
+                    'invitation_accepted',
+                    'user',
+                    $existing->id,
+                    [
+                        'before' => UserResponse::toArray($existing),
+                        'after' => UserResponse::toArray($activated),
+                    ],
+                );
+
+                return $activated;
+            },
+        );
+    }
+}

--- a/src/User/AcceptInvitationUseCaseInterface.php
+++ b/src/User/AcceptInvitationUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface AcceptInvitationUseCaseInterface
+{
+    /**
+     * Consume an invitation: set the user's password and activate the account.
+     *
+     * @throws InvitationInvalidException unknown / already-accepted token
+     * @throws InvitationExpiredException token past its expiry
+     */
+    public function execute(AcceptInvitationInput $input): User;
+}

--- a/src/User/CreateUserUseCase.php
+++ b/src/User/CreateUserUseCase.php
@@ -13,14 +13,21 @@ use NeneClear\Auth\Role;
 
 final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
 {
+    /** How long an invitation link stays valid. */
+    private const string INVITE_TTL = '+7 days';
+
     /**
      * @param Closure(DatabaseQueryExecutorInterface): UserRepositoryInterface $users
      * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
+     * @param Closure(DatabaseQueryExecutorInterface): UserInvitationRepositoryInterface $invitations
      */
     public function __construct(
         private DatabaseTransactionManagerInterface $transactionManager,
         private Closure $users,
         private Closure $auditRecorder,
+        private Closure $invitations,
+        private InvitationMailerInterface $mailer,
+        private InvitationLinkBuilder $linkBuilder,
         private ClockInterface $clock,
     ) {
     }
@@ -34,15 +41,24 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
             throw new RoleNotAssignableException($input->role->value);
         }
 
-        // With a password the account is active; without one it is invited and
-        // cannot log in until a password is set (the hash is a random placeholder).
-        $status = $input->password !== null ? UserStatus::Active : UserStatus::Invited;
+        // With a password the account is active immediately; without one it is
+        // invited — it gets a random placeholder hash (unusable for login) and an
+        // invitation token whose raw value is e-mailed to the operator. The
+        // account becomes active only once they accept the invite and set a real
+        // password (AcceptInvitationUseCase).
+        $invited = $input->password === null;
+        $status = $invited ? UserStatus::Invited : UserStatus::Active;
         $hash = password_hash($input->password ?? bin2hex(random_bytes(16)), PASSWORD_BCRYPT);
 
-        // The uniqueness check, insert, and audit record commit (or roll back)
-        // together so a created account can never lack its audit event (Issue #122).
-        return $this->transactionManager->transactional(
-            function (DatabaseQueryExecutorInterface $tx) use ($input, $status, $hash): User {
+        $rawToken = $invited ? InvitationToken::newRaw() : null;
+        $expiresAt = $this->clock->now()->modify(self::INVITE_TTL)->format('Y-m-d H:i:s');
+
+        // The uniqueness check, user insert, invitation insert, and audit record
+        // commit (or roll back) together so a created account can never lack its
+        // audit event or its invitation (Issue #122). The e-mail is sent only
+        // after the transaction commits.
+        $created = $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input, $status, $hash, $invited, $rawToken, $expiresAt): User {
                 $users = ($this->users)($tx);
                 $auditRecorder = ($this->auditRecorder)($tx);
 
@@ -58,10 +74,19 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
                     organizationId: $input->organizationId,
                 ));
 
-                $created = $users->findById($id);
+                $user = $users->findById($id);
 
-                if ($created === null) {
+                if ($user === null) {
                     throw new UserNotFoundException($id);
+                }
+
+                if ($invited && $rawToken !== null) {
+                    ($this->invitations)($tx)->save(new UserInvitation(
+                        organizationId: $input->organizationId,
+                        userId: $user->id ?? $id,
+                        tokenHash: InvitationToken::hash($rawToken),
+                        expiresAt: $expiresAt,
+                    ));
                 }
 
                 // Audit: account creation carries `after` only (no prior state). The
@@ -72,12 +97,36 @@ final readonly class CreateUserUseCase implements CreateUserUseCaseInterface
                     $this->clock->now()->format('Y-m-d H:i:s'),
                     'user_created',
                     'user',
-                    $created->id,
-                    ['after' => UserResponse::toArray($created)],
+                    $user->id,
+                    ['after' => UserResponse::toArray($user)],
                 );
 
-                return $created;
+                return $user;
             },
         );
+
+        if ($invited && $rawToken !== null) {
+            $this->sendInvitation($created, $rawToken);
+        }
+
+        return $created;
+    }
+
+    private function sendInvitation(User $user, string $rawToken): void
+    {
+        $link = $this->linkBuilder->forToken($rawToken);
+        $body = "NeNe Clear への招待が届いています。\n\n"
+            . "以下のリンクからパスワードを設定すると、ログインできるようになります（リンクの有効期限は7日間です）。\n\n"
+            . $link . "\n\n"
+            . "心当たりがない場合は、このメールを破棄してください。\n";
+
+        $this->mailer->send(new InvitationMailPayload(
+            userId: $user->id ?? 0,
+            organizationId: $user->organizationId,
+            to: $user->email,
+            subject: 'NeNe Clear への招待',
+            body: $body,
+            acceptUrl: $link,
+        ));
     }
 }

--- a/src/User/GetInvitationHandler.php
+++ b/src/User/GetInvitationHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Public endpoint: validates an invitation token (from the e-mail link) and
+ * returns the invitee's e-mail so the accept-invite page can show who is being
+ * onboarded. Invalid/expired tokens surface as Problem Details.
+ */
+final readonly class GetInvitationHandler
+{
+    public function __construct(
+        private GetInvitationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getQueryParams();
+        $token = isset($params['token']) && is_string($params['token']) ? $params['token'] : '';
+
+        if ($token === '') {
+            throw new InvitationInvalidException();
+        }
+
+        $email = $this->useCase->execute($token);
+
+        return $this->response->create(['email' => $email]);
+    }
+}

--- a/src/User/GetInvitationUseCase.php
+++ b/src/User/GetInvitationUseCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Http\ClockInterface;
+
+final readonly class GetInvitationUseCase implements GetInvitationUseCaseInterface
+{
+    public function __construct(
+        private UserInvitationRepositoryInterface $invitations,
+        private UserRepositoryInterface $users,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(string $rawToken): string
+    {
+        $invitation = $this->resolve($rawToken);
+
+        $user = $this->users->findById($invitation->userId);
+        if ($user === null) {
+            throw new InvitationInvalidException();
+        }
+
+        return $user->email;
+    }
+
+    /**
+     * Look up and validate the token (shared by accept). Unknown or already
+     * accepted → invalid (no enumeration); past expiry → expired.
+     */
+    private function resolve(string $rawToken): UserInvitation
+    {
+        $invitation = $this->invitations->findByTokenHash(InvitationToken::hash($rawToken));
+        if ($invitation === null || $invitation->acceptedAt !== null) {
+            throw new InvitationInvalidException();
+        }
+
+        if ($invitation->expiresAt < $this->clock->now()->format('Y-m-d H:i:s')) {
+            throw new InvitationExpiredException();
+        }
+
+        return $invitation;
+    }
+}

--- a/src/User/GetInvitationUseCaseInterface.php
+++ b/src/User/GetInvitationUseCaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface GetInvitationUseCaseInterface
+{
+    /**
+     * Validate a raw invitation token and return the invitee's e-mail.
+     *
+     * @throws InvitationInvalidException unknown / already-accepted token
+     * @throws InvitationExpiredException token past its expiry
+     */
+    public function execute(string $rawToken): string;
+}

--- a/src/User/InvitationExpiredException.php
+++ b/src/User/InvitationExpiredException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use RuntimeException;
+
+/** The invitation token was valid but has passed its expiry. */
+final class InvitationExpiredException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The invitation token has expired.');
+    }
+}

--- a/src/User/InvitationExpiredExceptionHandler.php
+++ b/src/User/InvitationExpiredExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvitationExpiredExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvitationExpiredException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invitation-expired', 410);
+    }
+}

--- a/src/User/InvitationInvalidException.php
+++ b/src/User/InvitationInvalidException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use RuntimeException;
+
+/**
+ * The invitation token is unknown, malformed, or already accepted. Deliberately
+ * does not distinguish which, to avoid token/account enumeration.
+ */
+final class InvitationInvalidException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The invitation token is invalid.');
+    }
+}

--- a/src/User/InvitationInvalidExceptionHandler.php
+++ b/src/User/InvitationInvalidExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvitationInvalidExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvitationInvalidException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'invitation-invalid', 404);
+    }
+}

--- a/src/User/InvitationLinkBuilder.php
+++ b/src/User/InvitationLinkBuilder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * Builds the absolute accept-invite link placed in the invitation e-mail. The
+ * SPA serves `/accept-invite` as a public route (outside the auth shell). The
+ * base URL is configured per deployment (`NENE_CLEAR_APP_URL`); when empty the
+ * link is site-relative, which is fine for same-origin production.
+ */
+final readonly class InvitationLinkBuilder
+{
+    public function __construct(
+        private string $baseUrl,
+    ) {
+    }
+
+    public function forToken(string $rawToken): string
+    {
+        return rtrim($this->baseUrl, '/') . '/accept-invite?token=' . $rawToken;
+    }
+}

--- a/src/User/InvitationMailPayload.php
+++ b/src/User/InvitationMailPayload.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+final readonly class InvitationMailPayload
+{
+    public function __construct(
+        public int $userId,
+        public ?int $organizationId,
+        public string $to,
+        public string $subject,
+        public string $body,
+        public string $acceptUrl,
+    ) {
+    }
+}

--- a/src/User/InvitationMailerInterface.php
+++ b/src/User/InvitationMailerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface InvitationMailerInterface
+{
+    public function send(InvitationMailPayload $payload): void;
+}

--- a/src/User/InvitationRouteRegistrar.php
+++ b/src/User/InvitationRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Public (unauthenticated) invitation endpoints — the invitee has no session
+ * yet. Both paths are listed in AuthServiceProvider::PUBLIC_PATHS so the bearer
+ * middleware lets them through; the token itself is the credential.
+ */
+final readonly class InvitationRouteRegistrar
+{
+    public function __construct(
+        private GetInvitationHandler $getHandler,
+        private AcceptInvitationHandler $acceptHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $getHandler = $this->getHandler;
+        $acceptHandler = $this->acceptHandler;
+
+        $router->get('/admin/auth/invitation', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));
+        $router->post('/admin/auth/invitation/accept', static fn (ServerRequestInterface $r): ResponseInterface => $acceptHandler->handle($r));
+    }
+}

--- a/src/User/InvitationToken.php
+++ b/src/User/InvitationToken.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * Invitation token helpers. The raw token is high-entropy and travels only in
+ * the e-mail link; the database stores `hash()` of it (terminology.md:
+ * `token_hash`). Centralised here so the create and accept paths agree on the
+ * algorithm.
+ */
+final readonly class InvitationToken
+{
+    public static function newRaw(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+
+    public static function hash(string $raw): string
+    {
+        return hash('sha256', $raw);
+    }
+}

--- a/src/User/LogOnlyInvitationMailer.php
+++ b/src/User/LogOnlyInvitationMailer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * Fallback mailer used when no SMTP host is configured. The invitation link is
+ * written to the error log so the onboarding flow is exercisable in dev
+ * (and visible in Mailpit once SMTP is configured).
+ */
+final readonly class LogOnlyInvitationMailer implements InvitationMailerInterface
+{
+    public function send(InvitationMailPayload $payload): void
+    {
+        error_log(sprintf(
+            '[UserInvitation user=%d org=%s] to=%s subject=%s body=%s',
+            $payload->userId,
+            $payload->organizationId ?? 'null',
+            $payload->to,
+            $payload->subject,
+            $payload->body,
+        ));
+    }
+}

--- a/src/User/PdoUserInvitationRepository.php
+++ b/src/User/PdoUserInvitationRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoUserInvitationRepository implements UserInvitationRepositoryInterface
+{
+    private const string COLUMNS = 'id, organization_id, user_id, token_hash, expires_at, accepted_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function save(UserInvitation $invitation): int
+    {
+        $this->query->execute(
+            'INSERT INTO user_invitations (organization_id, user_id, token_hash, expires_at, accepted_at) '
+            . 'VALUES (?, ?, ?, ?, ?)',
+            [
+                $invitation->organizationId,
+                $invitation->userId,
+                $invitation->tokenHash,
+                $invitation->expiresAt,
+                $invitation->acceptedAt,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function findByTokenHash(string $tokenHash): ?UserInvitation
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM user_invitations WHERE token_hash = ?',
+            [$tokenHash],
+        );
+
+        return $row !== null ? $this->hydrate($row) : null;
+    }
+
+    public function markAccepted(int $id, string $acceptedAt): void
+    {
+        $this->query->execute(
+            'UPDATE user_invitations SET accepted_at = ? WHERE id = ?',
+            [$acceptedAt, $id],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): UserInvitation
+    {
+        return new UserInvitation(
+            organizationId: $row['organization_id'] !== null ? (int) $row['organization_id'] : null,
+            userId: (int) $row['user_id'],
+            tokenHash: (string) $row['token_hash'],
+            expiresAt: (string) $row['expires_at'],
+            acceptedAt: $row['accepted_at'] !== null ? (string) $row['accepted_at'] : null,
+            id: (int) $row['id'],
+        );
+    }
+}

--- a/src/User/SmtpInvitationMailer.php
+++ b/src/User/SmtpInvitationMailer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+final class SmtpInvitationMailer implements InvitationMailerInterface
+{
+    private readonly Mailer $mailer;
+
+    public function __construct(
+        string $smtpHost,
+        int $smtpPort,
+        private readonly string $fromAddress,
+        private readonly string $fromName,
+        string $username = '',
+        #[\SensitiveParameter] string $password = '',
+    ) {
+        // Credentials are passed to EsmtpTransport directly (not via a DSN) so
+        // they cannot leak into exception messages if the connection fails.
+        $transport = new EsmtpTransport($smtpHost, $smtpPort);
+        if ($username !== '') {
+            $transport->setUsername($username);
+            $transport->setPassword($password);
+        }
+        $this->mailer = new Mailer($transport);
+    }
+
+    public function send(InvitationMailPayload $payload): void
+    {
+        $email = (new Email())
+            ->from(new Address($this->fromAddress, $this->fromName))
+            ->to($payload->to)
+            ->subject($payload->subject)
+            ->text($payload->body);
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/User/UserInvitation.php
+++ b/src/User/UserInvitation.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+/**
+ * An operator onboarding token. The raw token is e-mailed to the invitee and
+ * never stored; only its SHA-256 hash lives here (terminology.md §3). An
+ * invitation is usable while `acceptedAt` is null and `expiresAt` is in the
+ * future; accepting it sets the user's password and flips the account to active.
+ */
+final readonly class UserInvitation
+{
+    public function __construct(
+        public ?int $organizationId,
+        public int $userId,
+        public string $tokenHash,
+        public string $expiresAt,
+        public ?string $acceptedAt = null,
+        public ?int $id = null,
+    ) {
+    }
+}

--- a/src/User/UserInvitationRepositoryInterface.php
+++ b/src/User/UserInvitationRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\User;
+
+interface UserInvitationRepositoryInterface
+{
+    public function save(UserInvitation $invitation): int;
+
+    /** Look up an invitation by its token hash (regardless of state). */
+    public function findByTokenHash(string $tokenHash): ?UserInvitation;
+
+    /** Mark an invitation consumed at the given timestamp. */
+    public function markAccepted(int $id, string $acceptedAt): void;
+}

--- a/src/User/UserServiceProvider.php
+++ b/src/User/UserServiceProvider.php
@@ -45,10 +45,37 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                 ),
             )
             ->set(
+                UserInvitationRepositoryInterface::class,
+                static fn (ContainerInterface $c): UserInvitationRepositoryInterface => new PdoUserInvitationRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
                 CreateUserUseCaseInterface::class,
                 static fn (ContainerInterface $c): CreateUserUseCaseInterface => new CreateUserUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserInvitationRepositoryInterface => new PdoUserInvitationRepository($tx),
+                    ServiceResolver::get($c, InvitationMailerInterface::class),
+                    ServiceResolver::get($c, InvitationLinkBuilder::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                GetInvitationUseCaseInterface::class,
+                static fn (ContainerInterface $c): GetInvitationUseCaseInterface => new GetInvitationUseCase(
+                    ServiceResolver::get($c, UserInvitationRepositoryInterface::class),
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                AcceptInvitationUseCaseInterface::class,
+                static fn (ContainerInterface $c): AcceptInvitationUseCaseInterface => new AcceptInvitationUseCase(
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserRepositoryInterface => new PdoUserRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): UserInvitationRepositoryInterface => new PdoUserInvitationRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
@@ -94,6 +121,31 @@ final readonly class UserServiceProvider implements ServiceProviderInterface
                         ServiceResolver::get($c, DeleteUserUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
                     ),
+                ),
+            )
+            ->set(
+                InvitationRouteRegistrar::class,
+                static fn (ContainerInterface $c): InvitationRouteRegistrar => new InvitationRouteRegistrar(
+                    new GetInvitationHandler(
+                        ServiceResolver::get($c, GetInvitationUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new AcceptInvitationHandler(
+                        ServiceResolver::get($c, AcceptInvitationUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                InvitationInvalidExceptionHandler::class,
+                static fn (ContainerInterface $c): InvitationInvalidExceptionHandler => new InvitationInvalidExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                InvitationExpiredExceptionHandler::class,
+                static fn (ContainerInterface $c): InvitationExpiredExceptionHandler => new InvitationExpiredExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
                 ),
             )
             ->set(

--- a/tests/Http/ExportCsvHttpTest.php
+++ b/tests/Http/ExportCsvHttpTest.php
@@ -216,6 +216,52 @@ final class ExportCsvHttpTest extends TestCase
         self::assertStringContainsString('client_credit_id', $body);
     }
 
+    public function test_export_dunning_notices_returns_csv(): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: 1,
+            invoiceNumber: 'INV-001',
+            clientId: 100,
+            outstandingCents: 110000,
+            totalCents: 110000,
+            dueAt: '2026-04-30',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+        $this->invoiceClient->addClient(new InvoiceClientInfo(100, 'ACME', 'accounts@acme.example'));
+
+        $token = $this->tokenFor('admin@acme.example');
+        self::assertSame(201, $this->post($token, '/admin/dunning-notices', ['invoice_id' => 1])->getStatusCode());
+
+        $response = $this->get($token, '/admin/export/dunning-notices');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/csv', $response->getHeaderLine('Content-Type'));
+        self::assertStringContainsString('attachment', $response->getHeaderLine('Content-Disposition'));
+
+        $body = (string) $response->getBody();
+        self::assertStringStartsWith("\xEF\xBB\xBF", $body, 'Expected UTF-8 BOM');
+        self::assertStringContainsString('dunning_notice_id', $body);
+        // Canonical column name (terminology.md): outstanding_at_send_cents, not outstanding_cents.
+        self::assertStringContainsString('outstanding_at_send_cents', $body);
+        self::assertStringContainsString('INV-001', $body);
+        self::assertStringContainsString('accounts@acme.example', $body);
+    }
+
+    public function test_export_dunning_notices_empty_has_header_only(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->get($token, '/admin/export/dunning-notices');
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        self::assertStringStartsWith("\xEF\xBB\xBF", $body);
+        self::assertStringContainsString('dunning_notice_id', $body);
+        $lines = array_filter(explode("\n", trim($body)));
+        self::assertCount(1, $lines, 'Expected header-only CSV when no notices exist');
+    }
+
     public function test_viewer_can_export(): void
     {
         $token = $this->tokenFor('viewer@acme.example');

--- a/tests/Http/InvitationHttpTest.php
+++ b/tests/Http/InvitationHttpTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\Tests\User\RecordingInvitationMailer;
+use NeneClear\User\PdoUserInvitationRepository;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserInvitation;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class InvitationHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string ADMIN_PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+    private RecordingInvitationMailer $mailer;
+    private \Nene2\Database\DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-invite-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->query = $kit->queryExecutor;
+
+        SchemaFixture::createUsers($this->query);
+        SchemaFixture::createLoginAttempts($this->query);
+        SchemaFixture::createUserInvitations($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+
+        $users = new PdoUserRepository($this->query);
+        $users->save(new User(
+            email: 'admin@acme.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::ADMIN_PASSWORD, PASSWORD_BCRYPT),
+            organizationId: 7,
+        ));
+
+        $this->mailer = new RecordingInvitationMailer();
+        $this->app = ApplicationFactory::create(
+            query: $this->query,
+            transactionManager: $kit->transactionManager,
+            jwtSecret: self::SECRET,
+            appBaseUrl: 'https://app.example',
+            invitationMailer: $this->mailer,
+        );
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function token(string $email, string $password): string
+    {
+        $req = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => $password])));
+        $body = $this->decode($this->app->handle($req));
+        self::assertIsString($body['token'] ?? null);
+
+        return $body['token'];
+    }
+
+    private function get(string $path, ?string $token = null): ResponseInterface
+    {
+        $req = $this->psr17->createServerRequest('GET', $path);
+        if ($token !== null) {
+            $req = $req->withHeader('Authorization', 'Bearer ' . $token);
+        }
+
+        return $this->app->handle($req);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function postJson(string $path, array $body, ?string $token = null): ResponseInterface
+    {
+        $req = $this->psr17->createServerRequest('POST', $path)
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode($body)));
+        if ($token !== null) {
+            $req = $req->withHeader('Authorization', 'Bearer ' . $token);
+        }
+
+        return $this->app->handle($req);
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    private function tokenFromMail(): string
+    {
+        self::assertCount(1, $this->mailer->sent);
+        $url = $this->mailer->sent[0]->acceptUrl;
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $q);
+        self::assertIsString($q['token'] ?? null);
+
+        return $q['token'];
+    }
+
+    public function test_invite_email_accept_then_login(): void
+    {
+        $adminToken = $this->token('admin@acme.example', self::ADMIN_PASSWORD);
+
+        // 1. Invite (no password) → invited user + e-mail with a token.
+        $created = $this->postJson('/admin/users', ['email' => 'newbie@acme.example', 'role' => 'member'], $adminToken);
+        self::assertSame(201, $created->getStatusCode());
+        self::assertSame('invited', $this->decode($created)['status'] ?? null);
+
+        $rawToken = $this->tokenFromMail();
+
+        // 2. The invitee (no session) validates the token and sees their e-mail.
+        $info = $this->get('/admin/auth/invitation?token=' . $rawToken);
+        self::assertSame(200, $info->getStatusCode());
+        self::assertSame('newbie@acme.example', $this->decode($info)['email'] ?? null);
+
+        // 3. Cannot log in before accepting (account still invited).
+        $earlyLogin = $this->postJson('/admin/auth/login', ['email' => 'newbie@acme.example', 'password' => 'My-new-pass-1']);
+        self::assertSame(401, $earlyLogin->getStatusCode());
+
+        // 4. Accept the invite → set password, activate.
+        $accept = $this->postJson('/admin/auth/invitation/accept', ['token' => $rawToken, 'password' => 'My-new-pass-1']);
+        self::assertSame(200, $accept->getStatusCode());
+        self::assertSame('active', $this->decode($accept)['status'] ?? null);
+
+        // 5. Now login works.
+        $login = $this->postJson('/admin/auth/login', ['email' => 'newbie@acme.example', 'password' => 'My-new-pass-1']);
+        self::assertSame(200, $login->getStatusCode());
+        self::assertIsString($this->decode($login)['token'] ?? null);
+    }
+
+    public function test_token_is_single_use(): void
+    {
+        $adminToken = $this->token('admin@acme.example', self::ADMIN_PASSWORD);
+        $this->postJson('/admin/users', ['email' => 'newbie@acme.example', 'role' => 'member'], $adminToken);
+        $rawToken = $this->tokenFromMail();
+
+        self::assertSame(200, $this->postJson('/admin/auth/invitation/accept', ['token' => $rawToken, 'password' => 'My-new-pass-1'])->getStatusCode());
+        // Second use is rejected as invalid (already accepted).
+        self::assertSame(404, $this->postJson('/admin/auth/invitation/accept', ['token' => $rawToken, 'password' => 'My-new-pass-2'])->getStatusCode());
+    }
+
+    public function test_unknown_token_is_invalid(): void
+    {
+        $res = $this->get('/admin/auth/invitation?token=deadbeef');
+        self::assertSame(404, $res->getStatusCode());
+        self::assertStringContainsString('invitation-invalid', (string) $res->getBody());
+    }
+
+    public function test_expired_token_is_rejected(): void
+    {
+        // Seed an already-expired invitation directly.
+        $users = new PdoUserRepository($this->query);
+        $userId = $users->save(new User(
+            email: 'stale@acme.example',
+            role: Role::Viewer,
+            status: UserStatus::Invited,
+            passwordHash: password_hash('x', PASSWORD_BCRYPT),
+            organizationId: 7,
+        ));
+        $raw = 'expired-raw-token';
+        (new PdoUserInvitationRepository($this->query))->save(new UserInvitation(
+            organizationId: 7,
+            userId: $userId,
+            tokenHash: hash('sha256', $raw),
+            expiresAt: '2000-01-01 00:00:00',
+        ));
+
+        $res = $this->get('/admin/auth/invitation?token=' . $raw);
+        self::assertSame(410, $res->getStatusCode());
+        self::assertStringContainsString('invitation-expired', (string) $res->getBody());
+    }
+
+    public function test_short_password_is_rejected(): void
+    {
+        $adminToken = $this->token('admin@acme.example', self::ADMIN_PASSWORD);
+        $this->postJson('/admin/users', ['email' => 'newbie@acme.example', 'role' => 'member'], $adminToken);
+        $rawToken = $this->tokenFromMail();
+
+        $res = $this->postJson('/admin/auth/invitation/accept', ['token' => $rawToken, 'password' => 'short']);
+        self::assertSame(422, $res->getStatusCode());
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -45,6 +45,21 @@ final class SchemaFixture
         );
     }
 
+    public static function createUserInvitations(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE user_invitations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER,
+                user_id INTEGER NOT NULL,
+                token_hash TEXT NOT NULL UNIQUE,
+                expires_at TEXT NOT NULL,
+                accepted_at TEXT,
+                created_at TEXT
+            )'
+        );
+    }
+
     public static function createLoginAttempts(DatabaseQueryExecutorInterface $query): void
     {
         $query->execute(

--- a/tests/User/CreateUserUseCaseTest.php
+++ b/tests/User/CreateUserUseCaseTest.php
@@ -11,6 +11,7 @@ use NeneClear\Tests\Support\FakeTransactionManager;
 use NeneClear\Tests\Support\FixedClock;
 use NeneClear\User\CreateUserInput;
 use NeneClear\User\CreateUserUseCase;
+use NeneClear\User\InvitationLinkBuilder;
 use NeneClear\User\User;
 use NeneClear\User\UserAlreadyExistsException;
 use NeneClear\User\UserStatus;
@@ -19,15 +20,27 @@ use PHPUnit\Framework\TestCase;
 final class CreateUserUseCaseTest extends TestCase
 {
     private InMemoryAuditEventRepository $audit;
+    private InMemoryUserInvitationRepository $invitations;
+    private RecordingInvitationMailer $mailer;
 
     protected function setUp(): void
     {
         $this->audit = new InMemoryAuditEventRepository();
+        $this->invitations = new InMemoryUserInvitationRepository();
+        $this->mailer = new RecordingInvitationMailer();
     }
 
     private function useCase(InMemoryUserRepository $repo): CreateUserUseCase
     {
-        return new CreateUserUseCase(new FakeTransactionManager(), fn () => $repo, fn () => new AuditRecorder($this->audit), new FixedClock('2026-06-01T10:00:00+00:00'));
+        return new CreateUserUseCase(
+            new FakeTransactionManager(),
+            fn () => $repo,
+            fn () => new AuditRecorder($this->audit),
+            fn () => $this->invitations,
+            $this->mailer,
+            new InvitationLinkBuilder('https://app.example'),
+            new FixedClock('2026-06-01T10:00:00+00:00'),
+        );
     }
 
     public function test_with_password_creates_active_user(): void
@@ -91,6 +104,27 @@ final class CreateUserUseCaseTest extends TestCase
         // A random placeholder hash must not verify against an empty password.
         self::assertFalse(password_verify('', $user->passwordHash));
         self::assertNotSame('', $user->passwordHash);
+
+        // An invitation e-mail is sent, carrying an accept link with a token.
+        self::assertCount(1, $this->mailer->sent);
+        $payload = $this->mailer->sent[0];
+        self::assertSame('invited@acme.example', $payload->to);
+        self::assertStringContainsString('https://app.example/accept-invite?token=', $payload->acceptUrl);
+    }
+
+    public function test_with_password_sends_no_invitation_email(): void
+    {
+        $useCase = $this->useCase(new InMemoryUserRepository());
+
+        $useCase->execute(new CreateUserInput(
+            organizationId: 7,
+            email: 'member@acme.example',
+            role: Role::Member,
+            password: 'secret-pass',
+            actorUserId: 42,
+        ));
+
+        self::assertCount(0, $this->mailer->sent);
     }
 
     public function test_rejects_duplicate_email(): void

--- a/tests/User/InMemoryUserInvitationRepository.php
+++ b/tests/User/InMemoryUserInvitationRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\User\UserInvitation;
+use NeneClear\User\UserInvitationRepositoryInterface;
+
+final class InMemoryUserInvitationRepository implements UserInvitationRepositoryInterface
+{
+    /** @var array<int, UserInvitation> */
+    private array $byId = [];
+
+    private int $nextId = 1;
+
+    public function save(UserInvitation $invitation): int
+    {
+        $id = $invitation->id ?? $this->nextId++;
+        $this->byId[$id] = new UserInvitation(
+            organizationId: $invitation->organizationId,
+            userId: $invitation->userId,
+            tokenHash: $invitation->tokenHash,
+            expiresAt: $invitation->expiresAt,
+            acceptedAt: $invitation->acceptedAt,
+            id: $id,
+        );
+
+        return $id;
+    }
+
+    public function findByTokenHash(string $tokenHash): ?UserInvitation
+    {
+        foreach ($this->byId as $invitation) {
+            if (hash_equals($invitation->tokenHash, $tokenHash)) {
+                return $invitation;
+            }
+        }
+
+        return null;
+    }
+
+    public function markAccepted(int $id, string $acceptedAt): void
+    {
+        $existing = $this->byId[$id] ?? null;
+        if ($existing === null) {
+            return;
+        }
+
+        $this->byId[$id] = new UserInvitation(
+            organizationId: $existing->organizationId,
+            userId: $existing->userId,
+            tokenHash: $existing->tokenHash,
+            expiresAt: $existing->expiresAt,
+            acceptedAt: $acceptedAt,
+            id: $id,
+        );
+    }
+}

--- a/tests/User/RecordingInvitationMailer.php
+++ b/tests/User/RecordingInvitationMailer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\User;
+
+use NeneClear\User\InvitationMailerInterface;
+use NeneClear\User\InvitationMailPayload;
+
+/** Captures sent invitation payloads so tests can assert on / replay them. */
+final class RecordingInvitationMailer implements InvitationMailerInterface
+{
+    /** @var list<InvitationMailPayload> */
+    public array $sent = [];
+
+    public function send(InvitationMailPayload $payload): void
+    {
+        $this->sent[] = $payload;
+    }
+}


### PR DESCRIPTION
Closes #146

## Why

The user-invite UI said "招待メールが送信されます", but the flow was a façade:
no e-mail was sent, no invitation token was issued, an invited user got a
random unknowable password hash, and there was no set-password endpoint — so an
invited user was a **dead record that could never log in**. This implements the
whole onboarding flow.

## Flow

invite (admin) → invitation token + e-mail → invitee opens the public
`/accept-invite?token=…` page → sets a password (account activated) → logs in.

## Backend

- **`user_invitations`** table (migration + SchemaFixture): `token_hash` (sha256), `expires_at`, `accepted_at`. Only the hash is stored; single-use + 7-day expiry.
- Creating a user **without a password** now issues an invitation and sends an e-mail with a tokenised accept link. **`InvitationMailer`** (`Smtp`/`LogOnly`, mirrors the dunning mailer; SMTP when `SMTP_HOST` set → visible in Mailpit).
- **Public endpoints** (added to `PUBLIC_PATHS`): `GET /admin/auth/invitation` (validate → `{email}`), `POST /admin/auth/invitation/accept` (set password + activate + consume). Token is re-validated inside the transaction to close a double-accept race; activation audited as `invitation_accepted`.
- OpenAPI: both paths.

## Frontend

- Public **`/accept-invite`** route (outside `RequireAuth`): validates the token, shows the invitee's e-mail, collects a password (with confirm + min length), activates, then routes to login. ja/en strings added.

## Terminology (registered first — binding)

entity `UserInvitation`/`user_invitations`/`user_invitation_id`; audit `invitation_accepted`; fields `token_hash`/`expires_at`/`accepted_at`; slugs `invitation-invalid`/`invitation-expired`; operationIds `getInvitation`/`acceptInvitation`.

## Security

Token stored hashed (sha256), single-use, 7-day expiry; invalid vs already-accepted are not distinguished (no enumeration); password min 8; activation audited.

## Tests

`InvitationHttpTest`: full invite→email→accept→login, plus single-use, unknown-token (404 `invitation-invalid`), expired (410 `invitation-expired`), short-password (422). `CreateUserUseCaseTest`: invite sends e-mail with tokenised link; password-create sends none.

- `composer check`: 261 backend tests (6 skipped) ✅, PHPStan level 8 ✅, PHP-CS-Fixer ✅, OpenAPI contract ✅
- `npm run check`: type-check ✅, eslint ✅, 38 Vitest ✅

## Note (not part of this PR)

The new endpoints query `user_invitations`, so the DB needs the migration. The project's documented MySQL is **3383** (CLAUDE.md / docker-compose), which I migrated; the running backend's `.env` has `DB_PORT=3306`. Worth aligning `.env` to 3383 (or migrating the DB the backend actually uses) so the live flow + Mailpit demo works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)