### PR TITLE
feat(reconciliation): 消込候補に手入力売掛をユニオン (Issue 4b, #161)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2179,13 +2179,29 @@ components:
       additionalProperties: false
     MatchSuggestion:
       type: object
-      required: [invoice_id, amount_cents, score]
+      required: [source, amount_cents, score]
       properties:
+        source:
+          type: string
+          enum: [invoice_upstream, manual]
+          description: Candidate receivable type (ADR 0014).
         invoice_id:
           type: integer
           format: int64
+          nullable: true
+          description: Set for invoice_upstream candidates.
         invoice_number:
           type: string
+          nullable: true
+        manual_receivable_id:
+          type: integer
+          format: int64
+          nullable: true
+          description: Set for manual candidates (ADR 0014).
+        reference_number:
+          type: string
+          nullable: true
+          description: Manual receivable document number.
         amount_cents:
           type: integer
           format: int64
@@ -2198,7 +2214,7 @@ components:
           description: Confidence 0..1 (rules-based in Phase 1).
         reason:
           type: string
-          description: Why this invoice was suggested (e.g. exact amount, invoice number in counterparty).
+          description: Why this candidate was suggested (e.g. exact amount, payer/invoice number in counterparty).
     ProposeMatchResponse:
       type: object
       required: [bank_transaction_id, suggestions]

--- a/src/Reconciliation/MatchSuggestion.php
+++ b/src/Reconciliation/MatchSuggestion.php
@@ -4,15 +4,48 @@ declare(strict_types=1);
 
 namespace NeneClear\Reconciliation;
 
+use NeneClear\Receivable\ReceivableSource;
+
+/**
+ * One ranked candidate a deposit could be reconciled against. The target is
+ * either an upstream invoice or a manually-entered receivable (ADR 0014),
+ * distinguished by `source`. Build via the source-specific factories so exactly
+ * one target id is ever set.
+ */
 final readonly class MatchSuggestion
 {
-    public function __construct(
-        public int $invoiceId,
-        public string $invoiceNumber,
+    private function __construct(
+        public ReceivableSource $source,
+        public ?int $invoiceId,
+        public ?string $invoiceNumber,
+        public ?int $manualReceivableId,
+        public ?string $referenceNumber,
         public int $amountCents,
         public int $outstandingCents,
         public float $score,
         public string $reason,
     ) {
+    }
+
+    public static function upstream(
+        int $invoiceId,
+        string $invoiceNumber,
+        int $amountCents,
+        int $outstandingCents,
+        float $score,
+        string $reason,
+    ): self {
+        return new self(ReceivableSource::InvoiceUpstream, $invoiceId, $invoiceNumber, null, null, $amountCents, $outstandingCents, $score, $reason);
+    }
+
+    public static function manual(
+        int $manualReceivableId,
+        string $referenceNumber,
+        int $amountCents,
+        int $outstandingCents,
+        float $score,
+        string $reason,
+    ): self {
+        return new self(ReceivableSource::Manual, null, null, $manualReceivableId, $referenceNumber, $amountCents, $outstandingCents, $score, $reason);
     }
 }

--- a/src/Reconciliation/ProposeMatchHandler.php
+++ b/src/Reconciliation/ProposeMatchHandler.php
@@ -39,8 +39,11 @@ final readonly class ProposeMatchHandler
             'bank_transaction_id' => $output->bankTransactionId,
             'suggestions' => array_map(
                 static fn (MatchSuggestion $s): array => [
+                    'source' => $s->source->value,
                     'invoice_id' => $s->invoiceId,
                     'invoice_number' => $s->invoiceNumber,
+                    'manual_receivable_id' => $s->manualReceivableId,
+                    'reference_number' => $s->referenceNumber,
                     'amount_cents' => $s->amountCents,
                     'outstanding_cents' => $s->outstandingCents,
                     'score' => $s->score,

--- a/src/Reconciliation/ProposeMatchUseCase.php
+++ b/src/Reconciliation/ProposeMatchUseCase.php
@@ -5,18 +5,25 @@ declare(strict_types=1);
 namespace NeneClear\Reconciliation;
 
 use Nene2\Http\ClockInterface;
+use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Receivable\ManualReceivableFilter;
+use NeneClear\Receivable\ManualReceivableRepositoryInterface;
+use NeneClear\Receivable\ManualReceivableStatus;
 
 final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
 {
     private const int MAX_SUGGESTIONS = 10;
     private const int DUE_SOON_DAYS = 30;
+    /** Upper bound on manual receivables scanned for candidates. */
+    private const int MANUAL_SCAN_LIMIT = 200;
 
     public function __construct(
         private BankTransactionRepositoryInterface $transactions,
         private InvoiceUpstreamClientInterface $invoiceClient,
+        private ManualReceivableRepositoryInterface $manualReceivables,
         private ClockInterface $clock,
     ) {
     }
@@ -29,11 +36,29 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
             throw new BankTransactionNotFoundException($input->bankTransactionId);
         }
 
-        $invoices = $this->invoiceClient->listInvoices($input->organizationId, ['issued', 'partially_paid']);
-
         $today = $this->clock->now();
-        $suggestions = [];
 
+        $suggestions = [
+            ...$this->upstreamSuggestions($input->organizationId, $tx, $today),
+            ...$this->manualSuggestions($input->organizationId, $tx, $today),
+        ];
+
+        usort($suggestions, static fn (MatchSuggestion $a, MatchSuggestion $b): int => $b->score <=> $a->score);
+
+        return new ProposeMatchOutput(
+            bankTransactionId: $input->bankTransactionId,
+            suggestions: array_slice($suggestions, 0, self::MAX_SUGGESTIONS),
+        );
+    }
+
+    /**
+     * @return list<MatchSuggestion>
+     */
+    private function upstreamSuggestions(int $organizationId, BankTransaction $tx, \DateTimeImmutable $today): array
+    {
+        $invoices = $this->invoiceClient->listInvoices($organizationId, ['issued', 'partially_paid']);
+
+        $out = [];
         foreach ($invoices as $invoice) {
             $score = 0.0;
             $reasons = [];
@@ -42,23 +67,14 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
                 $score += 0.5;
                 $reasons[] = 'exact amount match';
             }
-
             if (stripos($tx->counterpartyText, $invoice->invoiceNumber) !== false) {
                 $score += 0.3;
                 $reasons[] = 'invoice number in counterparty';
             }
-
-            if ($score > 0.0 || count($reasons) > 0) {
-                $dueAt = new \DateTimeImmutable($invoice->dueAt);
-                $daysUntilDue = (int) $today->diff($dueAt)->days;
-                if ($dueAt >= $today && $daysUntilDue <= self::DUE_SOON_DAYS) {
-                    $score += 0.2;
-                    $reasons[] = 'due soon';
-                }
-            }
+            $score += $this->dueSoonBonus($invoice->dueAt, $today, $score > 0.0 || $reasons !== [], $reasons);
 
             if ($score > 0.0) {
-                $suggestions[] = new MatchSuggestion(
+                $out[] = MatchSuggestion::upstream(
                     invoiceId: $invoice->invoiceId,
                     invoiceNumber: $invoice->invoiceNumber,
                     amountCents: $invoice->totalCents,
@@ -69,11 +85,72 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
             }
         }
 
-        usort($suggestions, static fn (MatchSuggestion $a, MatchSuggestion $b): int => $b->score <=> $a->score);
+        return $out;
+    }
 
-        return new ProposeMatchOutput(
-            bankTransactionId: $input->bankTransactionId,
-            suggestions: array_slice($suggestions, 0, self::MAX_SUGGESTIONS),
-        );
+    /**
+     * @return list<MatchSuggestion>
+     */
+    private function manualSuggestions(int $organizationId, BankTransaction $tx, \DateTimeImmutable $today): array
+    {
+        $receivables = $this->manualReceivables->findByOrganization($organizationId, new ManualReceivableFilter(), self::MANUAL_SCAN_LIMIT, 0);
+
+        $out = [];
+        foreach ($receivables as $receivable) {
+            if ($receivable->status !== ManualReceivableStatus::Open && $receivable->status !== ManualReceivableStatus::PartiallyPaid) {
+                continue;
+            }
+
+            $score = 0.0;
+            $reasons = [];
+
+            if ($receivable->outstandingCents === $tx->amountCents) {
+                $score += 0.5;
+                $reasons[] = 'exact amount match';
+            }
+            if ($receivable->clientName !== '' && stripos($tx->counterpartyText, $receivable->clientName) !== false) {
+                $score += 0.3;
+                $reasons[] = 'payer name in counterparty';
+            }
+            if ($receivable->dueAt !== null) {
+                $score += $this->dueSoonBonus($receivable->dueAt, $today, $score > 0.0 || $reasons !== [], $reasons);
+            }
+
+            if ($score > 0.0 && $receivable->id !== null) {
+                $out[] = MatchSuggestion::manual(
+                    manualReceivableId: $receivable->id,
+                    referenceNumber: $receivable->referenceNumber,
+                    amountCents: $receivable->totalCents,
+                    outstandingCents: $receivable->outstandingCents,
+                    score: $score,
+                    reason: implode('; ', $reasons),
+                );
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * +0.2 when the receivable is due within the next {@see DUE_SOON_DAYS} days,
+     * but only when there is already another matching signal. Appends the reason.
+     *
+     * @param list<string> $reasons
+     */
+    private function dueSoonBonus(string $dueAt, \DateTimeImmutable $today, bool $hasOtherSignal, array &$reasons): float
+    {
+        if (!$hasOtherSignal) {
+            return 0.0;
+        }
+
+        $due = new \DateTimeImmutable($dueAt);
+        $daysUntilDue = (int) $today->diff($due)->days;
+        if ($due >= $today && $daysUntilDue <= self::DUE_SOON_DAYS) {
+            $reasons[] = 'due soon';
+
+            return 0.2;
+        }
+
+        return 0.0;
     }
 }

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -48,6 +48,7 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                 static fn (ContainerInterface $c): ProposeMatchUseCaseInterface => new ProposeMatchUseCase(
                     ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    ServiceResolver::get($c, ManualReceivableRepositoryInterface::class),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),
             )

--- a/tests/Http/ReconciliationHttpTest.php
+++ b/tests/Http/ReconciliationHttpTest.php
@@ -12,6 +12,9 @@ use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\Http\ApplicationFactory;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableStatus;
+use NeneClear\Receivable\PdoManualReceivableRepository;
 use NeneClear\Tests\Support\SchemaFixture;
 use NeneClear\User\PdoUserRepository;
 use NeneClear\User\User;
@@ -31,6 +34,7 @@ final class ReconciliationHttpTest extends TestCase
     private RequestHandlerInterface $app;
     private Psr17Factory $psr17;
     private FakeInvoiceUpstreamClient $invoiceClient;
+    private PdoManualReceivableRepository $manualReceivables;
 
     protected function setUp(): void
     {
@@ -47,6 +51,7 @@ final class ReconciliationHttpTest extends TestCase
         SchemaFixture::createPaymentReconciliations($query);
         SchemaFixture::createReconciliationAllocations($query);
         SchemaFixture::createClientCredits($query);
+        SchemaFixture::createManualReceivables($query);
 
         $users = new PdoUserRepository($query);
         $users->save($this->user('admin@acme.example', Role::Admin));
@@ -66,6 +71,7 @@ final class ReconciliationHttpTest extends TestCase
             csvHeaderRows: 1,
         ));
 
+        $this->manualReceivables = new PdoManualReceivableRepository($query);
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
         $this->app = ApplicationFactory::create(query: $query, transactionManager: $kit->transactionManager, jwtSecret: self::SECRET, invoiceClient: $this->invoiceClient);
         $this->psr17 = new Psr17Factory();
@@ -197,6 +203,67 @@ final class ReconciliationHttpTest extends TestCase
 
         $txDetail = $this->decode($this->get($token, '/admin/bank-transactions/' . $txId));
         self::assertSame('matched', $txDetail['status']);
+    }
+
+    private function seedManualReceivable(int $totalCents): int
+    {
+        return $this->manualReceivables->save(new ManualReceivable(
+            organizationId: 7,
+            referenceNumber: 'MR-001',
+            clientName: 'カ）アクメ',
+            recipientEmail: 'ar@acme.example',
+            totalCents: $totalCents,
+            outstandingCents: $totalCents,
+            currency: 'JPY',
+            issuedAt: '2026-03-31',
+            dueAt: '2026-04-30',
+            status: ManualReceivableStatus::Open,
+            createdBy: 1,
+            createdAt: '2026-04-01 09:00:00',
+        ));
+    }
+
+    public function test_confirm_against_a_manual_receivable(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token); // 110000 deposit
+
+        // A receivable entered directly in Clear (no upstream invoice).
+        $mrId = $this->seedManualReceivable(110000);
+
+        $response = $this->post($token, '/admin/reconciliations', [
+            'bank_transaction_id' => $txId,
+            'allocations' => [['source' => 'manual', 'manual_receivable_id' => $mrId, 'amount_cents' => 110000]],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertSame('confirmed', $body['status']);
+        self::assertCount(1, $body['allocations']);
+        self::assertSame('manual', $body['allocations'][0]['source']);
+        self::assertSame($mrId, $body['allocations'][0]['manual_receivable_id']);
+        self::assertNull($body['allocations'][0]['invoice_id']);
+        self::assertNull($body['allocations'][0]['payment_id']);
+
+        // Clear owns the manual receivable's balance — it is now fully paid.
+        $mr = $this->decode($this->get($token, '/admin/manual-receivables/' . $mrId));
+        self::assertSame('paid', $mr['status']);
+        self::assertSame(0, $mr['outstanding_cents']);
+
+        self::assertSame('matched', $this->decode($this->get($token, '/admin/bank-transactions/' . $txId))['status']);
+    }
+
+    public function test_propose_includes_manual_receivable_candidates(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+        $txId = $this->importCsv($token); // 110000 deposit
+        $mrId = $this->seedManualReceivable(110000);
+
+        $body = $this->decode($this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]));
+
+        $manual = array_values(array_filter($body['suggestions'], static fn (array $s): bool => $s['source'] === 'manual'));
+        self::assertCount(1, $manual);
+        self::assertSame($mrId, $manual[0]['manual_receivable_id']);
     }
 
     public function test_list_reconciliations(): void

--- a/tests/Reconciliation/ProposeMatchUseCaseTest.php
+++ b/tests/Reconciliation/ProposeMatchUseCaseTest.php
@@ -9,6 +9,9 @@ use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionStatus;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\Receivable\ManualReceivable;
+use NeneClear\Receivable\ManualReceivableStatus;
+use NeneClear\Receivable\ReceivableSource;
 use NeneClear\Reconciliation\ProposeMatchInput;
 use NeneClear\Reconciliation\ProposeMatchUseCase;
 use NeneClear\Tests\BankImport\InMemoryBankTransactionRepository;
@@ -19,15 +22,18 @@ final class ProposeMatchUseCaseTest extends TestCase
 {
     private InMemoryBankTransactionRepository $transactions;
     private FakeInvoiceUpstreamClient $invoiceClient;
+    private InMemoryManualReceivableRepository $manualReceivables;
     private ProposeMatchUseCase $useCase;
 
     protected function setUp(): void
     {
         $this->transactions = new InMemoryBankTransactionRepository();
         $this->invoiceClient = new FakeInvoiceUpstreamClient();
+        $this->manualReceivables = new InMemoryManualReceivableRepository();
         $this->useCase = new ProposeMatchUseCase(
             $this->transactions,
             $this->invoiceClient,
+            $this->manualReceivables,
             new FixedClock('2026-05-30T09:00:00+00:00'),
         );
     }
@@ -58,6 +64,81 @@ final class ProposeMatchUseCaseTest extends TestCase
             status: 'issued',
             currency: 'JPY',
         );
+    }
+
+    private function makeManualReceivable(
+        string $reference,
+        int $outstandingCents,
+        string $clientName = 'カ）アクメ',
+        ManualReceivableStatus $status = ManualReceivableStatus::Open,
+        ?string $dueAt = '2026-12-31',
+    ): int {
+        return $this->manualReceivables->save(new ManualReceivable(
+            organizationId: 7,
+            referenceNumber: $reference,
+            clientName: $clientName,
+            recipientEmail: null,
+            totalCents: $outstandingCents,
+            outstandingCents: $outstandingCents,
+            currency: 'JPY',
+            issuedAt: '2026-03-31',
+            dueAt: $dueAt,
+            status: $status,
+            createdBy: 1,
+            createdAt: '2026-04-01 09:00:00',
+        ));
+    }
+
+    public function test_manual_receivable_exact_amount_is_suggested(): void
+    {
+        $txId = $this->makeTx(100000);
+        $mrId = $this->makeManualReceivable('MR-1', 100000);
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(ReceivableSource::Manual, $output->suggestions[0]->source);
+        self::assertSame($mrId, $output->suggestions[0]->manualReceivableId);
+        self::assertNull($output->suggestions[0]->invoiceId);
+        self::assertSame('MR-1', $output->suggestions[0]->referenceNumber);
+        self::assertSame(0.5, $output->suggestions[0]->score);
+    }
+
+    public function test_manual_payer_name_in_counterparty_adds_score(): void
+    {
+        $txId = $this->makeTx(200000, 'FURIKOMI カ）アクメ');
+        $this->makeManualReceivable('MR-2', 150000, clientName: 'カ）アクメ');
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(0.3, $output->suggestions[0]->score);
+        self::assertStringContainsString('payer name in counterparty', $output->suggestions[0]->reason);
+    }
+
+    public function test_paid_or_cancelled_manual_receivables_are_not_suggested(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->makeManualReceivable('PAID', 100000, status: ManualReceivableStatus::Paid);
+        $this->makeManualReceivable('CANCELLED', 100000, status: ManualReceivableStatus::Cancelled);
+
+        self::assertCount(0, $this->useCase->execute(new ProposeMatchInput(7, $txId))->suggestions);
+    }
+
+    public function test_upstream_and_manual_candidates_are_merged(): void
+    {
+        $txId = $this->makeTx(100000, 'INV-001 payment');
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000)); // upstream exact + number
+        $this->makeManualReceivable('MR-1', 100000);                                // manual exact
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(2, $output->suggestions);
+        $sources = array_map(static fn ($s) => $s->source, $output->suggestions);
+        self::assertContains(ReceivableSource::InvoiceUpstream, $sources);
+        self::assertContains(ReceivableSource::Manual, $sources);
+        // Upstream (exact + number = 0.8) ranks above manual (exact = 0.5).
+        self::assertSame(ReceivableSource::InvoiceUpstream, $output->suggestions[0]->source);
     }
 
     public function test_exact_amount_match_scores_highest(): void


