### PR TITLE
feat(db): add PostgreSQL (pgsql) adapter support across wiring and data layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,16 @@ NENE_INVOICE_API_BASE_URL=
 NENE_INVOICE_BEARER_TOKEN=
 
 # Database (Phase 1+). sqlite for local/dev and tests.
+# Adapters: sqlite (default) | mysql | pgsql.
+#   mysql : docker compose up -d mysql     → DB_PORT=3383
+#   pgsql : docker compose up -d postgres  → DB_PORT=5483 (DB_CHARSET ignored)
 DB_ADAPTER=sqlite
 DB_HOST=127.0.0.1
 DB_PORT=3383
 DB_NAME=nene_clear
 DB_USER=nene_clear
 DB_PASSWORD=nene_clear
+# Ignored by the pgsql adapter (PostgreSQL derives encoding from server_encoding).
 DB_CHARSET=utf8mb4
 
 # SMTP (dunning email). Use docker-compose Mailpit for local dev (host=127.0.0.1 port=1383).

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -50,3 +50,49 @@ jobs:
       # Contract tests auto-skip without NENE_INVOICE_API_BASE_URL.
       - name: Run checks
         run: composer check
+
+  # Validates that every Phinx migration applies cleanly on PostgreSQL. The unit
+  # suite builds its own SQLite schema, so this is the regression guard for the
+  # pgsql adapter (DB_ADAPTER=pgsql) and the RETURNING id / boolean SQL paths.
+  postgres-migrate:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: nene_clear
+          POSTGRES_USER: nene_clear
+          POSTGRES_PASSWORD: nene_clear
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U nene_clear -d nene_clear"
+          --health-interval 5s --health-timeout 5s --health-retries 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_pgsql, mbstring
+          coverage: none
+
+      - name: Clone NENE2 (local path dependency)
+        run: git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Migrate on PostgreSQL
+        env:
+          DB_ADAPTER: pgsql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 5432
+          DB_NAME: nene_clear
+          DB_USER: nene_clear
+          DB_PASSWORD: nene_clear
+        run: composer migrations:migrate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ All ports are fixed for this project to avoid collisions with sibling apps.
 | Service | Host port | Notes |
 | --- | --- | --- |
 | MySQL | **3383** | `docker-compose.yml` |
+| PostgreSQL | **5483** | `docker-compose.yml`; optional `DB_ADAPTER=pgsql` |
 | Mailpit SMTP | **1383** | `docker-compose.yml`; set `SMTP_HOST=127.0.0.1 SMTP_PORT=1383` |
 | Mailpit Web UI | **8383** | `http://localhost:8383` |
 | PHP backend | **8384** | `NENE_CLEAR_PORT=8384` in `.env` |

