### PR TITLE
chore(planning): add Adoption Readiness (2026-06) milestone + refresh TODO

### DIFF
--- a/docs/milestones/2026-06-adoption-readiness.md
+++ b/docs/milestones/2026-06-adoption-readiness.md
@@ -1,0 +1,58 @@
+# Milestone: Adoption Readiness (2026-06)
+
+Goal: turn the 2026-06 adoption review (#190,
+[`../explanation/adoption-review-2026-06.md`](../explanation/adoption-review-2026-06.md))
+into shipped changes that remove the **structural adoption blockers** —
+without touching the validated core (immutable audit trail, safety-railed
+dunning, human-confirmed reconciliation, first-class partial/overpayment, UI).
+
+**Status: in progress (started 2026-06-27)**
+
+The review's verdict was adopt 0 / consider 3 / pass 7: features and UI are
+validated, but distribution / connectivity / operations block adoption. This
+milestone is the engineering-ownable slice of the fix.
+
+## Acceptance Criteria
+
+Execution order (quick, high-confidence first; P0 levers interleaved):
+
+- [ ] **UI polish (#196)** — localize all audit-log event-type labels (no raw
+      slugs like `clear_settings_updated`), resolve the dashboard
+      "残高合計取得中" state, neutralize B2B-only sample data, add tooltips for
+      bookkeeping terms (annotate, do not rename).
+- [ ] **Mask bank account number (#192)** — mask `account_number` in the UI;
+      reveal-on-demand; record the reveal as a (newly registered) audit event.
+- [ ] **Standalone receivables, first-class (#191, P0)** — surface the existing
+      `importManualReceivables` path in onboarding/empty states; add per-tool
+      CSV import presets (freee / MF / 弥生 / MISOCA); reposition copy so Clear
+      reads as usable without NeNe Invoice.
+- [ ] **Dunning hardening (#194)** — staged templates (initial/reminder/final),
+      body preview + test send, deliverability (SPF/DKIM/DMARC) guidance,
+      do-not-send / contact-only mode. Stay within the self-collection boundary
+      (ADR 0011).
+- [ ] **Security (#195)** — MFA (TOTP) for admin login; encryption-at-rest for
+      sensitive fields (implement and/or document).
+- [ ] **Retract Tier A recommendation (#193)** — stop recommending shared
+      hosting for this data; recommend Tier B (VPS+Docker) + install-service /
+      managed. **Product-owner sign-off required** (intersects roadmap Phase 3).
+
+## Out of scope (business / owner, tracked in the review doc — not this milestone)
+
+- Official **managed / SaaS** offering and the **support-supply** model.
+- **Pricing** (layered A/B/C) and the tax-advisor **MSP channel**.
+
+These are the largest pay-levers but are not code tasks; they need a
+product-owner decision (see the review doc's pay-levers + "supply gap").
+
+## Definition of done
+
+- Each in-scope issue (#191, #192, #194, #195, #196) merged with green
+  `composer check` + frontend `check` + E2E, and any new identifiers registered
+  in [`../explanation/terminology.md`](../explanation/terminology.md) first.
+- #193 reflected in README / product-vision / roadmap once the owner signs off.
+
+## Follow-up
+
+After this milestone, resume the prior roadmap: activate the real Invoice
+upstream (live contract tests), Phase 4 ecosystem (MCP tools), and the CSV-export
+tax-advisor sign-off. See [`../roadmap.md`](../roadmap.md).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-06-06
+Last updated: 2026-06-27
 
 ## Status
 
@@ -67,25 +67,45 @@ Fixed local ports (see `CLAUDE.md`; do **not** revert to framework defaults).
 
 ## Next steps
 
-0. **Manual receivables (standalone use without NeNe Invoice)** — accepted
-   [ADR 0014](../adr/0014-accept-manual-receivables.md); design +
-   Issue breakdown in
-   [`manual-receivables-design.md`](../development/manual-receivables-design.md).
-   A `source` (`invoice_upstream` | `manual`) discriminator lets Clear reconcile
-   and dun directly-entered receivables; X2 narrowed (manual = Clear-owned, no
-   competing system), X1 unchanged. Sequenced Issues 1–6 (foundation → CRUD →
-   CSV import → reconcile → dun → frontend).
-1. **Activate real Invoice upstream** — set env vars, run contract tests live.
-2. **Dunning template customization** — operator-editable templates per org
-   (currently a single hardcoded `lang/ja.php` template).
-3. **CSV export — tax advisor sign-off** — review column set per compliance §9 before calling it production-ready.
-4. **Phase 3 — Tier A shared hosting** — web installer, release ZIP, two-app
-   (Invoice + Clear) operator setup guide.
-5. **Phase 4 — Ecosystem** — MCP tools (`listUnmatchedTransactions`,
+**Current milestone — Adoption Readiness (2026-06):**
+[`../milestones/2026-06-adoption-readiness.md`](../milestones/2026-06-adoption-readiness.md).
+Turns the 2026-06 adoption review (#190,
+[`../explanation/adoption-review-2026-06.md`](../explanation/adoption-review-2026-06.md);
+adopt 0 / consider 3 / pass 7 — core validated, distribution/ops blocks adoption)
+into shipped changes. Execution order (working from the top):
+
+1. **UI polish (#196)** — audit-log label i18n (no raw slugs), dashboard
+   "残高合計取得中" state, neutral sample data, bookkeeping-term tooltips.
+2. **Mask bank account number (#192)** — mask in UI + reveal-on-demand + audit.
+3. **Standalone receivables, first-class (#191, P0)** — surface existing
+   `importManualReceivables`, add per-tool CSV import presets (freee/MF/弥生/MISOCA),
+   reposition copy (usable without NeNe Invoice).
+4. **Dunning hardening (#194)** — staged templates, preview/test send,
+   deliverability, do-not-send mode (within ADR 0011).
+5. **Security (#195)** — MFA (TOTP) + encryption-at-rest for sensitive fields.
+6. **Retract Tier A recommendation (#193)** — recommend Tier B + managed;
+   **owner sign-off required** (intersects Phase 3).
+
+Business/owner levers (not code; see review doc): official managed/SaaS supply,
+pricing (A/B/C), tax-advisor MSP channel.
+
+**Then resume prior roadmap:**
+7. **Activate real Invoice upstream** — set env vars, run contract tests live.
+8. **CSV export — tax advisor sign-off** — review column set per compliance §9.
+9. **Phase 4 — Ecosystem** — MCP tools (`listUnmatchedTransactions`,
    `proposeMatch`, `sendDunningNotice`).
+
+> Note: **Phase 3 (Tier A shared hosting)** in [`../roadmap.md`](../roadmap.md)
+> is under review per #193 — the adoption review found shared hosting unsuitable
+> for this data. Pending owner decision.
 
 ## Recently completed
 
+- 2026-06 adoption review (10-persona simulation): findings doc
+  [`../explanation/adoption-review-2026-06.md`](../explanation/adoption-review-2026-06.md)
+  (#190) + follow-up issues #191–#196, scheduled in the Adoption Readiness milestone.
+- Dev tooling: one-command `/dev-up` via `.claude/skills/run-local/run-local.sh`
+  (php -S + SQLite + Vite + Mailpit); public-repo wording fixes.
 - Post-Phase-2 hardening merged to main (PR #99–#118): see Status above.
 - i18n message catalog (ja/en), multi-tenant SQL scoping, audit before/after
   snapshots, reconciliation idempotency, operator guide (電子帳簿保存法 §3.4).


### PR DESCRIPTION
Adds `docs/milestones/2026-06-adoption-readiness.md` sequencing the engineering-ownable follow-ups from the 2026-06 adoption review (#190): #196 → #192 → #191 → #194 → #195 → #193. Business/owner pay-levers (managed supply, pricing, MSP channel) are explicitly out of scope. Refreshes `docs/todo/current.md` and flags roadmap Phase 3 (Tier A) as under review per #193.

Planning only — no code change.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)