### PR TITLE
fix(invoice-upstream): align client with Invoice contract — nullable due_at, paging, ext-curl (#163, #164, #165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Next: Phase 3 (Tier A shared-hosting installer / release ZIP) and Phase 4
 docker compose up -d
 cp .env.example .env            # adjust DB_*, NENE_CLEAR_JWT_SECRET as needed
 
-# 2. Backend (PHP 8.4). NENE2 is a local path dependency (../NENE2).
+# 2. Backend (PHP 8.4 with ext-curl — required by the Invoice upstream client).
 composer install
 composer migrations:migrate     # apply schema
 php -S localhost:8384 -t public_html/    # or your preferred SAPI (NENE_CLEAR_PORT=8384)
@@ -86,6 +86,28 @@ npm --prefix frontend run check # type-check + lint + Vitest
 
 `DB_ADAPTER=sqlite` (the `.env.example` default) needs no container; set
 `DB_ADAPTER=mysql` to use the docker-compose database.
+
+## Invoice integration (optional)
+
+Reconciliation and dunning against **NeNe Invoice** receivables are activated by
+two env vars; without them Clear runs standalone (manual receivables only,
+ADR 0014). `ext-curl` is required for the HTTP client.
+
+```bash
+# In .env (or the environment):
+NENE_INVOICE_API_BASE_URL=https://invoice.example.com
+NENE_INVOICE_BEARER_TOKEN=<service token>
+```
+
+Obtain the service token from the Invoice side (`nene-invoice` →
+`tools/issue-service-token.php`). With both set, the contract suite runs against
+the live Invoice API:
+
+```bash
+NENE_INVOICE_API_BASE_URL=… NENE_INVOICE_BEARER_TOKEN=… vendor/bin/phpunit --filter InvoiceUpstreamContractTest
+```
+
+See [`docs/integrations/invoice-upstream-contract.md`](./docs/integrations/invoice-upstream-contract.md).
 
 ## Ecosystem
 

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
+        "ext-curl": "*",
         "firebase/php-jwt": "^7",
         "hideyukimori/nene2": "@dev",
         "symfony/mailer": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db4e4e9e249d5d79cc37a19013167890",
+    "content-hash": "db6490278807888d2badb8f13846733e",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -6697,7 +6697,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4.1 <9.0"
+        "php": ">=8.4.1 <9.0",
+        "ext-curl": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -27,7 +27,7 @@ function SendModal({ invoice, onClose }: { invoice: UpstreamInvoice; onClose: ()
       <div className="kv">
         <div className="kv-row"><span className="k">{t('table.invoice')}</span><span className="v mono">{invoice.invoice_number}</span></div>
         <div className="kv-row"><span className="k">{t('table.outstanding')}</span><span className="v">{yen(invoice.outstanding_cents)}</span></div>
-        <div className="kv-row"><span className="k">{t('table.dueDate')}</span><span className="v" style={{ color: 'var(--bad)' }}>{t('dunning.dueElapsed', { date: invoice.due_at, days: daysOverdue(invoice.due_at) })}</span></div>
+        <div className="kv-row"><span className="k">{t('table.dueDate')}</span><span className="v" style={{ color: 'var(--bad)' }}>{t('dunning.dueElapsed', { date: invoice.due_at ?? '—', days: daysOverdue(invoice.due_at) })}</span></div>
       </div>
       <Notice variant="info">{t('dunning.sendInfo')}</Notice>
       {mut.isError && <Notice variant="bad">{mut.error.message}</Notice>}
@@ -168,7 +168,7 @@ export default function DunningPage() {
                     {inv.status === 'overdue' ? <Badge variant="bad" dot>{t('dunning.status.overdue')}</Badge> : <Badge variant="warn" dot>{t('dunning.status.partial')}</Badge>}
                   </td>
                   <td className="num">{yen(inv.outstanding_cents)}</td>
-                  <td className="muted">{inv.due_at}</td>
+                  <td className="muted">{inv.due_at ?? '—'}</td>
                   <td style={{ color: daysNum > 0 ? (daysNum > 14 ? 'var(--bad)' : 'var(--warn)') : 'var(--muted)', fontWeight: 600 }}>{elap}</td>
                   <td className="row-act">
                     {paused

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,7 +107,7 @@ export interface DunningNotice {
   client_id: number
   recipient_email: string
   outstanding_at_send_cents: number
-  due_at: string
+  due_at: string | null
   channel: string
   template_version: string
   sent_by: number
@@ -189,7 +189,7 @@ export interface UpstreamInvoice {
   invoice_number: string
   client_id: number
   issued_at: string
-  due_at: string
+  due_at: string | null
   total_cents: number
   outstanding_cents: number
   status: 'issued' | 'partially_paid' | 'paid'

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -13,8 +13,9 @@ export function formatDateTime(iso: string): string {
   return iso.slice(0, 16).replace('T', ' ')
 }
 
-/** Days elapsed since a due date; returns `${n}日` or '—' when not yet due. */
-export function daysOverdue(due: string): string {
+/** Days elapsed since a due date; '—' when not yet due or no due date (nullable per the Invoice contract). */
+export function daysOverdue(due: string | null): string {
+  if (due === null || due === '') return '—'
   const days = Math.floor((Date.now() - new Date(due).getTime()) / 86400000)
   return days > 0 ? `${days}日` : '—'
 }

--- a/src/Dunning/DunningNotice.php
+++ b/src/Dunning/DunningNotice.php
@@ -17,7 +17,8 @@ final readonly class DunningNotice
         public int $clientId,
         public string $recipientEmail,
         public int $outstandingCents,
-        public string $dueAt,
+        /** Snapshot of the invoice due date; null when the invoice had no due date. */
+        public ?string $dueAt,
         public string $channel,
         public string $templateVersion,
         public int $sentBy,

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -152,7 +152,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
             clientId: (int) $row['client_id'],
             recipientEmail: (string) $row['recipient_email'],
             outstandingCents: (int) $row['outstanding_cents'],
-            dueAt: (string) $row['due_at'],
+            dueAt: isset($row['due_at']) ? (string) $row['due_at'] : null,
             channel: (string) $row['channel'],
             templateVersion: (string) $row['template_version'],
             sentBy: (int) $row['sent_by'],

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -75,13 +75,14 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             $this->catalog->get('dunning_email.subject', Locale::Ja),
             $invoice->invoiceNumber,
         );
+        $dueAtLabel = $invoice->dueAt ?? '—';
         $body = sprintf(
             $this->catalog->get('dunning_email.body', Locale::Ja),
             $client->contactName,
             $invoice->invoiceNumber,
-            $invoice->dueAt,
+            $dueAtLabel,
             number_format((int) ($invoice->outstandingCents / 100)),
-            $invoice->dueAt,
+            $dueAtLabel,
             number_format((int) ($invoice->outstandingCents / 100)),
         );
 

--- a/src/InvoiceUpstream/InvoiceItem.php
+++ b/src/InvoiceUpstream/InvoiceItem.php
@@ -12,7 +12,8 @@ final readonly class InvoiceItem
         public int $clientId,
         public int $outstandingCents,
         public int $totalCents,
-        public string $dueAt,
+        /** Nullable per the Invoice contract — an invoice may be issued with no due date. */
+        public ?string $dueAt,
         public string $status,
         public string $currency,
     ) {

--- a/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
@@ -17,6 +17,10 @@ final readonly class InvoiceUpstreamHttpClient implements InvoiceUpstreamClientI
 {
     private const int CONNECT_TIMEOUT = 5;
     private const int READ_TIMEOUT = 10;
+    /** Invoice contract caps `limit` at 100; sending more is a 422. */
+    private const int PAGE_LIMIT = 100;
+    /** Safety bound so a misbehaving upstream can't loop forever (≤ 10k invoices). */
+    private const int MAX_PAGES = 100;
 
     public function __construct(
         private string $baseUrl,
@@ -26,38 +30,53 @@ final readonly class InvoiceUpstreamHttpClient implements InvoiceUpstreamClientI
 
     public function listInvoices(int $organizationId, array $statuses): array
     {
-        $query = http_build_query(['status' => $statuses, 'limit' => 200, 'offset' => 0]);
-        $body = $this->request('GET', '/api/invoices?' . $query);
+        // The Invoice contract caps `limit` at 100 (more → 422), so page through
+        // with `offset` until a short page returns. Reconciliation needs the full
+        // set of open invoices, not just the first page.
+        $invoices = [];
+        $offset = 0;
 
-        return array_values(array_map(
-            static fn (array $item): InvoiceItem => new InvoiceItem(
-                invoiceId: (int) $item['invoice_id'],
-                invoiceNumber: (string) $item['invoice_number'],
-                clientId: (int) $item['client_id'],
-                outstandingCents: (int) $item['outstanding_cents'],
-                totalCents: (int) $item['total_cents'],
-                dueAt: (string) $item['due_at'],
-                status: (string) $item['status'],
-                currency: (string) ($item['currency'] ?? 'JPY'),
-            ),
-            (array) ($body['items'] ?? []),
-        ));
+        for ($page = 0; $page < self::MAX_PAGES; ++$page) {
+            $query = http_build_query(['status' => $statuses, 'limit' => self::PAGE_LIMIT, 'offset' => $offset]);
+            $body = $this->request('GET', '/api/invoices?' . $query);
+            $items = (array) ($body['items'] ?? []);
+
+            foreach ($items as $item) {
+                /** @var array<string, mixed> $item */
+                $invoices[] = $this->hydrateInvoice($item);
+            }
+
+            if (count($items) < self::PAGE_LIMIT) {
+                break;
+            }
+            $offset += self::PAGE_LIMIT;
+        }
+
+        return $invoices;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function hydrateInvoice(array $item): InvoiceItem
+    {
+        return new InvoiceItem(
+            invoiceId: (int) $item['invoice_id'],
+            invoiceNumber: (string) $item['invoice_number'],
+            clientId: (int) $item['client_id'],
+            outstandingCents: (int) $item['outstanding_cents'],
+            totalCents: (int) $item['total_cents'],
+            dueAt: isset($item['due_at']) ? (string) $item['due_at'] : null,
+            status: (string) $item['status'],
+            currency: (string) ($item['currency'] ?? 'JPY'),
+        );
     }
 
     public function getInvoice(int $organizationId, int $invoiceId): InvoiceItem
     {
         $body = $this->request('GET', '/api/invoices/' . $invoiceId, resourceId: $invoiceId);
 
-        return new InvoiceItem(
-            invoiceId: (int) $body['invoice_id'],
-            invoiceNumber: (string) $body['invoice_number'],
-            clientId: (int) $body['client_id'],
-            outstandingCents: (int) $body['outstanding_cents'],
-            totalCents: (int) $body['total_cents'],
-            dueAt: (string) $body['due_at'],
-            status: (string) $body['status'],
-            currency: (string) ($body['currency'] ?? 'JPY'),
-        );
+        return $this->hydrateInvoice($body);
     }
 
     public function createPayment(

--- a/src/Reconciliation/ProposeMatchUseCase.php
+++ b/src/Reconciliation/ProposeMatchUseCase.php
@@ -85,7 +85,9 @@ final readonly class ProposeMatchUseCase implements ProposeMatchUseCaseInterface
                 $score += 0.3;
                 $reasons[] = 'invoice number in counterparty';
             }
-            $score += $this->dueSoonBonus($invoice->dueAt, $today, $score > 0.0 || $reasons !== [], $reasons);
+            if ($invoice->dueAt !== null) {
+                $score += $this->dueSoonBonus($invoice->dueAt, $today, $score > 0.0 || $reasons !== [], $reasons);
+            }
 
             if ($score > 0.0) {
                 $out[] = MatchSuggestion::upstream(

--- a/tests/Contract/InvoiceUpstreamContractTest.php
+++ b/tests/Contract/InvoiceUpstreamContractTest.php
@@ -49,7 +49,11 @@ final class InvoiceUpstreamContractTest extends TestCase
             self::assertNotEmpty($invoice->invoiceNumber);
             self::assertGreaterThanOrEqual(0, $invoice->outstandingCents);
             self::assertGreaterThan(0, $invoice->totalCents);
-            self::assertNotEmpty($invoice->dueAt);
+            // due_at is nullable per the contract (an invoice may have no due date);
+            // when present it must be a non-empty date string.
+            if ($invoice->dueAt !== null) {
+                self::assertNotEmpty($invoice->dueAt);
+            }
             self::assertContains($invoice->status, ['issued', 'partially_paid', 'paid']);
             self::assertSame('JPY', $invoice->currency);
         }

--- a/tests/Reconciliation/ProposeMatchUseCaseTest.php
+++ b/tests/Reconciliation/ProposeMatchUseCaseTest.php
@@ -176,6 +176,27 @@ final class ProposeMatchUseCaseTest extends TestCase
         self::assertStringContainsString('exact amount match', $output->suggestions[0]->reason);
     }
 
+    public function test_upstream_invoice_with_null_due_date_is_handled(): void
+    {
+        // due_at is nullable per the Invoice contract (#164) — must not crash.
+        $txId = $this->makeTx(100000);
+        $this->invoiceClient->addInvoice(new InvoiceItem(
+            invoiceId: 1,
+            invoiceNumber: 'INV-001',
+            clientId: 100,
+            outstandingCents: 100000,
+            totalCents: 100000,
+            dueAt: null,
+            status: 'issued',
+            currency: 'JPY',
+        ));
+
+        $output = $this->useCase->execute(new ProposeMatchInput(7, $txId));
+
+        self::assertCount(1, $output->suggestions);
+        self::assertSame(0.5, $output->suggestions[0]->score); // exact amount only; no due-soon bonus
+    }
+
     public function test_invoice_number_in_counterparty_adds_score(): void
     {
         $txId = $this->makeTx(200000, 'Payment for INV-999 ACME');


### PR DESCRIPTION
## Summary

Phase A live contract testing against **nene-invoice** (2026-06-08) surfaced three integration blockers. This branch addresses all three in one pass; the client and contract tests now match the binding [`docs/integrations/invoice-upstream-contract.md`](./docs/integrations/invoice-upstream-contract.md).

| Issue | Blocker | Fix |
| --- | --- | --- |
| #163 | `listInvoices` sent `limit=200`; contract caps `limit` at 100 (>100 → 422, breaking every read/write flow) | Page with `limit=100` + `offset`, `MAX_PAGES` guard, so reconciliation still sees the full open-invoice set |
| #164 | `due_at` is nullable per the contract (an invoice may be issued with no due date; real data inv12) | Propagate `?string` through upstream client / dunning / reconciliation; treat null as "no due date = not overdue"; relax contract assertion |
| #165 | HTTP client uses `curl_init()`; without `ext-curl` every upstream call fails | Require `ext-curl` in composer; document the Invoice-integration runbook (env vars + service token) in README |

## Changes

- `InvoiceItem` / `DunningNotice`: `due_at` → `?string`
- `InvoiceUpstreamHttpClient`: `limit=100` offset paging + `isset` guard + `hydrateInvoice()`
- `SendDunningUseCase` / `PdoDunningNoticeRepository`: null → `—` fallback
- `ProposeMatchUseCase`: skip due-soon bonus when `due_at` is null
- frontend: `due_at: string | null`, `daysOverdue()` null-guard, `—` display
- composer: require `ext-curl`; README Invoice integration section
- tests: relax contract assertion; add null-due-date propose case

## Verification

- PHPUnit (affected): `InvoiceUpstreamContractTest` + `ProposeMatchUseCaseTest` — green (6 live-API tests skipped without env)
- `npm --prefix frontend run check`: type-check + eslint + vitest (46) green
- PHPStan: no errors

Closes #163, #164, #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)