### PR TITLE
feat(receivable): 手入力売掛 CRUD + CSV取込 + 消込対応 (Issues 2–4a, #161)

### DIFF
--- a/database/migrations/20260608140000_add_source_to_allocations_and_credits.php
+++ b/database/migrations/20260608140000_add_source_to_allocations_and_credits.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Makes reconciliation allocations and client credits source-aware (ADR 0014):
+ * an allocation/credit can target an upstream invoice (Invoice is SSOR, payment
+ * written back) or a manually-entered receivable (Clear is SSOR, no write-back).
+ * Existing rows default to `invoice_upstream` — behaviour is unchanged.
+ */
+final class AddSourceToAllocationsAndCredits extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('reconciliation_allocations')
+            ->addColumn('source', 'string', ['limit' => 32, 'default' => 'invoice_upstream'])
+            ->addColumn('manual_receivable_id', 'biginteger', ['signed' => false, 'null' => true])
+            ->addIndex(['manual_receivable_id'])
+            ->update();
+
+        // For a manual overpayment there is no upstream client_id; the payer is
+        // snapshotted as client_name instead. invoice/upstream credits keep client_id.
+        $this->table('client_credits')
+            ->changeColumn('client_id', 'biginteger', ['signed' => false, 'null' => true])
+            ->addColumn('source', 'string', ['limit' => 32, 'default' => 'invoice_upstream'])
+            ->addColumn('manual_receivable_id', 'biginteger', ['signed' => false, 'null' => true])
+            ->addColumn('client_name', 'string', ['limit' => 255, 'null' => true])
+            ->update();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -263,7 +263,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listUpstreamInvoices` | Invoice upstream (read-only) |
 | `proposeMatch`, `confirmMatch`, `reverseReconciliation`, `listReconciliations`, `getReconciliationById` | Reconciliation |
 | `listClientCredits`, `applyClientCredit` | Client credit |
-| `listManualReceivables`, `getManualReceivableById`, `createManualReceivable`, `updateManualReceivable`, `cancelManualReceivable` | Manual receivable (ADR 0014) |
+| `listManualReceivables`, `getManualReceivableById`, `createManualReceivable`, `updateManualReceivable`, `cancelManualReceivable`, `importManualReceivables` | Manual receivable (ADR 0014) |
 | `listDunningNotices`, `getDunningNoticeById`, `sendDunningNotice` | Dunning |
 | `listAuditEvents` | Audit trail (admin) |
 

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -109,6 +109,9 @@ follows `{entity}_{past-tense-verb}` in lowercase snake_case.
 | `reconciliation_confirmed` | Match confirmed | `before` + `after` |
 | `reconciliation_reversed` | Match reversed | `before` + `after` |
 | `client_credit_applied` | Overpayment credit applied | `before` + `after` |
+| `manual_receivable_created` | Manual receivable entered (ADR 0014) | `after` |
+| `manual_receivable_updated` | Manual receivable edited | `before` + `after` |
+| `manual_receivable_cancelled` | Manual receivable cancelled | `before` + `after` |
 | `dunning_sent` | Dunning notice sent | `before` + `after` |
 | `dunning_paused` | Dunning paused for an invoice | `before` + `after` |
 | `dunning_resumed` | Dunning resumed for an invoice | `before` + `after` |
@@ -138,6 +141,7 @@ login). New events MUST map to one of these registered `entity_type` values:
 | `bank_import_batch` | `bank_import_batch_id` | `bank_import`, `bank_import_batch_reversed` |
 | `payment_reconciliation` | `payment_reconciliation_id` | `reconciliation_confirmed`, `reconciliation_reversed` |
 | `client_credit` | `client_credit_id` | `client_credit_applied` |
+| `manual_receivable` | `manual_receivable_id` | `manual_receivable_created`, `manual_receivable_updated`, `manual_receivable_cancelled` |
 | `dunning_notice` | `dunning_notice_id` | `dunning_sent` |
 | `invoice` | upstream `invoice_id` | `dunning_paused`, `dunning_resumed` |
 | `user` | `user_id` (null on failed login) | `user_created/updated/deleted`, `invitation_accepted`, `login_succeeded`, `login_failed` |
@@ -222,6 +226,9 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `bank-transaction-not-found` | Bank transaction id not found |
 | `reconciliation-not-found` | Reconciliation id not found |
 | `client-credit-not-found` | Client credit id not found |
+| `manual-receivable-not-found` | Manual receivable id not found / not in caller's org (ADR 0014) |
+| `manual-receivable-already-exists` | Create/rename rejected — `reference_number` already used in the tenant (ADR 0014) |
+| `manual-receivable-cancelled` | Edit/cancel rejected — the receivable is already cancelled (ADR 0014) |
 | `dunning-notice-not-found` | Dunning notice id not found |
 | `invalid-state-transition` | Disallowed status change (e.g. reverse an already-reversed match) |
 | `duplicate-bank-import` | Re-import of same file hash / duplicate line key |
@@ -256,6 +263,7 @@ match between OpenAPI, route registration, and `docs/mcp/tools.json`.
 | `listUpstreamInvoices` | Invoice upstream (read-only) |
 | `proposeMatch`, `confirmMatch`, `reverseReconciliation`, `listReconciliations`, `getReconciliationById` | Reconciliation |
 | `listClientCredits`, `applyClientCredit` | Client credit |
+| `listManualReceivables`, `getManualReceivableById`, `createManualReceivable`, `updateManualReceivable`, `cancelManualReceivable` | Manual receivable (ADR 0014) |
 | `listDunningNotices`, `getDunningNoticeById`, `sendDunningNotice` | Dunning |
 | `listAuditEvents` | Audit trail (admin) |
 
@@ -272,6 +280,7 @@ exact spellings; do not invent variants per endpoint.
 | --- | --- |
 | `{field}_min_cents` / `{field}_max_cents` | Inclusive integer-cents range (e.g. `amount_min_cents`, `remaining_max_cents`) |
 | `{field}_from` / `{field}_to` | Inclusive date range `YYYY-MM-DD` (e.g. `created_from`, `value_date_from`) |
+| `q` | Free-text substring search across the row's text columns (the handler defines which) |
 | `sort_by` | Sort column; the handler validates it against a per-endpoint whitelist |
 | `sort_dir` | `asc` or `desc` (default `desc`) |
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2213,32 +2213,53 @@ components:
 
     Allocation:
       type: object
-      required: [invoice_id, amount_cents]
+      required: [amount_cents]
       properties:
+        source:
+          type: string
+          enum: [invoice_upstream, manual]
+          default: invoice_upstream
+          description: Target receivable type (ADR 0014). Defaults to invoice_upstream.
         invoice_id:
           type: integer
           format: int64
+          description: Required when source is invoice_upstream.
+        manual_receivable_id:
+          type: integer
+          format: int64
+          description: Required when source is manual.
         amount_cents:
           type: integer
           format: int64
       additionalProperties: false
     ReconciliationAllocation:
       type: object
-      required: [reconciliation_allocation_id, invoice_id, amount_cents]
+      required: [reconciliation_allocation_id, source, amount_cents]
       properties:
         reconciliation_allocation_id:
           type: integer
           format: int64
+        source:
+          type: string
+          enum: [invoice_upstream, manual]
         invoice_id:
           type: integer
           format: int64
+          nullable: true
+          description: Set for invoice_upstream allocations.
+        manual_receivable_id:
+          type: integer
+          format: int64
+          nullable: true
+          description: Set for manual allocations (ADR 0014).
         amount_cents:
           type: integer
           format: int64
         payment_id:
           type: integer
           format: int64
-          description: Upstream payment id returned by NeNe Invoice.
+          nullable: true
+          description: Upstream payment id (invoice_upstream only); null for manual.
         external_reference:
           type: string
           example: clear:recon:777

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -40,6 +40,8 @@ tags:
     description: Match proposal, confirmation, reversal (human-confirmed).
   - name: ClientCredit
     description: Overpayment credit balances and their application.
+  - name: ManualReceivable
+    description: Receivables entered directly in Clear, with no Invoice upstream (ADR 0014). A reconciliation reference, not an issued invoice.
   - name: Dunning
     description: Overdue reminders — send, history, pause/resume per invoice.
   - name: Export
@@ -1042,6 +1044,183 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '503':
           $ref: '#/components/responses/UpstreamUnavailable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/manual-receivables:
+    get:
+      tags: [ManualReceivable]
+      summary: List manual receivables
+      description: Receivables entered directly in Clear (ADR 0014). Requires `view_reconciliation`.
+      operationId: listManualReceivables
+      parameters:
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/ManualReceivableStatus'
+        - name: q
+          in: query
+          description: Free-text substring match on reference_number or client_name.
+          schema: { type: string }
+        - name: due_from
+          in: query
+          description: Inclusive lower bound on due_at (YYYY-MM-DD).
+          schema: { type: string, format: date }
+        - name: due_to
+          in: query
+          description: Inclusive upper bound on due_at (YYYY-MM-DD).
+          schema: { type: string, format: date }
+        - name: sort_by
+          in: query
+          description: "Sort column: id | due_at | total_cents | outstanding_cents | created_at."
+          schema: { type: string }
+        - name: sort_dir
+          in: query
+          schema: { type: string, enum: [asc, desc] }
+      responses:
+        '200':
+          description: A page of manual receivables.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivableListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags: [ManualReceivable]
+      summary: Create a manual receivable
+      description: >
+        Record a receivable that has no Invoice upstream. It is a reconciliation
+        reference (a receivable stub), not an issued invoice / 適格請求書 — Clear
+        issues nothing and computes no tax (scope-contract X1). Requires
+        `manage_reconciliation`.
+      operationId: createManualReceivable
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateManualReceivableRequest'
+      responses:
+        '201':
+          description: Created; the new receivable is returned.
+          headers:
+            Location:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivable'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: A receivable with this reference_number already exists in the tenant.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/manual-receivables/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    get:
+      tags: [ManualReceivable]
+      summary: Get a manual receivable
+      operationId: getManualReceivableById
+      responses:
+        '200':
+          description: The receivable.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivable'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    put:
+      tags: [ManualReceivable]
+      summary: Update a manual receivable
+      description: >
+        Full replace of the editable fields. A cancelled receivable cannot be
+        edited. Requires `manage_reconciliation`.
+      operationId: updateManualReceivable
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateManualReceivableRequest'
+      responses:
+        '200':
+          description: Updated; the receivable is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivable'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The receivable is cancelled, or the new reference_number is already used.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/manual-receivables/{id}/cancel:
+    parameters:
+      - $ref: '#/components/parameters/IdPath'
+    post:
+      tags: [ManualReceivable]
+      summary: Cancel a manual receivable
+      description: >
+        Mark the receivable cancelled (a soft, audited state change — never a
+        hard delete). An already-cancelled receivable returns 409. Requires
+        `manage_reconciliation`.
+      operationId: cancelManualReceivable
+      responses:
+        '200':
+          description: Cancelled; the receivable is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivable'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The receivable is already cancelled.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -2128,6 +2307,108 @@ components:
           type: integer
         total:
           type: integer
+    ManualReceivableStatus:
+      type: string
+      enum: [open, partially_paid, paid, cancelled]
+    ManualReceivable:
+      type: object
+      required: [manual_receivable_id, organization_id, source, reference_number, client_name,
+                 total_cents, outstanding_cents, currency, status, created_at, updated_at]
+      properties:
+        manual_receivable_id:
+          type: integer
+          format: int64
+        organization_id:
+          type: integer
+          format: int64
+        source:
+          type: string
+          enum: [manual]
+          description: Discriminator vs Invoice-sourced receivables (ADR 0014); always `manual` here.
+        reference_number:
+          type: string
+          maxLength: 64
+          description: External document number; not an invoice number Clear issues (X1).
+        client_name:
+          type: string
+          maxLength: 255
+        recipient_email:
+          type: string
+          format: email
+          nullable: true
+        total_cents:
+          type: integer
+          format: int64
+        outstanding_cents:
+          type: integer
+          format: int64
+          description: Clear-computed (= total_cents − Σ confirmed allocations).
+        currency:
+          type: string
+          enum: [JPY]
+        issued_at:
+          type: string
+          format: date
+          nullable: true
+        due_at:
+          type: string
+          format: date
+          nullable: true
+          description: Required before the receivable can be dunned or aged.
+        status:
+          $ref: '#/components/schemas/ManualReceivableStatus'
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    ManualReceivableListResponse:
+      type: object
+      required: [items, limit, offset, total]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManualReceivable'
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+    CreateManualReceivableRequest:
+      type: object
+      required: [reference_number, client_name, total_cents]
+      properties:
+        reference_number:
+          type: string
+          minLength: 1
+          maxLength: 64
+        client_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+        recipient_email:
+          type: string
+          format: email
+        total_cents:
+          type: integer
+          format: int64
+          minimum: 1
+        currency:
+          type: string
+          enum: [JPY]
+          default: JPY
+        issued_at:
+          type: string
+          format: date
+        due_at:
+          type: string
+          format: date
+      additionalProperties: false
+    UpdateManualReceivableRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateManualReceivableRequest'
+      description: Full replace of the editable fields (omitting an optional field clears it).
     ApplyClientCreditRequest:
       type: object
       required: [invoice_id, amount_cents]

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1191,6 +1191,45 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /admin/manual-receivable-imports:
+    post:
+      tags: [ManualReceivable]
+      summary: Import manual receivables from CSV
+      description: >
+        Bulk-create receivables from a header-mapped CSV (columns: reference_number,
+        client_name, total_cents, and optionally recipient_email, due_at, issued_at,
+        currency). Amounts are integers in the smallest unit (¥1 = 1). Partial
+        success: valid new rows are created, duplicate reference numbers are
+        skipped, invalid rows are reported by line number. A header missing a
+        required column fails the whole request (422). Requires `manage_reconciliation`.
+      operationId: importManualReceivables
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Import summary.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManualReceivableImportResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /admin/manual-receivables/{id}/cancel:
     parameters:
       - $ref: '#/components/parameters/IdPath'
@@ -2375,6 +2414,32 @@ components:
           type: integer
         total:
           type: integer
+    ManualReceivableImportResult:
+      type: object
+      required: [created, skipped, errors]
+      properties:
+        created:
+          type: integer
+          description: Number of receivables created.
+        skipped:
+          type: integer
+          description: Rows skipped as duplicates (existing reference_number).
+        errors:
+          type: array
+          items:
+            type: object
+            required: [row, errors]
+            properties:
+              row:
+                type: integer
+                description: 1-based CSV line number of the invalid row.
+              errors:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    field: { type: string }
+                    message: { type: string }
     CreateManualReceivableRequest:
       type: object
       required: [reference_number, client_name, total_cents]

--- a/lang/en.php
+++ b/lang/en.php
@@ -67,6 +67,15 @@ return [
     'problem.client-credit-not-found.title'  => 'Client Credit Not Found',
     'problem.client-credit-not-found.detail' => 'The requested client credit was not found.',
 
+    'problem.manual-receivable-not-found.title'  => 'Receivable Not Found',
+    'problem.manual-receivable-not-found.detail' => 'The requested manual receivable was not found.',
+
+    'problem.manual-receivable-already-exists.title'  => 'Receivable Already Exists',
+    'problem.manual-receivable-already-exists.detail' => 'A receivable with this reference number already exists.',
+
+    'problem.manual-receivable-cancelled.title'  => 'Receivable Cancelled',
+    'problem.manual-receivable-cancelled.detail' => 'This receivable is cancelled and can no longer be changed.',
+
     'problem.dunning-notice-not-found.title'  => 'Dunning Notice Not Found',
     'problem.dunning-notice-not-found.detail' => 'The requested dunning notice was not found.',
 

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -67,6 +67,15 @@ return [
     'problem.client-credit-not-found.title'  => '前受金が見つかりません',
     'problem.client-credit-not-found.detail' => '指定された前受金は存在しません。',
 
+    'problem.manual-receivable-not-found.title'  => '売掛が見つかりません',
+    'problem.manual-receivable-not-found.detail' => '指定された手入力売掛は存在しません。',
+
+    'problem.manual-receivable-already-exists.title'  => '売掛が既に存在します',
+    'problem.manual-receivable-already-exists.detail' => 'この請求書番号の売掛は既に登録されています。',
+
+    'problem.manual-receivable-cancelled.title'  => '売掛は取消済みです',
+    'problem.manual-receivable-cancelled.detail' => 'この売掛は取消済みのため変更できません。',
+
     'problem.dunning-notice-not-found.title'  => '督促記録が見つかりません',
     'problem.dunning-notice-not-found.detail' => '指定された督促記録は存在しません。',
 

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -109,6 +109,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                             '/admin/bank-transactions' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/manual-receivables' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                             '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
                             '/admin/upstream/invoices' => CapabilityRule::same(Capability::ViewReconciliation),

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -110,6 +110,7 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                             '/admin/reconciliations' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/client-credits' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/manual-receivables' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
+                            '/admin/manual-receivable-imports' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::ManageReconciliation),
                             '/admin/clear-settings' => CapabilityRule::same(Capability::ManageClearSettings),
                             '/admin/dunning-notices' => new CapabilityRule(read: Capability::ViewReconciliation, write: Capability::SendDunning),
                             '/admin/upstream/invoices' => CapabilityRule::same(Capability::ViewReconciliation),

--- a/src/Http/ApplicationServiceProvider.php
+++ b/src/Http/ApplicationServiceProvider.php
@@ -40,6 +40,10 @@ use NeneClear\Organization\OrganizationAlreadyExistsExceptionHandler;
 use NeneClear\Organization\OrganizationNotFoundExceptionHandler;
 use NeneClear\Organization\OrganizationRouteRegistrar;
 use NeneClear\Organization\OrganizationServiceProvider;
+use NeneClear\Receivable\ManualReceivableAlreadyExistsExceptionHandler;
+use NeneClear\Receivable\ManualReceivableCancelledExceptionHandler;
+use NeneClear\Receivable\ManualReceivableNotFoundExceptionHandler;
+use NeneClear\Receivable\ManualReceivableRouteRegistrar;
 use NeneClear\Receivable\ManualReceivableServiceProvider;
 use NeneClear\Reconciliation\AllocationExceedsOutstandingExceptionHandler;
 use NeneClear\Reconciliation\BankTransactionNotMatchableExceptionHandler;
@@ -98,6 +102,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, AuditRouteRegistrar::class),
                     ServiceResolver::get($c, BankImportRouteRegistrar::class),
                     ServiceResolver::get($c, ClearSettingsRouteRegistrar::class),
+                    ServiceResolver::get($c, ManualReceivableRouteRegistrar::class),
                     ServiceResolver::get($c, ReconciliationRouteRegistrar::class),
                     ServiceResolver::get($c, InvoiceUpstreamRouteRegistrar::class),
                     ServiceResolver::get($c, ExportRouteRegistrar::class),
@@ -129,6 +134,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, ReconciliationAlreadyReversedExceptionHandler::class),
                     ServiceResolver::get($c, ClientCreditNotFoundExceptionHandler::class),
                     ServiceResolver::get($c, CreditExceedsRemainingExceptionHandler::class),
+                    ServiceResolver::get($c, ManualReceivableNotFoundExceptionHandler::class),
+                    ServiceResolver::get($c, ManualReceivableAlreadyExistsExceptionHandler::class),
+                    ServiceResolver::get($c, ManualReceivableCancelledExceptionHandler::class),
                     ServiceResolver::get($c, AllocationExceedsOutstandingExceptionHandler::class),
                     ServiceResolver::get($c, BankTransactionNotMatchableExceptionHandler::class),
                     ServiceResolver::get($c, UpstreamInvoiceUnavailableExceptionHandler::class),

--- a/src/Receivable/CancelManualReceivableHandler.php
+++ b/src/Receivable/CancelManualReceivableHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CancelManualReceivableHandler
+{
+    public function __construct(
+        private CancelManualReceivableUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $receivable = $this->useCase->execute(
+            $id,
+            AuthContext::organizationId($request) ?? 0,
+            AuthContext::userId($request),
+        );
+
+        return $this->response->create(ManualReceivableResponse::toArray($receivable));
+    }
+}

--- a/src/Receivable/CancelManualReceivableUseCase.php
+++ b/src/Receivable/CancelManualReceivableUseCase.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditRecorderInterface;
+
+final readonly class CancelManualReceivableUseCase implements CancelManualReceivableUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ManualReceivableRepositoryInterface $receivables
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $receivables,
+        private Closure $auditRecorder,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(int $id, int $callerOrganizationId, int $actorUserId): ManualReceivable
+    {
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($id, $callerOrganizationId, $actorUserId): ManualReceivable {
+                $receivables = ($this->receivables)($tx);
+
+                $existing = $receivables->findById($id);
+                if ($existing === null || $existing->organizationId !== $callerOrganizationId) {
+                    throw new ManualReceivableNotFoundException($id);
+                }
+                if ($existing->status === ManualReceivableStatus::Cancelled) {
+                    throw new ManualReceivableCancelledException($id);
+                }
+
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $cancelled = new ManualReceivable(
+                    organizationId: $existing->organizationId,
+                    referenceNumber: $existing->referenceNumber,
+                    clientName: $existing->clientName,
+                    recipientEmail: $existing->recipientEmail,
+                    totalCents: $existing->totalCents,
+                    outstandingCents: $existing->outstandingCents,
+                    currency: $existing->currency,
+                    issuedAt: $existing->issuedAt,
+                    dueAt: $existing->dueAt,
+                    status: ManualReceivableStatus::Cancelled,
+                    createdBy: $existing->createdBy,
+                    createdAt: $existing->createdAt,
+                    updatedAt: $now,
+                    id: $existing->id,
+                );
+
+                $receivables->update($cancelled);
+
+                ($this->auditRecorder)($tx)->record(
+                    $existing->organizationId,
+                    $actorUserId,
+                    $now,
+                    'manual_receivable_cancelled',
+                    'manual_receivable',
+                    $existing->id,
+                    [
+                        'before' => ['status' => $existing->status->value],
+                        'after' => ['status' => $cancelled->status->value],
+                    ],
+                );
+
+                return $cancelled;
+            },
+        );
+    }
+}

--- a/src/Receivable/CancelManualReceivableUseCaseInterface.php
+++ b/src/Receivable/CancelManualReceivableUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface CancelManualReceivableUseCaseInterface
+{
+    public function execute(int $id, int $callerOrganizationId, int $actorUserId): ManualReceivable;
+}

--- a/src/Receivable/CreateManualReceivableHandler.php
+++ b/src/Receivable/CreateManualReceivableHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateManualReceivableHandler
+{
+    public function __construct(
+        private CreateManualReceivableUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $fields = ManualReceivableValidator::validate(JsonRequestBodyParser::parse($request));
+
+        $receivable = $this->useCase->execute(new CreateManualReceivableInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            referenceNumber: $fields['reference_number'],
+            clientName: $fields['client_name'],
+            recipientEmail: $fields['recipient_email'],
+            totalCents: $fields['total_cents'],
+            currency: $fields['currency'],
+            issuedAt: $fields['issued_at'],
+            dueAt: $fields['due_at'],
+            actorUserId: AuthContext::userId($request),
+        ));
+
+        return $this->response->create(
+            ManualReceivableResponse::toArray($receivable),
+            201,
+            ['Location' => '/admin/manual-receivables/' . $receivable->id],
+        );
+    }
+}

--- a/src/Receivable/CreateManualReceivableInput.php
+++ b/src/Receivable/CreateManualReceivableInput.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class CreateManualReceivableInput
+{
+    public function __construct(
+        public int $organizationId,
+        public string $referenceNumber,
+        public string $clientName,
+        public ?string $recipientEmail,
+        public int $totalCents,
+        public string $currency,
+        public ?string $issuedAt,
+        public ?string $dueAt,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/Receivable/CreateManualReceivableUseCase.php
+++ b/src/Receivable/CreateManualReceivableUseCase.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditRecorderInterface;
+
+final readonly class CreateManualReceivableUseCase implements CreateManualReceivableUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ManualReceivableRepositoryInterface $receivables
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $receivables,
+        private Closure $auditRecorder,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(CreateManualReceivableInput $input): ManualReceivable
+    {
+        // Dedupe check, insert, and audit commit together so a created receivable
+        // can never lack its audit event (Issue #122). A new receivable starts
+        // fully open: outstanding equals total (no allocations exist yet).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): ManualReceivable {
+                $receivables = ($this->receivables)($tx);
+
+                if ($receivables->findByReferenceNumber($input->organizationId, $input->referenceNumber) !== null) {
+                    throw new ManualReceivableAlreadyExistsException($input->referenceNumber);
+                }
+
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $id = $receivables->save(new ManualReceivable(
+                    organizationId: $input->organizationId,
+                    referenceNumber: $input->referenceNumber,
+                    clientName: $input->clientName,
+                    recipientEmail: $input->recipientEmail,
+                    totalCents: $input->totalCents,
+                    outstandingCents: $input->totalCents,
+                    currency: $input->currency,
+                    issuedAt: $input->issuedAt,
+                    dueAt: $input->dueAt,
+                    status: ManualReceivableStatus::Open,
+                    createdBy: $input->actorUserId,
+                    createdAt: $now,
+                    updatedAt: $now,
+                ));
+
+                $created = $receivables->findById($id);
+                if ($created === null) {
+                    throw new ManualReceivableNotFoundException($id);
+                }
+
+                ($this->auditRecorder)($tx)->record(
+                    $input->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'manual_receivable_created',
+                    'manual_receivable',
+                    $created->id,
+                    ['after' => ManualReceivableResponse::toArray($created)],
+                );
+
+                return $created;
+            },
+        );
+    }
+}

--- a/src/Receivable/CreateManualReceivableUseCaseInterface.php
+++ b/src/Receivable/CreateManualReceivableUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface CreateManualReceivableUseCaseInterface
+{
+    public function execute(CreateManualReceivableInput $input): ManualReceivable;
+}

--- a/src/Receivable/GetManualReceivableByIdUseCase.php
+++ b/src/Receivable/GetManualReceivableByIdUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class GetManualReceivableByIdUseCase implements GetManualReceivableByIdUseCaseInterface
+{
+    public function __construct(
+        private ManualReceivableRepositoryInterface $receivables,
+    ) {
+    }
+
+    public function execute(int $id, int $callerOrganizationId): ManualReceivable
+    {
+        $receivable = $this->receivables->findById($id);
+
+        if ($receivable === null || $receivable->organizationId !== $callerOrganizationId) {
+            throw new ManualReceivableNotFoundException($id);
+        }
+
+        return $receivable;
+    }
+}

--- a/src/Receivable/GetManualReceivableByIdUseCaseInterface.php
+++ b/src/Receivable/GetManualReceivableByIdUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface GetManualReceivableByIdUseCaseInterface
+{
+    public function execute(int $id, int $callerOrganizationId): ManualReceivable;
+}

--- a/src/Receivable/GetManualReceivableHandler.php
+++ b/src/Receivable/GetManualReceivableHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetManualReceivableHandler
+{
+    public function __construct(
+        private GetManualReceivableByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+
+        $receivable = $this->useCase->execute($id, AuthContext::organizationId($request) ?? 0);
+
+        return $this->response->create(ManualReceivableResponse::toArray($receivable));
+    }
+}

--- a/src/Receivable/ImportManualReceivablesHandler.php
+++ b/src/Receivable/ImportManualReceivablesHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+final readonly class ImportManualReceivablesHandler
+{
+    public function __construct(
+        private ImportManualReceivablesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $file = $request->getUploadedFiles()['file'] ?? null;
+        if (!$file instanceof UploadedFileInterface) {
+            throw new ValidationException([new ValidationError('file', 'A CSV file upload is required.', 'required')]);
+        }
+
+        $output = $this->useCase->execute(new ImportManualReceivablesInput(
+            organizationId: AuthContext::organizationId($request) ?? 0,
+            contents: (string) $file->getStream(),
+            actorUserId: AuthContext::userId($request),
+        ));
+
+        return $this->response->create([
+            'created' => $output->created,
+            'skipped' => $output->skipped,
+            'errors' => $output->errors,
+        ]);
+    }
+}

--- a/src/Receivable/ImportManualReceivablesInput.php
+++ b/src/Receivable/ImportManualReceivablesInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class ImportManualReceivablesInput
+{
+    public function __construct(
+        public int $organizationId,
+        public string $contents,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/Receivable/ImportManualReceivablesOutput.php
+++ b/src/Receivable/ImportManualReceivablesOutput.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Summary of a receivables CSV import. Partial success is expected: valid new
+ * rows are created, duplicate reference numbers are skipped, and invalid rows
+ * are reported (with their CSV line number) without failing the whole import.
+ */
+final readonly class ImportManualReceivablesOutput
+{
+    /**
+     * @param list<array{row: int, errors: list<array{field: string, message: string}>}> $errors
+     */
+    public function __construct(
+        public int $created,
+        public int $skipped,
+        public array $errors,
+    ) {
+    }
+}

--- a/src/Receivable/ImportManualReceivablesUseCase.php
+++ b/src/Receivable/ImportManualReceivablesUseCase.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Bulk-imports receivables from a CSV by reusing the single-create path: each
+ * row is validated ({@see ManualReceivableValidator}) and created
+ * ({@see CreateManualReceivableUseCaseInterface}, which audits and dedupes). A
+ * duplicate `reference_number` is skipped (not an error); an invalid row is
+ * reported by its CSV line number. A header missing a required column fails the
+ * whole request (422) since every row would otherwise be invalid.
+ */
+final readonly class ImportManualReceivablesUseCase implements ImportManualReceivablesUseCaseInterface
+{
+    private const array REQUIRED_HEADERS = ['reference_number', 'client_name', 'total_cents'];
+
+    public function __construct(
+        private ManualReceivableCsvParser $parser,
+        private CreateManualReceivableUseCaseInterface $create,
+    ) {
+    }
+
+    public function execute(ImportManualReceivablesInput $input): ImportManualReceivablesOutput
+    {
+        $parsed = $this->parser->parse($input->contents);
+
+        $missing = array_values(array_diff(self::REQUIRED_HEADERS, $parsed->headers));
+        if ($missing !== []) {
+            throw new ValidationException(array_map(
+                static fn (string $column): ValidationError => new ValidationError(
+                    $column,
+                    sprintf('A "%s" column is required in the CSV header.', $column),
+                    'required',
+                ),
+                $missing,
+            ));
+        }
+
+        $created = 0;
+        $skipped = 0;
+        $errors = [];
+
+        foreach ($parsed->rows as $row) {
+            try {
+                $fields = ManualReceivableValidator::validate($row['data']);
+                $this->create->execute(new CreateManualReceivableInput(
+                    organizationId: $input->organizationId,
+                    referenceNumber: $fields['reference_number'],
+                    clientName: $fields['client_name'],
+                    recipientEmail: $fields['recipient_email'],
+                    totalCents: $fields['total_cents'],
+                    currency: $fields['currency'],
+                    issuedAt: $fields['issued_at'],
+                    dueAt: $fields['due_at'],
+                    actorUserId: $input->actorUserId,
+                ));
+                ++$created;
+            } catch (ManualReceivableAlreadyExistsException) {
+                ++$skipped;
+            } catch (ValidationException $e) {
+                $errors[] = [
+                    'row' => $row['row'],
+                    'errors' => array_map(
+                        static fn (ValidationError $error): array => ['field' => $error->field, 'message' => $error->message],
+                        $e->errors(),
+                    ),
+                ];
+            }
+        }
+
+        return new ImportManualReceivablesOutput($created, $skipped, $errors);
+    }
+}

--- a/src/Receivable/ImportManualReceivablesUseCaseInterface.php
+++ b/src/Receivable/ImportManualReceivablesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface ImportManualReceivablesUseCaseInterface
+{
+    public function execute(ImportManualReceivablesInput $input): ImportManualReceivablesOutput;
+}

--- a/src/Receivable/ListManualReceivablesHandler.php
+++ b/src/Receivable/ListManualReceivablesHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
+use Nene2\Http\PaginationResponse;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListManualReceivablesHandler
+{
+    public function __construct(
+        private ListManualReceivablesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $page = PaginationQueryParser::parse($request, 50, 200);
+        $filter = ManualReceivableFilter::fromQueryParams((array) $request->getQueryParams());
+        $output = $this->useCase->execute(AuthContext::organizationId($request) ?? 0, $filter, $page->limit, $page->offset);
+
+        return $this->response->create((new PaginationResponse(
+            items: array_map(ManualReceivableResponse::toArray(...), $output->items),
+            limit: $output->limit,
+            offset: $output->offset,
+            total: $output->total,
+        ))->toArray());
+    }
+}

--- a/src/Receivable/ListManualReceivablesOutput.php
+++ b/src/Receivable/ListManualReceivablesOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class ListManualReceivablesOutput
+{
+    /**
+     * @param list<ManualReceivable> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Receivable/ListManualReceivablesUseCase.php
+++ b/src/Receivable/ListManualReceivablesUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class ListManualReceivablesUseCase implements ListManualReceivablesUseCaseInterface
+{
+    public function __construct(
+        private ManualReceivableRepositoryInterface $receivables,
+    ) {
+    }
+
+    public function execute(int $organizationId, ManualReceivableFilter $filter, int $limit, int $offset): ListManualReceivablesOutput
+    {
+        return new ListManualReceivablesOutput(
+            items: $this->receivables->findByOrganization($organizationId, $filter, $limit, $offset),
+            total: $this->receivables->countByOrganization($organizationId, $filter),
+            limit: $limit,
+            offset: $offset,
+        );
+    }
+}

--- a/src/Receivable/ListManualReceivablesUseCaseInterface.php
+++ b/src/Receivable/ListManualReceivablesUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface ListManualReceivablesUseCaseInterface
+{
+    public function execute(int $organizationId, ManualReceivableFilter $filter, int $limit, int $offset): ListManualReceivablesOutput;
+}

--- a/src/Receivable/ManualReceivableAlreadyExistsException.php
+++ b/src/Receivable/ManualReceivableAlreadyExistsException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use RuntimeException;
+
+/** Raised when a non-deleted receivable already uses the same reference_number in the tenant. */
+final class ManualReceivableAlreadyExistsException extends RuntimeException
+{
+    public function __construct(public readonly string $referenceNumber)
+    {
+        parent::__construct(sprintf('Manual receivable with reference "%s" already exists.', $referenceNumber));
+    }
+}

--- a/src/Receivable/ManualReceivableAlreadyExistsExceptionHandler.php
+++ b/src/Receivable/ManualReceivableAlreadyExistsExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ManualReceivableAlreadyExistsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ManualReceivableAlreadyExistsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'manual-receivable-already-exists', 409);
+    }
+}

--- a/src/Receivable/ManualReceivableCancelledException.php
+++ b/src/Receivable/ManualReceivableCancelledException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use RuntimeException;
+
+/** Raised when editing or cancelling a receivable that is already cancelled. */
+final class ManualReceivableCancelledException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Manual receivable %d is cancelled.', $id));
+    }
+}

--- a/src/Receivable/ManualReceivableCancelledExceptionHandler.php
+++ b/src/Receivable/ManualReceivableCancelledExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ManualReceivableCancelledExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ManualReceivableCancelledException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'manual-receivable-cancelled', 409);
+    }
+}

--- a/src/Receivable/ManualReceivableCsvParser.php
+++ b/src/Receivable/ManualReceivableCsvParser.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Parses a receivables CSV by header name (not fixed column positions — unlike
+ * the bank CSV, which is per-account). Recognized columns map to the same field
+ * names the API uses; unknown columns are ignored. Amounts are integers in the
+ * smallest currency unit (¥1 = 1), like the bank importer. Validation of each
+ * row's values is the import use case's job (it reuses ManualReceivableValidator).
+ */
+final readonly class ManualReceivableCsvParser
+{
+    private const array RECOGNIZED = [
+        'reference_number', 'client_name', 'total_cents',
+        'recipient_email', 'due_at', 'issued_at', 'currency',
+    ];
+
+    public function parse(string $contents): ParsedReceivableRows
+    {
+        // Strip a UTF-8 BOM if present, then split on any newline style.
+        $contents = preg_replace('/^\xEF\xBB\xBF/', '', $contents) ?? $contents;
+        $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];
+
+        $headerMap = null; // column index => recognized field name
+        $headers = [];
+        $rows = [];
+        $lineNumber = 0;
+
+        foreach ($lines as $raw) {
+            ++$lineNumber;
+            if (trim($raw) === '') {
+                continue;
+            }
+            $cells = str_getcsv($raw, ',', '"', '\\');
+
+            if ($headerMap === null) {
+                $headerMap = [];
+                foreach ($cells as $index => $name) {
+                    $key = strtolower(trim((string) $name));
+                    if (in_array($key, self::RECOGNIZED, true)) {
+                        $headerMap[$index] = $key;
+                        $headers[] = $key;
+                    }
+                }
+                continue;
+            }
+
+            $data = [];
+            foreach ($headerMap as $index => $field) {
+                $data[$field] = trim((string) ($cells[$index] ?? ''));
+            }
+            $rows[] = ['row' => $lineNumber, 'data' => $data];
+        }
+
+        return new ParsedReceivableRows($headers, $rows);
+    }
+}

--- a/src/Receivable/ManualReceivableFilter.php
+++ b/src/Receivable/ManualReceivableFilter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Server-side filter + sort for the manual-receivable list. Every field is
+ * optional; null/empty means "no constraint". `sortColumn` / `sortDirection`
+ * are validated against a whitelist in the repository, so they are always safe
+ * to interpolate into ORDER BY.
+ */
+final readonly class ManualReceivableFilter
+{
+    public function __construct(
+        public ?ManualReceivableStatus $status = null,
+        /** Substring match on reference_number or client_name. */
+        public ?string $q = null,
+        public ?string $dueFrom = null,
+        public ?string $dueTo = null,
+        public string $sortColumn = 'id',
+        public string $sortDirection = 'desc',
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $q
+     */
+    public static function fromQueryParams(array $q): self
+    {
+        $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;
+        $statusParam = $q['status'] ?? null;
+
+        return new self(
+            status: is_string($statusParam) ? ManualReceivableStatus::tryFrom($statusParam) : null,
+            q: $str('q'),
+            dueFrom: $str('due_from'),
+            dueTo: $str('due_to'),
+            sortColumn: $str('sort_by') ?? 'id',
+            sortDirection: $str('sort_dir') ?? 'desc',
+        );
+    }
+}

--- a/src/Receivable/ManualReceivableNotFoundException.php
+++ b/src/Receivable/ManualReceivableNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use RuntimeException;
+
+final class ManualReceivableNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly int $id)
+    {
+        parent::__construct(sprintf('Manual receivable %d was not found.', $id));
+    }
+}

--- a/src/Receivable/ManualReceivableNotFoundExceptionHandler.php
+++ b/src/Receivable/ManualReceivableNotFoundExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ManualReceivableNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ManualReceivableNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'manual-receivable-not-found', 404);
+    }
+}

--- a/src/Receivable/ManualReceivableRepositoryInterface.php
+++ b/src/Receivable/ManualReceivableRepositoryInterface.php
@@ -11,7 +11,9 @@ interface ManualReceivableRepositoryInterface
     /**
      * @return list<ManualReceivable>
      */
-    public function findByOrganization(int $organizationId): array;
+    public function findByOrganization(int $organizationId, ManualReceivableFilter $filter, int $limit, int $offset): array;
+
+    public function countByOrganization(int $organizationId, ManualReceivableFilter $filter): int;
 
     /**
      * The soft-uniqueness / dedupe key for manual entry and CSV import: at most
@@ -20,6 +22,9 @@ interface ManualReceivableRepositoryInterface
     public function findByReferenceNumber(int $organizationId, string $referenceNumber): ?ManualReceivable;
 
     public function save(ManualReceivable $receivable): int;
+
+    /** Updates the mutable fields (and `updated_at`) of an existing row by id. */
+    public function update(ManualReceivable $receivable): void;
 
     /** Soft-delete only — receivables are never hard-deleted (scope-contract X12). */
     public function softDelete(int $id, string $deletedAt): void;

--- a/src/Receivable/ManualReceivableResponse.php
+++ b/src/Receivable/ManualReceivableResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Maps a {@see ManualReceivable} to its public JSON shape (terminology.md /
+ * openapi.yaml). `source` is the constant `manual` so a unified receivable view
+ * can tell Clear-owned receivables from Invoice-sourced ones (ADR 0014).
+ */
+final readonly class ManualReceivableResponse
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toArray(ManualReceivable $receivable): array
+    {
+        return [
+            'manual_receivable_id' => $receivable->id,
+            'organization_id' => $receivable->organizationId,
+            'source' => 'manual',
+            'reference_number' => $receivable->referenceNumber,
+            'client_name' => $receivable->clientName,
+            'recipient_email' => $receivable->recipientEmail,
+            'total_cents' => $receivable->totalCents,
+            'outstanding_cents' => $receivable->outstandingCents,
+            'currency' => $receivable->currency,
+            'issued_at' => $receivable->issuedAt,
+            'due_at' => $receivable->dueAt,
+            'status' => $receivable->status->value,
+            'created_at' => $receivable->createdAt,
+            'updated_at' => $receivable->updatedAt,
+        ];
+    }
+}

--- a/src/Receivable/ManualReceivableRouteRegistrar.php
+++ b/src/Receivable/ManualReceivableRouteRegistrar.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ManualReceivableRouteRegistrar
+{
+    public function __construct(
+        private ListManualReceivablesHandler $listHandler,
+        private CreateManualReceivableHandler $createHandler,
+        private GetManualReceivableHandler $getHandler,
+        private UpdateManualReceivableHandler $updateHandler,
+        private CancelManualReceivableHandler $cancelHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listHandler = $this->listHandler;
+        $createHandler = $this->createHandler;
+        $getHandler = $this->getHandler;
+        $updateHandler = $this->updateHandler;
+        $cancelHandler = $this->cancelHandler;
+
+        $router->get('/admin/manual-receivables', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
+        $router->post('/admin/manual-receivables', static fn (ServerRequestInterface $r): ResponseInterface => $createHandler->handle($r));
+        $router->get('/admin/manual-receivables/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));
+        $router->put('/admin/manual-receivables/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $updateHandler->handle($r));
+        $router->post('/admin/manual-receivables/{id}/cancel', static fn (ServerRequestInterface $r): ResponseInterface => $cancelHandler->handle($r));
+    }
+}

--- a/src/Receivable/ManualReceivableRouteRegistrar.php
+++ b/src/Receivable/ManualReceivableRouteRegistrar.php
@@ -16,6 +16,7 @@ final readonly class ManualReceivableRouteRegistrar
         private GetManualReceivableHandler $getHandler,
         private UpdateManualReceivableHandler $updateHandler,
         private CancelManualReceivableHandler $cancelHandler,
+        private ImportManualReceivablesHandler $importHandler,
     ) {
     }
 
@@ -26,7 +27,9 @@ final readonly class ManualReceivableRouteRegistrar
         $getHandler = $this->getHandler;
         $updateHandler = $this->updateHandler;
         $cancelHandler = $this->cancelHandler;
+        $importHandler = $this->importHandler;
 
+        $router->post('/admin/manual-receivable-imports', static fn (ServerRequestInterface $r): ResponseInterface => $importHandler->handle($r));
         $router->get('/admin/manual-receivables', static fn (ServerRequestInterface $r): ResponseInterface => $listHandler->handle($r));
         $router->post('/admin/manual-receivables', static fn (ServerRequestInterface $r): ResponseInterface => $createHandler->handle($r));
         $router->get('/admin/manual-receivables/{id}', static fn (ServerRequestInterface $r): ResponseInterface => $getHandler->handle($r));

--- a/src/Receivable/ManualReceivableServiceProvider.php
+++ b/src/Receivable/ManualReceivableServiceProvider.php
@@ -73,6 +73,13 @@ final readonly class ManualReceivableServiceProvider implements ServiceProviderI
                 ),
             )
             ->set(
+                ImportManualReceivablesUseCaseInterface::class,
+                static fn (ContainerInterface $c): ImportManualReceivablesUseCaseInterface => new ImportManualReceivablesUseCase(
+                    new ManualReceivableCsvParser(),
+                    ServiceResolver::get($c, CreateManualReceivableUseCaseInterface::class),
+                ),
+            )
+            ->set(
                 ManualReceivableRouteRegistrar::class,
                 static fn (ContainerInterface $c): ManualReceivableRouteRegistrar => new ManualReceivableRouteRegistrar(
                     new ListManualReceivablesHandler(
@@ -93,6 +100,10 @@ final readonly class ManualReceivableServiceProvider implements ServiceProviderI
                     ),
                     new CancelManualReceivableHandler(
                         ServiceResolver::get($c, CancelManualReceivableUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new ImportManualReceivablesHandler(
+                        ServiceResolver::get($c, ImportManualReceivablesUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
                     ),
                 ),

--- a/src/Receivable/ManualReceivableServiceProvider.php
+++ b/src/Receivable/ManualReceivableServiceProvider.php
@@ -5,25 +5,115 @@ declare(strict_types=1);
 namespace NeneClear\Receivable;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneClear\Audit\AuditRecorder;
+use NeneClear\Audit\AuditRecorderInterface;
+use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use Psr\Container\ContainerInterface;
 
 /**
- * Wires the manual-receivables domain (ADR 0014). Foundation only: the
- * repository. CRUD use cases, CSV import, and route registrars land in later
- * Issues and register here.
+ * Wires the manual-receivables domain (ADR 0014): repository, CRUD use cases,
+ * route registrar, and domain exception handlers. CSV import (Issue 3) and
+ * reconciliation/dunning support (Issues 4–5) register here later.
  */
 final readonly class ManualReceivableServiceProvider implements ServiceProviderInterface
 {
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            ManualReceivableRepositoryInterface::class,
-            static fn (ContainerInterface $c): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository(
-                ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
-            ),
-        );
+        $builder
+            ->set(
+                ManualReceivableRepositoryInterface::class,
+                static fn (ContainerInterface $c): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                ListManualReceivablesUseCaseInterface::class,
+                static fn (ContainerInterface $c): ListManualReceivablesUseCaseInterface => new ListManualReceivablesUseCase(
+                    ServiceResolver::get($c, ManualReceivableRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                GetManualReceivableByIdUseCaseInterface::class,
+                static fn (ContainerInterface $c): GetManualReceivableByIdUseCaseInterface => new GetManualReceivableByIdUseCase(
+                    ServiceResolver::get($c, ManualReceivableRepositoryInterface::class),
+                ),
+            )
+            ->set(
+                CreateManualReceivableUseCaseInterface::class,
+                static fn (ContainerInterface $c): CreateManualReceivableUseCaseInterface => new CreateManualReceivableUseCase(
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                UpdateManualReceivableUseCaseInterface::class,
+                static fn (ContainerInterface $c): UpdateManualReceivableUseCaseInterface => new UpdateManualReceivableUseCase(
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                CancelManualReceivableUseCaseInterface::class,
+                static fn (ContainerInterface $c): CancelManualReceivableUseCaseInterface => new CancelManualReceivableUseCase(
+                    ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                ManualReceivableRouteRegistrar::class,
+                static fn (ContainerInterface $c): ManualReceivableRouteRegistrar => new ManualReceivableRouteRegistrar(
+                    new ListManualReceivablesHandler(
+                        ServiceResolver::get($c, ListManualReceivablesUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new CreateManualReceivableHandler(
+                        ServiceResolver::get($c, CreateManualReceivableUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new GetManualReceivableHandler(
+                        ServiceResolver::get($c, GetManualReceivableByIdUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new UpdateManualReceivableHandler(
+                        ServiceResolver::get($c, UpdateManualReceivableUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                    new CancelManualReceivableHandler(
+                        ServiceResolver::get($c, CancelManualReceivableUseCaseInterface::class),
+                        ServiceResolver::get($c, JsonResponseFactory::class),
+                    ),
+                ),
+            )
+            ->set(
+                ManualReceivableNotFoundExceptionHandler::class,
+                static fn (ContainerInterface $c): ManualReceivableNotFoundExceptionHandler => new ManualReceivableNotFoundExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                ManualReceivableAlreadyExistsExceptionHandler::class,
+                static fn (ContainerInterface $c): ManualReceivableAlreadyExistsExceptionHandler => new ManualReceivableAlreadyExistsExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            )
+            ->set(
+                ManualReceivableCancelledExceptionHandler::class,
+                static fn (ContainerInterface $c): ManualReceivableCancelledExceptionHandler => new ManualReceivableCancelledExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
     }
 }

--- a/src/Receivable/ManualReceivableValidator.php
+++ b/src/Receivable/ManualReceivableValidator.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+
+/**
+ * Shared request-body validation for create/update. Returns a normalized array
+ * of fields, or throws {@see ValidationException} (→ 422). Validating here keeps
+ * the use cases free of HTTP/body concerns. Currency is JPY-only for now and
+ * dates are calendar `YYYY-MM-DD`.
+ *
+ * @phpstan-type ManualReceivableFields array{
+ *   reference_number: string, client_name: string, recipient_email: ?string,
+ *   total_cents: int, currency: string, issued_at: ?string, due_at: ?string
+ * }
+ */
+final readonly class ManualReceivableValidator
+{
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return ManualReceivableFields
+     */
+    public static function validate(array $body): array
+    {
+        $errors = [];
+
+        $referenceNumber = trim((string) ($body['reference_number'] ?? ''));
+        if ($referenceNumber === '') {
+            $errors[] = new ValidationError('reference_number', 'Reference number is required.', 'required');
+        } elseif (mb_strlen($referenceNumber) > 64) {
+            $errors[] = new ValidationError('reference_number', 'Reference number is too long (max 64).', 'too_long');
+        }
+
+        $clientName = trim((string) ($body['client_name'] ?? ''));
+        if ($clientName === '') {
+            $errors[] = new ValidationError('client_name', 'Client name is required.', 'required');
+        } elseif (mb_strlen($clientName) > 255) {
+            $errors[] = new ValidationError('client_name', 'Client name is too long (max 255).', 'too_long');
+        }
+
+        $rawTotal = $body['total_cents'] ?? null;
+        $totalCents = is_int($rawTotal) || (is_string($rawTotal) && ctype_digit($rawTotal)) ? (int) $rawTotal : null;
+        if ($totalCents === null || $totalCents <= 0) {
+            $errors[] = new ValidationError('total_cents', 'A positive total amount (in cents) is required.', 'invalid');
+        }
+
+        $recipientEmail = self::optionalString($body, 'recipient_email');
+        if ($recipientEmail !== null && filter_var($recipientEmail, FILTER_VALIDATE_EMAIL) === false) {
+            $errors[] = new ValidationError('recipient_email', 'Recipient email is not a valid address.', 'invalid');
+        }
+
+        $currencyRaw = self::optionalString($body, 'currency');
+        $currency = $currencyRaw ?? 'JPY';
+        if ($currency !== 'JPY') {
+            $errors[] = new ValidationError('currency', 'Only JPY is supported.', 'unsupported');
+        }
+
+        $issuedAt = self::optionalString($body, 'issued_at');
+        if ($issuedAt !== null && !self::isCalendarDate($issuedAt)) {
+            $errors[] = new ValidationError('issued_at', 'Issue date must be YYYY-MM-DD.', 'invalid');
+        }
+
+        $dueAt = self::optionalString($body, 'due_at');
+        if ($dueAt !== null && !self::isCalendarDate($dueAt)) {
+            $errors[] = new ValidationError('due_at', 'Due date must be YYYY-MM-DD.', 'invalid');
+        }
+
+        if ($errors !== [] || $totalCents === null) {
+            throw new ValidationException($errors);
+        }
+
+        return [
+            'reference_number' => $referenceNumber,
+            'client_name' => $clientName,
+            'recipient_email' => $recipientEmail,
+            'total_cents' => $totalCents,
+            'currency' => $currency,
+            'issued_at' => $issuedAt,
+            'due_at' => $dueAt,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private static function optionalString(array $body, string $key): ?string
+    {
+        $value = $body[$key] ?? null;
+
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+
+    private static function isCalendarDate(string $value): bool
+    {
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        return $date !== false && $date->format('Y-m-d') === $value;
+    }
+}

--- a/src/Receivable/ParsedReceivableRows.php
+++ b/src/Receivable/ParsedReceivableRows.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Result of parsing a receivables CSV: the recognized header names present and
+ * the data rows. Each row keeps its 1-based CSV line number so import errors can
+ * point the operator at the offending line.
+ */
+final readonly class ParsedReceivableRows
+{
+    /**
+     * @param list<string>                                   $headers recognized field headers present
+     * @param list<array{row: int, data: array<string, string>}> $rows
+     */
+    public function __construct(
+        public array $headers,
+        public array $rows,
+    ) {
+    }
+}

--- a/src/Receivable/PdoManualReceivableRepository.php
+++ b/src/Receivable/PdoManualReceivableRepository.php
@@ -26,14 +26,27 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
         return $row !== null ? $this->hydrate($row) : null;
     }
 
-    public function findByOrganization(int $organizationId): array
+    public function findByOrganization(int $organizationId, ManualReceivableFilter $filter, int $limit, int $offset): array
     {
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $params[] = $limit;
+        $params[] = $offset;
+
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM manual_receivables WHERE organization_id = ? AND is_deleted = 0 ORDER BY id DESC',
-            [$organizationId],
+            'SELECT ' . self::COLUMNS . ' FROM manual_receivables WHERE ' . $where
+            . ' ORDER BY ' . self::orderBy($filter) . ' LIMIT ? OFFSET ?',
+            $params,
         );
 
         return array_map($this->hydrate(...), $rows);
+    }
+
+    public function countByOrganization(int $organizationId, ManualReceivableFilter $filter): int
+    {
+        [$where, $params] = $this->whereClause($organizationId, $filter);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM manual_receivables WHERE ' . $where, $params);
+
+        return (int) ($row['c'] ?? 0);
     }
 
     public function findByReferenceNumber(int $organizationId, string $referenceNumber): ?ManualReceivable
@@ -73,12 +86,83 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
         return $this->query->lastInsertId();
     }
 
+    public function update(ManualReceivable $receivable): void
+    {
+        $this->query->execute(
+            'UPDATE manual_receivables SET reference_number = ?, client_name = ?, recipient_email = ?, '
+            . 'total_cents = ?, outstanding_cents = ?, currency = ?, issued_at = ?, due_at = ?, status = ?, updated_at = ? '
+            . 'WHERE id = ? AND is_deleted = 0',
+            [
+                $receivable->referenceNumber,
+                $receivable->clientName,
+                $receivable->recipientEmail,
+                $receivable->totalCents,
+                $receivable->outstandingCents,
+                $receivable->currency,
+                $receivable->issuedAt,
+                $receivable->dueAt,
+                $receivable->status->value,
+                $receivable->updatedAt ?? $receivable->createdAt,
+                $receivable->id,
+            ],
+        );
+    }
+
     public function softDelete(int $id, string $deletedAt): void
     {
         $this->query->execute(
             'UPDATE manual_receivables SET is_deleted = 1, deleted_at = ? WHERE id = ? AND is_deleted = 0',
             [$deletedAt, $id],
         );
+    }
+
+    /**
+     * @return array{0: string, 1: list<string|int>}
+     */
+    private function whereClause(int $organizationId, ManualReceivableFilter $filter): array
+    {
+        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        /** @var list<string|int> $params */
+        $params = [$organizationId];
+
+        if ($filter->status !== null) {
+            $clauses[] = 'status = ?';
+            $params[] = $filter->status->value;
+        }
+        if ($filter->q !== null) {
+            $clauses[] = '(reference_number LIKE ? OR client_name LIKE ?)';
+            $like = '%' . $filter->q . '%';
+            $params[] = $like;
+            $params[] = $like;
+        }
+        if ($filter->dueFrom !== null) {
+            $clauses[] = 'due_at >= ?';
+            $params[] = $filter->dueFrom;
+        }
+        if ($filter->dueTo !== null) {
+            $clauses[] = 'due_at <= ?';
+            $params[] = $filter->dueTo;
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    /**
+     * Whitelisted ORDER BY — column and direction map from a closed set, so user
+     * input is never interpolated into SQL.
+     */
+    private static function orderBy(ManualReceivableFilter $filter): string
+    {
+        $column = match ($filter->sortColumn) {
+            'due_at' => 'due_at',
+            'total_cents' => 'total_cents',
+            'outstanding_cents' => 'outstanding_cents',
+            'created_at' => 'created_at',
+            default => 'id',
+        };
+        $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
+
+        return $column . ' ' . $direction . ', id DESC';
     }
 
     /**

--- a/src/Receivable/ReceivableSource.php
+++ b/src/Receivable/ReceivableSource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+/**
+ * Where a receivable (the target a deposit is reconciled against / dunning
+ * targets) comes from (ADR 0014). `invoice_upstream` is owned by NeNe Invoice
+ * (Invoice is the system of record; Clear writes payments back). `manual` is
+ * entered directly in Clear, which owns it because no other system holds it.
+ */
+enum ReceivableSource: string
+{
+    case InvoiceUpstream = 'invoice_upstream';
+    case Manual = 'manual';
+}

--- a/src/Receivable/UpdateManualReceivableHandler.php
+++ b/src/Receivable/UpdateManualReceivableHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateManualReceivableHandler
+{
+    public function __construct(
+        private UpdateManualReceivableUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($params['id'] ?? 0);
+        $fields = ManualReceivableValidator::validate(JsonRequestBodyParser::parse($request));
+
+        $receivable = $this->useCase->execute(new UpdateManualReceivableInput(
+            id: $id,
+            callerOrganizationId: AuthContext::organizationId($request) ?? 0,
+            referenceNumber: $fields['reference_number'],
+            clientName: $fields['client_name'],
+            recipientEmail: $fields['recipient_email'],
+            totalCents: $fields['total_cents'],
+            currency: $fields['currency'],
+            issuedAt: $fields['issued_at'],
+            dueAt: $fields['due_at'],
+            actorUserId: AuthContext::userId($request),
+        ));
+
+        return $this->response->create(ManualReceivableResponse::toArray($receivable));
+    }
+}

--- a/src/Receivable/UpdateManualReceivableInput.php
+++ b/src/Receivable/UpdateManualReceivableInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+final readonly class UpdateManualReceivableInput
+{
+    public function __construct(
+        public int $id,
+        public int $callerOrganizationId,
+        public string $referenceNumber,
+        public string $clientName,
+        public ?string $recipientEmail,
+        public int $totalCents,
+        public string $currency,
+        public ?string $issuedAt,
+        public ?string $dueAt,
+        public int $actorUserId,
+    ) {
+    }
+}

--- a/src/Receivable/UpdateManualReceivableUseCase.php
+++ b/src/Receivable/UpdateManualReceivableUseCase.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Http\ClockInterface;
+use NeneClear\Audit\AuditRecorderInterface;
+
+final readonly class UpdateManualReceivableUseCase implements UpdateManualReceivableUseCaseInterface
+{
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ManualReceivableRepositoryInterface $receivables
+     * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
+     */
+    public function __construct(
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $receivables,
+        private Closure $auditRecorder,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function execute(UpdateManualReceivableInput $input): ManualReceivable
+    {
+        // Read, update, and audit share one transaction so before/after always
+        // matches what was persisted (Issue #122).
+        return $this->transactionManager->transactional(
+            function (DatabaseQueryExecutorInterface $tx) use ($input): ManualReceivable {
+                $receivables = ($this->receivables)($tx);
+
+                $existing = $receivables->findById($input->id);
+                if ($existing === null || $existing->organizationId !== $input->callerOrganizationId) {
+                    throw new ManualReceivableNotFoundException($input->id);
+                }
+                if ($existing->status === ManualReceivableStatus::Cancelled) {
+                    throw new ManualReceivableCancelledException($input->id);
+                }
+
+                // A reference_number change must keep the per-tenant dedupe invariant.
+                if ($input->referenceNumber !== $existing->referenceNumber) {
+                    $clash = $receivables->findByReferenceNumber($input->callerOrganizationId, $input->referenceNumber);
+                    if ($clash !== null && $clash->id !== $existing->id) {
+                        throw new ManualReceivableAlreadyExistsException($input->referenceNumber);
+                    }
+                }
+
+                // No allocations exist yet (Issue 4 adds reconciliation), so a manual
+                // receivable's outstanding always equals its total here.
+                $now = $this->clock->now()->format('Y-m-d H:i:s');
+                $updated = new ManualReceivable(
+                    organizationId: $existing->organizationId,
+                    referenceNumber: $input->referenceNumber,
+                    clientName: $input->clientName,
+                    recipientEmail: $input->recipientEmail,
+                    totalCents: $input->totalCents,
+                    outstandingCents: $input->totalCents,
+                    currency: $input->currency,
+                    issuedAt: $input->issuedAt,
+                    dueAt: $input->dueAt,
+                    status: $existing->status,
+                    createdBy: $existing->createdBy,
+                    createdAt: $existing->createdAt,
+                    updatedAt: $now,
+                    id: $existing->id,
+                );
+
+                $receivables->update($updated);
+
+                ($this->auditRecorder)($tx)->record(
+                    $existing->organizationId,
+                    $input->actorUserId,
+                    $now,
+                    'manual_receivable_updated',
+                    'manual_receivable',
+                    $existing->id,
+                    [
+                        'before' => ManualReceivableResponse::toArray($existing),
+                        'after' => ManualReceivableResponse::toArray($updated),
+                    ],
+                );
+
+                return $updated;
+            },
+        );
+    }
+}

--- a/src/Receivable/UpdateManualReceivableUseCaseInterface.php
+++ b/src/Receivable/UpdateManualReceivableUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Receivable;
+
+interface UpdateManualReceivableUseCaseInterface
+{
+    public function execute(UpdateManualReceivableInput $input): ManualReceivable;
+}

--- a/src/Reconciliation/AllocationInput.php
+++ b/src/Reconciliation/AllocationInput.php
@@ -4,11 +4,39 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use NeneClear\Receivable\ReceivableSource;
+
+/**
+ * One allocation in a confirm request: an amount applied to a single receivable,
+ * which is either an upstream invoice (Invoice is SSOR; payment written back) or
+ * a manually-entered receivable (Clear is SSOR; no write-back). Build via the
+ * source-specific factories so exactly one target id is ever set (ADR 0014).
+ */
 final readonly class AllocationInput
 {
-    public function __construct(
-        public int $invoiceId,
+    private function __construct(
+        public ReceivableSource $source,
+        public ?int $invoiceId,
+        public ?int $manualReceivableId,
         public int $amountCents,
     ) {
+    }
+
+    public static function upstream(int $invoiceId, int $amountCents): self
+    {
+        return new self(ReceivableSource::InvoiceUpstream, $invoiceId, null, $amountCents);
+    }
+
+    public static function manual(int $manualReceivableId, int $amountCents): self
+    {
+        return new self(ReceivableSource::Manual, null, $manualReceivableId, $amountCents);
+    }
+
+    /** The target receivable id, whichever source this allocation uses. */
+    public function targetId(): int
+    {
+        return $this->source === ReceivableSource::Manual
+            ? (int) $this->manualReceivableId
+            : (int) $this->invoiceId;
     }
 }

--- a/src/Reconciliation/ClientCredit.php
+++ b/src/Reconciliation/ClientCredit.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use NeneClear\Receivable\ReceivableSource;
+
 final readonly class ClientCredit
 {
     public function __construct(
         public int $organizationId,
-        public int $clientId,
+        /** Upstream client id (`invoice_upstream`); null for `manual` (payer is in clientName). */
+        public ?int $clientId,
         public int $amountCents,
         public int $remainingCents,
         public ClientCreditStatus $status,
@@ -17,6 +20,9 @@ final readonly class ClientCredit
         public int $createdBy,
         public string $createdAt,
         public ?int $id = null,
+        public ReceivableSource $source = ReceivableSource::InvoiceUpstream,
+        public ?int $manualReceivableId = null,
+        public ?string $clientName = null,
     ) {
     }
 }

--- a/src/Reconciliation/ConfirmMatchHandler.php
+++ b/src/Reconciliation/ConfirmMatchHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Receivable\ReceivableSource;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -46,12 +47,28 @@ final readonly class ConfirmMatchHandler
             if (!is_array($raw)) {
                 throw new ValidationException([new ValidationError("allocations.$i", 'Each allocation must be an object.', 'invalid')]);
             }
-            $invoiceId = is_numeric($raw['invoice_id'] ?? null) ? (int) $raw['invoice_id'] : 0;
             $amountCents = is_numeric($raw['amount_cents'] ?? null) ? (int) $raw['amount_cents'] : 0;
-            if ($invoiceId <= 0 || $amountCents <= 0) {
-                throw new ValidationException([new ValidationError("allocations.$i", 'invoice_id and amount_cents must be positive integers.', 'invalid')]);
+            if ($amountCents <= 0) {
+                throw new ValidationException([new ValidationError("allocations.$i", 'amount_cents must be a positive integer.', 'invalid')]);
             }
-            $allocations[] = new AllocationInput($invoiceId, $amountCents);
+
+            // Default source keeps existing (upstream-only) clients working unchanged.
+            $source = is_string($raw['source'] ?? null) ? (string) $raw['source'] : ReceivableSource::InvoiceUpstream->value;
+            if ($source === ReceivableSource::Manual->value) {
+                $manualReceivableId = is_numeric($raw['manual_receivable_id'] ?? null) ? (int) $raw['manual_receivable_id'] : 0;
+                if ($manualReceivableId <= 0) {
+                    throw new ValidationException([new ValidationError("allocations.$i", 'manual_receivable_id must be a positive integer for a manual allocation.', 'invalid')]);
+                }
+                $allocations[] = AllocationInput::manual($manualReceivableId, $amountCents);
+            } elseif ($source === ReceivableSource::InvoiceUpstream->value) {
+                $invoiceId = is_numeric($raw['invoice_id'] ?? null) ? (int) $raw['invoice_id'] : 0;
+                if ($invoiceId <= 0) {
+                    throw new ValidationException([new ValidationError("allocations.$i", 'invoice_id must be a positive integer.', 'invalid')]);
+                }
+                $allocations[] = AllocationInput::upstream($invoiceId, $amountCents);
+            } else {
+                throw new ValidationException([new ValidationError("allocations.$i", 'source must be invoice_upstream or manual.', 'invalid')]);
+            }
         }
 
         $reasonCode = isset($body['reason_code']) && is_string($body['reason_code']) ? $body['reason_code'] : null;

--- a/src/Reconciliation/ConfirmMatchUseCase.php
+++ b/src/Reconciliation/ConfirmMatchUseCase.php
@@ -13,6 +13,12 @@ use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableCancelledException;
+use NeneClear\Receivable\ManualReceivableNotFoundException;
+use NeneClear\Receivable\ManualReceivableRepositoryInterface;
+use NeneClear\Receivable\ManualReceivableStatus;
+use NeneClear\Receivable\ReceivableSource;
 
 final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
 {
@@ -21,6 +27,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
      * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
      * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
+     * @param Closure(DatabaseQueryExecutorInterface): ManualReceivableRepositoryInterface $manualReceivables
      * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
@@ -29,6 +36,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
         private Closure $transactions,
         private Closure $reconciliations,
         private Closure $clientCredits,
+        private Closure $manualReceivables,
         private InvoiceUpstreamClientInterface $invoiceClient,
         private Closure $auditRecorder,
         private ClockInterface $clock,
@@ -59,46 +67,77 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
 
         $now = $this->clock->now()->format('Y-m-d H:i:s');
 
-        // Validate outstanding and call upstream for each allocation. Upstream payment
-        // creation is an external side effect and must happen OUTSIDE the database
-        // transaction (it cannot be rolled back); the local writes below are atomic.
-        $paymentsCreated = [];
+        // Validate outstanding per allocation. For UPSTREAM, the invoice payment is an
+        // external side effect created here (OUTSIDE the db transaction, since it cannot
+        // be rolled back). For MANUAL, Clear is the system of record — no upstream call;
+        // the balance is adjusted in the atomic block below.
+        $prepared = [];
         foreach ($input->allocations as $allocation) {
-            $invoice = $this->invoiceClient->getInvoice($input->organizationId, $allocation->invoiceId);
+            if ($allocation->source === ReceivableSource::Manual) {
+                $manualId = (int) $allocation->manualReceivableId;
+                $receivable = ($this->manualReceivables)($this->reader)->findById($manualId);
+                if ($receivable === null || $receivable->organizationId !== $input->organizationId) {
+                    throw new ManualReceivableNotFoundException($manualId);
+                }
+                if ($receivable->status === ManualReceivableStatus::Cancelled) {
+                    throw new ManualReceivableCancelledException($manualId);
+                }
+                if ($allocation->amountCents > $receivable->outstandingCents) {
+                    throw new AllocationExceedsOutstandingException($manualId, $receivable->outstandingCents);
+                }
+
+                $prepared[] = [
+                    'allocation' => $allocation,
+                    'source' => ReceivableSource::Manual,
+                    'payment' => null,
+                    'outstandingBefore' => $receivable->outstandingCents,
+                    'clientId' => null,
+                    'clientName' => $receivable->clientName,
+                    'manualReceivableId' => $manualId,
+                ];
+
+                continue;
+            }
+
+            $invoiceId = (int) $allocation->invoiceId;
+            $invoice = $this->invoiceClient->getInvoice($input->organizationId, $invoiceId);
 
             if ($allocation->amountCents > $invoice->outstandingCents) {
-                throw new AllocationExceedsOutstandingException($allocation->invoiceId, $invoice->outstandingCents);
+                throw new AllocationExceedsOutstandingException($invoiceId, $invoice->outstandingCents);
             }
 
             $externalRef = sprintf('clear:recon:pending:%s', bin2hex(random_bytes(8)));
-            $idempotencyKey = sprintf('clear:recon:confirm:%d:%d:%s', $input->bankTransactionId, $allocation->invoiceId, bin2hex(random_bytes(8)));
+            $idempotencyKey = sprintf('clear:recon:confirm:%d:%d:%s', $input->bankTransactionId, $invoiceId, bin2hex(random_bytes(8)));
 
             $payment = $this->invoiceClient->createPayment(
                 organizationId: $input->organizationId,
-                invoiceId: $allocation->invoiceId,
+                invoiceId: $invoiceId,
                 amountCents: $allocation->amountCents,
                 paidAt: $tx->valueDate,
                 externalReference: $externalRef,
                 idempotencyKey: $idempotencyKey,
             );
 
-            $paymentsCreated[] = [
+            $prepared[] = [
                 'allocation' => $allocation,
+                'source' => ReceivableSource::InvoiceUpstream,
                 'payment' => $payment,
-                'externalRef' => $externalRef,
-                'invoiceOutstandingBefore' => $invoice->outstandingCents,
+                'outstandingBefore' => $invoice->outstandingCents,
                 'clientId' => $invoice->clientId,
+                'clientName' => null,
+                'manualReceivableId' => null,
             ];
         }
 
         // Atomic local writes + audit: the reconciliation, its allocations, the bank
-        // transaction status, any overpayment credit, and the audit record commit (or
-        // roll back) together so a confirmed match can never lack its audit (Issue #122).
+        // transaction status, any manual-receivable balance update, any overpayment
+        // credit, and the audit record commit (or roll back) together (Issue #122).
         return $this->transactionManager->transactional(
-            function (DatabaseQueryExecutorInterface $ex) use ($input, $tx, $now, $paymentsCreated): ConfirmMatchOutput {
+            function (DatabaseQueryExecutorInterface $ex) use ($input, $tx, $now, $prepared): ConfirmMatchOutput {
                 $reconciliations = ($this->reconciliations)($ex);
                 $transactions = ($this->transactions)($ex);
                 $clientCredits = ($this->clientCredits)($ex);
+                $manualReceivables = ($this->manualReceivables)($ex);
                 $auditRecorder = ($this->auditRecorder)($ex);
 
                 $reconciliationId = $reconciliations->save(new Reconciliation(
@@ -112,20 +151,32 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 ));
 
                 $totalAllocated = 0;
-                foreach ($paymentsCreated as $entry) {
+                foreach ($prepared as $entry) {
                     /** @var AllocationInput $allocation */
                     $allocation = $entry['allocation'];
-                    $payment = $entry['payment'];
-                    $externalRef = sprintf('clear:recon:%d:%d', $reconciliationId, $allocation->invoiceId);
 
-                    $reconciliations->saveAllocation(new ReconciliationAllocation(
-                        organizationId: $input->organizationId,
-                        reconciliationId: $reconciliationId,
-                        invoiceId: $allocation->invoiceId,
-                        amountCents: $allocation->amountCents,
-                        paymentId: $payment->paymentId,
-                        externalReference: $externalRef,
-                    ));
+                    if ($entry['source'] === ReceivableSource::Manual) {
+                        $reconciliations->saveAllocation(new ReconciliationAllocation(
+                            organizationId: $input->organizationId,
+                            reconciliationId: $reconciliationId,
+                            invoiceId: null,
+                            amountCents: $allocation->amountCents,
+                            source: ReceivableSource::Manual,
+                            manualReceivableId: $entry['manualReceivableId'],
+                        ));
+                        $this->applyManualBalance($manualReceivables, (int) $entry['manualReceivableId'], -$allocation->amountCents, $now);
+                    } else {
+                        $payment = $entry['payment'];
+                        $externalRef = sprintf('clear:recon:%d:%d', $reconciliationId, (int) $allocation->invoiceId);
+                        $reconciliations->saveAllocation(new ReconciliationAllocation(
+                            organizationId: $input->organizationId,
+                            reconciliationId: $reconciliationId,
+                            invoiceId: $allocation->invoiceId,
+                            amountCents: $allocation->amountCents,
+                            paymentId: $payment->paymentId,
+                            externalReference: $externalRef,
+                        ));
+                    }
 
                     $totalAllocated += $allocation->amountCents;
                 }
@@ -135,9 +186,12 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 $transactions->updateStatusById($input->organizationId, $input->bankTransactionId, $newStatus);
 
                 if ($remainder > 0) {
+                    // The overpayment is attributed to the first allocation's payer; for a
+                    // manual receivable that is a client_name (no upstream client_id).
+                    $first = $prepared[0];
                     $clientCredits->save(new ClientCredit(
                         organizationId: $input->organizationId,
-                        clientId: $paymentsCreated[0]['clientId'],
+                        clientId: $first['clientId'],
                         amountCents: $remainder,
                         remainingCents: $remainder,
                         status: ClientCreditStatus::Open,
@@ -145,6 +199,9 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                         reconciliationId: $reconciliationId,
                         createdBy: $input->actorUserId,
                         createdAt: $now,
+                        source: $first['source'],
+                        manualReceivableId: $first['manualReceivableId'],
+                        clientName: $first['clientName'],
                     ));
                 }
 
@@ -159,13 +216,7 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                         'before' => [
                             'bank_transaction_status' => $tx->status->value,
                             'bank_transaction_amount_cents' => $tx->amountCents,
-                            'allocations' => array_map(
-                                static fn (array $e): array => [
-                                    'invoice_id' => $e['allocation']->invoiceId,
-                                    'invoice_outstanding_cents' => $e['invoiceOutstandingBefore'],
-                                ],
-                                $paymentsCreated,
-                            ),
+                            'allocations' => array_map(self::auditTarget(...), $prepared),
                         ],
                         'after' => [
                             'payment_reconciliation_id' => $reconciliationId,
@@ -173,12 +224,19 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                             'total_allocated_cents' => $totalAllocated,
                             'remainder_cents' => $remainder,
                             'allocations' => array_map(
-                                static fn (array $e): array => [
-                                    'invoice_id' => $e['allocation']->invoiceId,
-                                    'amount_cents' => $e['allocation']->amountCents,
-                                    'payment_id' => $e['payment']->paymentId,
-                                ],
-                                $paymentsCreated,
+                                static function (array $e): array {
+                                    /** @var AllocationInput $a */
+                                    $a = $e['allocation'];
+
+                                    return [
+                                        'source' => $e['source']->value,
+                                        'invoice_id' => $a->invoiceId,
+                                        'manual_receivable_id' => $e['manualReceivableId'],
+                                        'amount_cents' => $a->amountCents,
+                                        'payment_id' => $e['payment']?->paymentId,
+                                    ];
+                                },
+                                $prepared,
                             ),
                         ],
                     ],
@@ -187,5 +245,60 @@ final readonly class ConfirmMatchUseCase implements ConfirmMatchUseCaseInterface
                 return new ConfirmMatchOutput(reconciliationId: $reconciliationId);
             },
         );
+    }
+
+    /**
+     * Adjusts a manual receivable's outstanding by `$delta` (negative to apply a
+     * payment, positive to restore on reversal) and recomputes its status. Clear
+     * owns this balance (ADR 0014).
+     */
+    private function applyManualBalance(ManualReceivableRepositoryInterface $repo, int $id, int $delta, string $now): void
+    {
+        $receivable = $repo->findById($id);
+        if ($receivable === null) {
+            return;
+        }
+
+        $outstanding = max(0, $receivable->outstandingCents + $delta);
+        $status = match (true) {
+            $outstanding <= 0 => ManualReceivableStatus::Paid,
+            $outstanding < $receivable->totalCents => ManualReceivableStatus::PartiallyPaid,
+            default => ManualReceivableStatus::Open,
+        };
+
+        $repo->update(new ManualReceivable(
+            organizationId: $receivable->organizationId,
+            referenceNumber: $receivable->referenceNumber,
+            clientName: $receivable->clientName,
+            recipientEmail: $receivable->recipientEmail,
+            totalCents: $receivable->totalCents,
+            outstandingCents: $outstanding,
+            currency: $receivable->currency,
+            issuedAt: $receivable->issuedAt,
+            dueAt: $receivable->dueAt,
+            status: $status,
+            createdBy: $receivable->createdBy,
+            createdAt: $receivable->createdAt,
+            updatedAt: $now,
+            id: $receivable->id,
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     *
+     * @return array<string, mixed>
+     */
+    private static function auditTarget(array $entry): array
+    {
+        /** @var AllocationInput $allocation */
+        $allocation = $entry['allocation'];
+
+        return [
+            'source' => $entry['source']->value,
+            'invoice_id' => $allocation->invoiceId,
+            'manual_receivable_id' => $entry['manualReceivableId'],
+            'outstanding_before_cents' => $entry['outstandingBefore'],
+        ];
     }
 }

--- a/src/Reconciliation/PdoClientCreditRepository.php
+++ b/src/Reconciliation/PdoClientCreditRepository.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\Receivable\ReceivableSource;
 
 final readonly class PdoClientCreditRepository implements ClientCreditRepositoryInterface
 {
     private const string COLUMNS = 'id, organization_id, client_id, amount_cents, remaining_cents, status, '
-        . 'source_bank_transaction_id, reconciliation_id, created_by, created_at';
+        . 'source_bank_transaction_id, reconciliation_id, created_by, created_at, source, manual_receivable_id, client_name';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -20,7 +21,8 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
     {
         $this->query->execute(
             'INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status, '
-            . 'source_bank_transaction_id, reconciliation_id, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            . 'source_bank_transaction_id, reconciliation_id, created_by, created_at, source, manual_receivable_id, client_name) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $credit->organizationId,
                 $credit->clientId,
@@ -31,6 +33,9 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
                 $credit->reconciliationId,
                 $credit->createdBy,
                 $credit->createdAt,
+                $credit->source->value,
+                $credit->manualReceivableId,
+                $credit->clientName,
             ],
         );
 
@@ -181,7 +186,7 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
     {
         return new ClientCredit(
             organizationId: (int) $row['organization_id'],
-            clientId: (int) $row['client_id'],
+            clientId: isset($row['client_id']) ? (int) $row['client_id'] : null,
             amountCents: (int) $row['amount_cents'],
             remainingCents: (int) $row['remaining_cents'],
             status: ClientCreditStatus::from((string) $row['status']),
@@ -190,6 +195,9 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
             createdBy: (int) $row['created_by'],
             createdAt: (string) $row['created_at'],
             id: (int) $row['id'],
+            source: ReceivableSource::from((string) ($row['source'] ?? 'invoice_upstream')),
+            manualReceivableId: isset($row['manual_receivable_id']) ? (int) $row['manual_receivable_id'] : null,
+            clientName: isset($row['client_name']) ? (string) $row['client_name'] : null,
         );
     }
 }

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\Receivable\ReceivableSource;
 
 final readonly class PdoReconciliationRepository implements ReconciliationRepositoryInterface
 {
@@ -12,7 +13,7 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
         . 'confirmed_by, confirmed_at, reversed_at, reversal_reason, idempotency_key';
 
     private const string ALLOC_COLUMNS = 'id, organization_id, payment_reconciliation_id, invoice_id, '
-        . 'amount_cents, payment_id, external_reference';
+        . 'amount_cents, payment_id, external_reference, source, manual_receivable_id';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -132,8 +133,8 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
     public function saveAllocation(ReconciliationAllocation $allocation): int
     {
         $this->query->execute(
-            'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents, payment_id, external_reference) '
-            . 'VALUES (?, ?, ?, ?, ?, ?)',
+            'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents, payment_id, external_reference, source, manual_receivable_id) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $allocation->organizationId,
                 $allocation->reconciliationId,
@@ -141,6 +142,8 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
                 $allocation->amountCents,
                 $allocation->paymentId,
                 $allocation->externalReference,
+                $allocation->source->value,
+                $allocation->manualReceivableId,
             ],
         );
 
@@ -192,11 +195,13 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
         return new ReconciliationAllocation(
             organizationId: (int) $row['organization_id'],
             reconciliationId: (int) $row['payment_reconciliation_id'],
-            invoiceId: (int) $row['invoice_id'],
+            invoiceId: isset($row['invoice_id']) ? (int) $row['invoice_id'] : null,
             amountCents: (int) $row['amount_cents'],
             paymentId: isset($row['payment_id']) ? (int) $row['payment_id'] : null,
             externalReference: isset($row['external_reference']) ? (string) $row['external_reference'] : null,
             id: (int) $row['id'],
+            source: ReceivableSource::from((string) ($row['source'] ?? 'invoice_upstream')),
+            manualReceivableId: isset($row['manual_receivable_id']) ? (int) $row['manual_receivable_id'] : null,
         );
     }
 }

--- a/src/Reconciliation/ReconciliationAllocation.php
+++ b/src/Reconciliation/ReconciliationAllocation.php
@@ -4,16 +4,22 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use NeneClear\Receivable\ReceivableSource;
+
 final readonly class ReconciliationAllocation
 {
     public function __construct(
         public int $organizationId,
         public int $reconciliationId,
-        public int $invoiceId,
+        /** Set for `invoice_upstream`; null for `manual` (see manualReceivableId). */
+        public ?int $invoiceId,
         public int $amountCents,
         public ?int $paymentId = null,
         public ?string $externalReference = null,
         public ?int $id = null,
+        public ReceivableSource $source = ReceivableSource::InvoiceUpstream,
+        /** Set for `manual`; null for `invoice_upstream`. */
+        public ?int $manualReceivableId = null,
     ) {
     }
 }

--- a/src/Reconciliation/ReconciliationResponse.php
+++ b/src/Reconciliation/ReconciliationResponse.php
@@ -25,7 +25,9 @@ final readonly class ReconciliationResponse
             'allocations' => array_map(
                 static fn (ReconciliationAllocation $a): array => [
                     'reconciliation_allocation_id' => $a->id,
+                    'source' => $a->source->value,
                     'invoice_id' => $a->invoiceId,
+                    'manual_receivable_id' => $a->manualReceivableId,
                     'amount_cents' => $a->amountCents,
                     'payment_id' => $a->paymentId,
                     'external_reference' => $a->externalReference,

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -18,6 +18,8 @@ use NeneClear\BankImport\PdoBankTransactionRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Receivable\ManualReceivableRepositoryInterface;
+use NeneClear\Receivable\PdoManualReceivableRepository;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -57,6 +59,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): ReconciliationRepositoryInterface => new PdoReconciliationRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
@@ -70,6 +73,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     static fn (DatabaseQueryExecutorInterface $tx): ReconciliationRepositoryInterface => new PdoReconciliationRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): ClientCreditRepositoryInterface => new PdoClientCreditRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ManualReceivableRepositoryInterface => new PdoManualReceivableRepository($tx),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),

--- a/src/Reconciliation/ReverseReconciliationUseCase.php
+++ b/src/Reconciliation/ReverseReconciliationUseCase.php
@@ -12,6 +12,10 @@ use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableRepositoryInterface;
+use NeneClear\Receivable\ManualReceivableStatus;
+use NeneClear\Receivable\ReceivableSource;
 
 final readonly class ReverseReconciliationUseCase implements ReverseReconciliationUseCaseInterface
 {
@@ -20,6 +24,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
      * @param Closure(DatabaseQueryExecutorInterface): ReconciliationRepositoryInterface $reconciliations
      * @param Closure(DatabaseQueryExecutorInterface): ClientCreditRepositoryInterface $clientCredits
      * @param Closure(DatabaseQueryExecutorInterface): BankTransactionRepositoryInterface $transactions
+     * @param Closure(DatabaseQueryExecutorInterface): ManualReceivableRepositoryInterface $manualReceivables
      * @param Closure(DatabaseQueryExecutorInterface): AuditRecorderInterface $auditRecorder
      */
     public function __construct(
@@ -28,6 +33,7 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
         private Closure $reconciliations,
         private Closure $clientCredits,
         private Closure $transactions,
+        private Closure $manualReceivables,
         private InvoiceUpstreamClientInterface $invoiceClient,
         private Closure $auditRecorder,
         private ClockInterface $clock,
@@ -51,8 +57,10 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
 
         // Upstream payment voids are external side effects and run OUTSIDE the
         // database transaction; the local writes below are atomic (Issue #122).
+        // Manual allocations have no upstream payment — their balance is restored
+        // locally in the transaction.
         foreach ($allocations as $allocation) {
-            if ($allocation->paymentId !== null) {
+            if ($allocation->source === ReceivableSource::InvoiceUpstream && $allocation->paymentId !== null && $allocation->invoiceId !== null) {
                 $idempotencyKey = sprintf('clear:recon:reverse:%d:%d', $input->reconciliationId, $allocation->invoiceId);
                 $this->invoiceClient->voidPayment(
                     organizationId: $input->organizationId,
@@ -69,11 +77,19 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
                 $reconciliations = ($this->reconciliations)($ex);
                 $transactions = ($this->transactions)($ex);
                 $clientCredits = ($this->clientCredits)($ex);
+                $manualReceivables = ($this->manualReceivables)($ex);
                 $auditRecorder = ($this->auditRecorder)($ex);
 
                 $reconciliations->reverseById($input->reconciliationId, $now, $input->reversalReason);
                 $transactions->updateStatusById($input->organizationId, $reconciliation->bankTransactionId, BankTransactionStatus::Unmatched);
                 $clientCredits->voidByReconciliation($input->reconciliationId);
+
+                // Restore each manual receivable's outstanding (Clear is its SSOR).
+                foreach ($allocations as $allocation) {
+                    if ($allocation->source === ReceivableSource::Manual && $allocation->manualReceivableId !== null) {
+                        $this->restoreManualBalance($manualReceivables, $allocation->manualReceivableId, $allocation->amountCents, $now);
+                    }
+                }
 
                 $auditRecorder->record(
                     $input->organizationId,
@@ -90,7 +106,9 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
                             'confirmed_at' => $reconciliation->confirmedAt,
                             'allocations' => array_map(
                                 static fn (ReconciliationAllocation $a): array => [
+                                    'source' => $a->source->value,
                                     'invoice_id' => $a->invoiceId,
+                                    'manual_receivable_id' => $a->manualReceivableId,
                                     'amount_cents' => $a->amountCents,
                                     'payment_id' => $a->paymentId,
                                 ],
@@ -108,5 +126,44 @@ final readonly class ReverseReconciliationUseCase implements ReverseReconciliati
                 return new ReverseReconciliationOutput(reconciliationId: $input->reconciliationId);
             },
         );
+    }
+
+    /**
+     * Adds `$amountCents` back to a manual receivable's outstanding on reversal and
+     * recomputes its status. A receivable cancelled after the match keeps its
+     * cancelled status (only the balance is restored).
+     */
+    private function restoreManualBalance(ManualReceivableRepositoryInterface $repo, int $id, int $amountCents, string $now): void
+    {
+        $receivable = $repo->findById($id);
+        if ($receivable === null) {
+            return;
+        }
+
+        $outstanding = min($receivable->totalCents, $receivable->outstandingCents + $amountCents);
+        $status = $receivable->status === ManualReceivableStatus::Cancelled
+            ? ManualReceivableStatus::Cancelled
+            : match (true) {
+                $outstanding <= 0 => ManualReceivableStatus::Paid,
+                $outstanding < $receivable->totalCents => ManualReceivableStatus::PartiallyPaid,
+                default => ManualReceivableStatus::Open,
+            };
+
+        $repo->update(new ManualReceivable(
+            organizationId: $receivable->organizationId,
+            referenceNumber: $receivable->referenceNumber,
+            clientName: $receivable->clientName,
+            recipientEmail: $receivable->recipientEmail,
+            totalCents: $receivable->totalCents,
+            outstandingCents: $outstanding,
+            currency: $receivable->currency,
+            issuedAt: $receivable->issuedAt,
+            dueAt: $receivable->dueAt,
+            status: $status,
+            createdBy: $receivable->createdBy,
+            createdAt: $receivable->createdAt,
+            updatedAt: $now,
+            id: $receivable->id,
+        ));
     }
 }

--- a/tests/Database/PdoManualReceivableRepositoryTest.php
+++ b/tests/Database/PdoManualReceivableRepositoryTest.php
@@ -7,6 +7,7 @@ namespace NeneClear\Tests\Database;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Testing\DatabaseTestKit;
 use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableFilter;
 use NeneClear\Receivable\ManualReceivableStatus;
 use NeneClear\Receivable\PdoManualReceivableRepository;
 use NeneClear\Tests\Support\SchemaFixture;
@@ -86,9 +87,10 @@ final class PdoManualReceivableRepositoryTest extends TestCase
         $this->seed('INV-B');
         $this->seed('OTHER-ORG', orgId: 99);
 
-        $rows = $this->repo->findByOrganization(7);
+        $rows = $this->repo->findByOrganization(7, new ManualReceivableFilter(), 50, 0);
 
         self::assertCount(2, $rows);
+        self::assertSame(2, $this->repo->countByOrganization(7, new ManualReceivableFilter()));
         // newest (highest id) first
         self::assertSame('INV-B', $rows[0]->referenceNumber);
         self::assertSame('INV-A', $rows[1]->referenceNumber);
@@ -114,7 +116,7 @@ final class PdoManualReceivableRepositoryTest extends TestCase
 
         self::assertNull($this->repo->findById($id));
         self::assertNull($this->repo->findByReferenceNumber(7, 'INV-DEL'));
-        self::assertCount(0, $this->repo->findByOrganization(7));
+        self::assertCount(0, $this->repo->findByOrganization(7, new ManualReceivableFilter(), 50, 0));
     }
 
     public function test_soft_deleted_reference_number_can_be_reused(): void

--- a/tests/Http/ManualReceivableCrudHttpTest.php
+++ b/tests/Http/ManualReceivableCrudHttpTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ManualReceivableCrudHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-mrcrud-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createLoginAttempts($query);
+        SchemaFixture::createAuditEvents($query);
+        SchemaFixture::createManualReceivables($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('admin@acme.example', Role::Admin, 7));
+        $users->save($this->user('member@acme.example', Role::Member, 7));
+        $users->save($this->user('viewer@acme.example', Role::Viewer, 7));
+        $users->save($this->user('member@org8.example', Role::Member, 8));
+
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role, int $org): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: $org,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, mixed>|null $json
+     */
+    private function request(string $method, string $path, string $token, ?array $json = null): ResponseInterface
+    {
+        $request = $this->psr17->createServerRequest($method, $path)->withHeader('Authorization', 'Bearer ' . $token);
+        if ($json !== null) {
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->psr17->createStream((string) json_encode($json)));
+        }
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validBody(string $reference = 'INV-2026-001'): array
+    {
+        return [
+            'reference_number' => $reference,
+            'client_name' => 'カ）アクメ',
+            'recipient_email' => 'ar@acme.example',
+            'total_cents' => 110000,
+            'due_at' => '2026-04-30',
+        ];
+    }
+
+    public function test_member_can_create_list_get_update_and_cancel(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+
+        $created = $this->request('POST', '/admin/manual-receivables', $token, $this->validBody());
+        self::assertSame(201, $created->getStatusCode());
+        $body = $this->decode($created);
+        $id = $body['manual_receivable_id'] ?? null;
+        self::assertIsInt($id);
+        self::assertSame('manual', $body['source'] ?? null);
+        self::assertSame('open', $body['status'] ?? null);
+        self::assertSame(110000, $body['total_cents'] ?? null);
+        self::assertSame(110000, $body['outstanding_cents'] ?? null);
+        self::assertSame(7, $body['organization_id'] ?? null);
+
+        $list = $this->request('GET', '/admin/manual-receivables', $token);
+        self::assertSame(200, $list->getStatusCode());
+        self::assertSame(1, $this->decode($list)['total'] ?? null);
+
+        $got = $this->request('GET', '/admin/manual-receivables/' . $id, $token);
+        self::assertSame(200, $got->getStatusCode());
+        self::assertSame('INV-2026-001', $this->decode($got)['reference_number'] ?? null);
+
+        $updated = $this->request('PUT', '/admin/manual-receivables/' . $id, $token, [
+            'reference_number' => 'INV-2026-001',
+            'client_name' => 'カ）アクメ（改）',
+            'total_cents' => 90000,
+            'due_at' => '2026-05-31',
+        ]);
+        self::assertSame(200, $updated->getStatusCode());
+        $u = $this->decode($updated);
+        self::assertSame('カ）アクメ（改）', $u['client_name'] ?? null);
+        self::assertSame(90000, $u['total_cents'] ?? null);
+        self::assertSame(90000, $u['outstanding_cents'] ?? null);
+        // PUT is a full replace: omitting recipient_email clears it.
+        self::assertArrayHasKey('recipient_email', $u);
+        self::assertNull($u['recipient_email']);
+
+        $cancelled = $this->request('POST', '/admin/manual-receivables/' . $id . '/cancel', $token);
+        self::assertSame(200, $cancelled->getStatusCode());
+        self::assertSame('cancelled', $this->decode($cancelled)['status'] ?? null);
+
+        // A cancelled receivable can no longer be edited or cancelled again.
+        self::assertSame(409, $this->request('PUT', '/admin/manual-receivables/' . $id, $token, $this->validBody())->getStatusCode());
+        self::assertSame(409, $this->request('POST', '/admin/manual-receivables/' . $id . '/cancel', $token)->getStatusCode());
+    }
+
+    public function test_duplicate_reference_number_is_rejected(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+        self::assertSame(201, $this->request('POST', '/admin/manual-receivables', $token, $this->validBody('DUP-1'))->getStatusCode());
+
+        $second = $this->request('POST', '/admin/manual-receivables', $token, $this->validBody('DUP-1'));
+        self::assertSame(409, $second->getStatusCode());
+        self::assertStringContainsString('manual-receivable-already-exists', (string) $this->decode($second)['type']);
+    }
+
+    public function test_validation_rejects_missing_and_bad_fields(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+
+        self::assertSame(422, $this->request('POST', '/admin/manual-receivables', $token, [
+            'reference_number' => '',
+            'client_name' => '',
+            'total_cents' => 0,
+        ])->getStatusCode());
+
+        self::assertSame(422, $this->request('POST', '/admin/manual-receivables', $token, [
+            'reference_number' => 'X',
+            'client_name' => 'Y',
+            'total_cents' => 1000,
+            'due_at' => '2026-13-40',
+            'recipient_email' => 'not-an-email',
+        ])->getStatusCode());
+    }
+
+    public function test_tenant_isolation(): void
+    {
+        $org8 = $this->tokenFor('member@org8.example');
+        $org8Id = $this->decode($this->request('POST', '/admin/manual-receivables', $org8, $this->validBody('ORG8-1')))['manual_receivable_id'];
+
+        $org7 = $this->tokenFor('member@acme.example');
+        self::assertSame(404, $this->request('GET', '/admin/manual-receivables/' . $org8Id, $org7)->getStatusCode());
+        self::assertSame(0, $this->decode($this->request('GET', '/admin/manual-receivables', $org7))['total'] ?? null);
+    }
+
+    public function test_viewer_can_read_but_not_create(): void
+    {
+        $member = $this->tokenFor('member@acme.example');
+        $this->request('POST', '/admin/manual-receivables', $member, $this->validBody('V-1'));
+
+        $viewer = $this->tokenFor('viewer@acme.example');
+        self::assertSame(200, $this->request('GET', '/admin/manual-receivables', $viewer)->getStatusCode());
+        self::assertSame(403, $this->request('POST', '/admin/manual-receivables', $viewer, $this->validBody('V-2'))->getStatusCode());
+    }
+}

--- a/tests/Http/ManualReceivableImportHttpTest.php
+++ b/tests/Http/ManualReceivableImportHttpTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\PdoUserRepository;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ManualReceivableImportHttpTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery';
+
+    private const string CSV = "reference_number,client_name,total_cents,due_at,recipient_email\n"
+        . "REF-1,カ）アクメ,110000,2026-04-30,ar@acme.example\n"
+        . "REF-2,カ）サクラ,50000,2026-05-31,\n"
+        . "REF-1,カ）アクメ,110000,2026-04-30,ar@acme.example\n"
+        . "BAD-1,,abc,,\n";
+
+    private string $dbPath;
+    private RequestHandlerInterface $app;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-mrimp-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        $query = $kit->queryExecutor;
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createLoginAttempts($query);
+        SchemaFixture::createAuditEvents($query);
+        SchemaFixture::createManualReceivables($query);
+
+        $users = new PdoUserRepository($query);
+        $users->save($this->user('member@acme.example', Role::Member, 7));
+        $users->save($this->user('viewer@acme.example', Role::Viewer, 7));
+
+        $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET);
+        $this->psr17 = new Psr17Factory();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function user(string $email, Role $role, int $org): User
+    {
+        return new User(
+            email: $email,
+            role: $role,
+            status: UserStatus::Active,
+            passwordHash: password_hash(self::PASSWORD, PASSWORD_BCRYPT),
+            organizationId: $org,
+        );
+    }
+
+    private function tokenFor(string $email): string
+    {
+        $request = $this->psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psr17->createStream((string) json_encode(['email' => $email, 'password' => self::PASSWORD])));
+        $token = $this->decode($this->app->handle($request))['token'] ?? null;
+        self::assertIsString($token);
+
+        return $token;
+    }
+
+    private function upload(string $token, string $csv): ResponseInterface
+    {
+        $file = $this->psr17->createUploadedFile($this->psr17->createStream($csv), strlen($csv), UPLOAD_ERR_OK, 'receivables.csv', 'text/csv');
+        $request = $this->psr17->createServerRequest('POST', '/admin/manual-receivable-imports')
+            ->withHeader('Authorization', 'Bearer ' . $token)
+            ->withUploadedFiles(['file' => $file]);
+
+        return $this->app->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        $data = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($data);
+
+        return $data;
+    }
+
+    public function test_imports_valid_rows_skips_duplicates_and_reports_errors(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+
+        $result = $this->upload($token, self::CSV);
+        self::assertSame(200, $result->getStatusCode());
+        $body = $this->decode($result);
+        self::assertSame(2, $body['created']);   // REF-1, REF-2
+        self::assertSame(1, $body['skipped']);   // REF-1 duplicate
+        self::assertIsArray($body['errors']);
+        self::assertCount(1, $body['errors']);   // BAD-1 (empty client, non-numeric total)
+        self::assertSame(5, $body['errors'][0]['row'] ?? null); // 1-based CSV line
+
+        $list = $this->decode($this->app->handle(
+            $this->psr17->createServerRequest('GET', '/admin/manual-receivables')->withHeader('Authorization', 'Bearer ' . $token),
+        ));
+        self::assertSame(2, $list['total'] ?? null);
+    }
+
+    public function test_missing_required_header_is_rejected(): void
+    {
+        $token = $this->tokenFor('member@acme.example');
+        // No total_cents column.
+        $csv = "reference_number,client_name\nREF-9,カ）アクメ\n";
+        self::assertSame(422, $this->upload($token, $csv)->getStatusCode());
+    }
+
+    public function test_viewer_cannot_import(): void
+    {
+        $token = $this->tokenFor('viewer@acme.example');
+        self::assertSame(403, $this->upload($token, self::CSV)->getStatusCode());
+    }
+}

--- a/tests/Reconciliation/ConfirmMatchUseCaseTest.php
+++ b/tests/Reconciliation/ConfirmMatchUseCaseTest.php
@@ -10,6 +10,8 @@ use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableStatus;
 use NeneClear\Reconciliation\AllocationExceedsOutstandingException;
 use NeneClear\Reconciliation\AllocationInput;
 use NeneClear\Reconciliation\BankTransactionNotMatchableException;
@@ -29,6 +31,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
     private InMemoryBankTransactionRepository $transactions;
     private InMemoryReconciliationRepository $reconciliations;
     private InMemoryClientCreditRepository $clientCredits;
+    private InMemoryManualReceivableRepository $manualReceivables;
     private FakeInvoiceUpstreamClient $invoiceClient;
     private InMemoryAuditEventRepository $audit;
     private ConfirmMatchUseCase $useCase;
@@ -38,6 +41,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->transactions = new InMemoryBankTransactionRepository();
         $this->reconciliations = new InMemoryReconciliationRepository();
         $this->clientCredits = new InMemoryClientCreditRepository();
+        $this->manualReceivables = new InMemoryManualReceivableRepository();
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
         $this->audit = new InMemoryAuditEventRepository();
         $this->useCase = new ConfirmMatchUseCase(
@@ -46,6 +50,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
             fn () => $this->transactions,
             fn () => $this->reconciliations,
             fn () => $this->clientCredits,
+            fn () => $this->manualReceivables,
             $this->invoiceClient,
             fn () => new AuditRecorder($this->audit),
             new FixedClock(),
@@ -80,6 +85,102 @@ final class ConfirmMatchUseCaseTest extends TestCase
         ));
     }
 
+    private function makeManualReceivable(int $totalCents): int
+    {
+        return $this->manualReceivables->save(new ManualReceivable(
+            organizationId: 7,
+            referenceNumber: 'MR-' . $totalCents,
+            clientName: 'カ）アクメ',
+            recipientEmail: 'ar@acme.example',
+            totalCents: $totalCents,
+            outstandingCents: $totalCents,
+            currency: 'JPY',
+            issuedAt: '2026-03-31',
+            dueAt: '2026-04-30',
+            status: ManualReceivableStatus::Open,
+            createdBy: 1,
+            createdAt: '2026-04-01 09:00:00',
+        ));
+    }
+
+    public function test_manual_allocation_reduces_outstanding_without_upstream_payment(): void
+    {
+        $txId = $this->makeTx(100000);
+        $mrId = $this->makeManualReceivable(100000);
+
+        $output = $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [AllocationInput::manual($mrId, 100000)],
+            actorUserId: 42,
+        ));
+
+        self::assertSame(BankTransactionStatus::Matched, $this->transactions->findById(7, $txId)?->status);
+        self::assertSame(ReconciliationStatus::Confirmed, $this->reconciliations->findById(7, $output->reconciliationId)?->status);
+
+        $mr = $this->manualReceivables->findById($mrId);
+        self::assertNotNull($mr);
+        self::assertSame(0, $mr->outstandingCents);
+        self::assertSame(ManualReceivableStatus::Paid, $mr->status);
+
+        // Clear is the SSOR for manual receivables — no upstream payment was created.
+        self::assertEmpty($this->clientCredits->all());
+    }
+
+    public function test_manual_partial_allocation_sets_partially_paid(): void
+    {
+        $txId = $this->makeTx(40000);
+        $mrId = $this->makeManualReceivable(100000);
+
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [AllocationInput::manual($mrId, 40000)],
+            actorUserId: 42,
+        ));
+
+        $mr = $this->manualReceivables->findById($mrId);
+        self::assertNotNull($mr);
+        self::assertSame(60000, $mr->outstandingCents);
+        self::assertSame(ManualReceivableStatus::PartiallyPaid, $mr->status);
+    }
+
+    public function test_manual_overpayment_creates_manual_client_credit(): void
+    {
+        $txId = $this->makeTx(150000);
+        $mrId = $this->makeManualReceivable(100000);
+
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [AllocationInput::manual($mrId, 100000)],
+            actorUserId: 42,
+        ));
+
+        self::assertSame(BankTransactionStatus::PartiallyMatched, $this->transactions->findById(7, $txId)?->status);
+
+        $credits = $this->clientCredits->all();
+        self::assertCount(1, $credits);
+        self::assertSame(50000, $credits[0]->amountCents);
+        self::assertNull($credits[0]->clientId);
+        self::assertSame('カ）アクメ', $credits[0]->clientName);
+        self::assertSame($mrId, $credits[0]->manualReceivableId);
+    }
+
+    public function test_manual_allocation_over_outstanding_is_rejected(): void
+    {
+        $txId = $this->makeTx(120000);
+        $mrId = $this->makeManualReceivable(100000);
+
+        $this->expectException(AllocationExceedsOutstandingException::class);
+        $this->useCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [AllocationInput::manual($mrId, 120000)],
+            actorUserId: 42,
+        ));
+    }
+
     public function test_exact_match_sets_status_to_matched(): void
     {
         $txId = $this->makeTx(100000);
@@ -88,7 +189,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $output = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -114,7 +215,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $output = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -136,7 +237,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $output = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 200000), new AllocationInput(2, 100000)],
+            allocations: [AllocationInput::upstream(1, 200000), AllocationInput::upstream(2, 100000)],
             actorUserId: 42,
         ));
 
@@ -156,7 +257,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 150000)],
+            allocations: [AllocationInput::upstream(1, 150000)],
             actorUserId: 42,
         ));
     }
@@ -169,7 +270,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $first = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
             idempotencyKey: 'key-abc-123',
         ));
@@ -178,7 +279,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $replay = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
             idempotencyKey: 'key-abc-123',
         ));
@@ -197,7 +298,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $first = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
             idempotencyKey: 'key-abc-111',
         ));
@@ -209,7 +310,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $second = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId2,
-            allocations: [new AllocationInput(2, 50000)],
+            allocations: [AllocationInput::upstream(2, 50000)],
             actorUserId: 42,
             idempotencyKey: 'key-abc-222',
         ));
@@ -224,7 +325,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: 9999,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
     }
@@ -238,7 +339,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
     }
@@ -252,7 +353,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 999, // different org cannot see org 7 transactions
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
     }
@@ -266,7 +367,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $output1 = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -296,7 +397,7 @@ final class ConfirmMatchUseCaseTest extends TestCase
         $confirmOutput = $this->useCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 

--- a/tests/Reconciliation/InMemoryClientCreditRepository.php
+++ b/tests/Reconciliation/InMemoryClientCreditRepository.php
@@ -30,6 +30,9 @@ final class InMemoryClientCreditRepository implements ClientCreditRepositoryInte
             createdBy: $credit->createdBy,
             createdAt: $credit->createdAt,
             id: $id,
+            source: $credit->source,
+            manualReceivableId: $credit->manualReceivableId,
+            clientName: $credit->clientName,
         );
 
         return $id;
@@ -59,6 +62,9 @@ final class InMemoryClientCreditRepository implements ClientCreditRepositoryInte
             createdBy: $credit->createdBy,
             createdAt: $credit->createdAt,
             id: $credit->id,
+            source: $credit->source,
+            manualReceivableId: $credit->manualReceivableId,
+            clientName: $credit->clientName,
         );
 
         return $this->byId[$id];
@@ -90,6 +96,9 @@ final class InMemoryClientCreditRepository implements ClientCreditRepositoryInte
                     createdBy: $credit->createdBy,
                     createdAt: $credit->createdAt,
                     id: $credit->id,
+                    source: $credit->source,
+                    manualReceivableId: $credit->manualReceivableId,
+                    clientName: $credit->clientName,
                 );
             }
         }
@@ -157,7 +166,7 @@ final class InMemoryClientCreditRepository implements ClientCreditRepositoryInte
     private function sortKey(ClientCredit $c, string $column): int|string
     {
         return match ($column) {
-            'client_id' => $c->clientId,
+            'client_id' => $c->clientId ?? 0,
             'amount_cents' => $c->amountCents,
             'remaining_cents' => $c->remainingCents,
             'created_at' => $c->createdAt,

--- a/tests/Reconciliation/InMemoryManualReceivableRepository.php
+++ b/tests/Reconciliation/InMemoryManualReceivableRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Reconciliation;
+
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableFilter;
+use NeneClear\Receivable\ManualReceivableRepositoryInterface;
+
+/** In-memory ManualReceivable repository for use-case unit tests. */
+final class InMemoryManualReceivableRepository implements ManualReceivableRepositoryInterface
+{
+    /** @var array<int, ManualReceivable> */
+    private array $rows = [];
+    private int $nextId = 1;
+
+    public function findById(int $id): ?ManualReceivable
+    {
+        return array_key_exists($id, $this->rows) ? $this->rows[$id] : null;
+    }
+
+    public function findByOrganization(int $organizationId, ManualReceivableFilter $filter, int $limit, int $offset): array
+    {
+        $items = array_values(array_filter($this->rows, static fn (ManualReceivable $r): bool => $r->organizationId === $organizationId));
+
+        return array_slice($items, $offset, $limit);
+    }
+
+    public function countByOrganization(int $organizationId, ManualReceivableFilter $filter): int
+    {
+        return count(array_filter($this->rows, static fn (ManualReceivable $r): bool => $r->organizationId === $organizationId));
+    }
+
+    public function findByReferenceNumber(int $organizationId, string $referenceNumber): ?ManualReceivable
+    {
+        foreach ($this->rows as $r) {
+            if ($r->organizationId === $organizationId && $r->referenceNumber === $referenceNumber) {
+                return $r;
+            }
+        }
+
+        return null;
+    }
+
+    public function save(ManualReceivable $receivable): int
+    {
+        $id = $this->nextId++;
+        $this->rows[$id] = $this->withId($receivable, $id);
+
+        return $id;
+    }
+
+    public function update(ManualReceivable $receivable): void
+    {
+        if ($receivable->id !== null && isset($this->rows[$receivable->id])) {
+            $this->rows[$receivable->id] = $receivable;
+        }
+    }
+
+    public function softDelete(int $id, string $deletedAt): void
+    {
+        unset($this->rows[$id]);
+    }
+
+    private function withId(ManualReceivable $r, int $id): ManualReceivable
+    {
+        return new ManualReceivable(
+            organizationId: $r->organizationId,
+            referenceNumber: $r->referenceNumber,
+            clientName: $r->clientName,
+            recipientEmail: $r->recipientEmail,
+            totalCents: $r->totalCents,
+            outstandingCents: $r->outstandingCents,
+            currency: $r->currency,
+            issuedAt: $r->issuedAt,
+            dueAt: $r->dueAt,
+            status: $r->status,
+            createdBy: $r->createdBy,
+            createdAt: $r->createdAt,
+            updatedAt: $r->updatedAt,
+            id: $id,
+        );
+    }
+}

--- a/tests/Reconciliation/InMemoryReconciliationRepository.php
+++ b/tests/Reconciliation/InMemoryReconciliationRepository.php
@@ -89,6 +89,8 @@ final class InMemoryReconciliationRepository implements ReconciliationRepository
             paymentId: $allocation->paymentId,
             externalReference: $allocation->externalReference,
             id: $id,
+            source: $allocation->source,
+            manualReceivableId: $allocation->manualReceivableId,
         );
 
         return $id;

--- a/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
+++ b/tests/Reconciliation/ReverseReconciliationUseCaseTest.php
@@ -9,6 +9,8 @@ use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableStatus;
 use NeneClear\Reconciliation\AllocationInput;
 use NeneClear\Reconciliation\ClientCreditStatus;
 use NeneClear\Reconciliation\ConfirmMatchInput;
@@ -30,6 +32,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
     private InMemoryBankTransactionRepository $transactions;
     private InMemoryReconciliationRepository $reconciliations;
     private InMemoryClientCreditRepository $clientCredits;
+    private InMemoryManualReceivableRepository $manualReceivables;
     private FakeInvoiceUpstreamClient $invoiceClient;
     private InMemoryAuditEventRepository $audit;
     private ConfirmMatchUseCase $confirmUseCase;
@@ -40,6 +43,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         $this->transactions = new InMemoryBankTransactionRepository();
         $this->reconciliations = new InMemoryReconciliationRepository();
         $this->clientCredits = new InMemoryClientCreditRepository();
+        $this->manualReceivables = new InMemoryManualReceivableRepository();
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
         $this->audit = new InMemoryAuditEventRepository();
 
@@ -50,6 +54,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
             fn () => $this->transactions,
             fn () => $this->reconciliations,
             fn () => $this->clientCredits,
+            fn () => $this->manualReceivables,
             $this->invoiceClient,
             fn () => new AuditRecorder($this->audit),
             $clock,
@@ -60,6 +65,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
             fn () => $this->reconciliations,
             fn () => $this->clientCredits,
             fn () => $this->transactions,
+            fn () => $this->manualReceivables,
             $this->invoiceClient,
             fn () => new AuditRecorder($this->audit),
             $clock,
@@ -94,6 +100,48 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         ));
     }
 
+    private function makeManualReceivable(int $totalCents): int
+    {
+        return $this->manualReceivables->save(new ManualReceivable(
+            organizationId: 7,
+            referenceNumber: 'MR-' . $totalCents,
+            clientName: 'カ）アクメ',
+            recipientEmail: 'ar@acme.example',
+            totalCents: $totalCents,
+            outstandingCents: $totalCents,
+            currency: 'JPY',
+            issuedAt: '2026-03-31',
+            dueAt: '2026-04-30',
+            status: ManualReceivableStatus::Open,
+            createdBy: 1,
+            createdAt: '2026-04-01 09:00:00',
+        ));
+    }
+
+    public function test_reverse_restores_manual_receivable_outstanding(): void
+    {
+        $txId = $this->makeTx(100000);
+        $mrId = $this->makeManualReceivable(100000);
+        $confirmOutput = $this->confirmUseCase->execute(new ConfirmMatchInput(
+            organizationId: 7,
+            bankTransactionId: $txId,
+            allocations: [AllocationInput::manual($mrId, 100000)],
+            actorUserId: 42,
+        ));
+
+        // Sanity: fully applied before reversal.
+        self::assertSame(ManualReceivableStatus::Paid, $this->manualReceivables->findById($mrId)?->status);
+
+        $this->reverseUseCase->execute($this->reverseInput($confirmOutput->reconciliationId));
+
+        self::assertSame(BankTransactionStatus::Unmatched, $this->transactions->findById(7, $txId)?->status);
+
+        $mr = $this->manualReceivables->findById($mrId);
+        self::assertNotNull($mr);
+        self::assertSame(100000, $mr->outstandingCents);
+        self::assertSame(ManualReceivableStatus::Open, $mr->status);
+    }
+
     private function reverseInput(int $reconciliationId, int $orgId = 7): ReverseReconciliationInput
     {
         return new ReverseReconciliationInput(
@@ -111,7 +159,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         $confirmOutput = $this->confirmUseCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -141,7 +189,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         $confirmOutput = $this->confirmUseCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -167,7 +215,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         $output = $this->confirmUseCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 
@@ -182,7 +230,7 @@ final class ReverseReconciliationUseCaseTest extends TestCase
         $output = $this->confirmUseCase->execute(new ConfirmMatchInput(
             organizationId: 7,
             bankTransactionId: $txId,
-            allocations: [new AllocationInput(1, 100000)],
+            allocations: [AllocationInput::upstream(1, 100000)],
             actorUserId: 42,
         ));
 

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -181,10 +181,12 @@ final class SchemaFixture
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 organization_id INTEGER NOT NULL,
                 payment_reconciliation_id INTEGER NOT NULL,
-                invoice_id INTEGER NOT NULL,
+                invoice_id INTEGER,
                 amount_cents INTEGER NOT NULL,
                 payment_id INTEGER,
                 external_reference TEXT,
+                source TEXT NOT NULL DEFAULT \'invoice_upstream\',
+                manual_receivable_id INTEGER,
                 created_at TEXT
             )'
         );
@@ -196,14 +198,17 @@ final class SchemaFixture
             'CREATE TABLE client_credits (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 organization_id INTEGER NOT NULL,
-                client_id INTEGER NOT NULL,
+                client_id INTEGER,
                 amount_cents INTEGER NOT NULL,
                 remaining_cents INTEGER NOT NULL,
                 status TEXT NOT NULL DEFAULT \'open\',
                 source_bank_transaction_id INTEGER NOT NULL,
                 reconciliation_id INTEGER NOT NULL,
                 created_by INTEGER NOT NULL,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT \'invoice_upstream\',
+                manual_receivable_id INTEGER,
+                client_name TEXT
             )'
         );
     }


### PR DESCRIPTION
ADR 0014（手入力売掛 / 手動消込）の **Issue 2・3・4a** をまとめて。Issue 1（基盤）は #162 で merge 済み。依存関係のある3コミットなので、コミット単位でレビューできます。

## コミット

1. **Issue 2 — CRUD API** (`478aad0`)
   `GET/POST/PUT /admin/manual-receivables`・`/{id}`・`/{id}/cancel`。バリデーション・書き込み監査・重複409・取消済み409・capability・OpenAPI・i18n。
2. **Issue 3 — 売掛CSV取込** (`3481da2`)
   `POST /admin/manual-receivable-imports`。ヘッダーマッピング、部分成功（作成/重複スキップ/行エラー）、CreateUseCase 再利用で取込分も監査。
3. **Issue 4a — 消込/取消 manual対応** (`f8c5a24`)
   `source`（invoice_upstream | manual）で配賦先を分岐。manual は Clear が SSOR（書き戻しなし）、残高/ステータス算出、過入金→manual前受金、reverse で残高復元。**upstream フローは無変更**。

## スコープと不変条件
- **X1 不変**: 発行・税計算・PDFなし（手入力は消込用の参照）。
- **X2 narrow**: manual は競合する系が無いので Clear が SSOR（ADR 0014）。
- 既存 upstream 消込は完全に後方互換（`source` デフォルト invoice_upstream）。
- ソフトデリート/取消のみ、全書き込み監査。

## 品質ゲート
PHPUnit **283**（新規: CRUD 5 / Import 3 / 消込 5）/ PHPStan level 8 / PHP-CS-Fixer / OpenAPI契約 すべて green。マイグレーション2本（dev SQLite 適用確認済み）。

## Issue 4b へ繰り延べ
候補サジェストのユニオン（propose が manual 候補も返す）、manual confirm の HTTP 統合テスト、フロント（Issue 6）。

Part of #161（Issue 2・3・4a を完了）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)