### PR TITLE
feat(docker): one-command setup via `docker compose up` (#180)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the build context lean and avoid shadowing image-built artifacts with
+# host copies (vendor symlinks, node_modules, the host .env).
+.git
+.github
+
+# PHP / Composer — installed inside the image.
+vendor
+
+# Node — installed/built inside the frontend stage.
+node_modules
+frontend/node_modules
+tests/e2e/node_modules
+
+# Built SPA — produced by the frontend stage into public_html/assets.
+public_html/assets
+
+# Local runtime / caches / dev DB.
+var
+.env
+*.cache
+.php-cs-fixer.cache
+.phpstan.cache
+.phpunit.cache
+database/*.sqlite3
+database/nene_clear
+
+# Editor / tooling noise.
+.cursor
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+
+# NeNe Clear — single production-like app image.
+# Builds the React/Vite admin SPA, then serves it together with the PHP API on
+# one port (8384) via the PHP built-in server. See docker-compose.yml.
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the admin SPA → public_html/assets
+# ---------------------------------------------------------------------------
+FROM node:22-alpine AS frontend
+WORKDIR /app
+# vite.config.ts reads NENE_CLEAR_* from the project-root .env; the build itself
+# is static (no proxy/backend needed), so only the frontend sources are required.
+COPY frontend ./frontend
+RUN mkdir -p public_html \
+    && cd frontend \
+    && npm ci \
+    && npm run build
+# → /app/public_html/assets (build.outDir = ../public_html/assets, emptyOutDir)
+
+# ---------------------------------------------------------------------------
+# Stage 2: PHP runtime serving SPA + API
+# ---------------------------------------------------------------------------
+FROM php:8.4-cli AS app
+
+# System libs for the PHP extensions we need:
+#   pdo_mysql (default DB) · pdo_pgsql (DB_ADAPTER=pgsql) · mbstring · curl.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git unzip libonig-dev libpq-dev libzip-dev libcurl4-openssl-dev \
+    && docker-php-ext-install pdo_mysql pdo_pgsql mbstring \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer (pinned major).
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# NENE2 framework — composer.json references it as a path repo (../NENE2,
+# symlink: true), so it must live next to the app at /NENE2 and persist at
+# runtime. Public repo; cloned the same way CI does.
+RUN git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git /NENE2
+
+WORKDIR /app
+
+# Install PHP deps first (better layer caching). dev deps are kept on purpose:
+# phinx (require-dev) runs migrations from the entrypoint.
+COPY composer.json composer.lock ./
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader --no-scripts
+
+# Application source (vendor/node_modules/etc. excluded via .dockerignore).
+COPY . .
+
+# Re-run to wire autoloading for the now-present src/ and finalise.
+RUN composer install --no-interaction --prefer-dist --optimize-autoloader \
+    && mkdir -p var
+
+# Built SPA from stage 1.
+COPY --from=frontend /app/public_html/assets ./public_html/assets
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8384
+ENTRYPOINT ["entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,33 @@ Next: Phase 3 (Tier A shared-hosting installer / release ZIP) and Phase 4
 
 **Billing documents (見積・請求・入金):** [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice) — not this repo.
 
+## Run with Docker (one command)
+
+Clone and bring the whole stack up — the app image builds the admin SPA,
+installs PHP deps, waits for MySQL, applies migrations, and serves the UI + API
+on a single port:
+
+```bash
+git clone https://github.com/hideyukiMORI/nene-clear.git
+cd nene-clear
+docker compose up            # add --build to force a rebuild after code changes
+```
+
+- **Admin UI + API** → http://localhost:8384
+- **Mailpit (dunning email)** → http://localhost:8383
+
+This starts `app` + `mysql` (`:3383`, persistent volume) + `mailpit`. PostgreSQL
+is opt-in: `docker compose --profile pgsql up` (then set `DB_ADAPTER=pgsql` /
+`DB_HOST=postgres` on the `app` service). Override `NENE_CLEAR_JWT_SECRET`,
+`DB_PASSWORD`, and the optional `NENE_INVOICE_API_BASE_URL` /
+`NENE_INVOICE_BEARER_TOKEN` via the environment for any real deployment — the
+compose defaults are for local use only. No hot reload: rerun with `--build`
+to pick up source changes.
+
 ## Quickstart (local development)
+
+For an active edit/reload loop, run the backend and frontend directly on the
+host instead:
 
 ```bash
 # 1. Infrastructure (MySQL 8.4 on :3383, Mailpit SMTP :1383 / web UI :8383)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,40 @@
 services:
+  # NeNe Clear app — builds the SPA + serves it with the PHP API on :8384.
+  # `docker compose up` brings up app + mysql + mailpit (postgres is opt-in via
+  # the `pgsql` profile). The entrypoint waits for MySQL and runs migrations.
+  app:
+    build: .
+    container_name: nene-clear-app
+    ports:
+      - "8384:8384"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      APP_ENV: production
+      APP_DEBUG: "false"
+      APP_NAME: "NeNe Clear"
+      PROBLEM_DETAILS_BASE_URL: https://nene-clear.dev/problems/
+      # Default DB: the bundled MySQL service (internal port 3306, host 3383).
+      DB_ADAPTER: mysql
+      DB_HOST: mysql
+      DB_PORT: "3306"
+      DB_NAME: ${DB_NAME:-nene_clear}
+      DB_USER: ${DB_USER:-nene_clear}
+      DB_PASSWORD: ${DB_PASSWORD:-nene_clear}
+      DB_CHARSET: utf8mb4
+      # CHANGE THIS in any real deployment.
+      NENE_CLEAR_JWT_SECRET: ${NENE_CLEAR_JWT_SECRET:-nene-clear-dev-secret-change-in-production}
+      NENE_CLEAR_APP_URL: http://localhost:8384
+      # Dunning email → bundled Mailpit (internal SMTP 1025, web UI :8383).
+      SMTP_HOST: mailpit
+      SMTP_PORT: "1025"
+      SMTP_FROM_ADDRESS: noreply@nene-clear.dev
+      SMTP_FROM_NAME: "NeNe Clear"
+      # Optional NeNe Invoice upstream — set both to activate (else standalone).
+      NENE_INVOICE_API_BASE_URL: ${NENE_INVOICE_API_BASE_URL:-}
+      NENE_INVOICE_BEARER_TOKEN: ${NENE_INVOICE_BEARER_TOKEN:-}
+
   mysql:
     image: mysql:8.4
     container_name: nene-clear-db
@@ -25,6 +61,10 @@ services:
   postgres:
     image: postgres:17
     container_name: nene-clear-pg
+    # Opt-in only: `docker compose --profile pgsql up`. Default up stays minimal
+    # (app + mysql + mailpit). Set DB_ADAPTER=pgsql + DB_HOST=postgres on the app
+    # service to actually use it.
+    profiles: ["pgsql"]
     ports:
       - "5483:5432"
     environment:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Container entrypoint: apply DB schema, then serve SPA + API on :8384.
+set -e
+
+# The DB container is gated by compose depends_on: service_healthy, but keep a
+# short retry so a slow first-boot (volume init) doesn't race the migration.
+echo "Waiting for database (${DB_ADAPTER:-sqlite} @ ${DB_HOST:-127.0.0.1}:${DB_PORT:-})..."
+i=0
+until composer migrations:migrate; do
+    i=$((i + 1))
+    if [ "$i" -ge 20 ]; then
+        echo "Migrations failed after $i attempts — aborting." >&2
+        exit 1
+    fi
+    echo "  migrate attempt $i failed; retrying in 3s..."
+    sleep 3
+done
+
+echo "Starting PHP server on :8384"
+exec php -S 0.0.0.0:8384 -t public_html/


### PR DESCRIPTION
## Summary

Makes a fresh clone runnable with a single `docker compose up`. A new
production-like **`app`** container builds the admin SPA, installs PHP deps,
waits for MySQL, applies migrations, and serves the SPA + API on `:8384`.

## Changes

- **`Dockerfile`** (new) — multi-stage: `node:22` builds the SPA into
  `public_html/assets`; `php:8.4-cli` runtime with `pdo_mysql` / `pdo_pgsql` /
  `mbstring`, Composer, and the NENE2 path dependency cloned at `/NENE2`
  (matching the `../NENE2` symlink repo in `composer.json`).
- **`docker/entrypoint.sh`** (new) — `migrations:migrate` (with retry), then
  `php -S 0.0.0.0:8384 -t public_html/`.
- **`.dockerignore`** (new) — lean context; avoids shadowing image-built
  `vendor/`, `node_modules/`, and the host `.env`.
- **`docker-compose.yml`** — adds the `app` service (default DB = bundled MySQL,
  `depends_on` healthy); moves `postgres` behind a `pgsql` profile so the
  default `up` stays minimal (app + mysql + mailpit).
- **`README.md`** — "Run with Docker (one command)" section.

Infra/devex only — no application logic, schema, or terminology changes. The
existing host `php -S` / `vite` dev loop (with hot reload) remains documented.

## Verification

`docker compose down -v && docker compose up`, on a clean state:

- app waits for MySQL healthy, then the entrypoint applies all 18 migrations to
  MySQL and starts the server on `:8384`.
- `docker compose ps`: app / mysql (healthy) / mailpit (healthy); **postgres
  does not start** (profile-gated).
- Smoke tests:
  - `GET /` → **200**
  - `GET /admin/api/v1/health` (no auth) → **401 Problem Details JSON**
  - `GET /admin/reconciliation` (Accept: text/html) → **SPA index.html** (fallback)
  - `SHOW TABLES` in `nene_clear` → business tables + `phinxlog` present

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)