### PR TITLE
feat(reconciliation): Invoice 不通時は手入力候補で degrade (C案, #161)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2217,11 +2217,17 @@ components:
           description: Why this candidate was suggested (e.g. exact amount, payer/invoice number in counterparty).
     ProposeMatchResponse:
       type: object
-      required: [bank_transaction_id, suggestions]
+      required: [bank_transaction_id, suggestions, upstream_unavailable]
       properties:
         bank_transaction_id:
           type: integer
           format: int64
+        upstream_unavailable:
+          type: boolean
+          description: >
+            True when the Invoice upstream could not be reached, so only manual
+            candidates are returned (ADR 0014 degraded mode). The UI surfaces this
+            instead of failing the whole proposal.
         suggestions:
           type: array
           items:

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -235,7 +235,7 @@ export interface MatchSuggestion {
 }
 
 export function proposeMatch(bankTransactionId: number) {
-  return api.post<{ bank_transaction_id: number; suggestions: MatchSuggestion[] }>(
+  return api.post<{ bank_transaction_id: number; upstream_unavailable: boolean; suggestions: MatchSuggestion[] }>(
     `${BASE}/reconciliations/propose`,
     { bank_transaction_id: bankTransactionId },
   )

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -161,6 +161,7 @@ export const en: Record<MessageKey, string> = {
   'reconciliation.target': 'Target',
   'reconciliation.source.invoice': 'Invoice',
   'reconciliation.source.manual': 'Manual',
+  'reconciliation.upstreamUnavailable': 'NeNe Invoice candidates are currently unavailable. Showing manual receivable candidates only.',
   'reconciliation.allocationAmount': 'Allocation (¥)',
   'reconciliation.addAllocation': 'Add allocation',
   'reconciliation.allocationTotal': 'Allocated / deposit',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -157,6 +157,7 @@ export const ja = {
   'reconciliation.target': '消込先',
   'reconciliation.source.invoice': 'Invoice',
   'reconciliation.source.manual': '手入力',
+  'reconciliation.upstreamUnavailable': 'NeNe Invoice 側の候補は現在取得できませんでした。手入力売掛の候補のみ表示しています。',
   'reconciliation.allocationAmount': '配賦額（¥）',
   'reconciliation.addAllocation': '配賦を追加',
   'reconciliation.allocationTotal': '配賦合計 / 入金額',

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -94,6 +94,9 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
       <div className="sugg">
         <div className="sugg-h"><Icon name="reconcile" size="sm" />{t('reconciliation.suggestions')}</div>
         {suggestQ.isLoading && <p className="muted" style={{ fontSize: 12, margin: 0 }}>{t('reconciliation.searchingSuggestions')}</p>}
+        {suggestQ.data?.upstream_unavailable && (
+          <Notice variant="warn">{t('reconciliation.upstreamUnavailable')}</Notice>
+        )}
         {suggestQ.data?.suggestions.length === 0 && <p className="muted" style={{ fontSize: 12, margin: 0 }}>{t('reconciliation.noSuggestions')}</p>}
         {suggestQ.data?.suggestions.map((s, i) => (
           <div key={`${s.source}-${s.invoice_id ?? s.manual_receivable_id}-${i}`} className="sugg-row">

--- a/src/Reconciliation/ProposeMatchHandler.php
+++ b/src/Reconciliation/ProposeMatchHandler.php
@@ -37,6 +37,7 @@ final readonly class ProposeMatchHandler
 
         return $this->response->create([
             'bank_transaction_id' => $output->bankTransactionId,
+            'upstream_unavailable' => $output->upstreamUnavailable,
             'suggestions' => array_map(
                 static fn (MatchSuggestion $s): array => [
                     'source' => $s->source->value,

--- a/src/Reconciliation/ProposeMatchOutput.php
+++ b/src/Reconciliation/ProposeMatchOutput.php
@@ -8,10 +8,14 @@ final readonly class ProposeMatchOutput
 {
     /**
      * @param list<MatchSuggestion> $suggestions
+     * @param bool $upstreamUnavailable true when the Invoice upstream could not be
+     *             reached, so only manual candidates are returned (ADR 0014 degraded
+     *             mode — the UI surfaces this rather than failing the whole request)
      */
     public function __construct(
         public int $bankTransactionId,
         public array $suggestions,
+        public bool $upstreamUnavailable = false,
     ) {
     }
 }

--- a/src/Reconciliation/ProposeMatchUseCase.php
+++ b/src/Reconciliation/ProposeMatchUseCase.php
@@ -9,6 +9,7 @@ use NeneClear\BankImport\BankTransaction;
 use NeneClear\BankImport\BankTransactionNotFoundException;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableException;
 use NeneClear\Receivable\ManualReceivableFilter;
 use NeneClear\Receivable\ManualReceivableRepositoryInterface;
 use NeneClear\Receivable\ManualReceivableStatus;
@@ -38,8 +39,20 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
 
         $today = $this->clock->now();
 
+        // Degraded mode (ADR 0014): if the Invoice upstream is unavailable, still
+        // return the manual candidates and flag the gap, rather than failing the
+        // whole proposal. A user with no upstream configured hits the fake client
+        // (empty list, no throw), so this only affects a configured-but-down Invoice.
+        $upstreamUnavailable = false;
+        try {
+            $upstream = $this->upstreamSuggestions($input->organizationId, $tx, $today);
+        } catch (UpstreamInvoiceUnavailableException) {
+            $upstream = [];
+            $upstreamUnavailable = true;
+        }
+
         $suggestions = [
-            ...$this->upstreamSuggestions($input->organizationId, $tx, $today),
+            ...$upstream,
             ...$this->manualSuggestions($input->organizationId, $tx, $today),
         ];
 
@@ -48,6 +61,7 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
         return new ProposeMatchOutput(
             bankTransactionId: $input->bankTransactionId,
             suggestions: array_slice($suggestions, 0, self::MAX_SUGGESTIONS),
+            upstreamUnavailable: $upstreamUnavailable,
         );
     }
 

--- a/tests/Http/ReconciliationHttpTest.php
+++ b/tests/Http/ReconciliationHttpTest.php
@@ -360,16 +360,23 @@ final class ReconciliationHttpTest extends TestCase
         self::assertSame(50000, $body['outstanding_cents'] ?? null);
     }
 
-    public function test_upstream_unavailable_returns_503(): void
+    public function test_upstream_unavailable_degrades_to_manual_candidates(): void
     {
+        // Invoice upstream is down, but the operator has a manual receivable that
+        // matches the deposit — propose must still return it (with a flag), not 503.
         $this->invoiceClient->makeUnavailable();
 
         $token = $this->tokenFor('admin@acme.example');
-        $txId = $this->importCsv($token);
+        $txId = $this->importCsv($token); // 110000 deposit
+        $this->seedManualReceivable(110000);
 
         $response = $this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]);
 
-        self::assertSame(503, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decode($response);
+        self::assertTrue($body['upstream_unavailable']);
+        $manual = array_values(array_filter($body['suggestions'], static fn (array $s): bool => $s['source'] === 'manual'));
+        self::assertCount(1, $manual);
     }
 
     public function test_double_reverse_returns_409(): void

--- a/tests/Reconciliation/ProposeMatchUseCaseTest.php
+++ b/tests/Reconciliation/ProposeMatchUseCaseTest.php
@@ -141,6 +141,27 @@ final class ProposeMatchUseCaseTest extends TestCase
         self::assertSame(ReceivableSource::InvoiceUpstream, $output->suggestions[0]->source);
     }
 
+    public function test_degraded_returns_manual_with_flag_when_upstream_unavailable(): void
+    {
+        $this->invoiceClient->makeUnavailable();
+        $txId = $this->makeTx(100000);
+        $this->makeManualReceivable('MR-1', 100000);
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertTrue($output->upstreamUnavailable);
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(ReceivableSource::Manual, $output->suggestions[0]->source);
+    }
+
+    public function test_upstream_available_sets_flag_false(): void
+    {
+        $txId = $this->makeTx(100000);
+        $this->invoiceClient->addInvoice($this->makeInvoice(1, 'INV-001', 100000));
+
+        self::assertFalse($this->useCase->execute(new ProposeMatchInput(7, $txId))->upstreamUnavailable);
+    }
+
     public function test_exact_amount_match_scores_highest(): void
     {
         $txId = $this->makeTx(100000);


### PR DESCRIPTION
ADR 0014 フォローアップ（**C案**）。NeNe Invoice が一時的に落ちている時、消込候補サジェストを **503 で失敗させず**、手入力売掛の候補を返しつつ `upstream_unavailable` フラグで UI に知らせます。

## 背景
- Invoice **未設定**の人は元々問題なし（Fake クライアントが空を返す＝エラーにならない）。
- Invoice **設定済みだが一時的に不通**の時だけ、従来は候補機能ごと 503 になっていた（手入力候補も巻き添え）。
- C案: 手入力候補は出す＋「Invoice側は今取得できませんでした」と小さく表示（作業継続できて、障害にも気づける）。

## 変更
- `ProposeMatchUseCase` が `UpstreamInvoiceUnavailableException` を捕捉し、フラグを立てて手入力候補を返す。
- `ProposeMatchOutput`／ハンドラ応答／OpenAPI に `upstream_unavailable` 追加。
- 消込確定モーダルに warn 表示。

## 契約変更の注意
propose は upstream 不通時に **503 を返さなくなりました**（200＋フラグ）。旧 `returns_503` テストは degraded 挙動に更新。

## ゲート
backend PHPUnit **291** / PHPStan L8 / CS、frontend type-check / eslint / **46 Vitest** すべて green。

Part of #161。

🤖 Generated with [Claude Code](https://claude.com/claude-code)