### PR TITLE
feat(filters): 日付範囲フィルタの初期値を当会計年度（決算月起点）に (#157)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -126,11 +126,21 @@ paths:
       operationId: getCurrentUser
       responses:
         '200':
-          description: The authenticated user.
+          description: >
+            The authenticated user, plus the org's fiscal year-end month
+            (surfaced here so non-admins can default date-range filters).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                allOf:
+                  - $ref: '#/components/schemas/User'
+                  - type: object
+                    properties:
+                      fiscal_year_end_month:
+                        type: integer
+                        nullable: true
+                        minimum: 1
+                        maximum: 12
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,6 +1,8 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from '@/hooks/useTranslation'
 import { clearToken, isAdmin } from '@/api/client'
+import { getCurrentUser } from '@/api/endpoints'
 import { Icon, LogoMark } from '@/components/ui'
 import { KeyboardShortcuts, openShortcutsOverlay } from '@/components/keyboard'
 import type { MessageKey } from '@/locales'
@@ -45,6 +47,17 @@ export default function AppShell() {
   const navigate = useNavigate()
   const admin = isAdmin()
   const adminNav = ADMIN_NAV.filter(item => !item.adminOnly || admin)
+
+  // Load the session/org context (incl. the org's fiscal year-end month) once
+  // per session and hold it in the query cache. Page content waits for it so
+  // pages can read the fiscal-year default synchronously at mount — no
+  // per-page effect. Settings changes invalidate ['auth','me'] to refresh it.
+  const meQ = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: ({ signal }) => getCurrentUser(signal),
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
 
   function handleLogout() {
     // Clearing the token flips the reactive auth store → the login screen
@@ -117,7 +130,9 @@ export default function AppShell() {
         </header>
         <div className="scroll">
           <div className="page">
-            <Outlet />
+            {meQ.isFetched
+              ? <Outlet />
+              : <p className="muted" style={{ padding: 24 }}>{t('common.loading')}</p>}
           </div>
         </div>
       </div>

--- a/frontend/src/hooks/useFiscalYearDefault.ts
+++ b/frontend/src/hooks/useFiscalYearDefault.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { getCurrentUser } from '@/api/endpoints'
+import { fiscalYearStart, todayIso } from '@/utils/fiscal'
+
+/**
+ * Resolves the org's current fiscal year as a default date range for list
+ * filters. Reads `fiscal_year_end_month` from a cached `/me` query (shared
+ * across pages). Returns `range = null` when the month is unset or `/me` fails,
+ * so callers keep their "no default → all" behaviour. `settled` flips once the
+ * query resolves (success or error), so callers apply the default exactly once.
+ */
+export function useFiscalYearDefault(): { range: { fromIso: string; toIso: string } | null; settled: boolean } {
+  const meQ = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: ({ signal }) => getCurrentUser(signal),
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
+
+  const month = meQ.data?.fiscal_year_end_month ?? null
+  const range = meQ.isSuccess && month != null
+    ? { fromIso: fiscalYearStart(month), toIso: todayIso() }
+    : null
+
+  return { range, settled: meQ.isSuccess || meQ.isError }
+}

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listBankTransactions, bankTransactionsExportPath, downloadCsv } from '@/api/endpoints'
 import type { BankTransaction } from '@/types'
@@ -6,6 +6,7 @@ import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, Filte
 import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useFiscalYearDefault } from '@/hooks/useFiscalYearDefault'
 import { useRowCursor } from '@/components/keyboard'
 import { yen } from '@/utils/format'
 
@@ -30,6 +31,23 @@ export default function BankTransactionsPage() {
   const [counterparty, setCounterparty] = useState('')
   const [applied, setApplied] = useState<AppliedFilter>({ status: '', dateFrom: '', dateTo: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
   const [sort, setSort] = useState<SortState>({ by: 'value_date', dir: 'desc' })
+
+  // Default the value-date range to the current fiscal year (decided by the
+  // org's 決算月) once /me resolves — applied once; the Clear button resets to all.
+  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
+  const fyApplied = useRef(false)
+  useEffect(() => {
+    if (!fySettled || fyApplied.current) return
+    fyApplied.current = true
+    if (!fyRange) return
+    // One-time sync of the async org fiscal-year default into editable filter
+    // state (kept editable afterwards); not derivable at first render.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setDateFrom(fyRange.fromIso)
+    setDateTo(fyRange.toIso)
+    setApplied(p => ({ ...p, dateFrom: fyRange.fromIso, dateTo: fyRange.toIso, offset: 0 }))
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [fySettled, fyRange])
 
   // Filter the export mirrors what the list shows (same params, minus paging).
   const txFilter = {

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listBankTransactions, bankTransactionsExportPath, downloadCsv } from '@/api/endpoints'
 import type { BankTransaction } from '@/types'
@@ -23,31 +23,18 @@ type AppliedFilter = { status: string; dateFrom: string; dateTo: string; amountM
 
 export default function BankTransactionsPage() {
   const { t } = useTranslation()
+  // The org's current fiscal year (decided by 決算月) seeds the value-date
+  // range. /me is loaded by AppShell before this page mounts, so it's available
+  // synchronously here; the Clear button resets to all.
+  const { range: fyRange } = useFiscalYearDefault()
   const [status, setStatus] = useState('')
-  const [dateFrom, setDateFrom] = useState('')
-  const [dateTo, setDateTo] = useState('')
+  const [dateFrom, setDateFrom] = useState(fyRange?.fromIso ?? '')
+  const [dateTo, setDateTo] = useState(fyRange?.toIso ?? '')
   const [amountMin, setAmountMin] = useState('')
   const [amountMax, setAmountMax] = useState('')
   const [counterparty, setCounterparty] = useState('')
-  const [applied, setApplied] = useState<AppliedFilter>({ status: '', dateFrom: '', dateTo: '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
+  const [applied, setApplied] = useState<AppliedFilter>({ status: '', dateFrom: fyRange?.fromIso ?? '', dateTo: fyRange?.toIso ?? '', amountMin: '', amountMax: '', counterparty: '', offset: 0 })
   const [sort, setSort] = useState<SortState>({ by: 'value_date', dir: 'desc' })
-
-  // Default the value-date range to the current fiscal year (decided by the
-  // org's 決算月) once /me resolves — applied once; the Clear button resets to all.
-  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
-  const fyApplied = useRef(false)
-  useEffect(() => {
-    if (!fySettled || fyApplied.current) return
-    fyApplied.current = true
-    if (!fyRange) return
-    // One-time sync of the async org fiscal-year default into editable filter
-    // state (kept editable afterwards); not derivable at first render.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setDateFrom(fyRange.fromIso)
-    setDateTo(fyRange.toIso)
-    setApplied(p => ({ ...p, dateFrom: fyRange.fromIso, dateTo: fyRange.toIso, offset: 0 }))
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [fySettled, fyRange])
 
   // Filter the export mirrors what the list shows (same params, minus paging).
   const txFilter = {

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listClientCredits, applyClientCredit, downloadCsv, clientCreditsExportPath } from '@/api/endpoints'
 import type { ClientCredit } from '@/types'
@@ -62,31 +62,21 @@ const isoDate = (v: string) => (v ? v.replace(/\//g, '-') : undefined)
 
 export default function ClientCreditsPage() {
   const { t } = useTranslation()
-  const [applyTarget, setApplyTarget] = useState<ClientCredit | null>(null)
 
-  const [f, setF] = useState<Filters>(EMPTY)
-  const [applied, setApplied] = useState<Filters>(EMPTY)
+  // Current fiscal year (org 決算月) seeds the created-date range. /me is loaded
+  // by AppShell before this page mounts → available synchronously; Clear resets
+  // to all (EMPTY). DatePicker uses YYYY/MM/DD, so convert the ISO range.
+  const { range: fyRange } = useFiscalYearDefault()
+  const initialFilters: Filters = fyRange
+    ? { ...EMPTY, createdFrom: fyRange.fromIso.replace(/-/g, '/'), createdTo: fyRange.toIso.replace(/-/g, '/') }
+    : EMPTY
+
+  const [applyTarget, setApplyTarget] = useState<ClientCredit | null>(null)
+  const [f, setF] = useState<Filters>(initialFilters)
+  const [applied, setApplied] = useState<Filters>(initialFilters)
   const [sort, setSort] = useState<SortState>({ by: 'id', dir: 'desc' })
   const [offset, setOffset] = useState(0)
   const set = (k: keyof Filters) => (v: string) => setF(prev => ({ ...prev, [k]: v }))
-
-  // Default the created-date range to the current fiscal year (org 決算月) once
-  // /me resolves; applied once, Clear resets to all. DatePicker uses YYYY/MM/DD.
-  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
-  const fyApplied = useRef(false)
-  useEffect(() => {
-    if (!fySettled || fyApplied.current) return
-    fyApplied.current = true
-    if (!fyRange) return
-    const createdFrom = fyRange.fromIso.replace(/-/g, '/')
-    const createdTo = fyRange.toIso.replace(/-/g, '/')
-    // One-time sync of the async org fiscal-year default into editable filter state.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setF(prev => ({ ...prev, createdFrom, createdTo }))
-    setApplied(prev => ({ ...prev, createdFrom, createdTo }))
-    setOffset(0)
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [fySettled, fyRange])
 
   // Export mirrors the list's current filter (same params, minus paging).
   const creditFilter = {

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listClientCredits, applyClientCredit, downloadCsv, clientCreditsExportPath } from '@/api/endpoints'
 import type { ClientCredit } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useFiscalYearDefault } from '@/hooks/useFiscalYearDefault'
 import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDate } from '@/utils/format'
 
@@ -68,6 +69,24 @@ export default function ClientCreditsPage() {
   const [sort, setSort] = useState<SortState>({ by: 'id', dir: 'desc' })
   const [offset, setOffset] = useState(0)
   const set = (k: keyof Filters) => (v: string) => setF(prev => ({ ...prev, [k]: v }))
+
+  // Default the created-date range to the current fiscal year (org 決算月) once
+  // /me resolves; applied once, Clear resets to all. DatePicker uses YYYY/MM/DD.
+  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
+  const fyApplied = useRef(false)
+  useEffect(() => {
+    if (!fySettled || fyApplied.current) return
+    fyApplied.current = true
+    if (!fyRange) return
+    const createdFrom = fyRange.fromIso.replace(/-/g, '/')
+    const createdTo = fyRange.toIso.replace(/-/g, '/')
+    // One-time sync of the async org fiscal-year default into editable filter state.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setF(prev => ({ ...prev, createdFrom, createdTo }))
+    setApplied(prev => ({ ...prev, createdFrom, createdTo }))
+    setOffset(0)
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [fySettled, fyRange])
 
   // Export mirrors the list's current filter (same params, minus paging).
   const creditFilter = {

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listDunningNotices, sendDunningNotice, listUpstreamInvoices,
@@ -64,31 +64,20 @@ export default function DunningPage() {
     queryKey: ['upstream-invoices', { status: 'issued,partially_paid,overdue' }],
     queryFn: ({ signal }) => listUpstreamInvoices({ status: 'issued,partially_paid,overdue' }, signal),
   })
+  // Current fiscal year (org 決算月) seeds the sent-date range. /me is loaded by
+  // AppShell before this page mounts → available synchronously; Clear resets to
+  // all. DatePicker uses YYYY/MM/DD, so convert the ISO range.
+  const { range: fyRange } = useFiscalYearDefault()
+  const fyFrom = fyRange ? fyRange.fromIso.replace(/-/g, '/') : ''
+  const fyTo = fyRange ? fyRange.toIso.replace(/-/g, '/') : ''
+
   const HPAGE = 50
   const [hInvoice, setHInvoice] = useState('')
   const [hEmail, setHEmail] = useState('')
-  const [hFrom, setHFrom] = useState('')
-  const [hTo, setHTo] = useState('')
-  const [hApplied, setHApplied] = useState({ invoice: '', email: '', from: '', to: '', offset: 0 })
+  const [hFrom, setHFrom] = useState(fyFrom)
+  const [hTo, setHTo] = useState(fyTo)
+  const [hApplied, setHApplied] = useState({ invoice: '', email: '', from: fyFrom, to: fyTo, offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'sent_at', dir: 'desc' })
-
-  // Default the sent-date range to the current fiscal year (org 決算月) once /me
-  // resolves; applied once, Clear resets to all. DatePicker uses YYYY/MM/DD.
-  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
-  const fyApplied = useRef(false)
-  useEffect(() => {
-    if (!fySettled || fyApplied.current) return
-    fyApplied.current = true
-    if (!fyRange) return
-    const from = fyRange.fromIso.replace(/-/g, '/')
-    const to = fyRange.toIso.replace(/-/g, '/')
-    // One-time sync of the async org fiscal-year default into editable filter state.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setHFrom(from)
-    setHTo(to)
-    setHApplied(p => ({ ...p, from, to, offset: 0 }))
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [fySettled, fyRange])
   // Export mirrors the history list's current filter (same params, minus paging).
   const noticesFilter = {
     invoiceNumber: hApplied.invoice || undefined,

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listDunningNotices, sendDunningNotice, listUpstreamInvoices,
@@ -8,6 +8,7 @@ import type { UpstreamInvoice } from '@/types'
 import { Icon, Badge, Button, Card, CardHead, DataTable, TableStateRow, Modal, Notice, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useFiscalYearDefault } from '@/hooks/useFiscalYearDefault'
 import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDateTime, daysOverdue } from '@/utils/format'
 
@@ -70,6 +71,24 @@ export default function DunningPage() {
   const [hTo, setHTo] = useState('')
   const [hApplied, setHApplied] = useState({ invoice: '', email: '', from: '', to: '', offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'sent_at', dir: 'desc' })
+
+  // Default the sent-date range to the current fiscal year (org 決算月) once /me
+  // resolves; applied once, Clear resets to all. DatePicker uses YYYY/MM/DD.
+  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
+  const fyApplied = useRef(false)
+  useEffect(() => {
+    if (!fySettled || fyApplied.current) return
+    fyApplied.current = true
+    if (!fyRange) return
+    const from = fyRange.fromIso.replace(/-/g, '/')
+    const to = fyRange.toIso.replace(/-/g, '/')
+    // One-time sync of the async org fiscal-year default into editable filter state.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setHFrom(from)
+    setHTo(to)
+    setHApplied(p => ({ ...p, from, to, offset: 0 }))
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [fySettled, fyRange])
   // Export mirrors the history list's current filter (same params, minus paging).
   const noticesFilter = {
     invoiceNumber: hApplied.invoice || undefined,

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listUnmatchedTransactions, listReconciliations,
@@ -193,32 +193,21 @@ export default function ReconciliationPage() {
   function uOnSort(col: string) { setUSort(s => nextSort(s, col)); setUApplied(p => ({ ...p, offset: 0 })) }
   const uTotal = unmatchedQ.data?.total ?? 0
 
+  // Current fiscal year (org 決算月) seeds the confirmed-date range. /me is
+  // loaded by AppShell before this page mounts → available synchronously here;
+  // Clear resets to all. DatePicker uses YYYY/MM/DD, so convert the ISO range.
+  const { range: fyRange } = useFiscalYearDefault()
+  const fyFrom = fyRange ? fyRange.fromIso.replace(/-/g, '/') : ''
+  const fyTo = fyRange ? fyRange.toIso.replace(/-/g, '/') : ''
+
   const HPAGE = 50
   const [hStatus, setHStatus] = useState('')
   const [hInvoice, setHInvoice] = useState('')
-  const [hFrom, setHFrom] = useState('')
-  const [hTo, setHTo] = useState('')
-  const [hApplied, setHApplied] = useState({ status: '', invoice: '', from: '', to: '', offset: 0 })
+  const [hFrom, setHFrom] = useState(fyFrom)
+  const [hTo, setHTo] = useState(fyTo)
+  const [hApplied, setHApplied] = useState({ status: '', invoice: '', from: fyFrom, to: fyTo, offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'id', dir: 'desc' })
 
-  // Default the confirmed-date range to the current fiscal year (org 決算月)
-  // once /me resolves; applied once, Clear resets to all. DatePicker uses
-  // YYYY/MM/DD, so convert the ISO range.
-  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
-  const fyApplied = useRef(false)
-  useEffect(() => {
-    if (!fySettled || fyApplied.current) return
-    fyApplied.current = true
-    if (!fyRange) return
-    const from = fyRange.fromIso.replace(/-/g, '/')
-    const to = fyRange.toIso.replace(/-/g, '/')
-    // One-time sync of the async org fiscal-year default into editable filter state.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    setHFrom(from)
-    setHTo(to)
-    setHApplied(p => ({ ...p, from, to, offset: 0 }))
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [fySettled, fyRange])
   // Export mirrors the history list's current filter (same params, minus paging).
   const reconFilter = {
     status: hApplied.status || undefined,

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listUnmatchedTransactions, listReconciliations,
@@ -11,6 +11,7 @@ import { Icon, Badge, StatusBadge, Button, Card, DataTable, TableStateRow, Modal
 import type { SortState } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
+import { useFiscalYearDefault } from '@/hooks/useFiscalYearDefault'
 import { useRowCursor } from '@/components/keyboard'
 import { yen, formatDate } from '@/utils/format'
 
@@ -199,6 +200,25 @@ export default function ReconciliationPage() {
   const [hTo, setHTo] = useState('')
   const [hApplied, setHApplied] = useState({ status: '', invoice: '', from: '', to: '', offset: 0 })
   const [hSort, setHSort] = useState<SortState>({ by: 'id', dir: 'desc' })
+
+  // Default the confirmed-date range to the current fiscal year (org 決算月)
+  // once /me resolves; applied once, Clear resets to all. DatePicker uses
+  // YYYY/MM/DD, so convert the ISO range.
+  const { range: fyRange, settled: fySettled } = useFiscalYearDefault()
+  const fyApplied = useRef(false)
+  useEffect(() => {
+    if (!fySettled || fyApplied.current) return
+    fyApplied.current = true
+    if (!fyRange) return
+    const from = fyRange.fromIso.replace(/-/g, '/')
+    const to = fyRange.toIso.replace(/-/g, '/')
+    // One-time sync of the async org fiscal-year default into editable filter state.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    setHFrom(from)
+    setHTo(to)
+    setHApplied(p => ({ ...p, from, to, offset: 0 }))
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [fySettled, fyRange])
   // Export mirrors the history list's current filter (same params, minus paging).
   const reconFilter = {
     status: hApplied.status || undefined,

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -24,7 +24,13 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
 
   const saveMut = useMutation({
     mutationFn: () => updateClearSettings({ upstream_base_url: upstreamUrl, upstream_token_ref: upstreamToken, dunning_min_interval_days: dunningInterval, fiscal_year_end_month: fiscalMonth, bank_accounts: accounts } as Partial<ClearSettings>),
-    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['clear-settings'] }); setSaved(true); setTimeout(() => setSaved(false), 3000) },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['clear-settings'] })
+      // The org's fiscal year-end month is held in the /me cache (it drives the
+      // fiscal-year date-range defaults); refresh it after a settings change.
+      void qc.invalidateQueries({ queryKey: ['auth', 'me'] })
+      setSaved(true); setTimeout(() => setSaved(false), 3000)
+    },
   })
 
   // The dunning interval must be at least one day. Guard client-side so an

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,8 @@ export interface User {
   email: string
   role: 'superadmin' | 'admin' | 'member' | 'viewer'
   status: 'active' | 'invited'
+  /** Org fiscal year-end month (1–12), surfaced on /me. Null when unset. */
+  fiscal_year_end_month?: number | null
 }
 
 export interface BankImportBatch {

--- a/frontend/src/utils/fiscal.test.ts
+++ b/frontend/src/utils/fiscal.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { fiscalYearStart, todayIso } from './fiscal'
+
+describe('fiscalYearStart', () => {
+  it('March year-end (3) → fiscal year starts April 1; current year when past April', () => {
+    expect(fiscalYearStart(3, new Date(2026, 5, 8))).toBe('2026-04-01') // June 8 → FY started Apr 1
+  })
+
+  it('March year-end (3) → previous April when before April', () => {
+    expect(fiscalYearStart(3, new Date(2026, 1, 15))).toBe('2025-04-01') // Feb → still FY2025
+  })
+
+  it('boundary: on April 1 itself uses the current year', () => {
+    expect(fiscalYearStart(3, new Date(2026, 3, 1))).toBe('2026-04-01')
+  })
+
+  it('December year-end (12) → calendar year (Jan 1)', () => {
+    expect(fiscalYearStart(12, new Date(2026, 5, 8))).toBe('2026-01-01')
+  })
+
+  it('January year-end (1) → starts Feb 1', () => {
+    expect(fiscalYearStart(1, new Date(2026, 5, 8))).toBe('2026-02-01')
+    expect(fiscalYearStart(1, new Date(2026, 0, 15))).toBe('2025-02-01')
+  })
+
+  it('todayIso formats local date', () => {
+    expect(todayIso(new Date(2026, 5, 8))).toBe('2026-06-08')
+  })
+})

--- a/frontend/src/utils/fiscal.ts
+++ b/frontend/src/utils/fiscal.ts
@@ -1,0 +1,28 @@
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function toIso(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/** Today as a local YYYY-MM-DD string. */
+export function todayIso(today: Date = new Date()): string {
+  return toIso(today)
+}
+
+/**
+ * Start date (YYYY-MM-DD) of the current fiscal year, given the fiscal year-end
+ * month (決算月, 1–12). The fiscal year starts on the 1st of the month *after*
+ * the end month; the current one is the most recent such 1st on or before today.
+ *
+ * e.g. end month 3 (March) → starts Apr 1; end month 12 → starts Jan 1.
+ */
+export function fiscalYearStart(fiscalYearEndMonth: number, today: Date = new Date()): string {
+  const startMonth = (fiscalYearEndMonth % 12) + 1 // 1–12, month after the end month
+  const candidate = new Date(today.getFullYear(), startMonth - 1, 1)
+  const start = candidate.getTime() <= today.getTime()
+    ? candidate
+    : new Date(today.getFullYear() - 1, startMonth - 1, 1)
+  return toIso(start)
+}

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -13,6 +13,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Audit\AuditRecorderInterface;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\User\UserRepositoryInterface;
@@ -71,6 +72,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         ServiceResolver::get($c, UserRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
                         ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                        ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
                     ),
                 ),
             )

--- a/src/Auth/GetCurrentUserHandler.php
+++ b/src/Auth/GetCurrentUserHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Auth;
 
 use Nene2\Http\JsonResponseFactory;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\User\UserRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -16,6 +17,7 @@ final readonly class GetCurrentUserHandler
         private UserRepositoryInterface $users,
         private JsonResponseFactory $response,
         private LocalizedProblemDetailsFactory $problemDetails,
+        private ClearSettingsRepositoryInterface $settings,
     ) {
     }
 
@@ -31,12 +33,16 @@ final readonly class GetCurrentUserHandler
             return $this->problemDetails->create($request, 'unauthorized', 401);
         }
 
+        // Org-level fiscal year-end month is surfaced here so any authenticated
+        // user (not just admins, who alone can read full clear-settings) can
+        // default date-range filters to the current fiscal year.
         return $this->response->create([
             'user_id' => $user->id,
             'organization_id' => $user->organizationId,
             'email' => $user->email,
             'role' => $user->role->value,
             'status' => $user->status->value,
+            'fiscal_year_end_month' => $this->settings->fiscalYearEndMonth($user->organizationId ?? 0),
         ]);
     }
 }

--- a/src/ClearSettings/ClearSettingsRepositoryInterface.php
+++ b/src/ClearSettings/ClearSettingsRepositoryInterface.php
@@ -8,5 +8,8 @@ interface ClearSettingsRepositoryInterface
 {
     public function findByOrganization(int $organizationId): ?ClearSettings;
 
+    /** Lightweight read of just the fiscal year-end month (1–12), or null if unset/no row. */
+    public function fiscalYearEndMonth(int $organizationId): ?int;
+
     public function save(ClearSettings $settings): void;
 }

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -37,6 +37,16 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
         );
     }
 
+    public function fiscalYearEndMonth(int $organizationId): ?int
+    {
+        $row = $this->query->fetchOne(
+            'SELECT fiscal_year_end_month FROM clear_settings WHERE organization_id = ?',
+            [$organizationId],
+        );
+
+        return $row !== null && isset($row['fiscal_year_end_month']) ? (int) $row['fiscal_year_end_month'] : null;
+    }
+
     public function save(ClearSettings $settings): void
     {
         // Upsert without a destructive DELETE: update the existing row, and

--- a/tests/Dunning/InMemoryClearSettingsRepository.php
+++ b/tests/Dunning/InMemoryClearSettingsRepository.php
@@ -17,6 +17,11 @@ final class InMemoryClearSettingsRepository implements ClearSettingsRepositoryIn
         return $this->byOrg[$organizationId] ?? null;
     }
 
+    public function fiscalYearEndMonth(int $organizationId): ?int
+    {
+        return ($this->byOrg[$organizationId] ?? null)?->fiscalYearEndMonth;
+    }
+
     public function save(ClearSettings $settings): void
     {
         $this->byOrg[$settings->organizationId] = $settings;

--- a/tests/Http/AuthHttpTest.php
+++ b/tests/Http/AuthHttpTest.php
@@ -35,6 +35,7 @@ final class AuthHttpTest extends TestCase
         SchemaFixture::createUsers($this->query);
         SchemaFixture::createLoginAttempts($this->query);
         SchemaFixture::createAuditEvents($this->query);
+        SchemaFixture::createClearSettings($this->query);
 
         (new PdoUserRepository($this->query))->save(new User(
             email: 'admin@acme.example',
@@ -146,6 +147,34 @@ final class AuthHttpTest extends TestCase
         self::assertSame('admin@acme.example', $data['email'] ?? null);
         self::assertSame('admin', $data['role'] ?? null);
         self::assertSame(7, $data['organization_id'] ?? null);
+        // Org fiscal year-end month is surfaced (null until configured).
+        self::assertArrayHasKey('fiscal_year_end_month', $data);
+        self::assertNull($data['fiscal_year_end_month']);
+    }
+
+    public function test_me_includes_configured_fiscal_year_end_month(): void
+    {
+        (new \NeneClear\ClearSettings\PdoClearSettingsRepository(
+            $this->query,
+            new \NeneClear\BankImport\PdoBankAccountRepository($this->query),
+        ))->save(new \NeneClear\ClearSettings\ClearSettings(
+            organizationId: 7,
+            upstreamBaseUrl: '',
+            upstreamTokenRef: '',
+            dunningMinIntervalDays: 7,
+            fiscalYearEndMonth: 3,
+        ));
+
+        $token = $this->decode($this->postJson('/admin/auth/login', [
+            'email' => 'admin@acme.example',
+            'password' => self::PASSWORD,
+        ]))['token'];
+        self::assertIsString($token);
+
+        $response = $this->app->handle(
+            $this->psr17->createServerRequest('GET', '/admin/auth/me')->withHeader('Authorization', 'Bearer ' . $token),
+        );
+        self::assertSame(3, $this->decode($response)['fiscal_year_end_month'] ?? null);
     }
 
     public function test_me_requires_a_token(): void

--- a/tests/e2e/fixtures/helpers.ts
+++ b/tests/e2e/fixtures/helpers.ts
@@ -34,6 +34,20 @@ export async function bypassLogin(page: Page): Promise<void> {
     },
     [TOKEN_KEY, E2E_TOKEN],
   )
+  // AppShell loads /me on mount (session/org context) and gates page content on
+  // it. Default it so the gate opens deterministically; fiscal_year_end_month
+  // null = no fiscal-year date default, so date-filter specs are unaffected.
+  await mockMe(page)
+}
+
+/** Default /me mock. Override per-test by registering a later '/admin/auth/me' route. */
+export async function mockMe(page: Page, over: Record<string, unknown> = {}): Promise<void> {
+  await apiRoute(page, '**/admin/auth/me', (route) =>
+    json(route, 200, {
+      user_id: 1, organization_id: 7, email: 'admin@nene-clear.dev',
+      role: 'admin', status: 'active', fiscal_year_end_month: null, ...over,
+    }),
+  )
 }
 
 /**
@@ -53,6 +67,7 @@ export async function loginViaForm(
       user: { user_id: 1, email, role: opts.role ?? 'admin', organization_id: opts.orgId ?? 7 },
     }),
   )
+  await mockMe(page, { email, role: opts.role ?? 'admin', organization_id: opts.orgId ?? 7 })
   await page.goto('/admin')
   await page.locator('input[name="email"]').fill(email)
   await page.locator('input[name="password"]').fill('admin1234')

--- a/tests/e2e/specs/15-fiscal-default.spec.ts
+++ b/tests/e2e/specs/15-fiscal-default.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin, mockMe } from '../fixtures/helpers'
+
+test.describe('Fiscal-year default date range', () => {
+  test('date filter defaults to the current fiscal year derived from 決算月', async ({ page }) => {
+    await bypassLogin(page)
+    // March year-end → fiscal year starts April 1.
+    await mockMe(page, { fiscal_year_end_month: 3 })
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/bank-transactions')
+
+    // The value-date "from" input is pre-filled with this fiscal year's April 1.
+    await expect(page.locator('input[type="date"]').first()).toHaveValue(/^\d{4}-04-01$/)
+  })
+
+  test('no default when 決算月 is unset (export/filter cover all)', async ({ page }) => {
+    await bypassLogin(page)
+    await mockMe(page, { fiscal_year_end_month: null })
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) => json(route, 200, list([])))
+
+    await page.goto('/admin/bank-transactions')
+
+    await expect(page.locator('input[type="date"]').first()).toHaveValue('')
+  })
+})


### PR DESCRIPTION
Closes #157

## What

Date-range filters — and the CSV exports that mirror them (#153) — default to the org's **current fiscal year**: from the fiscal-year start (derived from `fiscal_year_end_month`, #155) to today. Clearable to "all"; when the fiscal month is unset, behaviour is unchanged.

## Fiscal-year start
Start month = month after the end month; current FY start = most recent (start-month, 1st) ≤ today. e.g. end month 3 → Apr 1; 12 → Jan 1. Unit-tested across boundaries.

## Design (held in the shell — no per-page effect)
`fiscal_year_end_month` is admin-only via `GET /admin/clear-settings`, but list pages are used by members, so it's surfaced on **`GET /admin/auth/me`** (org-level, lightweight read). **AppShell loads `/me` once and gates page content on it**, so each list page reads the fiscal-year default **synchronously in its `useState` initializer** — no effect, no `eslint-disable`. A settings save **invalidates `['auth','me']`** so the held value refreshes.

## Changes
- Backend: `/me` gains `fiscal_year_end_month`; `ClearSettingsRepository::fiscalYearEndMonth()` (no bank-account load); OpenAPI `/me` updated.
- Frontend: `fiscalYearStart()` util (+ Vitest, 6 cases); `useFiscalYearDefault()` reads the cached `/me`; `AppShell` holds/gates `/me`; bank-transactions, reconciliation (history), dunning (history), client-credits seed their date range; SettingsPage refreshes `/me` on save.

## Checks
- `composer check`: 265 backend tests (6 skipped) ✅, PHPStan level 8 ✅, PHP-CS-Fixer ✅, OpenAPI contract ✅
- `npm run check`: type-check ✅, eslint ✅ (no disables), 44 Vitest ✅
- Playwright: **50 passed** (incl. spec 15: fiscal default set → Apr 1 prefilled; unset → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)