### PR TITLE
feat(frontend): ヘルプページ＋免責事項を追加 (#159)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,6 +50,8 @@
       <symbol id="i-doc" viewBox="0 0 24 24"><rect x="4" y="3" width="16" height="18" rx="2"/><path d="M8 8h8M8 12h8M8 16h5"/></symbol>
       <symbol id="i-yen" viewBox="0 0 24 24"><path d="M6 4l6 8 6-8"/><path d="M12 12v8M8 14h8M8 17.5h8"/></symbol>
       <symbol id="i-key" viewBox="0 0 24 24"><circle cx="8" cy="15" r="4"/><path d="m11 12 9-9"/><path d="m17 6 2 2M14 9l2 2"/></symbol>
+      <symbol id="i-help" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9.2 9a2.8 2.8 0 0 1 5.5.8c0 1.9-2.7 2.5-2.7 2.5"/><path d="M12 17.2v.01"/></symbol>
+      <symbol id="i-arrow-up" viewBox="0 0 24 24"><path d="M12 19V5"/><path d="m6 11 6-6 6 6"/></symbol>
     </defs></svg>
 
     <div id="root"></div>

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -14,6 +14,7 @@ import DunningPage from '@/pages/dunning/DunningPage'
 import SettingsPage from '@/pages/settings/SettingsPage'
 import UsersPage from '@/pages/users/UsersPage'
 import AuditLogPage from '@/pages/audit/AuditLogPage'
+import HelpPage from '@/pages/help/HelpPage'
 
 /**
  * Auth shell. Subscribes to the reactive token store so an expired/cleared
@@ -57,6 +58,7 @@ export const router = createBrowserRouter([
       { path: 'settings', element: <RequireAdmin><SettingsPage /></RequireAdmin> },
       { path: 'users', element: <RequireAdmin><UsersPage /></RequireAdmin> },
       { path: 'audit-log', element: <RequireAdmin><AuditLogPage /></RequireAdmin> },
+      { path: 'help', element: <HelpPage /> },
     ],
   },
   {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { NavLink, Link, Outlet, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from '@/hooks/useTranslation'
 import { clearToken, isAdmin } from '@/api/client'
@@ -101,6 +101,7 @@ export default function AppShell() {
               <span>admin@example.com</span>
             </div>
           </div>
+          <Link to="/admin/help#disclaimer" className="side-legal">{t('nav.disclaimer')}</Link>
         </div>
       </aside>
 

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -17,6 +17,7 @@ const NAV: NavEntry[] = [
   { to: '/admin/client-credits', labelKey: 'nav.clientCredits', icon: 'credit' },
   { to: '/admin/manual-receivables', labelKey: 'nav.manualReceivables', icon: 'doc' },
   { to: '/admin/dunning', labelKey: 'nav.dunning', icon: 'bell' },
+  { to: '/admin/help', labelKey: 'nav.help', icon: 'info' },
 ]
 
 // Every entry here is administrators-only: the backend gates settings behind

--- a/frontend/src/components/keyboard/CommandPalette.tsx
+++ b/frontend/src/components/keyboard/CommandPalette.tsx
@@ -20,6 +20,7 @@ const COMMANDS: Command[] = [
   { id: 'users', labelKey: 'nav.users', path: '/admin/users', combo: ['g', 'u'] },
   { id: 'settings', labelKey: 'nav.settings', path: '/admin/settings', combo: ['g', 's'] },
   { id: 'audit', labelKey: 'nav.auditLog', path: '/admin/audit-log', combo: ['g', 'a'] },
+  { id: 'help', labelKey: 'nav.help', path: '/admin/help', combo: ['g', 'h'] },
 ]
 
 export function CommandPalette({ onClose }: { onClose: () => void }) {
@@ -41,10 +42,15 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
       void navigate(cmd.path)
     }
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'j' || e.key === 'ArrowDown') {
+      // Match on physical key (e.code) as well as e.key: with a kana input mode
+      // or a non-QWERTY layout, the J/K keys report e.key as 'ま'/'の' (etc.),
+      // so an e.key-only check would silently fail to move the cursor.
+      const down = e.key === 'j' || e.code === 'KeyJ' || e.key === 'ArrowDown'
+      const up = e.key === 'k' || e.code === 'KeyK' || e.key === 'ArrowUp'
+      if (down) {
         e.preventDefault()
         setCursor((c) => Math.min(c + 1, COMMANDS.length - 1))
-      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+      } else if (up) {
         e.preventDefault()
         setCursor((c) => Math.max(c - 1, 0))
       } else if (e.key === 'Enter' || e.key === ' ') {

--- a/frontend/src/components/keyboard/KeyboardShortcuts.tsx
+++ b/frontend/src/components/keyboard/KeyboardShortcuts.tsx
@@ -22,6 +22,7 @@ const GOTO: Record<string, string> = {
   u: '/admin/users',
   s: '/admin/settings',
   a: '/admin/audit-log',
+  h: '/admin/help',
 }
 
 /**

--- a/frontend/src/components/keyboard/shortcuts-data.ts
+++ b/frontend/src/components/keyboard/shortcuts-data.ts
@@ -31,6 +31,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { ja: 'ユーザー管理', en: 'Users', combos: [{ caps: ['g', 'u'], join: 'then' }] },
       { ja: '設定', en: 'Settings', combos: [{ caps: ['g', 's'], join: 'then' }] },
       { ja: '監査ログ', en: 'Audit log', combos: [{ caps: ['g', 'a'], join: 'then' }] },
+      { ja: 'ヘルプ', en: 'Help', combos: [{ caps: ['g', 'h'], join: 'then' }] },
     ],
   },
   {

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -22,6 +22,7 @@ export const en: Record<MessageKey, string> = {
   'nav.settings': 'Settings',
   'nav.users': 'Users',
   'nav.auditLog': 'Audit logs',
+  'nav.help': 'Help',
   'nav.logout': 'Sign out',
 
   // ── Login ──

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -23,6 +23,7 @@ export const en: Record<MessageKey, string> = {
   'nav.users': 'Users',
   'nav.auditLog': 'Audit logs',
   'nav.help': 'Help',
+  'nav.disclaimer': 'Disclaimer',
   'nav.logout': 'Sign out',
 
   // ── Login ──
@@ -39,6 +40,7 @@ export const en: Record<MessageKey, string> = {
   'login.submit': 'Sign in',
   'login.error': 'Email or password is incorrect.',
   'login.copyright': '© 2026 NeNe Clear — Accounts Receivable Suite',
+  'login.disclaimer': 'Provided without warranty under the MIT License. Final reconciliation, dunning, and tax checks are your responsibility.',
 
   // ── Common ──
   'common.cancel': 'Cancel',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -19,6 +19,7 @@ export const ja = {
   'nav.users': 'ユーザー管理',
   'nav.auditLog': '監査ログ',
   'nav.help': 'ヘルプ',
+  'nav.disclaimer': '免責事項',
   'nav.logout': 'ログアウト',
 
   // ── Login ──
@@ -35,6 +36,7 @@ export const ja = {
   'login.submit': 'サインイン',
   'login.error': 'メールアドレスまたはパスワードが正しくありません。',
   'login.copyright': '© 2026 NeNe Clear — Accounts Receivable Suite',
+  'login.disclaimer': '本ソフトウェアは MIT ライセンスに基づき無保証で提供されます。消込・督促・税務上の最終確認はご利用者の責任で行ってください。',
 
   // ── Common ──
   'common.cancel': 'キャンセル',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -18,6 +18,7 @@ export const ja = {
   'nav.settings': '設定',
   'nav.users': 'ユーザー管理',
   'nav.auditLog': '監査ログ',
+  'nav.help': 'ヘルプ',
   'nav.logout': 'ログアウト',
 
   // ── Login ──

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -1,0 +1,240 @@
+import { Fragment, useEffect, useState, type ReactNode } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import { HELP_LABELS, HELP_SECTIONS, type Bi, type HelpBlock } from './help-content'
+
+/**
+ * Help page (ported from nene-invoice, design 05): a hero, a sticky numbered
+ * table of contents with scroll-spy, and numbered sections built from rich
+ * blocks (steps, status flows, glossary cards, notes, option cards, a keyboard
+ * grid, and an FAQ accordion). Content lives in `help-content.ts` as ja/en
+ * pairs. Distinct from the `?` shortcut overlay.
+ */
+export default function HelpPage() {
+  const { locale } = useTranslation()
+  const pick = (b: Bi): string => (locale === 'en' ? b.en : b.ja)
+  const activeId = useScrollSpy()
+
+  return (
+    <div className="help-page" id="help-top">
+      <header className="help-hero">
+        <div className="eyebrow">{pick(HELP_LABELS.eyebrow)}</div>
+        <h1>{pick(HELP_LABELS.heroTitle)}</h1>
+        <p>{pick(HELP_LABELS.heroLede)}</p>
+        <div className="hero-meta">
+          <span className="hero-chip">{pick(HELP_LABELS.chipReconcile)}</span>
+          <span className="hero-chip">{pick(HELP_LABELS.chipSelfhost)}</span>
+          <span className="hero-chip">
+            <b>{pick(HELP_LABELS.chipUpdated)}</b>{' '}
+            <span className="num">{HELP_LABELS.updatedDate}</span>
+          </span>
+        </div>
+      </header>
+
+      <div className="help-layout">
+        <nav className="help-toc" id="toc" aria-label={pick(HELP_LABELS.toc)}>
+          <div className="toc-title">{pick(HELP_LABELS.toc)}</div>
+          {HELP_SECTIONS.map((s, i) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              className={[s.id === activeId ? 'active' : '', s.admin ? 'admin-only' : ''].filter(Boolean).join(' ')}
+            >
+              <span className="tn">{String(i + 1).padStart(2, '0')}</span>
+              {pick(s.title)}
+            </a>
+          ))}
+        </nav>
+
+        <article className="help-article">
+          {HELP_SECTIONS.map((s, i) => (
+            <section key={s.id} id={s.id} className="hsec">
+              <div className="hsec-head">
+                <span className="hsec-no">{String(i + 1).padStart(2, '0')}</span>
+                <h2>
+                  {pick(s.title)}
+                  {s.admin === true && <span className="tag-admin">{pick(HELP_LABELS.adminBadge)}</span>}
+                </h2>
+              </div>
+              {s.blocks.map((block, bi) => (
+                <Block key={bi} block={block} pick={pick} />
+              ))}
+              <a className="backtop" href="#toc">↑ {pick(HELP_LABELS.backToToc)}</a>
+            </section>
+          ))}
+
+          <div className="help-foot">
+            <div>
+              <div className="hf-t">{pick(HELP_LABELS.footTitle)}</div>
+              <div className="hf-d">{pick(HELP_LABELS.footDesc)}</div>
+            </div>
+          </div>
+        </article>
+      </div>
+    </div>
+  )
+}
+
+/** Highlights the ToC entry for the last section scrolled past the top band. */
+function useScrollSpy(): string {
+  const [activeId, setActiveId] = useState(HELP_SECTIONS[0]?.id ?? '')
+  useEffect(() => {
+    const ids = HELP_SECTIONS.map((s) => s.id)
+    const onScroll = (): void => {
+      const threshold = window.scrollY + 120
+      let current = ids[0] ?? ''
+      for (const id of ids) {
+        const el = document.getElementById(id)
+        if (el === null) continue
+        const docTop = el.getBoundingClientRect().top + window.scrollY
+        if (docTop <= threshold) current = id
+      }
+      setActiveId(current)
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
+  }, [])
+  return activeId
+}
+
+/** Renders `` `code` `` spans within a (possibly bold) text fragment. */
+function renderCode(text: string): ReactNode[] {
+  return text.split(/(`[^`]+`)/g).map((p, i) =>
+    p.startsWith('`') && p.endsWith('`')
+      ? <code key={i} className="tcode">{p.slice(1, -1)}</code>
+      : <Fragment key={i}>{p}</Fragment>,
+  )
+}
+
+/** Renders `**bold**` and `` `code` `` inline markup (code may nest in bold). */
+function Rich({ text }: { text: string }): ReactNode {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g)
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.startsWith('**') && p.endsWith('**')
+          ? <b key={i}>{renderCode(p.slice(2, -2))}</b>
+          : <Fragment key={i}>{renderCode(p)}</Fragment>,
+      )}
+    </>
+  )
+}
+
+function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): ReactNode {
+  switch (block.kind) {
+    case 'lede':
+      return <p className="lede"><Rich text={pick(block.text)} /></p>
+    case 'subhead':
+      return <div className="sub-h">{pick(block.text)}</div>
+    case 'steps':
+      return (
+        <ol className="steps">
+          {block.items.map((it, i) => (
+            <li key={i}>
+              <div className="st-t">{pick(it.title)}</div>
+              <div className="st-d"><Rich text={pick(it.desc)} /></div>
+            </li>
+          ))}
+        </ol>
+      )
+    case 'proc':
+      return (
+        <ol className="proc">
+          {block.items.map((it, i) => <li key={i}><Rich text={pick(it)} /></li>)}
+        </ol>
+      )
+    case 'flow':
+      return (
+        <div className="flow">
+          {block.chips.map((c, i) => (
+            <Fragment key={i}>
+              {i > 0 && <span className="farrow">→</span>}
+              <span className="fchip">{pick(c)}</span>
+            </Fragment>
+          ))}
+          {block.branch !== undefined && <span className="fbranch">{pick(block.branch)}</span>}
+        </div>
+      )
+    case 'terms':
+      return (
+        <dl className="terms">
+          {block.items.map((it, i) => (
+            <div key={i} className="term">
+              <dt>{pick(it.term)}</dt>
+              <dd><Rich text={pick(it.desc)} /></dd>
+            </div>
+          ))}
+        </dl>
+      )
+    case 'deflist':
+      return (
+        <div className="deflist">
+          {block.items.map((it, i) => (
+            <div key={i} className="row">
+              <div className="dl-t">{pick(it.term)}</div>
+              <div className="dl-d"><Rich text={pick(it.desc)} /></div>
+            </div>
+          ))}
+        </div>
+      )
+    case 'note':
+      return (
+        <div className={block.tone === 'warn' ? 'note warn' : 'note'}>
+          <span>
+            {block.title !== undefined && <span className="nt">{pick(block.title)}</span>}
+            <Rich text={pick(block.text)} />
+          </span>
+        </div>
+      )
+    case 'options':
+      return (
+        <div className="opt3">
+          {block.items.map((it, i) => (
+            <div key={i} className="opt">
+              <div className="opt-n">{String(i + 1).padStart(2, '0')}</div>
+              <div className="opt-t">{pick(it.title)}</div>
+              <div className="opt-d">{pick(it.desc)}</div>
+            </div>
+          ))}
+        </div>
+      )
+    case 'keys':
+      return (
+        <>
+          {block.groups.map((g, gi) => (
+            <Fragment key={gi}>
+              <div className="sub-h">{pick(g.heading)}</div>
+              <div className="kgrid">
+                {g.rows.map((r, ri) => (
+                  <div key={ri} className="kr">
+                    <span className="kl">{pick(r.label)}</span>
+                    <span className="kk">
+                      {r.caps.map((cap, ci) => <kbd key={ci} className="kbd">{cap}</kbd>)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </Fragment>
+          ))}
+        </>
+      )
+    case 'faq':
+      return (
+        <div className="faq">
+          {block.items.map((it, i) => (
+            <details key={i} open={i === 0}>
+              <summary>
+                <span className="q">Q</span>
+                <span className="qt">{pick(it.q)}</span>
+                <span className="chev" aria-hidden="true">⌄</span>
+              </summary>
+              <div className="fa-body"><Rich text={pick(it.a)} /></div>
+            </details>
+          ))}
+        </div>
+      )
+  }
+}

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -14,6 +14,13 @@ export default function HelpPage() {
   const pick = (b: Bi): string => (locale === 'en' ? b.en : b.ja)
   const activeId = useScrollSpy()
 
+  // Honour a deep link like /admin/help#disclaimer (the in-page ToC uses native
+  // anchors; this covers arriving from elsewhere). Scroll only — no state.
+  useEffect(() => {
+    const id = window.location.hash.slice(1)
+    if (id !== '') document.getElementById(id)?.scrollIntoView()
+  }, [])
+
   return (
     <div className="help-page" id="help-top">
       <header className="help-hero">

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -1,13 +1,16 @@
-import { Fragment, useEffect, useState, type ReactNode } from 'react'
+import { Fragment, useEffect, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Icon } from '@/components/ui'
 import { HELP_LABELS, HELP_SECTIONS, type Bi, type HelpBlock } from './help-content'
 
 /**
- * Help page (ported from nene-invoice, design 05): a hero, a sticky numbered
- * table of contents with scroll-spy, and numbered sections built from rich
- * blocks (steps, status flows, glossary cards, notes, option cards, a keyboard
- * grid, and an FAQ accordion). Content lives in `help-content.ts` as ja/en
- * pairs. Distinct from the `?` shortcut overlay.
+ * Help page (design handoff): a light hero band that bleeds to the topbar and
+ * content edges, a sticky numbered table of contents with scroll-spy, and
+ * numbered/iconed sections built from rich blocks (steps, status flows, glossary
+ * cards, notes with an icon, option cards, a keyboard grid, and an FAQ
+ * accordion). Content lives in `help-content.ts` as ja/en pairs. Scrolling is
+ * scoped to the app shell's `.scroll` container (the window does not scroll).
+ * Distinct from the `?` shortcut overlay.
  */
 export default function HelpPage() {
   const { locale } = useTranslation()
@@ -15,30 +18,47 @@ export default function HelpPage() {
   const activeId = useScrollSpy()
 
   // Honour a deep link like /admin/help#disclaimer (the in-page ToC uses native
-  // anchors; this covers arriving from elsewhere). Scroll only — no state.
+  // anchors; this covers arriving from elsewhere). Scroll the shell container,
+  // not the window.
   useEffect(() => {
     const id = window.location.hash.slice(1)
-    if (id !== '') document.getElementById(id)?.scrollIntoView()
+    if (id === '') return
+    const target = document.getElementById(id)
+    const scroller = scrollerOf(target)
+    if (target === null || scroller === null) return
+    scroller.scrollTo({ top: offsetWithin(target, scroller) - 16 })
   }, [])
 
   return (
     <div className="help-page" id="help-top">
       <header className="help-hero">
-        <div className="eyebrow">{pick(HELP_LABELS.eyebrow)}</div>
-        <h1>{pick(HELP_LABELS.heroTitle)}</h1>
-        <p>{pick(HELP_LABELS.heroLede)}</p>
-        <div className="hero-meta">
-          <span className="hero-chip">{pick(HELP_LABELS.chipReconcile)}</span>
-          <span className="hero-chip">{pick(HELP_LABELS.chipSelfhost)}</span>
-          <span className="hero-chip">
-            <b>{pick(HELP_LABELS.chipUpdated)}</b>{' '}
-            <span className="num">{HELP_LABELS.updatedDate}</span>
-          </span>
+        <div className="hero-grid" />
+        <div className="hero-inner">
+          <div className="eyebrow">
+            <Icon name="help" />
+            {pick(HELP_LABELS.eyebrow)}
+          </div>
+          <h1>{pick(HELP_LABELS.heroTitle)}</h1>
+          <p>{pick(HELP_LABELS.heroLede)}</p>
+          <div className="hero-meta">
+            <span className="hero-chip">
+              <Icon name="reconcile" />
+              {pick(HELP_LABELS.chipReconcile)}
+            </span>
+            <span className="hero-chip">
+              <Icon name="shield" />
+              {pick(HELP_LABELS.chipSelfhost)}
+            </span>
+            <span className="hero-chip">
+              <b>{pick(HELP_LABELS.chipUpdated)}</b>{' '}
+              <span className="num">{HELP_LABELS.updatedDate}</span>
+            </span>
+          </div>
         </div>
       </header>
 
       <div className="help-layout">
-        <nav className="help-toc" id="toc" aria-label={pick(HELP_LABELS.toc)}>
+        <nav className="help-toc" id="toc" aria-label={pick(HELP_LABELS.toc)} onClick={onTocClick}>
           <div className="toc-title">{pick(HELP_LABELS.toc)}</div>
           {HELP_SECTIONS.map((s, i) => (
             <a
@@ -47,7 +67,7 @@ export default function HelpPage() {
               className={[s.id === activeId ? 'active' : '', s.admin ? 'admin-only' : ''].filter(Boolean).join(' ')}
             >
               <span className="tn">{String(i + 1).padStart(2, '0')}</span>
-              {pick(s.title)}
+              <span className="tt">{pick(s.title)}</span>
             </a>
           ))}
         </nav>
@@ -58,6 +78,9 @@ export default function HelpPage() {
               <div className="hsec-head">
                 <span className="hsec-no">{String(i + 1).padStart(2, '0')}</span>
                 <h2>
+                  {s.icon !== undefined && (
+                    <span className="hsec-ic"><Icon name={s.icon} /></span>
+                  )}
                   {pick(s.title)}
                   {s.admin === true && <span className="tag-admin">{pick(HELP_LABELS.adminBadge)}</span>}
                 </h2>
@@ -65,14 +88,18 @@ export default function HelpPage() {
               {s.blocks.map((block, bi) => (
                 <Block key={bi} block={block} pick={pick} />
               ))}
-              <a className="backtop" href="#toc">↑ {pick(HELP_LABELS.backToToc)}</a>
+              <a className="backtop" href="#help-top" onClick={onBackToTop}>
+                <Icon name="arrow-up" />
+                {pick(HELP_LABELS.backToToc)}
+              </a>
             </section>
           ))}
 
           <div className="help-foot">
+            <div className="hf-ic"><Icon name="mail" /></div>
             <div>
               <div className="hf-t">{pick(HELP_LABELS.footTitle)}</div>
-              <div className="hf-d">{pick(HELP_LABELS.footDesc)}</div>
+              <div className="hf-d"><Rich text={pick(HELP_LABELS.footDesc)} /></div>
             </div>
           </div>
         </article>
@@ -81,26 +108,61 @@ export default function HelpPage() {
   )
 }
 
+/** The app shell's scrollable container that holds the routed page. */
+function scrollerOf(el: Element | null): HTMLElement | null {
+  return (el?.closest('.scroll') as HTMLElement | null) ?? null
+}
+
+/** Distance (px) from the scroll container's top to an element's top. */
+function offsetWithin(el: HTMLElement, scroller: HTMLElement): number {
+  return el.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop
+}
+
+/** Smooth-scrolls the shell container to a ToC target (native anchors would jump). */
+function onTocClick(e: ReactMouseEvent<HTMLElement>): void {
+  const link = (e.target as HTMLElement).closest('a')
+  if (link === null) return
+  const id = link.getAttribute('href')?.slice(1) ?? ''
+  const target = document.getElementById(id)
+  const scroller = scrollerOf(link)
+  if (target === null || scroller === null) return
+  e.preventDefault()
+  scroller.scrollTo({ top: offsetWithin(target, scroller) - 16, behavior: 'smooth' })
+  // preventDefault stops the native hash jump, so reflect the section in the URL
+  // ourselves — keeps deep-linking/bookmarking (and the e2e contract) intact.
+  history.pushState(null, '', '#' + id)
+}
+
+/** Smooth-scrolls the shell container back to the top. */
+function onBackToTop(e: ReactMouseEvent<HTMLAnchorElement>): void {
+  const scroller = scrollerOf(e.currentTarget)
+  if (scroller === null) return
+  e.preventDefault()
+  scroller.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
 /** Highlights the ToC entry for the last section scrolled past the top band. */
 function useScrollSpy(): string {
   const [activeId, setActiveId] = useState(HELP_SECTIONS[0]?.id ?? '')
   useEffect(() => {
+    const scroller = scrollerOf(document.getElementById('help-top'))
+    if (scroller === null) return
     const ids = HELP_SECTIONS.map((s) => s.id)
     const onScroll = (): void => {
-      const threshold = window.scrollY + 120
+      const probe = scroller.scrollTop + 100
       let current = ids[0] ?? ''
       for (const id of ids) {
         const el = document.getElementById(id)
         if (el === null) continue
-        const docTop = el.getBoundingClientRect().top + window.scrollY
-        if (docTop <= threshold) current = id
+        if (offsetWithin(el, scroller) <= probe) current = id
       }
       setActiveId(current)
     }
-    window.addEventListener('scroll', onScroll, { passive: true })
+    scroller.addEventListener('scroll', onScroll, { passive: true })
     window.addEventListener('resize', onScroll)
+    onScroll()
     return () => {
-      window.removeEventListener('scroll', onScroll)
+      scroller.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', onScroll)
     }
   }, [])
@@ -190,6 +252,7 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
     case 'note':
       return (
         <div className={block.tone === 'warn' ? 'note warn' : 'note'}>
+          <span className="note-ic"><Icon name={block.tone === 'warn' ? 'alert' : 'info'} /></span>
           <span>
             {block.title !== undefined && <span className="nt">{pick(block.title)}</span>}
             <Rich text={pick(block.text)} />
@@ -201,7 +264,7 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
         <div className="opt3">
           {block.items.map((it, i) => (
             <div key={i} className="opt">
-              <div className="opt-n">{String(i + 1).padStart(2, '0')}</div>
+              <div className="opt-n">ROLE {String(i + 1).padStart(2, '0')}</div>
               <div className="opt-t">{pick(it.title)}</div>
               <div className="opt-d">{pick(it.desc)}</div>
             </div>
@@ -219,7 +282,9 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
                   <div key={ri} className="kr">
                     <span className="kl">{pick(r.label)}</span>
                     <span className="kk">
-                      {r.caps.map((cap, ci) => <kbd key={ci} className="kbd">{cap}</kbd>)}
+                      {r.caps.map((cap, ci) => (
+                        <kbd key={ci} className={cap.length > 1 ? 'kbd wide' : 'kbd'}>{cap}</kbd>
+                      ))}
                     </span>
                   </div>
                 ))}
@@ -236,7 +301,7 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
               <summary>
                 <span className="q">Q</span>
                 <span className="qt">{pick(it.q)}</span>
-                <span className="chev" aria-hidden="true">⌄</span>
+                <span className="chev" aria-hidden="true"><Icon name="chev-d" /></span>
               </summary>
               <div className="fa-body"><Rich text={pick(it.a)} /></div>
             </details>

--- a/frontend/src/pages/help/help-content.ts
+++ b/frontend/src/pages/help/help-content.ts
@@ -391,4 +391,38 @@ export const HELP_SECTIONS: HelpSection[] = [
       },
     ],
   },
+  {
+    id: 'disclaimer',
+    title: { ja: '免責事項・ご利用にあたって', en: 'Disclaimer & terms of use' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '本ソフトウェア（NeNe Clear）は、入金消込・督促管理を補助するツールであり、税務・会計・法務に関する助言を提供するものではありません。消込結果の正確性、督促の内容・時期・送付の可否、税務申告および帳簿・書類の保存（電子帳簿保存法等）については、最終的にご利用者ご自身および顧問税理士の責任でご確認ください。',
+          en: 'This software (NeNe Clear) is a tool that assists with payment reconciliation and dunning. It does not provide tax, accounting, or legal advice. The accuracy of reconciliation results, the content / timing / appropriateness of dunning, and tax filing and record retention (including under the Electronic Books Preservation Act) are ultimately your responsibility and that of your tax accountant.',
+        },
+      },
+      {
+        kind: 'lede',
+        text: {
+          ja: '本ソフトウェアは MIT ライセンスに基づき「現状有姿（AS IS）」で提供され、明示・黙示を問わずいかなる保証も行いません。本ソフトウェアの使用または使用不能から生じたいかなる損害についても、作者および権利者は責任を負いません。',
+          en: 'This software is provided “AS IS” under the MIT License, without warranty of any kind, express or implied. The authors and copyright holders are not liable for any damages arising from the use of, or inability to use, this software.',
+        },
+      },
+      {
+        kind: 'lede',
+        text: {
+          ja: '自己ホスト型のため、データのバックアップ・保管・セキュリティおよび法定保存期間の遵守は、運用される事業者の責任となります。また、法令・制度の改正への追随を保証するものではありません。',
+          en: 'Because it is self-hosted, backing up, storing, and securing your data, and complying with statutory retention periods, are the responsibility of the operating business. Nor does it guarantee that it stays up to date with changes in laws or regulations.',
+        },
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: '督促メールの送信は、送信先・文面・頻度を含め、関連法令や取引先との契約に照らしてご利用者の判断と責任で行ってください。',
+          en: 'Sending dunning e-mails — including recipients, wording, and frequency — is done at your own discretion and responsibility, in light of applicable laws and your agreements with clients.',
+        },
+      },
+    ],
+  },
 ]

--- a/frontend/src/pages/help/help-content.ts
+++ b/frontend/src/pages/help/help-content.ts
@@ -1,0 +1,394 @@
+/**
+ * Help-page content for NeNe Clear. Co-located bilingual ja/en pairs (like
+ * `components/keyboard/shortcuts-data.ts`) rather than locale-catalog keys,
+ * since the page is long-form prose with steps, flows, and an FAQ that don't fit
+ * flat keys. `HelpPage` picks ja or en from the active locale.
+ *
+ * Inline markup inside any string: `**bold**` and `` `code` `` (rendered by the
+ * page's <Rich> helper). Keep wording aligned with the real UI labels so the
+ * guide stays accurate. Ported from nene-invoice's help page (design 05),
+ * rewritten for Clear's domain (入金消込・督促).
+ */
+
+/** A translated string: primary ja + secondary en. May contain inline markup. */
+export interface Bi {
+  ja: string
+  en: string
+}
+
+export type HelpBlock =
+  | { kind: 'lede'; text: Bi }
+  | { kind: 'subhead'; text: Bi }
+  | { kind: 'steps'; items: { title: Bi; desc: Bi }[] }
+  | { kind: 'proc'; items: Bi[] }
+  | { kind: 'flow'; chips: Bi[]; branch?: Bi }
+  | { kind: 'terms'; items: { term: Bi; desc: Bi }[] }
+  | { kind: 'deflist'; items: { term: Bi; desc: Bi }[] }
+  | { kind: 'note'; tone?: 'warn'; title?: Bi; text: Bi }
+  | { kind: 'options'; items: { title: Bi; desc: Bi }[] }
+  | { kind: 'keys'; groups: { heading: Bi; rows: { label: Bi; caps: string[] }[] }[] }
+  | { kind: 'faq'; items: { q: Bi; a: Bi }[] }
+
+export interface HelpSection {
+  /** Anchor id (also the ToC target). */
+  id: string
+  title: Bi
+  /** Marks the section as admin-only (badge in the ToC and the heading). */
+  admin?: boolean
+  blocks: HelpBlock[]
+}
+
+export const HELP_LABELS = {
+  eyebrow: { ja: 'ヘルプ', en: 'Help' },
+  heroTitle: { ja: '操作ガイド・よくある質問', en: 'Guides & FAQ' },
+  heroLede: {
+    ja: 'NeNe Clear を初めて使う方向けの操作ガイドです。銀行入金の取込から消込・督促までの流れと、つまずきやすいポイントをまとめています。',
+    en: 'A getting-started guide for people new to NeNe Clear. It walks through the flow from importing bank deposits to reconciliation and dunning, and the spots people commonly get stuck on.',
+  },
+  chipReconcile: { ja: '入金消込', en: 'Reconciliation' },
+  chipSelfhost: { ja: '自己ホスト型', en: 'Self-hosted' },
+  chipUpdated: { ja: '最終更新', en: 'Updated' },
+  updatedDate: '2026-06-08',
+  toc: { ja: '目次', en: 'Contents' },
+  adminBadge: { ja: '管理者', en: 'Admin' },
+  backToToc: { ja: '目次へ戻る', en: 'Back to contents' },
+  footTitle: { ja: '解決しませんでしたか？', en: 'Still need help?' },
+  footDesc: {
+    ja: '管理者にお問い合わせいただくか、キーボードショートカット一覧（? キー）もご活用ください。',
+    en: 'Contact your administrator, or press ? for the keyboard-shortcut list.',
+  },
+} as const
+
+export const HELP_SECTIONS: HelpSection[] = [
+  {
+    id: 'start',
+    title: { ja: 'はじめに（クイックスタート）', en: 'Getting started (quick start)' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: 'NeNe Clear は、銀行入金と請求を突き合わせて**入金消込**を行い、未収には**督促**を送る自己ホスト型システムです。請求書の作成は行いません（請求データは Invoice 連携から取得します）。',
+          en: 'NeNe Clear is a self-hosted system that matches bank deposits to invoices (**reconciliation**) and sends **dunning** for unpaid balances. It does not create invoices — invoice data comes from the Invoice integration.',
+        },
+      },
+      {
+        kind: 'lede',
+        text: {
+          ja: '全体の流れはシンプルです。銀行の入出金明細CSVを取り込み、入金を請求書に消し込み、未収には督促を送る。ダッシュボードで未消込・延滞・前受金の状況をいつでも把握できます。',
+          en: 'The flow is simple: import your bank statement CSV, reconcile deposits against invoices, and dun the unpaid ones. The dashboard shows your unmatched / overdue / client-credit situation at any time.',
+        },
+      },
+      {
+        kind: 'flow',
+        chips: [
+          { ja: '銀行CSVを取込', en: 'Import bank CSV' },
+          { ja: '入金を消込', en: 'Reconcile deposits' },
+          { ja: '未収へ督促', en: 'Dun the unpaid' },
+        ],
+        branch: { ja: '請求に紐づかない入金は「前受金」へ', en: 'Deposits with no invoice → client credits' },
+      },
+      {
+        kind: 'note',
+        title: { ja: '権限について', en: 'About roles' },
+        text: {
+          ja: '消込・督促はオペレーター以上で実行できます。**設定・ユーザー管理・監査ログは管理者のみ**です（メニューに表示されない場合は権限がありません）。',
+          en: 'Operators and above can reconcile and dun. **Settings, user management, and the audit log are admin-only** (if a menu item is missing, you lack the capability).',
+        },
+      },
+    ],
+  },
+  {
+    id: 'dashboard',
+    title: { ja: 'ダッシュボード', en: 'Dashboard' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: 'ログイン後の最初の画面です。未消込の取引、延滞している請求、当月の消込済み、前受金残高などの概況をまとめて確認できます。',
+          en: 'The first screen after login. It summarises unmatched transactions, overdue invoices, this month’s cleared amount, and the client-credit balance.',
+        },
+      },
+      {
+        kind: 'proc',
+        items: [
+          { ja: '気になる数字のカードから各画面へ移動できます。', en: 'Jump to each screen from the KPI card you care about.' },
+          { ja: '未消込の取引一覧から、そのまま消込作業に入れます。', en: 'Start reconciling straight from the unmatched-transactions list.' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'import',
+    title: { ja: '銀行CSVの取込', en: 'Importing bank CSV' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '銀行の入出金明細CSVを取り込み、消込対象の入金取引として登録します。口座ごとのCSV形式（文字コード・日付書式・列位置）は設定画面で登録しておきます。',
+          en: 'Import your bank statement CSV to register deposits as transactions for reconciliation. Each account’s CSV format (encoding, date format, column positions) is registered in Settings beforehand.',
+        },
+      },
+      {
+        kind: 'steps',
+        items: [
+          { title: { ja: '口座を選ぶ', en: 'Choose the account' }, desc: { ja: '取込先の銀行口座を選択します。', en: 'Pick the bank account to import into.' } },
+          { title: { ja: 'CSVを選ぶ', en: 'Choose the CSV' }, desc: { ja: 'ファイルをドラッグ＆ドロップ、またはクリックして選択します。', en: 'Drag & drop the file, or click to choose it.' } },
+          { title: { ja: '取込む', en: 'Import' }, desc: { ja: '「取込む」を押すと取引が登録されます。**重複行は自動でスキップ**されます。', en: 'Press Import to register the rows. **Duplicate rows are skipped automatically.**' } },
+        ],
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: '誤って取り込んだバッチは取込履歴から**取消**できます（消込済みの行を含むバッチは、先に消込を取り消す必要があります）。',
+          en: 'A wrong batch can be **reversed** from the import history (a batch with already-matched lines needs those reconciliations reversed first).',
+        },
+      },
+    ],
+  },
+  {
+    id: 'reconcile',
+    title: { ja: '入金の消込', en: 'Reconciling deposits' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '消込画面は「**未消込**」タブと「**消込一覧（履歴）**」タブに分かれています。未消込タブで入金取引を請求書に突き合わせて確定します。',
+          en: 'The Reconciliation screen has an **Unmatched** tab and a **Reconciliations (history)** tab. Match deposits to invoices and confirm them on the Unmatched tab.',
+        },
+      },
+      {
+        kind: 'steps',
+        items: [
+          { title: { ja: '取引を開く', en: 'Open a transaction' }, desc: { ja: '未消込タブで対象の入金の「消込を確定」を押します（一覧で **j / k** で移動し **Enter** でも開けます）。', en: 'Press “Confirm match” on a deposit in the Unmatched tab (or move with **j / k** and press **Enter**).' } },
+          { title: { ja: '候補を確認', en: 'Review candidates' }, desc: { ja: '金額や相手先から推定された請求書候補が表示されます。「選択」で配賦に取り込めます。', en: 'Suggested invoice candidates (by amount / payer) are shown. “Use” pulls one into the allocation.' } },
+          { title: { ja: '配賦を入力', en: 'Enter allocations' }, desc: { ja: '請求書IDと消込金額を入力します。**1件以上**必要です。1入金を複数請求へ分けることもできます。', en: 'Enter invoice ID and amount. **At least one** is required; one deposit can be split across several invoices.' } },
+          { title: { ja: '確定', en: 'Confirm' }, desc: { ja: '内容を確認して「消込を確定」。必要なら理由コード（相殺・手数料差引など）を残せます。', en: 'Review and confirm. Optionally record a reason code (offset, fee deduction, etc.).' } },
+        ],
+      },
+      {
+        kind: 'flow',
+        chips: [
+          { ja: '未消込', en: 'Unmatched' },
+          { ja: '一部消込', en: 'Partially matched' },
+          { ja: '消込済', en: 'Matched' },
+        ],
+        branch: { ja: '取消すと未消込へ戻ります', en: 'Reversing returns it to unmatched' },
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: '確定した消込は履歴タブから**取消**できます。取消理由は監査ログに残ります。入金額が請求の未収を超える場合は、超過分が**前受金**として記録されます。',
+          en: 'A confirmed match can be **reversed** from the history tab; the reason is audited. If a deposit exceeds the invoice’s outstanding balance, the excess is recorded as a **client credit**.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'credits',
+    title: { ja: '前受金', en: 'Client credits' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '請求に紐づかない入金や過入金は「前受金」として残高管理し、後から請求へ適用できます。',
+          en: 'Deposits not tied to an invoice, or overpayments, are held as client credits and can be applied to an invoice later.',
+        },
+      },
+      {
+        kind: 'proc',
+        items: [
+          { ja: '前受金一覧で対象の「適用」を押します。', en: 'Press “Apply” on a credit in the list.' },
+          { ja: '適用先の請求書IDと金額を入力します（残高の範囲内）。', en: 'Enter the target invoice ID and amount (within the remaining balance).' },
+          { ja: '適用すると残高が減り、全額適用で「無効（適用済み）」になります。', en: 'Applying reduces the balance; once fully applied the credit becomes voided/applied.' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'dunning',
+    title: { ja: '督促', en: 'Dunning' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '延滞・一部入金の請求に対して督促メールを送り、送信履歴を一元管理します。督促画面は対象請求の一覧と送信履歴で構成されます。',
+          en: 'Send dunning e-mails for overdue / partially-paid invoices and keep the send history in one place. The screen lists eligible invoices and the send history.',
+        },
+      },
+      {
+        kind: 'steps',
+        items: [
+          { title: { ja: '対象を選ぶ', en: 'Pick an invoice' }, desc: { ja: '督促対象の請求書一覧から送信したいものを選びます。', en: 'Choose one from the eligible-invoice list.' } },
+          { title: { ja: '送信', en: 'Send' }, desc: { ja: '「督促を送信」で、登録テンプレートのメールが送られ履歴に記録されます。', en: '“Send dunning” sends the templated e-mail and records it in the history.' } },
+          { title: { ja: '停止 / 再開', en: 'Pause / resume' }, desc: { ja: '入金調整中などは請求単位で**停止**できます（理由は履歴に残る）。再開で戻せます。', en: 'You can **pause** dunning per invoice (e.g. while arranging payment); the reason is kept. Resume to re-enable.' } },
+        ],
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: '同じ請求への督促には**最短間隔**（設定画面の「督促の最短間隔」）があり、間隔内の再送はブロックされます。実際のメール送信には SMTP の設定が必要です（未設定の場合はログのみ）。',
+          en: 'A **minimum interval** (Settings) applies per invoice; re-sending within it is blocked. Real e-mail delivery needs SMTP configured (otherwise it is log-only).',
+        },
+      },
+    ],
+  },
+  {
+    id: 'export',
+    title: { ja: 'CSVエクスポート', en: 'CSV export' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '各一覧（入金明細・消込・前受金・督促）は「CSV出力」で書き出せます。**画面で適用中の絞り込み（期間・金額・ステータス等）がそのままCSVに反映**されます。',
+          en: 'Each list (bank transactions, reconciliations, client credits, dunning) exports via “Export CSV”. **The filters currently applied on screen (date range, amount, status, …) are reflected in the CSV.**',
+        },
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: '日付範囲は、設定の**決算月**から算出した「当会計年度の期初〜本日」が初期値になります。全期間を出したいときは絞り込みを**クリア**してから出力してください。',
+          en: 'The date range defaults to the **current fiscal year** (from the fiscal-year start, derived from the fiscal year-end month in Settings, to today). To export everything, **Clear** the filters first.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: { ja: '設定', en: 'Settings' },
+    admin: true,
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '連携・ポリシー・口座をまとめて構成します（管理者のみ）。',
+          en: 'Configure integration, policy, and accounts in one place (admin only).',
+        },
+      },
+      {
+        kind: 'deflist',
+        items: [
+          { term: { ja: 'Invoice API 連携', en: 'Invoice API' }, desc: { ja: '請求データ取得元のURLとトークン参照。「接続テスト」で疎通を確認できます。', en: 'URL and token reference for the invoice source. “Test connection” checks reachability.' } },
+          { term: { ja: '督促の最短間隔', en: 'Dunning interval' }, desc: { ja: '同一請求への督促を再送できるまでの最短日数（1以上）。', en: 'Minimum days before dunning the same invoice again (≥ 1).' } },
+          { term: { ja: '決算月', en: 'Fiscal year-end month' }, desc: { ja: '会計年度の末月（1〜12、任意）。CSVの期間初期値に使われます。', en: 'The fiscal year-end month (1–12, optional). Used as the default CSV date range.' } },
+          { term: { ja: '銀行口座', en: 'Bank accounts' }, desc: { ja: '取込CSVの形式（文字コード・日付書式・列位置）を口座ごとに登録します。', en: 'Per-account CSV format (encoding, date format, column positions) for imports.' } },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'users',
+    title: { ja: 'ユーザー管理（招待）', en: 'User management (invitations)' },
+    admin: true,
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: 'メンバーをメールで招待します（管理者のみ）。招待された人は自分でパスワードを設定してから利用を開始します。',
+          en: 'Invite members by e-mail (admin only). Invitees set their own password before they can sign in.',
+        },
+      },
+      {
+        kind: 'steps',
+        items: [
+          { title: { ja: '招待', en: 'Invite' }, desc: { ja: 'ユーザー管理で「ユーザーを招待」→ メールアドレスとロールを入力して送信。', en: 'In Users, “Invite user” → enter e-mail and role, then send.' } },
+          { title: { ja: 'メールのリンク', en: 'E-mail link' }, desc: { ja: '招待者に届くメールのリンクを開きます（**有効期限7日**）。', en: 'The invitee opens the link in the e-mail (**valid for 7 days**).' } },
+          { title: { ja: 'パスワード設定', en: 'Set password' }, desc: { ja: 'パスワードを設定するとアカウントが有効化され、ログインできるようになります。', en: 'Setting a password activates the account, and they can sign in.' } },
+        ],
+      },
+      {
+        kind: 'note',
+        text: {
+          ja: 'ロールは **管理者 / オペレーター / 閲覧者**。オペレーターは消込・督促が可能、閲覧者は閲覧のみ。管理者だけが設定・ユーザー管理・監査ログにアクセスできます。',
+          en: 'Roles are **admin / operator / viewer**. Operators can reconcile and dun; viewers are read-only. Only admins reach Settings, Users, and the audit log.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'audit',
+    title: { ja: '監査ログ', en: 'Audit log' },
+    admin: true,
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '取込・消込・督促・設定変更・ログインなど、状態を変える操作はすべて記録されます（管理者のみ）。誰が・いつ・何を変更したかを追跡できます。',
+          en: 'Every state-changing operation — imports, reconciliations, dunning, settings changes, logins — is recorded (admin only), so you can trace who changed what and when.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'keys',
+    title: { ja: 'キーボードショートカット', en: 'Keyboard shortcuts' },
+    blocks: [
+      {
+        kind: 'lede',
+        text: {
+          ja: '`?` キーでいつでもショートカット一覧を開けます。主なものは次のとおりです。',
+          en: 'Press `?` anytime to open the shortcut list. The main ones:',
+        },
+      },
+      {
+        kind: 'keys',
+        groups: [
+          {
+            heading: { ja: '画面遷移（g に続けて）', en: 'Navigation (g, then…)' },
+            rows: [
+              { label: { ja: 'ダッシュボード', en: 'Dashboard' }, caps: ['g', 'd'] },
+              { label: { ja: '消込', en: 'Reconciliation' }, caps: ['g', 'r'] },
+              { label: { ja: '銀行CSV取込', en: 'Bank import' }, caps: ['g', 'i'] },
+              { label: { ja: '督促', en: 'Dunning' }, caps: ['g', 'n'] },
+            ],
+          },
+          {
+            heading: { ja: 'リスト操作', en: 'List' },
+            rows: [
+              { label: { ja: '次 / 前の行', en: 'Next / Prev row' }, caps: ['j', 'k'] },
+              { label: { ja: '選択行を開く', en: 'Open row' }, caps: ['Enter'] },
+              { label: { ja: '検索へフォーカス', en: 'Focus search' }, caps: ['/'] },
+            ],
+          },
+          {
+            heading: { ja: '全般', en: 'General' },
+            rows: [
+              { label: { ja: 'コマンドパレット', en: 'Command palette' }, caps: ['Ctrl', 'K'] },
+              { label: { ja: 'ショートカット一覧', en: 'Shortcut list' }, caps: ['?'] },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'faq',
+    title: { ja: 'よくある質問', en: 'FAQ' },
+    blocks: [
+      {
+        kind: 'faq',
+        items: [
+          {
+            q: { ja: 'メニューに「設定」や「ユーザー管理」が出てきません。', en: 'I don’t see Settings or Users in the menu.' },
+            a: { ja: 'それらは**管理者のみ**の画面です。オペレーター・閲覧者には表示されません。必要な場合は管理者にロール変更を依頼してください。', en: 'Those are **admin-only**. They are hidden for operators and viewers. Ask an admin to change your role if needed.' },
+          },
+          {
+            q: { ja: '消込の確定でエラーになります。', en: 'Confirming a match shows an error.' },
+            a: { ja: '消込先（請求書IDと消込金額）が**1件以上**入力されているか確認してください。金額が請求の未収を超える場合は超過分が前受金になります。', en: 'Check that **at least one** allocation (invoice ID + amount) is filled in. If the amount exceeds the invoice’s outstanding, the excess becomes a client credit.' },
+          },
+          {
+            q: { ja: '督促メールが届きません。', en: 'The dunning e-mail didn’t arrive.' },
+            a: { ja: '実送信には SMTP の設定が必要です（未設定だとログのみ）。また、同一請求への督促は設定の**最短間隔**内は再送できません。', en: 'Real delivery needs SMTP configured (otherwise log-only). Also, dunning the same invoice is blocked within the configured **minimum interval**.' },
+          },
+          {
+            q: { ja: 'CSVを全期間で出したい。', en: 'I want to export the full period in CSV.' },
+            a: { ja: '日付範囲が当会計年度で初期設定されています。絞り込みの**クリア**を押してから「CSV出力」してください。', en: 'The date range defaults to the current fiscal year. Press **Clear** on the filters, then “Export CSV”.' },
+          },
+          {
+            q: { ja: 'しばらく操作していなかったら画面が変わりました。', en: 'The screen changed after I was idle.' },
+            a: { ja: 'セッションが切れると、その場にログイン画面が表示されます。再ログインすると元の画面に戻れます。', en: 'When your session expires, the login screen appears in place. Sign in again to return to the same screen.' },
+          },
+        ],
+      },
+    ],
+  },
+]

--- a/frontend/src/pages/help/help-content.ts
+++ b/frontend/src/pages/help/help-content.ts
@@ -33,6 +33,8 @@ export interface HelpSection {
   /** Anchor id (also the ToC target). */
   id: string
   title: Bi
+  /** Sprite icon name (`#i-<icon>`) shown beside the section heading. */
+  icon?: string
   /** Marks the section as admin-only (badge in the ToC and the heading). */
   admin?: boolean
   blocks: HelpBlock[]
@@ -54,8 +56,8 @@ export const HELP_LABELS = {
   backToToc: { ja: '目次へ戻る', en: 'Back to contents' },
   footTitle: { ja: '解決しませんでしたか？', en: 'Still need help?' },
   footDesc: {
-    ja: '管理者にお問い合わせいただくか、キーボードショートカット一覧（? キー）もご活用ください。',
-    en: 'Contact your administrator, or press ? for the keyboard-shortcut list.',
+    ja: '管理者にお問い合わせいただくか、キーボードショートカット一覧（`?` キー）もご活用ください。',
+    en: 'Contact your administrator, or press `?` for the keyboard-shortcut list.',
   },
 } as const
 
@@ -100,6 +102,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'dashboard',
     title: { ja: 'ダッシュボード', en: 'Dashboard' },
+    icon: 'grid',
     blocks: [
       {
         kind: 'lede',
@@ -120,6 +123,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'import',
     title: { ja: '銀行CSVの取込', en: 'Importing bank CSV' },
+    icon: 'import',
     blocks: [
       {
         kind: 'lede',
@@ -148,6 +152,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'reconcile',
     title: { ja: '入金の消込', en: 'Reconciling deposits' },
+    icon: 'reconcile',
     blocks: [
       {
         kind: 'lede',
@@ -186,6 +191,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'credits',
     title: { ja: '前受金', en: 'Client credits' },
+    icon: 'credit',
     blocks: [
       {
         kind: 'lede',
@@ -207,6 +213,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'dunning',
     title: { ja: '督促', en: 'Dunning' },
+    icon: 'bell',
     blocks: [
       {
         kind: 'lede',
@@ -235,6 +242,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'export',
     title: { ja: 'CSVエクスポート', en: 'CSV export' },
+    icon: 'export',
     blocks: [
       {
         kind: 'lede',
@@ -255,6 +263,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'settings',
     title: { ja: '設定', en: 'Settings' },
+    icon: 'gear',
     admin: true,
     blocks: [
       {
@@ -278,6 +287,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'users',
     title: { ja: 'ユーザー管理（招待）', en: 'User management (invitations)' },
+    icon: 'users',
     admin: true,
     blocks: [
       {
@@ -296,17 +306,41 @@ export const HELP_SECTIONS: HelpSection[] = [
         ],
       },
       {
-        kind: 'note',
-        text: {
-          ja: 'ロールは **管理者 / オペレーター / 閲覧者**。オペレーターは消込・督促が可能、閲覧者は閲覧のみ。管理者だけが設定・ユーザー管理・監査ログにアクセスできます。',
-          en: 'Roles are **admin / operator / viewer**. Operators can reconcile and dun; viewers are read-only. Only admins reach Settings, Users, and the audit log.',
-        },
+        kind: 'subhead',
+        text: { ja: 'ロール', en: 'Roles' },
+      },
+      {
+        kind: 'options',
+        items: [
+          {
+            title: { ja: '管理者', en: 'Admin' },
+            desc: {
+              ja: 'すべての操作に加え、設定・ユーザー管理・監査ログにアクセスできます。',
+              en: 'Everything operators can do, plus access to Settings, user management, and the audit log.',
+            },
+          },
+          {
+            title: { ja: 'オペレーター', en: 'Operator' },
+            desc: {
+              ja: '消込・督促を含む日常業務を実行できます。管理機能は不可。',
+              en: 'Runs day-to-day work including reconciliation and dunning. No admin functions.',
+            },
+          },
+          {
+            title: { ja: '閲覧者', en: 'Viewer' },
+            desc: {
+              ja: 'データの閲覧のみ。消込・督促などの実行はできません。',
+              en: 'Read-only. Cannot reconcile, dun, or make other changes.',
+            },
+          },
+        ],
       },
     ],
   },
   {
     id: 'audit',
     title: { ja: '監査ログ', en: 'Audit log' },
+    icon: 'shield',
     admin: true,
     blocks: [
       {
@@ -321,6 +355,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'keys',
     title: { ja: 'キーボードショートカット', en: 'Keyboard shortcuts' },
+    icon: 'key',
     blocks: [
       {
         kind: 'lede',
@@ -363,6 +398,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'faq',
     title: { ja: 'よくある質問', en: 'FAQ' },
+    icon: 'help',
     blocks: [
       {
         kind: 'faq',
@@ -394,6 +430,7 @@ export const HELP_SECTIONS: HelpSection[] = [
   {
     id: 'disclaimer',
     title: { ja: '免責事項・ご利用にあたって', en: 'Disclaimer & terms of use' },
+    icon: 'doc',
     blocks: [
       {
         kind: 'lede',

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -99,7 +99,10 @@ export default function LoginPage() {
             </Button>
             {error && <Notice variant="bad">{error}</Notice>}
           </form>
-          <p className="faint" style={{ textAlign: 'center', marginTop: 26, fontSize: '11.5px' }}>
+          <p className="faint" style={{ textAlign: 'center', marginTop: 22, fontSize: '11px', lineHeight: 1.7 }}>
+            {t('login.disclaimer')}
+          </p>
+          <p className="faint" style={{ textAlign: 'center', marginTop: 10, fontSize: '11.5px' }}>
             {t('login.copyright')}
           </p>
         </div>

--- a/frontend/src/styles/design.css
+++ b/frontend/src/styles/design.css
@@ -707,6 +707,10 @@ tr.filter-empty:hover td{ background:var(--surface) !important; }
 /* ===== list row cursor (j/k highlight) ===== */
 tr.is-cursor, .is-cursor { background: var(--navy-100); box-shadow: inset 3px 0 0 var(--accent); }
 
+/* sidebar disclaimer link */
+.side-legal { display: inline-block; margin-top: 10px; font-size: 11px; color: var(--side-fg); opacity: .75; text-decoration: none; }
+.side-legal:hover { color: var(--side-fg-strong); opacity: 1; text-decoration: underline; }
+
 /* ===== Help page (ported from nene-invoice design 05, Clear tokens) ===== */
 .help-page { max-width: 1040px; margin: 0 auto; padding-bottom: 40px; }
 .help-hero { padding: 26px 0 22px; border-bottom: 1px solid var(--line); margin-bottom: 24px; }

--- a/frontend/src/styles/design.css
+++ b/frontend/src/styles/design.css
@@ -706,3 +706,100 @@ tr.filter-empty:hover td{ background:var(--surface) !important; }
 
 /* ===== list row cursor (j/k highlight) ===== */
 tr.is-cursor, .is-cursor { background: var(--navy-100); box-shadow: inset 3px 0 0 var(--accent); }
+
+/* ===== Help page (ported from nene-invoice design 05, Clear tokens) ===== */
+.help-page { max-width: 1040px; margin: 0 auto; padding-bottom: 40px; }
+.help-hero { padding: 26px 0 22px; border-bottom: 1px solid var(--line); margin-bottom: 24px; }
+.help-hero .eyebrow { font-size: 11.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); }
+.help-hero h1 { font-size: 27px; font-weight: 700; color: var(--ink); margin: 8px 0 10px; }
+.help-hero p { font-size: 13.5px; line-height: 1.85; color: var(--muted); max-width: 760px; margin: 0; }
+.hero-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+.hero-chip { font-size: 11.5px; color: var(--ink); background: var(--surface-2); border: 1px solid var(--line); padding: 4px 10px; border-radius: var(--radius); }
+.hero-chip .num { font-family: var(--mono); }
+
+.help-layout { display: grid; grid-template-columns: 220px 1fr; gap: 32px; align-items: start; }
+
+.help-toc { position: sticky; top: 72px; display: flex; flex-direction: column; gap: 1px; }
+.help-toc .toc-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--faint); padding: 0 10px 8px; }
+.help-toc a { display: flex; align-items: baseline; gap: 9px; padding: 7px 10px; font-size: 12.5px; color: var(--muted); text-decoration: none; border-left: 2px solid transparent; }
+.help-toc a:hover { color: var(--ink); background: var(--surface-2); }
+.help-toc a.active { color: var(--ink); font-weight: 600; border-left-color: var(--accent); background: var(--surface-2); }
+.help-toc a .tn { font-family: var(--mono); font-size: 11px; color: var(--faint); }
+.help-toc a.admin-only::after { content: "管理者"; font-size: 9.5px; font-weight: 700; color: var(--warn); background: var(--warn-bg); border: 1px solid var(--warn-line); padding: 0 5px; margin-left: auto; align-self: center; }
+
+.help-article { min-width: 0; }
+.hsec { scroll-margin-top: 76px; padding-bottom: 28px; margin-bottom: 28px; border-bottom: 1px solid var(--line); }
+.hsec:last-of-type { border-bottom: 0; }
+.hsec-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+.hsec-no { font-family: var(--mono); font-size: 13px; font-weight: 700; color: #fff; background: var(--primary); width: 30px; height: 30px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius); }
+.hsec h2 { font-size: 18px; font-weight: 700; color: var(--ink); margin: 0; display: flex; align-items: center; gap: 10px; }
+.tag-admin { font-size: 10px; font-weight: 700; color: var(--warn); background: var(--warn-bg); border: 1px solid var(--warn-line); padding: 1px 7px; border-radius: var(--radius); }
+
+.help-article .lede { font-size: 13.5px; line-height: 1.9; color: var(--ink); margin: 0 0 12px; }
+.help-article .sub-h { font-size: 12px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--faint); margin: 18px 0 10px; }
+
+.steps { list-style: none; counter-reset: st; margin: 4px 0 14px; padding: 0; }
+.steps li { counter-increment: st; position: relative; padding: 0 0 16px 38px; }
+.steps li::before { content: counter(st); position: absolute; left: 0; top: 0; width: 26px; height: 26px; display: inline-flex; align-items: center; justify-content: center; font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--accent); background: var(--surface-2); border: 1px solid var(--line); border-radius: 50%; }
+.steps li:not(:last-child)::after { content: ""; position: absolute; left: 13px; top: 28px; bottom: 2px; width: 1px; background: var(--line); }
+.steps .st-t { font-size: 13px; font-weight: 700; color: var(--ink); margin-bottom: 3px; }
+.steps .st-d { font-size: 12.5px; line-height: 1.8; color: var(--muted); }
+
+.proc { margin: 4px 0 14px; padding-left: 22px; }
+.proc li { font-size: 12.5px; line-height: 1.85; color: var(--muted); margin-bottom: 6px; }
+
+.flow { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 6px 0 16px; }
+.flow .fchip { font-size: 12px; font-weight: 600; color: var(--ink); background: var(--surface-2); border: 1px solid var(--line); padding: 6px 12px; border-radius: var(--radius); }
+.flow .farrow { color: var(--faint); font-weight: 700; }
+.flow .fbranch { font-size: 11.5px; color: var(--muted); margin-left: 4px; }
+
+.terms { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 6px 0 14px; }
+.terms .term { border: 1px solid var(--line); background: var(--surface); padding: 12px 14px; border-radius: var(--radius); }
+.terms dt { font-size: 12.5px; font-weight: 700; color: var(--ink); margin-bottom: 4px; }
+.terms dd { font-size: 12px; line-height: 1.75; color: var(--muted); margin: 0; }
+
+.deflist { margin: 6px 0 14px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+.deflist .row { display: grid; grid-template-columns: 200px 1fr; gap: 14px; padding: 11px 14px; border-bottom: 1px solid var(--line); }
+.deflist .row:last-child { border-bottom: 0; }
+.deflist .dl-t { font-size: 12.5px; font-weight: 700; color: var(--ink); }
+.deflist .dl-d { font-size: 12.5px; line-height: 1.75; color: var(--muted); }
+
+.note { display: flex; gap: 10px; font-size: 12.5px; line-height: 1.8; color: var(--ink); background: var(--info-bg); border: 1px solid var(--info-line); border-left: 3px solid var(--info); padding: 11px 14px; margin: 6px 0 14px; }
+.note.warn { background: var(--warn-bg); border-color: var(--warn-line); border-left-color: var(--warn); }
+.note .nt { font-weight: 700; margin-right: 4px; }
+
+.opt3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 6px 0 14px; }
+.opt { border: 1px solid var(--line); background: var(--surface); padding: 14px; border-radius: var(--radius); }
+.opt-n { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--accent); }
+.opt-t { font-size: 12.5px; font-weight: 700; color: var(--ink); margin: 6px 0 5px; }
+.opt-d { font-size: 12px; line-height: 1.7; color: var(--muted); }
+
+.kgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 4px 0 14px; }
+.kr { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 12px; border: 1px solid var(--line); background: var(--surface); border-radius: var(--radius); }
+.kr .kl { font-size: 12.5px; color: var(--ink); }
+.kr .kk { display: inline-flex; gap: 4px; }
+
+.faq { display: flex; flex-direction: column; gap: 8px; margin: 4px 0 6px; }
+.faq details { border: 1px solid var(--line); background: var(--surface); border-radius: var(--radius); }
+.faq summary { display: flex; align-items: center; gap: 10px; padding: 12px 14px; cursor: pointer; list-style: none; }
+.faq summary::-webkit-details-marker { display: none; }
+.faq .q { font-family: var(--mono); font-weight: 700; color: var(--accent); }
+.faq .qt { font-size: 13px; font-weight: 600; color: var(--ink); flex: 1; }
+.faq .chev { color: var(--faint); transition: transform .15s; }
+.faq details[open] .chev { transform: rotate(180deg); }
+.faq .fa-body { padding: 0 14px 14px 36px; font-size: 12.5px; line-height: 1.85; color: var(--muted); }
+
+.backtop { display: inline-block; margin-top: 12px; font-size: 11.5px; color: var(--faint); text-decoration: none; }
+.backtop:hover { color: var(--accent); }
+
+.help-foot { margin-top: 32px; padding: 18px 20px; background: var(--surface-2); border: 1px solid var(--line); }
+.help-foot .hf-t { font-size: 13px; font-weight: 700; color: var(--ink); }
+.help-foot .hf-d { font-size: 12px; color: var(--muted); margin-top: 3px; }
+
+.tcode { font-family: var(--mono); font-size: .92em; background: var(--surface-2); border: 1px solid var(--line); padding: 0 5px; border-radius: var(--radius-sm); }
+
+@media (max-width: 900px) {
+  .help-layout { grid-template-columns: 1fr; }
+  .help-toc { display: none; }
+  .terms, .opt3, .kgrid, .deflist .row { grid-template-columns: 1fr; }
+}

--- a/frontend/src/styles/design.css
+++ b/frontend/src/styles/design.css
@@ -711,99 +711,224 @@ tr.is-cursor, .is-cursor { background: var(--navy-100); box-shadow: inset 3px 0 
 .side-legal { display: inline-block; margin-top: 10px; font-size: 11px; color: var(--side-fg); opacity: .75; text-decoration: none; }
 .side-legal:hover { color: var(--side-fg-strong); opacity: 1; text-decoration: underline; }
 
-/* ===== Help page (ported from nene-invoice design 05, Clear tokens) ===== */
-.help-page { max-width: 1040px; margin: 0 auto; padding-bottom: 40px; }
-.help-hero { padding: 26px 0 22px; border-bottom: 1px solid var(--line); margin-bottom: 24px; }
-.help-hero .eyebrow { font-size: 11.5px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); }
-.help-hero h1 { font-size: 27px; font-weight: 700; color: var(--ink); margin: 8px 0 10px; }
-.help-hero p { font-size: 13.5px; line-height: 1.85; color: var(--muted); max-width: 760px; margin: 0; }
-.hero-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
-.hero-chip { font-size: 11.5px; color: var(--ink); background: var(--surface-2); border: 1px solid var(--line); padding: 4px 10px; border-radius: var(--radius); }
-.hero-chip .num { font-family: var(--mono); }
+/* =========================================================================
+   Help page (操作ガイド・よくある質問) — app-shell-native, design handoff.
+   Class names match HelpPage.tsx. Hero bleeds to the topbar/edges inside .page.
+   ========================================================================= */
 
-.help-layout { display: grid; grid-template-columns: 220px 1fr; gap: 32px; align-items: start; }
+/* ---- page frame inside the app shell ---------------------------------- */
+.help-page{ width:100%; padding-bottom:8px; }
 
-.help-toc { position: sticky; top: 72px; display: flex; flex-direction: column; gap: 1px; }
-.help-toc .toc-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--faint); padding: 0 10px 8px; }
-.help-toc a { display: flex; align-items: baseline; gap: 9px; padding: 7px 10px; font-size: 12.5px; color: var(--muted); text-decoration: none; border-left: 2px solid transparent; }
-.help-toc a:hover { color: var(--ink); background: var(--surface-2); }
-.help-toc a.active { color: var(--ink); font-weight: 600; border-left-color: var(--accent); background: var(--surface-2); }
-.help-toc a .tn { font-family: var(--mono); font-size: 11px; color: var(--faint); }
-.help-toc a.admin-only::after { content: "管理者"; font-size: 9.5px; font-weight: 700; color: var(--warn); background: var(--warn-bg); border: 1px solid var(--warn-line); padding: 0 5px; margin-left: auto; align-self: center; }
+/* On the help doc, let the header band run edge-to-edge at ANY width
+   (no 1760 cap → no grey gutters beside the band). The reading column
+   below still centers at a readable width. Scoped to this page only. */
+.page:has(> .help-page){ max-width:none; }
 
-.help-article { min-width: 0; }
-.hsec { scroll-margin-top: 76px; padding-bottom: 28px; margin-bottom: 28px; border-bottom: 1px solid var(--line); }
-.hsec:last-of-type { border-bottom: 0; }
-.hsec-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
-.hsec-no { font-family: var(--mono); font-size: 13px; font-weight: 700; color: #fff; background: var(--primary); width: 30px; height: 30px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius); }
-.hsec h2 { font-size: 18px; font-weight: 700; color: var(--ink); margin: 0; display: flex; align-items: center; gap: 10px; }
-.tag-admin { font-size: 10px; font-weight: 700; color: var(--warn); background: var(--warn-bg); border: 1px solid var(--warn-line); padding: 1px 7px; border-radius: var(--radius); }
+/* ---- hero: light header band; navy used only as accent ---------------- */
+.help-hero{
+  position:relative; overflow:hidden;
+  background:var(--surface); color:var(--ink);
+  /* bleed up to the topbar and out to the content edges (cancels .page padding) */
+  margin:-24px calc(-1 * clamp(28px,2.6vw,56px)) 30px;
+  padding:30px clamp(28px,2.6vw,56px) 28px;
+  border-bottom:1px solid var(--line);
+}
+.help-hero::after{ content:none; }
+.help-hero .hero-grid{ display:none; }
+.help-hero > .hero-inner{ position:relative; z-index:1; max-width:1080px; margin:0 auto; }
+.help-hero .eyebrow{
+  display:inline-flex; align-items:center; gap:7px;
+  font-size:11px; font-weight:700; letter-spacing:.12em; text-transform:uppercase;
+  color:var(--accent);
+}
+.help-hero .eyebrow .ic{ width:15px; height:15px; }
+.help-hero h1{ font-size:25px; font-weight:700; letter-spacing:.01em; color:var(--ink); margin:9px 0 10px; }
+.help-hero p{ font-size:13px; line-height:1.85; color:var(--muted); max-width:760px; margin:0; }
+.hero-meta{ display:flex; flex-wrap:wrap; gap:8px; margin-top:18px; }
+.hero-chip{
+  display:inline-flex; align-items:center; gap:7px; white-space:nowrap; flex:none;
+  font-size:11.5px; color:var(--ink-2); background:var(--surface-2);
+  border:1px solid var(--line); padding:5px 11px; border-radius:var(--radius);
+}
+.hero-chip b{ color:var(--ink); font-weight:700; }
+.hero-chip .num{ font-family:var(--mono); color:var(--ink); }
+.hero-chip .ic{ width:14px; height:14px; color:var(--accent); }
 
-.help-article .lede { font-size: 13.5px; line-height: 1.9; color: var(--ink); margin: 0 0 12px; }
-.help-article .sub-h { font-size: 12px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--faint); margin: 18px 0 10px; }
+/* ---- layout: sticky ToC + article ------------------------------------- */
+.help-layout{ max-width:1080px; margin:0 auto; display:grid; grid-template-columns:228px 1fr; gap:40px; align-items:start; }
 
-.steps { list-style: none; counter-reset: st; margin: 4px 0 14px; padding: 0; }
-.steps li { counter-increment: st; position: relative; padding: 0 0 16px 38px; }
-.steps li::before { content: counter(st); position: absolute; left: 0; top: 0; width: 26px; height: 26px; display: inline-flex; align-items: center; justify-content: center; font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--accent); background: var(--surface-2); border: 1px solid var(--line); border-radius: 50%; }
-.steps li:not(:last-child)::after { content: ""; position: absolute; left: 13px; top: 28px; bottom: 2px; width: 1px; background: var(--line); }
-.steps .st-t { font-size: 13px; font-weight: 700; color: var(--ink); margin-bottom: 3px; }
-.steps .st-d { font-size: 12.5px; line-height: 1.8; color: var(--muted); }
+.help-toc{ position:sticky; top:20px; display:flex; flex-direction:column; gap:1px; }
+.help-toc .toc-title{
+  font-size:10px; font-weight:700; letter-spacing:.14em; text-transform:uppercase;
+  color:var(--faint); padding:0 12px 9px; border-bottom:1px solid var(--line); margin-bottom:7px;
+}
+.help-toc a{
+  display:flex; align-items:center; gap:10px; padding:7px 12px;
+  font-size:12.5px; color:var(--muted); text-decoration:none;
+  border-left:2px solid transparent; transition:color .12s, background .12s, border-color .12s;
+}
+.help-toc a:hover{ color:var(--ink); background:var(--surface-2); }
+.help-toc a.active{ color:var(--navy-700); font-weight:700; border-left-color:var(--navy-600); background:var(--navy-50); }
+.help-toc a .tn{ font-family:var(--mono); font-size:11px; color:var(--faint); flex:none; width:16px; }
+.help-toc a.active .tn{ color:var(--navy-500); }
+.help-toc a .tt{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.help-toc a.admin-only .tt::after{
+  content:"管理者"; display:inline-block; font-size:9px; font-weight:700; line-height:1.4;
+  color:var(--warn); background:var(--warn-bg); border:1px solid var(--warn-line);
+  padding:0 5px; margin-left:7px; vertical-align:1px;
+}
 
-.proc { margin: 4px 0 14px; padding-left: 22px; }
-.proc li { font-size: 12.5px; line-height: 1.85; color: var(--muted); margin-bottom: 6px; }
+/* ---- article ----------------------------------------------------------- */
+.help-article{ min-width:0; }
+.hsec{ scroll-margin-top:20px; padding-bottom:34px; margin-bottom:34px; border-bottom:1px solid var(--line); }
+.hsec:last-of-type{ border-bottom:0; padding-bottom:8px; }
 
-.flow { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 6px 0 16px; }
-.flow .fchip { font-size: 12px; font-weight: 600; color: var(--ink); background: var(--surface-2); border: 1px solid var(--line); padding: 6px 12px; border-radius: var(--radius); }
-.flow .farrow { color: var(--faint); font-weight: 700; }
-.flow .fbranch { font-size: 11.5px; color: var(--muted); margin-left: 4px; }
+.hsec-head{ display:flex; align-items:center; gap:13px; margin-bottom:16px; }
+.hsec-no{
+  font-family:var(--mono); font-size:13px; font-weight:700; color:#fff; background:var(--primary);
+  width:30px; height:30px; flex:none; display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--radius);
+}
+.hsec-ic{
+  width:30px; height:30px; flex:none; display:inline-flex; align-items:center; justify-content:center;
+  background:var(--navy-50); color:var(--navy-600); border:1px solid var(--navy-100); border-radius:var(--radius);
+}
+.hsec-ic .ic{ width:17px; height:17px; }
+.hsec h2{ font-size:19px; font-weight:700; color:var(--ink); margin:0; display:flex; align-items:center; gap:10px; }
+.tag-admin{
+  font-size:10px; font-weight:700; color:var(--warn); background:var(--warn-bg);
+  border:1px solid var(--warn-line); padding:1px 7px; border-radius:var(--radius);
+}
 
-.terms { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 6px 0 14px; }
-.terms .term { border: 1px solid var(--line); background: var(--surface); padding: 12px 14px; border-radius: var(--radius); }
-.terms dt { font-size: 12.5px; font-weight: 700; color: var(--ink); margin-bottom: 4px; }
-.terms dd { font-size: 12px; line-height: 1.75; color: var(--muted); margin: 0; }
+.help-article .lede{ font-size:13.5px; line-height:1.95; color:var(--ink-2); margin:0 0 13px; }
+.help-article .lede b{ color:var(--ink); font-weight:700; }
+.help-article .sub-h{
+  font-size:11px; font-weight:700; letter-spacing:.1em; text-transform:uppercase;
+  color:var(--faint); margin:22px 0 11px; display:flex; align-items:center; gap:9px;
+}
+.help-article .sub-h::after{ content:""; flex:1; height:1px; background:var(--line); }
 
-.deflist { margin: 6px 0 14px; border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
-.deflist .row { display: grid; grid-template-columns: 200px 1fr; gap: 14px; padding: 11px 14px; border-bottom: 1px solid var(--line); }
-.deflist .row:last-child { border-bottom: 0; }
-.deflist .dl-t { font-size: 12.5px; font-weight: 700; color: var(--ink); }
-.deflist .dl-d { font-size: 12.5px; line-height: 1.75; color: var(--muted); }
+/* ---- steps (numbered, connector line) --------------------------------- */
+.steps{ list-style:none; counter-reset:st; margin:6px 0 16px; padding:0; }
+.steps li{ counter-increment:st; position:relative; padding:0 0 18px 40px; }
+.steps li:last-child{ padding-bottom:0; }
+.steps li::before{
+  content:counter(st); position:absolute; left:0; top:-1px; width:27px; height:27px;
+  display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--mono); font-size:12px; font-weight:700; color:var(--navy-600);
+  background:var(--surface); border:1px solid var(--line-strong); border-radius:50%; z-index:1;
+}
+.steps li:not(:last-child)::after{
+  content:""; position:absolute; left:13px; top:28px; bottom:4px; width:1px; background:var(--line-strong);
+}
+.steps .st-t{ font-size:13px; font-weight:700; color:var(--ink); margin-bottom:4px; }
+.steps .st-d{ font-size:12.5px; line-height:1.85; color:var(--muted); }
+.steps .st-d b{ color:var(--ink-2); }
 
-.note { display: flex; gap: 10px; font-size: 12.5px; line-height: 1.8; color: var(--ink); background: var(--info-bg); border: 1px solid var(--info-line); border-left: 3px solid var(--info); padding: 11px 14px; margin: 6px 0 14px; }
-.note.warn { background: var(--warn-bg); border-color: var(--warn-line); border-left-color: var(--warn); }
-.note .nt { font-weight: 700; margin-right: 4px; }
+/* ---- plain procedure list --------------------------------------------- */
+.proc{ margin:6px 0 16px; padding-left:0; list-style:none; counter-reset:pc; }
+.proc li{
+  counter-increment:pc; position:relative; padding:5px 0 5px 30px;
+  font-size:12.5px; line-height:1.85; color:var(--muted);
+}
+.proc li::before{
+  content:counter(pc); position:absolute; left:0; top:5px;
+  font-family:var(--mono); font-size:11px; font-weight:700; color:var(--navy-500);
+}
+.proc li + li{ border-top:1px solid var(--line); }
 
-.opt3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin: 6px 0 14px; }
-.opt { border: 1px solid var(--line); background: var(--surface); padding: 14px; border-radius: var(--radius); }
-.opt-n { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--accent); }
-.opt-t { font-size: 12.5px; font-weight: 700; color: var(--ink); margin: 6px 0 5px; }
-.opt-d { font-size: 12px; line-height: 1.7; color: var(--muted); }
+/* ---- flow (chips + arrows) -------------------------------------------- */
+.flow{ display:flex; flex-wrap:wrap; align-items:center; gap:9px; margin:8px 0 18px;
+  padding:14px 16px; background:var(--surface-2); border:1px solid var(--line); }
+.flow .fchip{
+  font-size:12px; font-weight:700; color:var(--ink); background:var(--surface);
+  border:1px solid var(--line-strong); padding:7px 13px; border-radius:var(--radius);
+}
+.flow .farrow{ color:var(--navy-400); font-weight:700; font-size:14px; }
+.flow .fbranch{ font-size:11.5px; color:var(--muted); margin-left:6px;
+  padding-left:12px; border-left:1px solid var(--line-strong); }
 
-.kgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 4px 0 14px; }
-.kr { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 7px 12px; border: 1px solid var(--line); background: var(--surface); border-radius: var(--radius); }
-.kr .kl { font-size: 12.5px; color: var(--ink); }
-.kr .kk { display: inline-flex; gap: 4px; }
+/* ---- terms (definition cards) ----------------------------------------- */
+.terms{ display:grid; grid-template-columns:1fr 1fr; gap:12px; margin:8px 0 16px; }
+.terms .term{ border:1px solid var(--line); background:var(--surface); padding:13px 15px; border-radius:var(--radius); }
+.terms dt{ font-size:12.5px; font-weight:700; color:var(--ink); margin-bottom:5px; }
+.terms dd{ font-size:12px; line-height:1.75; color:var(--muted); margin:0; }
 
-.faq { display: flex; flex-direction: column; gap: 8px; margin: 4px 0 6px; }
-.faq details { border: 1px solid var(--line); background: var(--surface); border-radius: var(--radius); }
-.faq summary { display: flex; align-items: center; gap: 10px; padding: 12px 14px; cursor: pointer; list-style: none; }
-.faq summary::-webkit-details-marker { display: none; }
-.faq .q { font-family: var(--mono); font-weight: 700; color: var(--accent); }
-.faq .qt { font-size: 13px; font-weight: 600; color: var(--ink); flex: 1; }
-.faq .chev { color: var(--faint); transition: transform .15s; }
-.faq details[open] .chev { transform: rotate(180deg); }
-.faq .fa-body { padding: 0 14px 14px 36px; font-size: 12.5px; line-height: 1.85; color: var(--muted); }
+/* ---- deflist (key | value rows) --------------------------------------- */
+.deflist{ margin:8px 0 16px; border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--surface); }
+.deflist .row{ display:grid; grid-template-columns:208px 1fr; gap:16px; padding:12px 16px; border-bottom:1px solid var(--line); align-items:baseline; }
+.deflist .row:last-child{ border-bottom:0; }
+.deflist .row:nth-child(even){ background:var(--surface-2); }
+.deflist .dl-t{ font-size:12.5px; font-weight:700; color:var(--ink); }
+.deflist .dl-d{ font-size:12.5px; line-height:1.8; color:var(--muted); }
 
-.backtop { display: inline-block; margin-top: 12px; font-size: 11.5px; color: var(--faint); text-decoration: none; }
-.backtop:hover { color: var(--accent); }
+/* ---- note / callout ---------------------------------------------------- */
+.note{
+  display:flex; gap:11px; font-size:12.5px; line-height:1.85; color:var(--ink-2);
+  background:var(--info-bg); border:1px solid var(--info-line); border-left:3px solid var(--info);
+  padding:12px 15px; margin:8px 0 16px; border-radius:var(--radius);
+}
+.note .note-ic{ flex:none; color:var(--info); margin-top:1px; }
+.note .note-ic .ic{ width:17px; height:17px; }
+.note.warn{ background:var(--warn-bg); border-color:var(--warn-line); border-left-color:var(--warn); color:var(--ink-2); }
+.note.warn .note-ic{ color:var(--warn); }
+.note b{ color:var(--ink); font-weight:700; }
+.note .nt{ font-weight:700; margin-right:2px; color:inherit; }
 
-.help-foot { margin-top: 32px; padding: 18px 20px; background: var(--surface-2); border: 1px solid var(--line); }
-.help-foot .hf-t { font-size: 13px; font-weight: 700; color: var(--ink); }
-.help-foot .hf-d { font-size: 12px; color: var(--muted); margin-top: 3px; }
+/* ---- options (3-up cards) --------------------------------------------- */
+.opt3{ display:grid; grid-template-columns:repeat(3,1fr); gap:14px; margin:8px 0 16px; }
+.opt{ border:1px solid var(--line); background:var(--surface); padding:15px; border-radius:var(--radius);
+  border-top:2px solid var(--navy-400); }
+.opt-n{ font-family:var(--mono); font-size:11px; font-weight:700; color:var(--navy-500); }
+.opt-t{ font-size:12.5px; font-weight:700; color:var(--ink); margin:7px 0 6px; }
+.opt-d{ font-size:12px; line-height:1.75; color:var(--muted); }
 
-.tcode { font-family: var(--mono); font-size: .92em; background: var(--surface-2); border: 1px solid var(--line); padding: 0 5px; border-radius: var(--radius-sm); }
+/* ---- keyboard shortcuts grid ------------------------------------------ */
+.kgrid{ display:grid; grid-template-columns:1fr 1fr; gap:9px; margin:6px 0 16px; }
+.kr{ display:flex; align-items:center; justify-content:space-between; gap:12px;
+  padding:9px 13px; border:1px solid var(--line); background:var(--surface); border-radius:var(--radius); }
+.kr .kl{ font-size:12.5px; color:var(--ink-2); }
+.kr .kk{ display:inline-flex; gap:5px; }
 
-@media (max-width: 900px) {
-  .help-layout { grid-template-columns: 1fr; }
-  .help-toc { display: none; }
-  .terms, .opt3, .kgrid, .deflist .row { grid-template-columns: 1fr; }
+/* ---- faq (accordion) --------------------------------------------------- */
+.faq{ display:flex; flex-direction:column; gap:9px; margin:6px 0 6px; }
+.faq details{ border:1px solid var(--line); background:var(--surface); border-radius:var(--radius); transition:border-color .12s; }
+.faq details[open]{ border-color:var(--line-strong); }
+.faq summary{ display:flex; align-items:center; gap:12px; padding:13px 15px; cursor:pointer; list-style:none; }
+.faq summary::-webkit-details-marker{ display:none; }
+.faq summary:hover{ background:var(--surface-2); }
+.faq .q{ font-family:var(--mono); font-weight:700; color:#fff; background:var(--navy-500);
+  width:22px; height:22px; flex:none; display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--radius); font-size:12px; }
+.faq .qt{ font-size:13px; font-weight:600; color:var(--ink); flex:1; }
+.faq .chev{ color:var(--faint); transition:transform .18s; flex:none; }
+.faq details[open] .chev{ transform:rotate(180deg); color:var(--navy-500); }
+.faq .fa-body{ padding:2px 15px 15px 49px; font-size:12.5px; line-height:1.9; color:var(--muted); }
+.faq .fa-body b{ color:var(--ink-2); }
+
+/* ---- back-to-top link -------------------------------------------------- */
+.backtop{ display:inline-flex; align-items:center; gap:5px; margin-top:14px;
+  font-size:11.5px; color:var(--faint); text-decoration:none; }
+.backtop .ic{ width:13px; height:13px; }
+.backtop:hover{ color:var(--navy-500); }
+
+/* ---- footer CTA -------------------------------------------------------- */
+.help-foot{ display:flex; align-items:center; gap:16px; margin-top:8px;
+  padding:20px 22px; background:var(--navy-50); border:1px solid var(--navy-100); border-radius:var(--radius); }
+.help-foot .hf-ic{ width:40px; height:40px; flex:none; display:flex; align-items:center; justify-content:center;
+  background:var(--surface); color:var(--navy-600); border:1px solid var(--navy-100); border-radius:var(--radius); }
+.help-foot .hf-ic .ic{ width:21px; height:21px; }
+.help-foot .hf-t{ font-size:13.5px; font-weight:700; color:var(--ink); }
+.help-foot .hf-d{ font-size:12px; color:var(--muted); margin-top:3px; }
+
+/* ---- inline code ------------------------------------------------------- */
+.tcode{ font-family:var(--mono); font-size:.9em; background:var(--surface-2);
+  border:1px solid var(--line); padding:1px 6px; border-radius:var(--radius-sm); color:var(--navy-700); }
+
+/* ---- responsive -------------------------------------------------------- */
+@media (max-width:900px){
+  .help-layout{ grid-template-columns:1fr; gap:0; }
+  .help-toc{ display:none; }
+  .terms, .opt3, .kgrid, .deflist .row{ grid-template-columns:1fr; }
+  .deflist .row{ gap:4px; }
 }

--- a/tests/e2e/specs/16-help.spec.ts
+++ b/tests/e2e/specs/16-help.spec.ts
@@ -24,4 +24,18 @@ test.describe('Help page', () => {
     await page.goto('/admin/help')
     await expect(page.locator('.help-toc a.admin-only').first()).toBeVisible()
   })
+
+  test('sidebar disclaimer link opens the help disclaimer section', async ({ page }) => {
+    await bypassLogin(page)
+    await page.goto('/admin')
+    await page.getByRole('link', { name: '免責事項' }).click()
+    await expect(page).toHaveURL(/\/admin\/help#disclaimer$/)
+    await expect(page.getByRole('heading', { level: 2, name: /免責事項/ })).toBeVisible()
+  })
+
+  test('login screen shows the warranty disclaimer', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.locator('input[name="email"]')).toBeVisible()
+    await expect(page.getByText(/MIT ライセンス/)).toBeVisible()
+  })
 })

--- a/tests/e2e/specs/16-help.spec.ts
+++ b/tests/e2e/specs/16-help.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { bypassLogin, navTo } from '../fixtures/helpers'
+
+test.describe('Help page', () => {
+  test('reachable from the sidebar; shows hero, ToC and an FAQ', async ({ page }) => {
+    await bypassLogin(page)
+    await page.goto('/admin')
+    await navTo(page, 'ヘルプ', /\/admin\/help/)
+
+    // Hero + table of contents render.
+    await expect(page.getByRole('heading', { level: 1, name: '操作ガイド・よくある質問' })).toBeVisible()
+    await expect(page.locator('.help-toc a').first()).toBeVisible()
+
+    // ToC jumps to a section anchor.
+    await page.locator('.help-toc a', { hasText: '督促' }).click()
+    await expect(page).toHaveURL(/#dunning$/)
+
+    // FAQ accordion: first item is open by default.
+    await expect(page.locator('.faq details').first()).toHaveAttribute('open', '')
+  })
+
+  test('admin-only sections are badged in the contents', async ({ page }) => {
+    await bypassLogin(page)
+    await page.goto('/admin/help')
+    await expect(page.locator('.help-toc a.admin-only').first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
Closes #159

## What
An in-app **Help page** (operation guide + FAQ) ported from nene-invoice (design 05) and rewritten for Clear's domain, plus a **disclaimer** in the places nene-invoice surfaces it.

### Help page
- `pages/help/HelpPage.tsx` + `help-content.ts`: bilingual ja/en blocks (lede, steps, status flow, glossary, deflist, notes, keyboard grid, FAQ). Hero + **sticky scroll-spy ToC**; admin-only sections badged.
- Sections: quick start, dashboard, bank CSV import, reconciliation, client credits, dunning, CSV export, settings (admin), user invitations (admin), audit log (admin), keyboard shortcuts, FAQ, **免責事項**.
- Route `/admin/help` (all authenticated users) + sidebar **ヘルプ** link. CSS ported to Clear tokens (reuses `.kbd`).

### Disclaimer (mirrors nene-invoice)
- Help: a `#disclaimer` section — not tax/accounting/legal advice; MIT / AS-IS / no warranty / no liability; self-hosted backup-retention-security is the operator's responsibility; dunning is sent at the user's discretion.
- **Login screen**: a short warranty/responsibility line.
- **Sidebar footer**: a 免責事項 link → `/admin/help#disclaimer` (HelpPage scrolls to the hash target on arrival — scroll only, no state).

Distinct from the `?` shortcut overlay. No backend change.

## Follow-up: ClaudeDesign redesign + discoverability (commit a155a15)
- **Redesign** of the Help page to the delivered ClaudeDesign: section/hero icons (sprite gains `i-help`, `i-arrow-up`), role cards, refined ToC/notes/FAQ. Scroll-spy + anchor scrolling rescoped to the app's `.scroll` container.
- **Hero runs edge-to-edge at any width** while the reading column stays centered (`.page:has(> .help-page){ max-width:none }`) — fixes the wide-screen grey gutters beside the hero band.
- **Discoverability**: Help added to the **command palette** + a `g h` global shortcut (and the `?` shortcut list).
- **Bug fix**: command-palette **j/k selection now works under kana input / non-QWERTY** (also matches `e.code` KeyJ/KeyK).

## Checks
- `npm run check`: type-check ✅, eslint ✅ (no disables), 44 Vitest ✅
- Playwright: **54 passed** (spec 16: nav→help, ToC anchor jump, FAQ, admin badge, sidebar disclaimer link, login disclaimer)
- Redesign verified visually at 1440/2560px (hero edge-to-edge; reading column centered) and palette j/k under simulated kana input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