### PR DESCRIPTION
ADR 0014 の **Issue 4b**。`propose`（消込候補サジェスト）が upstream invoice 候補と **手入力売掛候補**をユニオンします。Invoice upstream 無しで消込する人にも候補が出ます。

## 変更
- `MatchSuggestion` に `source` 識別子＋`manual_receivable_id`/`reference_number`（`upstream()`/`manual()` ファクトリ）。ハンドラ・OpenAPI スキーマも公開。
- `ProposeMatchUseCase`: open / partially_paid の手入力売掛を「完全一致額・相手先名一致・期日接近」でスコアリング、upstream 候補とマージしてランク付け。paid/cancelled は除外。
- **manual confirm の HTTP 統合テスト**（`POST /admin/reconciliations` の manual 配賦 → 201、レスポンス source=manual、残高反映）＋ propose-includes-manual 統合テスト。

## スコープ外（意図的・follow-up）
upstream 不通時、propose は従来どおり **503**（既存契約維持）。standalone 向けの degraded propose（upstream 不通時に manual 候補のみ返す）は、503↔200 のAPI契約変更を伴うため別途意思決定とします。

## ゲート
PHPUnit **289**（+6: propose 4 / 消込HTTP 2）/ PHPStan L8 / CS / OpenAPI契約 すべて green。

Part of #161（Issue 4 を完了）。これで #161 のバックエンド（Issues 1–4）が揃い、残りは Issue 6（フロント）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)