### PR TITLE
fix(dev): run-local is_up false-positives on a dead port, so the backend never starts

### DIFF
--- a/.claude/skills/run-local/run-local.sh
+++ b/.claude/skills/run-local/run-local.sh
@@ -25,7 +25,9 @@ ROOT="$(cd "$HERE" && git rev-parse --show-toplevel 2>/dev/null || true)"
 cd "$ROOT" || { printf '❌ repo ルートに移動できません: %s\n' "$ROOT" >&2; exit 1; }
 
 say() { printf '%s\n' "$*"; }
-http_code() { curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$1" 2>/dev/null || echo 000; }
+# curl prints `000` itself when it can't connect, so do NOT add `|| echo 000`
+# (that would emit `000000` and make is_up treat a dead port as up).
+http_code() { local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$1" 2>/dev/null)"; printf '%s' "${c:-000}"; }
 is_up() { [ "$(http_code "$1")" != "000" ]; }
 
 # --- .env（無ければ example から作る。dev は .env の DB_ADAPTER=sqlite を前提とする） ---


### PR DESCRIPTION
## Bug

`run-local.sh`'s liveness helper treats a **dead** port as up, so the backend is never cold-started — the script always reported "backend 既に起動済み" even with nothing listening on `:8384`.

```sh
http_code() { curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$1" 2>/dev/null || echo 000; }
```

When curl cannot connect it prints `000` itself (the `%{http_code}` value) **and** exits non-zero, so `|| echo 000` appends a second `000`. `http_code` returns `000000`, and `is_up` compares `"000000" != "000"` → **true** → the port is wrongly considered up. `php -S` then never launches.

## Fix

Drop `|| echo 000`, rely on curl's own `000`, capture the value once:

```sh
http_code() { local c; c="$(curl -s -o /dev/null -w '%{http_code}' --max-time 4 "$1" 2>/dev/null)"; printf '%s' "${c:-000}"; }
```

## Verification

- Dead port → helper returns `000` (down); live port → `200`.
- `run-local.sh` now cold-starts `php -S` on `:8384`: `/health` → 200, body `{"status":"ok","service":"NENE2"}`.
- End-to-end via the Vite proxy: `:5383/health` → 200; `:5383/` (SPA) → 200.
- Only the `mailpit` container runs (dev backend is `php -S` + SQLite, not the production `app` container).

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)