--- a/README.md
+++ b/README.md
@@ -84,8 +84,12 @@ npm --prefix frontend run check # type-check + lint + Vitest
 ( cd tests/e2e && npm install && npx playwright test )   # browser E2E
 ```
 
-`DB_ADAPTER=sqlite` (the `.env.example` default) needs no container; set
-`DB_ADAPTER=mysql` to use the docker-compose database.
+`DB_ADAPTER=sqlite` (the `.env.example` default) needs no container. For a
+server-grade database, set `DB_ADAPTER=mysql` (`docker compose up -d mysql`,
+`DB_PORT=3383`) or `DB_ADAPTER=pgsql` (`docker compose up -d postgres`,
+`DB_PORT=5483`); `DB_CHARSET` is ignored for pgsql. All three share one schema —
+run `composer migrations:migrate` after switching. The PHP `pdo_pgsql` extension
+is required for the pgsql adapter.
 
 ## Invoice integration (optional)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,28 @@ services:
       timeout: 5s
       retries: 20
 
+  # Optional PostgreSQL adapter (DB_ADAPTER=pgsql). MySQL stays the default Tier
+  # A target; start this only when running against PostgreSQL:
+  #   docker compose up -d postgres
+  # then set DB_ADAPTER=pgsql and DB_PORT=5483 in .env.
+  postgres:
+    image: postgres:17
+    container_name: nene-clear-pg
+    ports:
+      - "5483:5432"
+    environment:
+      POSTGRES_DB: ${DB_NAME:-nene_clear}
+      POSTGRES_USER: ${DB_USER:-nene_clear}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-nene_clear}
+      TZ: Asia/Tokyo
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-nene_clear} -d ${DB_NAME:-nene_clear}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
   mailpit:
     image: axllent/mailpit:latest
     container_name: nene-clear-mail
@@ -30,3 +52,4 @@ services:
 
 volumes:
   mysql_data:
+  postgres_data:

--- a/docs/explanation/operator-guide.md
+++ b/docs/explanation/operator-guide.md
@@ -135,7 +135,11 @@ In compliance with 電子帳簿保存法 and financial record-keeping requiremen
   situation). NeNe Clear does not auto-purge records.
 - **Backup:** Database backup is the operator's responsibility. NeNe Clear does
   not provide built-in backup; use database-level backup (e.g. `mysqldump` for
-  MySQL).
+  MySQL, `pg_dump` for PostgreSQL).
+- **Database adapter:** `DB_ADAPTER` selects the backend — `sqlite` (local/dev),
+  `mysql`, or `pgsql`. All three share one Phinx migration set. The pgsql adapter
+  needs the PHP `pdo_pgsql` extension and ignores `DB_CHARSET` (PostgreSQL derives
+  the client encoding from `server_encoding`).
 
 ---
 

--- a/phinx.php
+++ b/phinx.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 $adapter = getenv('DB_ADAPTER') ?: 'sqlite';
 
-$environment = $adapter === 'mysql'
-    ? [
+$environment = match ($adapter) {
+    'mysql' => [
         'adapter' => 'mysql',
         'host' => getenv('DB_HOST') ?: '127.0.0.1',
         'name' => getenv('DB_NAME') ?: 'nene_clear',
@@ -17,11 +17,22 @@ $environment = $adapter === 'mysql'
         'pass' => getenv('DB_PASSWORD') ?: 'nene_clear',
         'port' => (int) (getenv('DB_PORT') ?: 3306),
         'charset' => getenv('DB_CHARSET') ?: 'utf8mb4',
-    ]
-    : [
+    ],
+    // PostgreSQL: omit `charset` — Phinx/pgsql does not use it (encoding comes
+    // from server_encoding). See NENE2 docs/howto/use-postgresql.md.
+    'pgsql' => [
+        'adapter' => 'pgsql',
+        'host' => getenv('DB_HOST') ?: '127.0.0.1',
+        'name' => getenv('DB_NAME') ?: 'nene_clear',
+        'user' => getenv('DB_USER') ?: 'nene_clear',
+        'pass' => getenv('DB_PASSWORD') ?: 'nene_clear',
+        'port' => (int) (getenv('DB_PORT') ?: 5432),
+    ],
+    default => [
         'adapter' => 'sqlite',
         'name' => getenv('DB_NAME') ?: __DIR__ . '/database/nene_clear',
-    ];
+    ],
+};
 
 return [
     'paths' => [

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -9,6 +9,8 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\Http\ResponseEmitter;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
 use NeneClear\Http\ApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
@@ -32,11 +34,15 @@ $jwtSecret = $env('NENE_CLEAR_JWT_SECRET') ?: null;
 // executor, the transaction manager, and a JWT secret are all available (see
 // ApplicationFactory). The executor and the transaction manager share one
 // connection factory so transactional() can open its own connection (Issue #122).
-$connectionFactory = (static function () use ($env): ?DatabaseConnectionFactoryInterface {
+$adapter = $env('DB_ADAPTER', 'sqlite');
+
+$connectionFactory = (static function () use ($env, $adapter): ?DatabaseConnectionFactoryInterface {
     try {
-        $adapter = $env('DB_ADAPTER', 'sqlite');
-        $config = $adapter === 'mysql'
-            ? new DatabaseConfig(
+        // `charset` is intentionally omitted for pgsql — the DSN ignores it and
+        // PostgreSQL derives the client encoding from server_encoding (UTF-8 by
+        // default). See NENE2 docs/howto/use-postgresql.md.
+        $config = match ($adapter) {
+            'mysql' => new DatabaseConfig(
                 url: $env('DATABASE_URL') ?: null,
                 environment: $env('DB_ENV', 'production'),
                 adapter: 'mysql',
@@ -46,8 +52,22 @@ $connectionFactory = (static function () use ($env): ?DatabaseConnectionFactoryI
                 user: $env('DB_USER', 'nene_clear'),
                 password: $env('DB_PASSWORD'),
                 charset: $env('DB_CHARSET', 'utf8mb4'),
-            )
-            : DatabaseConfig::sqlite($env('DB_NAME') ?: dirname(__DIR__) . '/database/nene_clear.sqlite3');
+            ),
+            'pgsql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'pgsql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '5432'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                // Non-empty to satisfy DatabaseConfig validation; the pgsql DSN
+                // ignores it (encoding comes from server_encoding, UTF-8).
+                charset: $env('DB_CHARSET', 'utf8'),
+            ),
+            default => DatabaseConfig::sqlite($env('DB_NAME') ?: dirname(__DIR__) . '/database/nene_clear.sqlite3'),
+        };
 
         return new PdoConnectionFactory($config);
     } catch (\Throwable) {
@@ -55,8 +75,14 @@ $connectionFactory = (static function () use ($env): ?DatabaseConnectionFactoryI
     }
 })();
 
-$query = $connectionFactory !== null ? new PdoDatabaseQueryExecutor($connectionFactory) : null;
-$transactionManager = $connectionFactory !== null ? new PdoDatabaseTransactionManager($connectionFactory) : null;
+// Decorate so INSERT … RETURNING id is used on PostgreSQL (PDO::lastInsertId()
+// returns 0 there). No-op for mysql/sqlite. See NeneClear\Database decorators.
+$query = $connectionFactory !== null
+    ? new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter)
+    : null;
+$transactionManager = $connectionFactory !== null
+    ? new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter)
+    : null;
 
 $smtpHost = $env('SMTP_HOST') ?: null;
 $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;

--- a/src/Audit/PdoAuditEventRepository.php
+++ b/src/Audit/PdoAuditEventRepository.php
@@ -17,7 +17,7 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
 
     public function record(AuditEvent $event): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO audit_events (organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?)',
             [
@@ -30,8 +30,6 @@ final readonly class PdoAuditEventRepository implements AuditEventRepositoryInte
                 json_encode($event->payload, JSON_THROW_ON_ERROR),
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findByOrganization(int $organizationId, AuditEventFilter $filter, int $limit, int $offset): array

--- a/src/BankImport/PdoBankAccountRepository.php
+++ b/src/BankImport/PdoBankAccountRepository.php
@@ -18,7 +18,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
 
     public function findById(int $id): ?BankAccount
     {
-        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE id = ? AND is_deleted = 0', [$id]);
+        $row = $this->query->fetchOne('SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE id = ? AND is_deleted = FALSE', [$id]);
 
         return $row !== null ? $this->hydrate($row) : null;
     }
@@ -26,7 +26,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
     public function findByOrganization(int $organizationId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC',
+            'SELECT ' . self::COLUMNS . ' FROM bank_accounts WHERE organization_id = ? AND is_deleted = FALSE ORDER BY id ASC',
             [$organizationId],
         );
 
@@ -38,14 +38,14 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
         // Soft delete — bank accounts are referenced by import history and are
         // never hard-deleted. `$deletedAt` comes from the use case's clock.
         $this->query->execute(
-            'UPDATE bank_accounts SET is_deleted = 1, deleted_at = ? WHERE organization_id = ? AND is_deleted = 0',
+            'UPDATE bank_accounts SET is_deleted = TRUE, deleted_at = ? WHERE organization_id = ? AND is_deleted = FALSE',
             [$deletedAt, $organizationId],
         );
     }
 
     public function save(BankAccount $account): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO bank_accounts (organization_id, bank_name, bank_branch, account_type, account_number, '
             . 'csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -63,8 +63,6 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
                 $account->csvHeaderRows,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     /**

--- a/src/BankImport/PdoBankImportBatchRepository.php
+++ b/src/BankImport/PdoBankImportBatchRepository.php
@@ -33,7 +33,7 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
 
     public function save(BankImportBatch $batch): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, '
             . 'row_count, status, imported_by, imported_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             [
@@ -47,8 +47,6 @@ final readonly class PdoBankImportBatchRepository implements BankImportBatchRepo
                 $batch->importedAt,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findByOrganization(int $organizationId, BankImportBatchFilter $filter, int $limit, int $offset): array

--- a/src/BankImport/PdoBankTransactionRepository.php
+++ b/src/BankImport/PdoBankTransactionRepository.php
@@ -18,7 +18,7 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
 
     public function save(BankTransaction $transaction): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date, '
             . 'amount_cents, counterparty_text, line_key, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             [
@@ -32,8 +32,6 @@ final readonly class PdoBankTransactionRepository implements BankTransactionRepo
                 $transaction->status->value,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findById(int $organizationId, int $id): ?BankTransaction

--- a/src/Database/AdapterAwareQueryExecutor.php
+++ b/src/Database/AdapterAwareQueryExecutor.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+/**
+ * Wraps a framework {@see DatabaseQueryExecutorInterface} so that
+ * {@see insert()} returns the generated primary key on every supported adapter.
+ *
+ * On MySQL and SQLite the framework's {@see DatabaseQueryExecutorInterface::insert()}
+ * (execute + `lastInsertId()`) works as-is. On PostgreSQL `PDO::lastInsertId()`
+ * returns 0 without a sequence name, so this decorator appends `RETURNING id` to
+ * the INSERT and reads the value back in the same round trip — the pattern
+ * prescribed by NENE2 `docs/howto/use-postgresql.md`.
+ *
+ * Assumes the primary key column is named `id`, which holds for every table in
+ * this codebase (Phinx default auto-increment `id`). All other methods delegate
+ * verbatim to the wrapped executor.
+ *
+ * @phpstan-import-type SqlParameters from DatabaseQueryExecutorInterface
+ * @phpstan-import-type SqlRow from DatabaseQueryExecutorInterface
+ */
+final readonly class AdapterAwareQueryExecutor implements DatabaseQueryExecutorInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $inner,
+        private string $adapter,
+    ) {
+    }
+
+    public function execute(string $sql, array $parameters = []): int
+    {
+        return $this->inner->execute($sql, $parameters);
+    }
+
+    public function insert(string $sql, array $parameters = []): int
+    {
+        if ($this->adapter !== 'pgsql') {
+            return $this->inner->insert($sql, $parameters);
+        }
+
+        $row = $this->inner->fetchOne($sql . ' RETURNING id', $parameters);
+
+        return (int) ($row['id'] ?? 0);
+    }
+
+    public function lastInsertId(): int
+    {
+        return $this->inner->lastInsertId();
+    }
+
+    public function fetchOne(string $sql, array $parameters = []): ?array
+    {
+        return $this->inner->fetchOne($sql, $parameters);
+    }
+
+    public function fetchAll(string $sql, array $parameters = []): array
+    {
+        return $this->inner->fetchAll($sql, $parameters);
+    }
+}

--- a/src/Database/AdapterAwareTransactionManager.php
+++ b/src/Database/AdapterAwareTransactionManager.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
+
+/**
+ * Wraps a framework {@see DatabaseTransactionManagerInterface} so the executor
+ * handed to each transactional callback is decorated with
+ * {@see AdapterAwareQueryExecutor}.
+ *
+ * Repositories instantiated inside `transactional()` receive the transaction's
+ * executor (NENE2 `DatabaseTransactionManagerInterface`). Without this wrapper
+ * those in-transaction inserts would use the bare framework executor and fall
+ * back to `lastInsertId()`, which returns 0 on PostgreSQL. Decorating here keeps
+ * the `RETURNING id` behaviour consistent between container-scoped and
+ * transaction-scoped executors.
+ */
+final readonly class AdapterAwareTransactionManager implements DatabaseTransactionManagerInterface
+{
+    public function __construct(
+        private DatabaseTransactionManagerInterface $inner,
+        private string $adapter,
+    ) {
+    }
+
+    public function transactional(callable $callback): mixed
+    {
+        return $this->inner->transactional(
+            fn (DatabaseQueryExecutorInterface $tx): mixed
+                => $callback(new AdapterAwareQueryExecutor($tx, $this->adapter)),
+        );
+    }
+}

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -18,7 +18,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
 
     public function save(DunningNotice $notice): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, '
             . 'recipient_email, outstanding_cents, due_at, channel, template_version, sent_by, sent_at) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -36,8 +36,6 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
                 $notice->sentAt,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findById(int $organizationId, int $id): ?DunningNotice

--- a/src/Dunning/PdoDunningPauseRepository.php
+++ b/src/Dunning/PdoDunningPauseRepository.php
@@ -18,7 +18,7 @@ final readonly class PdoDunningPauseRepository implements DunningPauseRepository
 
     public function save(DunningPause $pause): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO dunning_pauses (organization_id, invoice_id, paused_by, paused_at, paused_reason) '
             . 'VALUES (?, ?, ?, ?, ?)',
             [
@@ -29,8 +29,6 @@ final readonly class PdoDunningPauseRepository implements DunningPauseRepository
                 $pause->pausedReason,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findActiveByInvoice(int $organizationId, int $invoiceId): ?DunningPause

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
     public function findById(int $id): ?Organization
     {
         $row = $this->query->fetchOne(
-            'SELECT id, slug, name FROM organizations WHERE id = ? AND is_deleted = 0',
+            'SELECT id, slug, name FROM organizations WHERE id = ? AND is_deleted = FALSE',
             [$id],
         );
 
@@ -26,7 +26,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
     public function findBySlug(string $slug): ?Organization
     {
         $row = $this->query->fetchOne(
-            'SELECT id, slug, name FROM organizations WHERE slug = ? AND is_deleted = 0',
+            'SELECT id, slug, name FROM organizations WHERE slug = ? AND is_deleted = FALSE',
             [$slug],
         );
 
@@ -35,13 +35,13 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function existsBySlug(string $slug): bool
     {
-        return $this->query->fetchOne('SELECT 1 FROM organizations WHERE slug = ? AND is_deleted = 0', [$slug]) !== null;
+        return $this->query->fetchOne('SELECT 1 FROM organizations WHERE slug = ? AND is_deleted = FALSE', [$slug]) !== null;
     }
 
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT id, slug, name FROM organizations WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            'SELECT id, slug, name FROM organizations WHERE is_deleted = FALSE ORDER BY id ASC LIMIT ? OFFSET ?',
             [$limit, $offset],
         );
 
@@ -50,7 +50,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function countAll(): int
     {
-        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM organizations WHERE is_deleted = 0');
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS c FROM organizations WHERE is_deleted = FALSE');
 
         if ($row === null) {
             return 0;
@@ -70,12 +70,10 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
             return $organization->id;
         }
 
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO organizations (slug, name) VALUES (?, ?)',
             [$organization->slug, $organization->name],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function delete(int $id, string $deletedAt): void
@@ -83,7 +81,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
         // Soft delete — auditable tenant history is never hard-deleted.
         // `$deletedAt` comes from the use case's injected clock.
         $this->query->execute(
-            'UPDATE organizations SET is_deleted = 1, deleted_at = ? WHERE id = ?',
+            'UPDATE organizations SET is_deleted = TRUE, deleted_at = ? WHERE id = ?',
             [$deletedAt, $id],
         );
     }

--- a/src/Receivable/PdoManualReceivableRepository.php
+++ b/src/Receivable/PdoManualReceivableRepository.php
@@ -19,7 +19,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
     public function findById(int $id): ?ManualReceivable
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM manual_receivables WHERE id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM manual_receivables WHERE id = ? AND is_deleted = FALSE',
             [$id],
         );
 
@@ -53,7 +53,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
     {
         $row = $this->query->fetchOne(
             'SELECT ' . self::COLUMNS . ' FROM manual_receivables '
-            . 'WHERE organization_id = ? AND reference_number = ? AND is_deleted = 0',
+            . 'WHERE organization_id = ? AND reference_number = ? AND is_deleted = FALSE',
             [$organizationId, $referenceNumber],
         );
 
@@ -62,7 +62,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
 
     public function save(ManualReceivable $receivable): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, '
             . 'total_cents, outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -82,8 +82,6 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
                 $receivable->updatedAt ?? $receivable->createdAt,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function update(ManualReceivable $receivable): void
@@ -91,7 +89,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
         $this->query->execute(
             'UPDATE manual_receivables SET reference_number = ?, client_name = ?, recipient_email = ?, '
             . 'total_cents = ?, outstanding_cents = ?, currency = ?, issued_at = ?, due_at = ?, status = ?, updated_at = ? '
-            . 'WHERE id = ? AND is_deleted = 0',
+            . 'WHERE id = ? AND is_deleted = FALSE',
             [
                 $receivable->referenceNumber,
                 $receivable->clientName,
@@ -111,7 +109,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
     public function softDelete(int $id, string $deletedAt): void
     {
         $this->query->execute(
-            'UPDATE manual_receivables SET is_deleted = 1, deleted_at = ? WHERE id = ? AND is_deleted = 0',
+            'UPDATE manual_receivables SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND is_deleted = FALSE',
             [$deletedAt, $id],
         );
     }
@@ -121,7 +119,7 @@ final readonly class PdoManualReceivableRepository implements ManualReceivableRe
      */
     private function whereClause(int $organizationId, ManualReceivableFilter $filter): array
     {
-        $clauses = ['organization_id = ?', 'is_deleted = 0'];
+        $clauses = ['organization_id = ?', 'is_deleted = FALSE'];
         /** @var list<string|int> $params */
         $params = [$organizationId];
 

--- a/src/Reconciliation/PdoClientCreditRepository.php
+++ b/src/Reconciliation/PdoClientCreditRepository.php
@@ -19,7 +19,7 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
 
     public function save(ClientCredit $credit): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status, '
             . 'source_bank_transaction_id, reconciliation_id, created_by, created_at, source, manual_receivable_id, client_name) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -38,8 +38,6 @@ final readonly class PdoClientCreditRepository implements ClientCreditRepository
                 $credit->clientName,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findById(int $organizationId, int $id): ?ClientCredit

--- a/src/Reconciliation/PdoReconciliationRepository.php
+++ b/src/Reconciliation/PdoReconciliationRepository.php
@@ -113,7 +113,7 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
 
     public function save(Reconciliation $reconciliation): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code, confirmed_by, confirmed_at, idempotency_key) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?)',
             [
@@ -126,13 +126,11 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
                 $reconciliation->idempotencyKey,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function saveAllocation(ReconciliationAllocation $allocation): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents, payment_id, external_reference, source, manual_receivable_id) '
             . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             [
@@ -146,8 +144,6 @@ final readonly class PdoReconciliationRepository implements ReconciliationReposi
                 $allocation->manualReceivableId,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findAllocationsByReconciliation(int $organizationId, int $reconciliationId): array

--- a/src/User/PdoUserInvitationRepository.php
+++ b/src/User/PdoUserInvitationRepository.php
@@ -17,7 +17,7 @@ final readonly class PdoUserInvitationRepository implements UserInvitationReposi
 
     public function save(UserInvitation $invitation): int
     {
-        $this->query->execute(
+        return $this->query->insert(
             'INSERT INTO user_invitations (organization_id, user_id, token_hash, expires_at, accepted_at) '
             . 'VALUES (?, ?, ?, ?, ?)',
             [
@@ -28,8 +28,6 @@ final readonly class PdoUserInvitationRepository implements UserInvitationReposi
                 $invitation->acceptedAt,
             ],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function findByTokenHash(string $tokenHash): ?UserInvitation

--- a/src/User/PdoUserRepository.php
+++ b/src/User/PdoUserRepository.php
@@ -19,7 +19,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findById(int $id): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM users WHERE id = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE id = ? AND is_deleted = FALSE',
             [$id],
         );
 
@@ -29,7 +29,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function findByEmail(string $email): ?User
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::COLUMNS . ' FROM users WHERE email = ? AND is_deleted = 0',
+            'SELECT ' . self::COLUMNS . ' FROM users WHERE email = ? AND is_deleted = FALSE',
             [$email],
         );
 
@@ -39,7 +39,7 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function existsByEmail(string $email): bool
     {
         return $this->query->fetchOne(
-            'SELECT 1 FROM users WHERE email = ? AND is_deleted = 0',
+            'SELECT 1 FROM users WHERE email = ? AND is_deleted = FALSE',
             [$email],
         ) !== null;
     }
@@ -48,13 +48,13 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     {
         if ($organizationId === null) {
             $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id IS NULL AND is_deleted = 0 '
+                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id IS NULL AND is_deleted = FALSE '
                 . 'ORDER BY id ASC LIMIT ? OFFSET ?',
                 [$limit, $offset],
             );
         } else {
             $rows = $this->query->fetchAll(
-                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id = ? AND is_deleted = 0 '
+                'SELECT ' . self::COLUMNS . ' FROM users WHERE organization_id = ? AND is_deleted = FALSE '
                 . 'ORDER BY id ASC LIMIT ? OFFSET ?',
                 [$organizationId, $limit, $offset],
             );
@@ -66,8 +66,8 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
     public function countByOrganization(?int $organizationId): int
     {
         $row = $organizationId === null
-            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id IS NULL AND is_deleted = 0')
-            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id = ? AND is_deleted = 0', [$organizationId]);
+            ? $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id IS NULL AND is_deleted = FALSE')
+            : $this->query->fetchOne('SELECT COUNT(*) AS c FROM users WHERE organization_id = ? AND is_deleted = FALSE', [$organizationId]);
 
         if ($row === null) {
             return 0;
@@ -87,12 +87,10 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
             return $user->id;
         }
 
-        $this->query->execute(
-            'INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (?, ?, ?, ?, ?, 0)',
+        return $this->query->insert(
+            'INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (?, ?, ?, ?, ?, FALSE)',
             [$user->organizationId, $user->email, $user->role->value, $user->status->value, $user->passwordHash],
         );
-
-        return $this->query->lastInsertId();
     }
 
     public function delete(?int $organizationId, int $id, string $deletedAt): void
@@ -102,12 +100,12 @@ final readonly class PdoUserRepository implements UserRepositoryInterface
         // and its audit event share one instant (no wall-clock read here).
         if ($organizationId !== null) {
             $this->query->execute(
-                'UPDATE users SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id = ?',
+                'UPDATE users SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id = ?',
                 [$deletedAt, $id, $organizationId],
             );
         } else {
             $this->query->execute(
-                'UPDATE users SET is_deleted = 1, deleted_at = ? WHERE id = ? AND organization_id IS NULL',
+                'UPDATE users SET is_deleted = TRUE, deleted_at = ? WHERE id = ? AND organization_id IS NULL',
                 [$deletedAt, $id],
             );
         }

--- a/tests/Database/AdapterAwareQueryExecutorTest.php
+++ b/tests/Database/AdapterAwareQueryExecutorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The PostgreSQL code path appends `RETURNING id`. SQLite (>= 3.35) supports the
+ * same clause, so these tests exercise the pgsql branch on SQLite without needing
+ * pdo_pgsql — the SQL the decorator emits is identical to what PostgreSQL runs.
+ */
+final class AdapterAwareQueryExecutorTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseTestKit $kit;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-adapter-', true) . '.sqlite';
+        $this->kit = DatabaseTestKit::sqlite($this->dbPath);
+        $this->kit->queryExecutor->execute(
+            'CREATE TABLE widgets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)',
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testInsertReturnsGeneratedIdOnPgsqlPath(): void
+    {
+        $executor = new AdapterAwareQueryExecutor($this->kit->queryExecutor, 'pgsql');
+
+        $first = $executor->insert('INSERT INTO widgets (name) VALUES (?)', ['alpha']);
+        $second = $executor->insert('INSERT INTO widgets (name) VALUES (?)', ['beta']);
+
+        self::assertSame(1, $first);
+        self::assertSame(2, $second);
+    }
+
+    public function testInsertReturnsGeneratedIdOnLastInsertIdPath(): void
+    {
+        foreach (['sqlite', 'mysql'] as $adapter) {
+            $executor = new AdapterAwareQueryExecutor($this->kit->queryExecutor, $adapter);
+
+            $id = $executor->insert('INSERT INTO widgets (name) VALUES (?)', ["row-$adapter"]);
+
+            self::assertGreaterThan(0, $id, "adapter $adapter should return the generated id");
+        }
+    }
+
+    public function testReadAndWriteMethodsDelegateToInnerExecutor(): void
+    {
+        $executor = new AdapterAwareQueryExecutor($this->kit->queryExecutor, 'pgsql');
+        $executor->insert('INSERT INTO widgets (name) VALUES (?)', ['gamma']);
+
+        self::assertSame(1, $executor->execute('UPDATE widgets SET name = ? WHERE id = 1', ['renamed']));
+        self::assertSame('renamed', $executor->fetchOne('SELECT name FROM widgets WHERE id = 1')['name'] ?? null);
+        self::assertCount(1, $executor->fetchAll('SELECT id FROM widgets'));
+    }
+
+    public function testTransactionManagerDecoratesExecutorWithReturningId(): void
+    {
+        $manager = new AdapterAwareTransactionManager($this->kit->transactionManager, 'pgsql');
+
+        $id = $manager->transactional(
+            static fn (DatabaseQueryExecutorInterface $tx): int
+                => $tx->insert('INSERT INTO widgets (name) VALUES (?)', ['in-tx']),
+        );
+
+        self::assertSame(1, $id);
+        self::assertSame('in-tx', $this->kit->queryExecutor->fetchOne('SELECT name FROM widgets WHERE id = 1')['name'] ?? null);
+    }
+}


### PR DESCRIPTION
Adds `DB_ADAPTER=pgsql` alongside MySQL (Tier A) and SQLite, sharing one Phinx migration set.

## What changed

**Phase 1 — wiring**
- `public_html/index.php`: `match($adapter)` with a `pgsql` arm (charset omitted from the DSN per the framework; non-empty default kept to satisfy `DatabaseConfig` validation).
- `phinx.php`: `pgsql` environment.
- New `AdapterAwareQueryExecutor` / `AdapterAwareTransactionManager` decorators so `insert()` uses `INSERT … RETURNING id` on PostgreSQL (`PDO::lastInsertId()` returns 0 there) and `lastInsertId()` on mysql/sqlite. Pattern per NENE2 `docs/howto/use-postgresql.md`.

**Phase 2 — data layer**
- 13 repository insert sites switched from `execute()`+`lastInsertId()` to `insert()`.
- `is_deleted` comparisons `0/1` → `FALSE/TRUE` (PostgreSQL rejects `boolean = integer`); users insert literal `0` → `FALSE`.
- `DATE(col)` date-range filters left unchanged — empirically verified portable on PostgreSQL 17.

**Phase 3 — infra / tests / docs**
- docker-compose: optional `postgres:17` service on host port **5483**.
- CI: `postgres-migrate` job validates all migrations apply on PostgreSQL.
- `AdapterAwareQueryExecutorTest` covers the RETURNING id path (SQLite ≥ 3.35).
- `.env.example`, README, operator-guide, CLAUDE.md ports table.

## Verification

Verified end-to-end against real **PostgreSQL 17**: all 22 migrations apply; insert `RETURNING id`, boolean soft-delete, and `DATE()` filters work. `composer check` green (296 tests, PHPStan level 8, PHP-CS-Fixer).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)