### PR TITLE
docs(readme): replace stale Private status badge with public

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
-[![Private](https://img.shields.io/badge/status-private-red)]()
+[![Status: public](https://img.shields.io/badge/status-public-brightgreen)]()
 
 **Payment reconciliation and dunning — self-hosted for Japan SMB.**
 


### PR DESCRIPTION
## Summary
The README header still showed a `status-private` (red) badge that linked nowhere and contradicted the MIT license badge beside it. This swaps it for a `status-public` (green) badge consistent with the open-source licensing.

```diff
-[![Private](https://img.shields.io/badge/status-private-red)]()
+[![Status: public](https://img.shields.io/badge/status-public-brightgreen)]()
```

## Test plan
- [x] Docs-only change; rendered badge markup verified.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)