### PR TITLE
fix(frontend): 消込確定モーダルの UX 改善（具体的な失敗理由＋キーボード操作）(#150 #152)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,21 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Human-facing message for an error from the API. Prefers the field-level
+ * validation reasons (`errors[]`) so the user sees *what* is wrong, then the
+ * localized `detail` (domain errors carry a translated one), then the title.
+ * Falls back to the raw Error message for non-API failures.
+ */
+export function describeApiError(error: unknown): string {
+  if (error instanceof ApiError) {
+    const fieldMessages = (error.problem.errors ?? []).map(e => e.message).filter(Boolean)
+    if (fieldMessages.length > 0) return fieldMessages.join(' / ')
+    return error.problem.detail || error.problem.title
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
 function getToken(): string | null {
   return sessionStorage.getItem(STORAGE_KEY)
 }

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -23,7 +23,9 @@ export function Button({ variant = 'primary', size, children, className, ...rest
     .filter(Boolean)
     .join(' ')
   return (
-    <button className={cls} {...rest}>
+    // Default to type="button" so a Button inside a <form> doesn't implicitly
+    // submit it; callers opt into submit with an explicit type="submit".
+    <button type="button" className={cls} {...rest}>
       {children}
     </button>
   )

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Icon } from './Icon'
 
 interface ModalProps {
@@ -10,9 +10,21 @@ interface ModalProps {
   children: ReactNode
   footer: ReactNode
   size?: 'narrow' | 'default' | 'wide'
+  /**
+   * When provided, the dialog renders as a <form> and submits on Enter — make
+   * the primary footer button `type="submit"`. Omit for modals where Enter
+   * should not confirm.
+   */
+  onSubmit?: () => void
 }
 
-export function Modal({ open, onClose, title, sub, children, footer, size = 'default' }: ModalProps) {
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export function Modal({ open, onClose, title, sub, children, footer, size = 'default', onSubmit }: ModalProps) {
+  const dialogRef = useRef<HTMLElement | null>(null)
+
+  // Escape closes (independent of focus, so it works from anywhere).
   useEffect(() => {
     if (!open) return
     const handle = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
@@ -20,23 +32,82 @@ export function Modal({ open, onClose, title, sub, children, footer, size = 'def
     return () => document.removeEventListener('keydown', handle)
   }, [open, onClose])
 
+  // Move focus into the dialog on open — so keyboard users can type/Tab/Enter
+  // immediately and the global j/k/Enter list shortcuts stop firing on <body> —
+  // and restore it to the trigger on close. Prefers an element marked
+  // [data-autofocus], else the first focusable element.
+  useEffect(() => {
+    if (!open) return
+    const dialog = dialogRef.current
+    if (dialog === null) return
+    const previouslyFocused = document.activeElement as HTMLElement | null
+
+    const target =
+      dialog.querySelector<HTMLElement>('[data-autofocus]')
+      ?? dialog.querySelector<HTMLElement>('.modal-body input, .modal-body select, .modal-body textarea')
+      ?? dialog.querySelector<HTMLElement>(FOCUSABLE)
+    target?.focus()
+
+    return () => {
+      if (previouslyFocused !== null && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus()
+      }
+    }
+  }, [open])
+
   if (!open) return null
 
   const modalClass = size === 'narrow' ? 'modal narrow' : size === 'wide' ? 'modal wide' : 'modal'
 
+  // Trap Tab within the dialog so focus never escapes to the page behind it.
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key !== 'Tab') return
+    const dialog = dialogRef.current
+    if (dialog === null) return
+    const focusables = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE))
+      .filter(el => el.offsetParent !== null || el === document.activeElement)
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement
+    if (e.shiftKey && active === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  const setRef = (el: HTMLElement | null) => { dialogRef.current = el }
+
+  const inner = (
+    <>
+      <div className="modal-head">
+        <div>
+          <h3>{title}</h3>
+          {sub && <p>{sub}</p>}
+        </div>
+        <button type="button" className="x" onClick={onClose}><Icon name="x" /></button>
+      </div>
+      <div className="modal-body">{children}</div>
+      <div className="modal-foot">{footer}</div>
+    </>
+  )
+
   return (
     <div className="modal-scrim" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
-      <div className={modalClass} role="dialog" aria-modal="true" aria-label={title}>
-        <div className="modal-head">
-          <div>
-            <h3>{title}</h3>
-            {sub && <p>{sub}</p>}
+      {onSubmit
+        ? (
+          <form ref={setRef} className={modalClass} role="dialog" aria-modal="true" aria-label={title} onKeyDown={onKeyDown} onSubmit={e => { e.preventDefault(); onSubmit() }}>
+            {inner}
+          </form>
+        )
+        : (
+          <div ref={setRef} className={modalClass} role="dialog" aria-modal="true" aria-label={title} onKeyDown={onKeyDown}>
+            {inner}
           </div>
-          <button className="x" onClick={onClose}><Icon name="x" /></button>
-        </div>
-        <div className="modal-body">{children}</div>
-        <div className="modal-foot">{footer}</div>
-      </div>
+        )}
     </div>
   )
 }

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -166,6 +166,8 @@ export const en: Record<MessageKey, string> = {
   'reconciliation.status.confirmed': 'Confirmed',
   'reconciliation.status.reversed': 'Reversed',
   'reconciliation.noUnmatched': 'No unmatched transactions',
+  'reconciliation.error.noAllocation': 'Enter at least one allocation (invoice ID and amount).',
+  'reconciliation.error.incompleteAllocation': 'Each allocation row needs both an invoice ID and an amount.',
 
   // ── Client credits ──
   'clientCredit.title': 'Client Credits',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -162,6 +162,8 @@ export const ja = {
   'reconciliation.status.confirmed': '確定済',
   'reconciliation.status.reversed': '取消済',
   'reconciliation.noUnmatched': '未消込の取引はありません',
+  'reconciliation.error.noAllocation': '消込先を1件以上入力してください（請求書IDと消込金額）。',
+  'reconciliation.error.incompleteAllocation': '消込先の行は、請求書IDと消込金額の両方を入力してください。',
 
   // ── Client credits ──
   'clientCredit.title': '前受金',

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/api/endpoints'
 import type { BankTransaction, Reconciliation, UpstreamInvoice } from '@/types'
 import type { AllocationInput } from '@/api/endpoints'
+import { describeApiError } from '@/api/client'
 import { Icon, Badge, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, Tabs, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
@@ -24,6 +25,7 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
   const qc = useQueryClient()
   const [allocs, setAllocs] = useState<AllocationInput[]>([{ invoice_id: 0, amount_cents: 0 }])
   const [reasonCode, setReasonCode] = useState('')
+  const [formError, setFormError] = useState('')
 
   const suggestQ = useQuery({
     queryKey: ['propose-match', tx.bank_transaction_id],
@@ -31,14 +33,30 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
     retry: false,
   })
 
+  const validAllocs = allocs.filter(a => a.invoice_id > 0 && a.amount_cents > 0)
+
   const confirmMut = useMutation({
-    mutationFn: () => confirmMatch(tx.bank_transaction_id, allocs.filter(a => a.invoice_id > 0 && a.amount_cents > 0), reasonCode || undefined),
+    mutationFn: () => confirmMatch(tx.bank_transaction_id, validAllocs, reasonCode || undefined),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['bank-transactions', 'unmatched'] })
       void qc.invalidateQueries({ queryKey: ['reconciliations'] })
       onClose()
     },
   })
+
+  // Validate in the browser first so the operator gets a specific, localized
+  // reason (the server's generic 422 "Validation Failed" only carries English
+  // field messages). Per-row issues are surfaced too: a row needs both a
+  // positive invoice ID and a positive amount.
+  function submit() {
+    if (validAllocs.length === 0) {
+      const partial = allocs.some(a => a.invoice_id > 0 || a.amount_cents > 0)
+      setFormError(partial ? t('reconciliation.error.incompleteAllocation') : t('reconciliation.error.noAllocation'))
+      return
+    }
+    setFormError('')
+    confirmMut.mutate()
+  }
 
   function applySuggestion(inv: UpstreamInvoice) {
     setAllocs([{ invoice_id: inv.invoice_id, amount_cents: inv.outstanding_cents }])
@@ -60,7 +78,7 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
       footer={
         <>
           <Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>
-          <Button variant="primary" disabled={confirmMut.isPending} onClick={() => confirmMut.mutate()}>
+          <Button variant="primary" disabled={confirmMut.isPending} onClick={submit}>
             <Icon name="check" />{confirmMut.isPending ? t('common.processing') : t('reconciliation.confirm')}
           </Button>
         </>
@@ -115,7 +133,9 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
         <label>{t('reconciliation.reasonCode')}</label>
         <input className="inp" placeholder={t('reconciliation.reasonCodePlaceholder')} value={reasonCode} onChange={e => setReasonCode(e.target.value)} />
       </div>
-      {confirmMut.isError && <Notice variant="bad">{confirmMut.error.message}</Notice>}
+      {(formError || confirmMut.isError) && (
+        <Notice variant="bad">{formError || describeApiError(confirmMut.error)}</Notice>
+      )}
     </Modal>
   )
 }

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -72,13 +72,14 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
     <Modal
       open
       onClose={onClose}
+      onSubmit={submit}
       title={t('reconciliation.confirm')}
       sub={`${tx.counterparty_text} — ${yen(tx.amount_cents)}（${tx.value_date}）`}
       size="wide"
       footer={
         <>
           <Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>
-          <Button variant="primary" disabled={confirmMut.isPending} onClick={submit}>
+          <Button variant="primary" type="submit" disabled={confirmMut.isPending}>
             <Icon name="check" />{confirmMut.isPending ? t('common.processing') : t('reconciliation.confirm')}
           </Button>
         </>
@@ -106,7 +107,7 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
           {allocs.map((a, i) => (
             <div key={i} className="alloc-row">
               <div className="field"><label style={{ fontSize: 11 }}>{t('reconciliation.invoiceId')}</label>
-                <input className="inp tnum" type="number" value={a.invoice_id || ''} onChange={e => updateAlloc(i, 'invoice_id', e.target.value)} />
+                <input className="inp tnum" type="number" data-autofocus={i === 0 ? true : undefined} value={a.invoice_id || ''} onChange={e => updateAlloc(i, 'invoice_id', e.target.value)} />
               </div>
               <div className="field"><label style={{ fontSize: 11 }}>{t('reconciliation.allocationAmount')}</label>
                 <input className="inp tnum" type="number" value={a.amount_cents > 0 ? a.amount_cents / 100 : ''} onChange={e => updateAlloc(i, 'amount_cents', e.target.value)} />


### PR DESCRIPTION
Closes #150
Closes #152

Two related improvements to the reconciliation **confirm match** modal (the second stacked on the first).

## 1. Specific failure reasons, not just "Validation Failed" (#150)

The modal rendered only `error.message` (the generic 422 title). Now:
- **Client-side pre-validation** (localized, immediate): require ≥1 allocation row with a positive invoice ID and amount; distinct messages for "no allocation" vs "incomplete row".
- **`describeApiError()`**: surface the server's field-level `errors[]` → localized `detail` (e.g. 消込金額超過) → title.

## 2. Keyboard-operable modals (#152)

Opening the modal via j/k + Enter left focus on `<body>`: Tab wandered behind the modal, the global list shortcuts kept firing (Enter re-opened the row), and there was no form so Enter never confirmed. Fixed in the shared `Modal` (benefits every dialog):
- **Initial focus** on open: `[data-autofocus]` → first body input → first focusable; restored to the trigger on close. The confirm modal marks the invoice-ID field. (Once focus is in an input, the global j/k/Enter handler bails, so the interference disappears.)
- **Focus trap**: Tab / Shift+Tab cycle within the dialog.
- **Enter confirms**: optional `Modal` `onSubmit` renders the dialog as a `<form>`; primary button `type="submit"`.
- **`Button` defaults to `type="button"`** so buttons inside a form-modal don't implicitly submit (existing submit buttons already set type explicitly).

## Verification
- `npm run check`: type-check ✅, eslint ✅, 38 Vitest ✅
- Playwright: **full suite 48 passed** (forms + all modal flows unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)