### PR TITLE
feat(export): CSVエクスポートに画面の絞り込みを反映（全4種）(#153)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -650,7 +650,8 @@ paths:
       description: >
         Convenience filter for `status=unmatched` / `partially_matched`,
         searchable by transaction date, amount, and counterparty and sortable
-        (same query contract as `listBankTransactions`, minus `status`).
+        (same query contract as `listBankTransactions`, minus `status`). The
+        export endpoint accepts the same filter params.
       operationId: listUnmatchedTransactions
       parameters:
         - $ref: '#/components/parameters/Limit'
@@ -1214,16 +1215,13 @@ paths:
         Requires `view_reconciliation`.
       operationId: exportReconciliations
       parameters:
-        - name: date_from
-          in: query
-          schema:
-            type: string
-            format: date
-        - name: date_to
-          in: query
-          schema:
-            type: string
-            format: date
+        - { name: status, in: query, schema: { $ref: '#/components/schemas/ReconciliationStatus' } }
+        - { name: bank_transaction_id, in: query, schema: { type: integer } }
+        - { name: invoice_id, in: query, schema: { type: integer } }
+        - { name: confirmed_from, in: query, schema: { type: string, format: date } }
+        - { name: confirmed_to, in: query, schema: { type: string, format: date } }
+        - { name: sort_by, in: query, schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: CSV file download.
@@ -1241,8 +1239,22 @@ paths:
     get:
       tags: [Export]
       summary: Export client credits as CSV
-      description: UTF-8 BOM CSV; one row per client credit record. Requires `view_reconciliation`.
+      description: >
+        UTF-8 BOM CSV; one row per client credit record. Accepts the same filter
+        params as listClientCredits so the export mirrors the list.
+        Requires `view_reconciliation`.
       operationId: exportClientCredits
+      parameters:
+        - { name: client_id, in: query, schema: { type: integer } }
+        - { name: status, in: query, schema: { $ref: '#/components/schemas/ClientCreditStatus' } }
+        - { name: amount_min_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: amount_max_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: remaining_min_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: remaining_max_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: created_from, in: query, schema: { type: string, format: date } }
+        - { name: created_to, in: query, schema: { type: string, format: date } }
+        - { name: sort_by, in: query, schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: CSV file download.
@@ -1263,8 +1275,19 @@ paths:
       description: >
         UTF-8 BOM CSV; one row per dunning send record (operational/audit copy).
         Columns reuse the dunning-notice response fields, incl.
-        `outstanding_at_send_cents`. Requires `view_reconciliation`.
+        `outstanding_at_send_cents`. Accepts the same filter params as
+        listDunningNotices so the export mirrors the list.
+        Requires `view_reconciliation`.
       operationId: exportDunningNotices
+      parameters:
+        - { name: invoice_number, in: query, schema: { type: string } }
+        - { name: recipient_email, in: query, schema: { type: string } }
+        - { name: outstanding_min_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: outstanding_max_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: sent_from, in: query, schema: { type: string, format: date } }
+        - { name: sent_to, in: query, schema: { type: string, format: date } }
+        - { name: sort_by, in: query, schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: CSV file download.
@@ -1284,20 +1307,19 @@ paths:
       summary: Export bank transactions as CSV
       description: >
         UTF-8 BOM CSV; one row per bank transaction. Acts as the 電帳法
-        evidence companion export. Supports date_from / date_to filters.
+        evidence companion export. Accepts the same filter params as
+        listBankTransactions so the export mirrors the list.
         Requires `view_reconciliation`.
       operationId: exportBankTransactions
       parameters:
-        - name: date_from
-          in: query
-          schema:
-            type: string
-            format: date
-        - name: date_to
-          in: query
-          schema:
-            type: string
-            format: date
+        - { name: status, in: query, schema: { $ref: '#/components/schemas/BankTransactionStatus' } }
+        - { name: value_date_from, in: query, schema: { type: string, format: date } }
+        - { name: value_date_to, in: query, schema: { type: string, format: date } }
+        - { name: amount_min_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: amount_max_cents, in: query, schema: { type: integer, format: int64 } }
+        - { name: counterparty, in: query, schema: { type: string } }
+        - { name: sort_by, in: query, schema: { type: string } }
+        - { name: sort_dir, in: query, schema: { type: string, enum: [asc, desc] } }
       responses:
         '200':
           description: CSV file download.

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -22,6 +22,12 @@ import type {
 
 const BASE = '/admin'
 
+/** Append a query string to a path when there are any params. */
+function withQuery(path: string, params: URLSearchParams): string {
+  const s = params.toString()
+  return s === '' ? path : `${path}?${s}`
+}
+
 // --- Auth ---
 export function login(email: string, password: string) {
   return api.post<{ token: string }>(`${BASE}/auth/login`, { email, password })
@@ -115,7 +121,9 @@ export interface BankTransactionFilter {
   offset?: number
 }
 
-export function listBankTransactions(filter: BankTransactionFilter, signal?: AbortSignal) {
+// Filter + sort params (no pagination) — shared by the list query and the CSV
+// export path so the export always mirrors what the page is showing.
+function bankTransactionQuery(filter: BankTransactionFilter): URLSearchParams {
   const q = new URLSearchParams()
   if (filter.status) q.set('status', filter.status)
   if (filter.value_date_from) q.set('value_date_from', filter.value_date_from)
@@ -125,9 +133,18 @@ export function listBankTransactions(filter: BankTransactionFilter, signal?: Abo
   if (filter.counterparty) q.set('counterparty', filter.counterparty)
   if (filter.sortBy) q.set('sort_by', filter.sortBy)
   if (filter.sortDir) q.set('sort_dir', filter.sortDir)
+  return q
+}
+
+export function listBankTransactions(filter: BankTransactionFilter, signal?: AbortSignal) {
+  const q = bankTransactionQuery(filter)
   q.set('limit', String(filter.limit ?? 50))
   q.set('offset', String(filter.offset ?? 0))
   return api.get<ListEnvelope<BankTransaction>>(`${BASE}/bank-transactions?${q}`, signal)
+}
+
+export function bankTransactionsExportPath(filter: BankTransactionFilter): string {
+  return withQuery(`${BASE}/export/bank-transactions`, bankTransactionQuery(filter))
 }
 
 export interface UnmatchedQuery {
@@ -167,8 +184,8 @@ export interface ReconciliationQuery {
   offset?: number
 }
 
-export function listReconciliations(params: ReconciliationQuery, signal?: AbortSignal) {
-  const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+function reconciliationQuery(params: ReconciliationQuery): URLSearchParams {
+  const q = new URLSearchParams()
   if (params.status) q.set('status', params.status)
   if (params.bankTransactionId) q.set('bank_transaction_id', params.bankTransactionId)
   if (params.invoiceId) q.set('invoice_id', params.invoiceId)
@@ -176,7 +193,18 @@ export function listReconciliations(params: ReconciliationQuery, signal?: AbortS
   if (params.confirmedTo) q.set('confirmed_to', params.confirmedTo)
   if (params.sortBy) q.set('sort_by', params.sortBy)
   if (params.sortDir) q.set('sort_dir', params.sortDir)
+  return q
+}
+
+export function listReconciliations(params: ReconciliationQuery, signal?: AbortSignal) {
+  const q = reconciliationQuery(params)
+  q.set('limit', String(params.limit ?? 50))
+  q.set('offset', String(params.offset ?? 0))
   return api.get<ListEnvelope<Reconciliation>>(`${BASE}/reconciliations?${q}`, signal)
+}
+
+export function reconciliationsExportPath(params: ReconciliationQuery): string {
+  return withQuery(`${BASE}/export/reconciliations`, reconciliationQuery(params))
 }
 
 export function getReconciliation(id: number, signal?: AbortSignal) {
@@ -223,8 +251,8 @@ export interface ClientCreditQuery {
   offset?: number
 }
 
-export function listClientCredits(params: ClientCreditQuery, signal?: AbortSignal) {
-  const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+function clientCreditQuery(params: ClientCreditQuery): URLSearchParams {
+  const q = new URLSearchParams()
   if (params.clientId) q.set('client_id', params.clientId)
   if (params.status) q.set('status', params.status)
   if (params.amountMinCents != null) q.set('amount_min_cents', String(params.amountMinCents))
@@ -235,7 +263,18 @@ export function listClientCredits(params: ClientCreditQuery, signal?: AbortSigna
   if (params.createdTo) q.set('created_to', params.createdTo)
   if (params.sortBy) q.set('sort_by', params.sortBy)
   if (params.sortDir) q.set('sort_dir', params.sortDir)
+  return q
+}
+
+export function listClientCredits(params: ClientCreditQuery, signal?: AbortSignal) {
+  const q = clientCreditQuery(params)
+  q.set('limit', String(params.limit ?? 50))
+  q.set('offset', String(params.offset ?? 0))
   return api.get<ListEnvelope<ClientCredit>>(`${BASE}/client-credits?${q}`, signal)
+}
+
+export function clientCreditsExportPath(params: ClientCreditQuery): string {
+  return withQuery(`${BASE}/export/client-credits`, clientCreditQuery(params))
 }
 
 export function applyClientCredit(creditId: number, invoiceId: number, amountCents: number) {
@@ -266,8 +305,8 @@ export interface DunningNoticeQuery {
   offset?: number
 }
 
-export function listDunningNotices(params: DunningNoticeQuery, signal?: AbortSignal) {
-  const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
+function dunningNoticeQuery(params: DunningNoticeQuery): URLSearchParams {
+  const q = new URLSearchParams()
   if (params.invoiceNumber) q.set('invoice_number', params.invoiceNumber)
   if (params.recipientEmail) q.set('recipient_email', params.recipientEmail)
   if (params.outstandingMinCents != null) q.set('outstanding_min_cents', String(params.outstandingMinCents))
@@ -276,7 +315,18 @@ export function listDunningNotices(params: DunningNoticeQuery, signal?: AbortSig
   if (params.sentTo) q.set('sent_to', params.sentTo)
   if (params.sortBy) q.set('sort_by', params.sortBy)
   if (params.sortDir) q.set('sort_dir', params.sortDir)
+  return q
+}
+
+export function listDunningNotices(params: DunningNoticeQuery, signal?: AbortSignal) {
+  const q = dunningNoticeQuery(params)
+  q.set('limit', String(params.limit ?? 50))
+  q.set('offset', String(params.offset ?? 0))
   return api.get<ListEnvelope<DunningNotice>>(`${BASE}/dunning-notices?${q}`, signal)
+}
+
+export function dunningNoticesExportPath(params: DunningNoticeQuery): string {
+  return withQuery(`${BASE}/export/dunning-notices`, dunningNoticeQuery(params))
 }
 
 // --- Audit trail (admin) ---

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { listBankTransactions, downloadCsv } from '@/api/endpoints'
+import { listBankTransactions, bankTransactionsExportPath, downloadCsv } from '@/api/endpoints'
 import type { BankTransaction } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead, SortableTh, nextSort } from '@/components/ui'
 import type { SortState } from '@/components/ui'
@@ -31,18 +31,20 @@ export default function BankTransactionsPage() {
   const [applied, setApplied] = useState<AppliedFilter>({ status: '', dateFrom: '', dateTo: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
   const [sort, setSort] = useState<SortState>({ by: 'value_date', dir: 'desc' })
 
+  // Filter the export mirrors what the list shows (same params, minus paging).
+  const txFilter = {
+    status: applied.status || undefined,
+    value_date_from: applied.dateFrom || undefined,
+    value_date_to: applied.dateTo || undefined,
+    amount_min_cents: applied.amountMin ? Math.round(Number(applied.amountMin) * 100) : undefined,
+    amount_max_cents: applied.amountMax ? Math.round(Number(applied.amountMax) * 100) : undefined,
+    counterparty: applied.counterparty || undefined,
+    sortBy: sort.by, sortDir: sort.dir,
+  }
+
   const txQ = useQuery({
     queryKey: ['bank-transactions', applied, sort],
-    queryFn: ({ signal }) => listBankTransactions({
-      status: applied.status || undefined,
-      value_date_from: applied.dateFrom || undefined,
-      value_date_to: applied.dateTo || undefined,
-      amount_min_cents: applied.amountMin ? Math.round(Number(applied.amountMin) * 100) : undefined,
-      amount_max_cents: applied.amountMax ? Math.round(Number(applied.amountMax) * 100) : undefined,
-      counterparty: applied.counterparty || undefined,
-      sortBy: sort.by, sortDir: sort.dir,
-      limit: PAGE, offset: applied.offset,
-    }, signal),
+    queryFn: ({ signal }) => listBankTransactions({ ...txFilter, limit: PAGE, offset: applied.offset }, signal),
   })
 
   function search() { setApplied({ status, dateFrom, dateTo, amountMin, amountMax, counterparty, offset: 0 }) }
@@ -61,7 +63,7 @@ export default function BankTransactionsPage() {
         title={t('bankTransaction.title')}
         sub={t('bankTransaction.subtitle')}
         actions={
-          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/bank-transactions', 'bank-transactions.csv')}>
+          <Button variant="ghost" onClick={() => void downloadCsv(bankTransactionsExportPath(txFilter), 'bank-transactions.csv')}>
             <Icon name="export" />{t('export.csv')}
           </Button>
         }

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listClientCredits, applyClientCredit, downloadCsv } from '@/api/endpoints'
+import { listClientCredits, applyClientCredit, downloadCsv, clientCreditsExportPath } from '@/api/endpoints'
 import type { ClientCredit } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
@@ -69,22 +69,22 @@ export default function ClientCreditsPage() {
   const [offset, setOffset] = useState(0)
   const set = (k: keyof Filters) => (v: string) => setF(prev => ({ ...prev, [k]: v }))
 
+  // Export mirrors the list's current filter (same params, minus paging).
+  const creditFilter = {
+    clientId: applied.clientId || undefined,
+    status: applied.status || undefined,
+    amountMinCents: yenToCents(applied.amountMin),
+    amountMaxCents: yenToCents(applied.amountMax),
+    remainingMinCents: yenToCents(applied.remainingMin),
+    remainingMaxCents: yenToCents(applied.remainingMax),
+    createdFrom: isoDate(applied.createdFrom),
+    createdTo: isoDate(applied.createdTo),
+    sortBy: sort.by,
+    sortDir: sort.dir,
+  }
   const creditsQ = useQuery({
     queryKey: ['client-credits', applied, sort, offset],
-    queryFn: ({ signal }) => listClientCredits({
-      clientId: applied.clientId || undefined,
-      status: applied.status || undefined,
-      amountMinCents: yenToCents(applied.amountMin),
-      amountMaxCents: yenToCents(applied.amountMax),
-      remainingMinCents: yenToCents(applied.remainingMin),
-      remainingMaxCents: yenToCents(applied.remainingMax),
-      createdFrom: isoDate(applied.createdFrom),
-      createdTo: isoDate(applied.createdTo),
-      sortBy: sort.by,
-      sortDir: sort.dir,
-      limit: PAGE,
-      offset,
-    }, signal),
+    queryFn: ({ signal }) => listClientCredits({ ...creditFilter, limit: PAGE, offset }, signal),
   })
 
   function search() { setApplied(f); setOffset(0) }
@@ -106,7 +106,7 @@ export default function ClientCreditsPage() {
         title={t('clientCredit.title')}
         sub={t('clientCredit.subtitle')}
         actions={
-          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/client-credits', 'client-credits.csv')}>
+          <Button variant="ghost" onClick={() => void downloadCsv(clientCreditsExportPath(creditFilter), 'client-credits.csv')}>
             <Icon name="export" />{t('export.csv')}
           </Button>
         }

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listDunningNotices, sendDunningNotice, listUpstreamInvoices,
-  listDunningPauses, pauseDunningNotice, resumeDunningNotice, downloadCsv,
+  listDunningPauses, pauseDunningNotice, resumeDunningNotice, downloadCsv, dunningNoticesExportPath,
 } from '@/api/endpoints'
 import type { UpstreamInvoice } from '@/types'
 import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
@@ -70,15 +70,17 @@ export default function DunningPage() {
   const [hTo, setHTo] = useState('')
   const [hApplied, setHApplied] = useState({ invoice: '', email: '', from: '', to: '', offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'sent_at', dir: 'desc' })
+  // Export mirrors the history list's current filter (same params, minus paging).
+  const noticesFilter = {
+    invoiceNumber: hApplied.invoice || undefined,
+    recipientEmail: hApplied.email || undefined,
+    sentFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
+    sentTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
+    sortBy: hSort.by, sortDir: hSort.dir,
+  }
   const noticesQ = useQuery({
     queryKey: ['dunning-notices', hApplied, hSort],
-    queryFn: ({ signal }) => listDunningNotices({
-      invoiceNumber: hApplied.invoice || undefined,
-      recipientEmail: hApplied.email || undefined,
-      sentFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
-      sentTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
-      sortBy: hSort.by, sortDir: hSort.dir, limit: HPAGE, offset: hApplied.offset,
-    }, signal),
+    queryFn: ({ signal }) => listDunningNotices({ ...noticesFilter, limit: HPAGE, offset: hApplied.offset }, signal),
   })
   function hSearch() { setHApplied({ invoice: hInvoice, email: hEmail, from: hFrom, to: hTo, offset: 0 }) }
   function hClear() { setHInvoice(''); setHEmail(''); setHFrom(''); setHTo(''); setHApplied({ invoice: '', email: '', from: '', to: '', offset: 0 }) }
@@ -107,7 +109,7 @@ export default function DunningPage() {
         title={t('dunning.title')}
         sub={t('dunning.subtitle')}
         actions={
-          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/dunning-notices', 'dunning-notices.csv')}>
+          <Button variant="ghost" onClick={() => void downloadCsv(dunningNoticesExportPath(noticesFilter), 'dunning-notices.csv')}>
             <Icon name="export" />{t('export.csv')}
           </Button>
         }

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listUnmatchedTransactions, listReconciliations,
-  confirmMatch, reverseReconciliation, proposeMatch, downloadCsv,
+  confirmMatch, reverseReconciliation, proposeMatch, downloadCsv, reconciliationsExportPath,
 } from '@/api/endpoints'
 import type { BankTransaction, Reconciliation, UpstreamInvoice } from '@/types'
 import type { AllocationInput } from '@/api/endpoints'
@@ -199,15 +199,17 @@ export default function ReconciliationPage() {
   const [hTo, setHTo] = useState('')
   const [hApplied, setHApplied] = useState({ status: '', invoice: '', from: '', to: '', offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'id', dir: 'desc' })
+  // Export mirrors the history list's current filter (same params, minus paging).
+  const reconFilter = {
+    status: hApplied.status || undefined,
+    invoiceId: hApplied.invoice || undefined,
+    confirmedFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
+    confirmedTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
+    sortBy: hSort.by, sortDir: hSort.dir,
+  }
   const reconciliationsQ = useQuery({
     queryKey: ['reconciliations', hApplied, hSort],
-    queryFn: ({ signal }) => listReconciliations({
-      status: hApplied.status || undefined,
-      invoiceId: hApplied.invoice || undefined,
-      confirmedFrom: hApplied.from ? hApplied.from.replace(/\//g, '-') : undefined,
-      confirmedTo: hApplied.to ? hApplied.to.replace(/\//g, '-') : undefined,
-      sortBy: hSort.by, sortDir: hSort.dir, limit: HPAGE, offset: hApplied.offset,
-    }, signal),
+    queryFn: ({ signal }) => listReconciliations({ ...reconFilter, limit: HPAGE, offset: hApplied.offset }, signal),
     enabled: tab === 'history',
   })
   function hSearch() { setHApplied({ status: hStatus, invoice: hInvoice, from: hFrom, to: hTo, offset: 0 }) }
@@ -234,7 +236,7 @@ export default function ReconciliationPage() {
         title={t('reconciliation.title')}
         sub={t('reconciliation.subtitle')}
         actions={
-          <Button variant="ghost" onClick={() => void downloadCsv('/admin/export/reconciliations', 'reconciliations.csv')}>
+          <Button variant="ghost" onClick={() => void downloadCsv(reconciliationsExportPath(reconFilter), 'reconciliations.csv')}>
             <Icon name="export" />{t('export.csv')}
           </Button>
         }

--- a/src/BankImport/BankTransactionFilter.php
+++ b/src/BankImport/BankTransactionFilter.php
@@ -18,4 +18,30 @@ final readonly class BankTransactionFilter
         public bool $openForMatchingOnly = false,
     ) {
     }
+
+    /**
+     * Build from request query params (shared by the list endpoint and the CSV
+     * export so both apply the same filter). `openForMatchingOnly` is not a
+     * query param — the unmatched endpoint passes it explicitly.
+     *
+     * @param array<string, mixed> $q
+     */
+    public static function fromQueryParams(array $q, bool $openForMatchingOnly = false): self
+    {
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+        $statusParam = $q['status'] ?? null;
+
+        return new self(
+            status: is_string($statusParam) ? BankTransactionStatus::tryFrom($statusParam) : null,
+            valueDateFrom: $str('value_date_from'),
+            valueDateTo: $str('value_date_to'),
+            amountMinCents: $int('amount_min_cents'),
+            amountMaxCents: $int('amount_max_cents'),
+            counterparty: $str('counterparty'),
+            sortColumn: $str('sort_by') ?? 'value_date',
+            sortDirection: $str('sort_dir') ?? 'desc',
+            openForMatchingOnly: $openForMatchingOnly,
+        );
+    }
 }

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -23,35 +23,7 @@ final readonly class ListBankTransactionsHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
-        $q = $request->getQueryParams();
-
-        $statusParam = $q['status'] ?? null;
-        $status = is_string($statusParam) ? BankTransactionStatus::tryFrom($statusParam) : null;
-
-        $valueDateFrom = isset($q['value_date_from']) && is_string($q['value_date_from']) ? $q['value_date_from'] : null;
-        $valueDateTo = isset($q['value_date_to']) && is_string($q['value_date_to']) ? $q['value_date_to'] : null;
-
-        $amountMinParam = $q['amount_min_cents'] ?? null;
-        $amountMinCents = is_numeric($amountMinParam) ? (int) $amountMinParam : null;
-
-        $amountMaxParam = $q['amount_max_cents'] ?? null;
-        $amountMaxCents = is_numeric($amountMaxParam) ? (int) $amountMaxParam : null;
-
-        $counterparty = isset($q['counterparty']) && is_string($q['counterparty']) ? $q['counterparty'] : null;
-
-        $sortBy = isset($q['sort_by']) && is_string($q['sort_by']) && $q['sort_by'] !== '' ? $q['sort_by'] : 'value_date';
-        $sortDir = isset($q['sort_dir']) && is_string($q['sort_dir']) && $q['sort_dir'] !== '' ? $q['sort_dir'] : 'desc';
-
-        $filter = new BankTransactionFilter(
-            status: $status,
-            valueDateFrom: $valueDateFrom,
-            valueDateTo: $valueDateTo,
-            amountMinCents: $amountMinCents,
-            amountMaxCents: $amountMaxCents,
-            counterparty: $counterparty,
-            sortColumn: $sortBy,
-            sortDirection: $sortDir,
-        );
+        $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams());
 
         return $this->response->create((new PaginationResponse(
             items: array_map(

--- a/src/BankImport/ListUnmatchedTransactionsHandler.php
+++ b/src/BankImport/ListUnmatchedTransactionsHandler.php
@@ -23,32 +23,7 @@ final readonly class ListUnmatchedTransactionsHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
-        $q = $request->getQueryParams();
-
-        $valueDateFrom = isset($q['value_date_from']) && is_string($q['value_date_from']) ? $q['value_date_from'] : null;
-        $valueDateTo = isset($q['value_date_to']) && is_string($q['value_date_to']) ? $q['value_date_to'] : null;
-
-        $amountMinParam = $q['amount_min_cents'] ?? null;
-        $amountMinCents = is_numeric($amountMinParam) ? (int) $amountMinParam : null;
-
-        $amountMaxParam = $q['amount_max_cents'] ?? null;
-        $amountMaxCents = is_numeric($amountMaxParam) ? (int) $amountMaxParam : null;
-
-        $counterparty = isset($q['counterparty']) && is_string($q['counterparty']) ? $q['counterparty'] : null;
-
-        $sortBy = isset($q['sort_by']) && is_string($q['sort_by']) && $q['sort_by'] !== '' ? $q['sort_by'] : 'value_date';
-        $sortDir = isset($q['sort_dir']) && is_string($q['sort_dir']) && $q['sort_dir'] !== '' ? $q['sort_dir'] : 'desc';
-
-        $filter = new BankTransactionFilter(
-            valueDateFrom: $valueDateFrom,
-            valueDateTo: $valueDateTo,
-            amountMinCents: $amountMinCents,
-            amountMaxCents: $amountMaxCents,
-            counterparty: $counterparty,
-            sortColumn: $sortBy,
-            sortDirection: $sortDir,
-            openForMatchingOnly: true,
-        );
+        $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams(), openForMatchingOnly: true);
 
         return $this->response->create((new PaginationResponse(
             items: array_map(

--- a/src/Dunning/DunningNoticeFilter.php
+++ b/src/Dunning/DunningNoticeFilter.php
@@ -25,4 +25,28 @@ final readonly class DunningNoticeFilter
         public string $sortDirection = 'desc',
     ) {
     }
+
+    /**
+     * Build from request query params, shared by the list endpoint and the CSV
+     * export so both apply the same filter.
+     *
+     * @param array<string, mixed> $q
+     */
+    public static function fromQueryParams(array $q): self
+    {
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+
+        return new self(
+            invoiceNumber: $str('invoice_number'),
+            recipientEmail: $str('recipient_email'),
+            outstandingMinCents: $int('outstanding_min_cents'),
+            outstandingMaxCents: $int('outstanding_max_cents'),
+            sentFrom: $str('sent_from'),
+            sentTo: $str('sent_to'),
+            sentBy: $int('sent_by'),
+            sortColumn: $str('sort_by') ?? 'sent_at',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
+    }
 }

--- a/src/Dunning/ListDunningNoticesHandler.php
+++ b/src/Dunning/ListDunningNoticesHandler.php
@@ -23,21 +23,7 @@ final readonly class ListDunningNoticesHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
-        $q = $request->getQueryParams();
-        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
-        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
-
-        $filter = new DunningNoticeFilter(
-            invoiceNumber: $str('invoice_number'),
-            recipientEmail: $str('recipient_email'),
-            outstandingMinCents: $int('outstanding_min_cents'),
-            outstandingMaxCents: $int('outstanding_max_cents'),
-            sentFrom: $str('sent_from'),
-            sentTo: $str('sent_to'),
-            sentBy: $int('sent_by'),
-            sortColumn: $str('sort_by') ?? 'sent_at',
-            sortDirection: $str('sort_dir') ?? 'desc',
-        );
+        $filter = DunningNoticeFilter::fromQueryParams($request->getQueryParams());
 
         return $this->response->create((new PaginationResponse(
             items: array_map(

--- a/src/Export/ExportBankTransactionsCsvHandler.php
+++ b/src/Export/ExportBankTransactionsCsvHandler.php
@@ -26,12 +26,7 @@ final readonly class ExportBankTransactionsCsvHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
-        $q = (array) $request->getQueryParams();
-
-        $filter = new BankTransactionFilter(
-            valueDateFrom: is_string($q['date_from'] ?? null) && $q['date_from'] !== '' ? $q['date_from'] : null,
-            valueDateTo: is_string($q['date_to'] ?? null) && $q['date_to'] !== '' ? $q['date_to'] : null,
-        );
+        $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams());
 
         $rows = [];
         $offset = 0;

--- a/src/Export/ExportClientCreditsCsvHandler.php
+++ b/src/Export/ExportClientCreditsCsvHandler.php
@@ -27,7 +27,7 @@ final readonly class ExportClientCreditsCsvHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
 
-        $filter = new ClientCreditFilter();
+        $filter = ClientCreditFilter::fromQueryParams($request->getQueryParams());
         $rows = [];
         $offset = 0;
         do {

--- a/src/Export/ExportDunningNoticesCsvHandler.php
+++ b/src/Export/ExportDunningNoticesCsvHandler.php
@@ -27,7 +27,7 @@ final readonly class ExportDunningNoticesCsvHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
 
-        $filter = new DunningNoticeFilter();
+        $filter = DunningNoticeFilter::fromQueryParams($request->getQueryParams());
         $rows = [];
         $offset = 0;
         do {

--- a/src/Export/ExportReconciliationsCsvHandler.php
+++ b/src/Export/ExportReconciliationsCsvHandler.php
@@ -28,11 +28,12 @@ final readonly class ExportReconciliationsCsvHandler
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
+        $filter = ReconciliationFilter::fromQueryParams($request->getQueryParams());
 
         $rows = [];
         $offset = 0;
         do {
-            $batch = $this->reconciliations->findByOrganization($organizationId, new ReconciliationFilter(), self::BATCH, $offset);
+            $batch = $this->reconciliations->findByOrganization($organizationId, $filter, self::BATCH, $offset);
             foreach ($batch as $recon) {
                 $tx = $this->transactions->findById($organizationId, $recon->bankTransactionId);
 

--- a/src/Reconciliation/ClientCreditFilter.php
+++ b/src/Reconciliation/ClientCreditFilter.php
@@ -26,4 +26,30 @@ final readonly class ClientCreditFilter
         public string $sortDirection = 'desc',
     ) {
     }
+
+    /**
+     * Build from request query params, shared by the list endpoint and the CSV
+     * export so both apply the same filter.
+     *
+     * @param array<string, mixed> $q
+     */
+    public static function fromQueryParams(array $q): self
+    {
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+        $statusParam = $q['status'] ?? null;
+
+        return new self(
+            clientId: $int('client_id'),
+            status: is_string($statusParam) ? ClientCreditStatus::tryFrom($statusParam) : null,
+            amountMinCents: $int('amount_min_cents'),
+            amountMaxCents: $int('amount_max_cents'),
+            remainingMinCents: $int('remaining_min_cents'),
+            remainingMaxCents: $int('remaining_max_cents'),
+            createdFrom: $str('created_from'),
+            createdTo: $str('created_to'),
+            sortColumn: $str('sort_by') ?? 'id',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
+    }
 }

--- a/src/Reconciliation/ListClientCreditsHandler.php
+++ b/src/Reconciliation/ListClientCreditsHandler.php
@@ -23,26 +23,7 @@ final readonly class ListClientCreditsHandler
     {
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
-        $q = $request->getQueryParams();
-
-        $int = static fn (string $key): ?int => isset($q[$key]) && is_numeric($q[$key]) ? (int) $q[$key] : null;
-        $str = static fn (string $key): ?string => isset($q[$key]) && is_string($q[$key]) && $q[$key] !== '' ? $q[$key] : null;
-
-        $statusParam = $q['status'] ?? null;
-        $status = is_string($statusParam) ? ClientCreditStatus::tryFrom($statusParam) : null;
-
-        $filter = new ClientCreditFilter(
-            clientId: $int('client_id'),
-            status: $status,
-            amountMinCents: $int('amount_min_cents'),
-            amountMaxCents: $int('amount_max_cents'),
-            remainingMinCents: $int('remaining_min_cents'),
-            remainingMaxCents: $int('remaining_max_cents'),
-            createdFrom: $str('created_from'),
-            createdTo: $str('created_to'),
-            sortColumn: $str('sort_by') ?? 'id',
-            sortDirection: $str('sort_dir') ?? 'desc',
-        );
+        $filter = ClientCreditFilter::fromQueryParams($request->getQueryParams());
 
         return $this->response->create((new PaginationResponse(
             items: array_map(

--- a/src/Reconciliation/ListReconciliationsHandler.php
+++ b/src/Reconciliation/ListReconciliationsHandler.php
@@ -24,22 +24,7 @@ final readonly class ListReconciliationsHandler
         $organizationId = AuthContext::organizationId($request) ?? 0;
         $page = PaginationQueryParser::parse($request, 50, 200);
 
-        $q = $request->getQueryParams();
-        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
-        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
-
-        $statusParam = $q['status'] ?? null;
-        $status = is_string($statusParam) ? ReconciliationStatus::tryFrom($statusParam) : null;
-
-        $filter = new ReconciliationFilter(
-            status: $status,
-            bankTransactionId: $int('bank_transaction_id'),
-            invoiceId: $int('invoice_id'),
-            confirmedFrom: $str('confirmed_from'),
-            confirmedTo: $str('confirmed_to'),
-            sortColumn: $str('sort_by') ?? 'id',
-            sortDirection: $str('sort_dir') ?? 'desc',
-        );
+        $filter = ReconciliationFilter::fromQueryParams($request->getQueryParams());
 
         return $this->response->create((new PaginationResponse(
             items: array_map(

--- a/src/Reconciliation/ReconciliationFilter.php
+++ b/src/Reconciliation/ReconciliationFilter.php
@@ -25,4 +25,27 @@ final readonly class ReconciliationFilter
         public string $sortDirection = 'desc',
     ) {
     }
+
+    /**
+     * Build from request query params, shared by the list endpoint and the CSV
+     * export so both apply the same filter.
+     *
+     * @param array<string, mixed> $q
+     */
+    public static function fromQueryParams(array $q): self
+    {
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
+        $statusParam = $q['status'] ?? null;
+
+        return new self(
+            status: is_string($statusParam) ? ReconciliationStatus::tryFrom($statusParam) : null,
+            bankTransactionId: $int('bank_transaction_id'),
+            invoiceId: $int('invoice_id'),
+            confirmedFrom: $str('confirmed_from'),
+            confirmedTo: $str('confirmed_to'),
+            sortColumn: $str('sort_by') ?? 'id',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
+    }
 }

--- a/tests/Http/ExportCsvHttpTest.php
+++ b/tests/Http/ExportCsvHttpTest.php
@@ -296,11 +296,43 @@ final class ExportCsvHttpTest extends TestCase
                 ->withParsedBody(['bank_account_id' => 1]),
         );
 
-        $future = $this->get($token, '/admin/export/bank-transactions?date_from=2030-01-01');
+        // The export honours the same filter params as the list endpoint
+        // (value_date_from/to), so a future lower bound yields a header-only CSV.
+        $future = $this->get($token, '/admin/export/bank-transactions?value_date_from=2030-01-01');
         self::assertSame(200, $future->getStatusCode());
         $body = (string) $future->getBody();
-        // Header row only (BOM + header); no data rows for future date
         $lines = array_filter(explode("\n", trim($body)));
         self::assertCount(1, $lines, 'Expected header-only CSV for future date filter');
+
+        // Counterparty filter is honoured too.
+        $byCounterparty = (string) $this->get($token, '/admin/export/bank-transactions?counterparty=INV-001')->getBody();
+        self::assertStringContainsString('INV-001', $byCounterparty);
+        $miss = (string) $this->get($token, '/admin/export/bank-transactions?counterparty=ZZZ')->getBody();
+        self::assertCount(1, array_filter(explode("\n", trim($miss))), 'Header-only when counterparty matches nothing');
+    }
+
+    public function test_export_dunning_notices_honours_filter(): void
+    {
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: 1,
+            invoiceNumber: 'INV-001',
+            clientId: 100,
+            outstandingCents: 110000,
+            totalCents: 110000,
+            dueAt: '2026-04-30',
+            status: 'issued',
+            currency: 'JPY',
+        ));
+        $this->invoiceClient->addClient(new InvoiceClientInfo(100, 'ACME', 'accounts@acme.example'));
+        $token = $this->tokenFor('admin@acme.example');
+        self::assertSame(201, $this->post($token, '/admin/dunning-notices', ['invoice_id' => 1])->getStatusCode());
+
+        // Matching invoice number → the row is present.
+        $hit = (string) $this->get($token, '/admin/export/dunning-notices?invoice_number=INV-001')->getBody();
+        self::assertStringContainsString('INV-001', $hit);
+
+        // A future sent_from lower bound excludes the just-sent notice → header only.
+        $miss = (string) $this->get($token, '/admin/export/dunning-notices?sent_from=2099-01-01')->getBody();
+        self::assertCount(1, array_filter(explode("\n", trim($miss))), 'Header-only when sent_from is in the future');
     }
 }


### PR DESCRIPTION
Closes #153

## Problem

The CSV export buttons (dunning / bank-transactions / reconciliations / client-credits) ignored the filters applied on the page and always exported **everything**. Users expect "Export CSV" to export the rows they're currently looking at.

## Fix — export mirrors the list

Each export endpoint now accepts the **same query params as its list endpoint** and applies the same filter; each page's export button passes its currently-applied filter + sort. No filter set → full export (unchanged).

**Backend (DRY)**
- `Filter::fromQueryParams()` on `BankTransactionFilter`, `ReconciliationFilter`, `ClientCreditFilter`, `DunningNoticeFilter`. Both the list handler and its export handler build the filter via this factory → guaranteed parity. `ListUnmatched` reuses it (`openForMatchingOnly: true`).
- `ExportBankTransactionsCsvHandler` switches from ad-hoc `date_from`/`date_to` to the list's `value_date_from`/`value_date_to` (+ status, amount range, counterparty, sort).

**Frontend**
- Shared per-domain query builders + `…ExportPath()` helpers; each page's export button passes the applied filter state.

**OpenAPI**: filter params documented on the four export paths (bank-transactions param names aligned to the list).

**Tests**: export-honours-filter cases (dunning `sent_from` → header-only; bank-tx `counterparty`); the bank-tx export date test updated to `value_date_from`.

## Design note
A *default* date range (calendar/fiscal year) is intentionally **not** baked into the export — the visible filter controls the range, avoiding silent row omission. Fiscal-year defaults would require a per-org fiscal-month setting (separate work).

## Checks
- `composer check`: 262 backend tests (6 skipped) ✅, PHPStan level 8 ✅, PHP-CS-Fixer ✅, OpenAPI contract ✅
- `npm run check`: type-check ✅, eslint ✅, 38 Vitest ✅
- Playwright: **full suite 48 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)