### PR TITLE
docs: mark repository as public, remove stray "private" wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent / AI Guide
 
-Entry point for AI agents working on **NeNe Clear** (private repo `nene-clear`).
+Entry point for AI agents working on **NeNe Clear** (public repo `nene-clear`).
 
 ## Domain split (read first)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — NeNe Clear
 
-Private repo for **NeNe Clear** — **入金消込・督促管理 only**.
+Public repo for **NeNe Clear** — **入金消込・督促管理 only**.
 
 **Not** `nene-invoice`. Invoice = 見積・請求・入金管理. **Separate domain. Not upper compatible.**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
-[![Private](https://img.shields.io/badge/status-private-red)]()
+[![Public](https://img.shields.io/badge/status-public-brightgreen)]()
 
 **Payment reconciliation and dunning — self-hosted for Japan SMB.**
 

--- a/docs/adr/0007-product-identity-nene-clear.md
+++ b/docs/adr/0007-product-identity-nene-clear.md
@@ -21,7 +21,7 @@ Strategy lives in
 - **Tagline (EN):** Clear deposits. Collect with confidence.
 - **Tagline (JA, marketing):** 入金を消込し、未収を見える化する。
 - **Domain:** Payment reconciliation & dunning — **not** quote or invoice issuance
-- **Repository:** `hideyukiMORI/nene-clear` (private until public launch)
+- **Repository:** `hideyukiMORI/nene-clear` (public)
 - **PHP namespace:** `NeneClear\`
 - **Problem Details base:** `https://nene-clear.dev/problems/`
 

--- a/docs/adr/0009-separate-from-nene-invoice.md
+++ b/docs/adr/0009-separate-from-nene-invoice.md
@@ -12,7 +12,7 @@ often conflate because both touch "money after billing":
 | Product | Repository | Domain |
 | --- | --- | --- |
 | **NeNe Invoice** (working title) | `nene-invoice` (public) | **Quote, invoice, and payment management** — 見積・請求・入金管理 |
-| **NeNe Clear** | `nene-clear` (private) | **Payment reconciliation and dunning** — 入金消込・督促管理 |
+| **NeNe Clear** | `nene-clear` (public) | **Payment reconciliation and dunning** — 入金消込・督促管理 |
 
 These are **not** the same product, **not** upper/lower layers of one stack,
 and **not** a migration path (`invoice` → `clear`). They are **separate

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -40,7 +40,7 @@ See: [`glossary.md`](./glossary.md), [`../development/naming-conventions.md`](..
 | Concept | Canonical | Notes |
 | --- | --- | --- |
 | Public product name | **NeNe Clear** | ADR 0007 |
-| Repository slug | `nene-clear` | Private until public launch |
+| Repository slug | `nene-clear` | Public |
 | PHP namespace | `NeneClear\` | ADR 0007 |
 | Problem Details base | `https://nene-clear.dev/problems/` | Until branding domain Issue |
 


### PR DESCRIPTION
## Summary

The "private repo" wording was carried over by mistake when the project was initially copied from another repository. `nene-clear` is a **public** repo. This updates all repository-status references accordingly.

## Changes

- `README.md` — status badge `status-private-red` → `status-public-brightgreen`
- `CLAUDE.md` — "Private repo" → "Public repo"
- `AGENTS.md` — "(private repo `nene-clear`)" → "(public repo `nene-clear`)"
- `docs/adr/0007-product-identity-nene-clear.md` — "(private until public launch)" → "(public)"
- `docs/adr/0009-separate-from-nene-invoice.md` — "`nene-clear` (private)" → "`nene-clear` (public)"
- `docs/explanation/terminology.md` — "Private until public launch" → "Public"

Unrelated uses of "private" (PHP `private` modifiers, "private URLs"/"private identifiers" about secrets) are intentionally left untouched.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)