### PR TITLE
fix(ui): localize all audit-log event labels + fix misleading dashboard subtitle

### DIFF
--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -102,7 +102,7 @@ export const en: Record<MessageKey, string> = {
   'dashboard.title': 'Dashboard',
   'dashboard.subtitle': 'Overview of reconciliation and receivables',
   'dashboard.kpi.unmatched': 'Unmatched transactions',
-  'dashboard.kpi.unmatchedSub': 'Total balance loading',
+  'dashboard.kpi.unmatchedSub': 'Awaiting reconciliation',
   'dashboard.kpi.overdue': 'Overdue invoices (dunning)',
   'dashboard.kpi.overdueSub': 'Up to 31 days overdue',
   'dashboard.kpi.cleared': 'Cleared this month',
@@ -307,6 +307,9 @@ export const en: Record<MessageKey, string> = {
   'audit.event.reconciliation_confirmed': 'Match confirmed',
   'audit.event.reconciliation_reversed': 'Match reversed',
   'audit.event.client_credit_applied': 'Client credit applied',
+  'audit.event.manual_receivable_created': 'Receivable created',
+  'audit.event.manual_receivable_updated': 'Receivable updated',
+  'audit.event.manual_receivable_cancelled': 'Receivable cancelled',
   'audit.event.dunning_sent': 'Dunning sent',
   'audit.event.dunning_paused': 'Dunning paused',
   'audit.event.dunning_resumed': 'Dunning resumed',
@@ -317,6 +320,7 @@ export const en: Record<MessageKey, string> = {
   'audit.event.organization_deleted': 'Organization deleted',
   'audit.event.login_succeeded': 'Login succeeded',
   'audit.event.login_failed': 'Login failed',
+  'audit.event.clear_settings_updated': 'Settings updated',
 
   // ── Keyboard shortcuts / command palette ──
   'shortcuts.title': 'Keyboard shortcuts',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -98,7 +98,7 @@ export const ja = {
   'dashboard.title': 'ダッシュボード',
   'dashboard.subtitle': '入金消込・債権状況の概況',
   'dashboard.kpi.unmatched': '未消込の取引',
-  'dashboard.kpi.unmatchedSub': '残高合計取得中',
+  'dashboard.kpi.unmatchedSub': '消込待ち',
   'dashboard.kpi.overdue': '延滞請求（督促対象）',
   'dashboard.kpi.overdueSub': '最長 31 日経過',
   'dashboard.kpi.cleared': '今月の消込済',
@@ -303,6 +303,9 @@ export const ja = {
   'audit.event.reconciliation_confirmed': '消込確定',
   'audit.event.reconciliation_reversed': '消込取消',
   'audit.event.client_credit_applied': '前受金充当',
+  'audit.event.manual_receivable_created': '手入力売掛 作成',
+  'audit.event.manual_receivable_updated': '手入力売掛 更新',
+  'audit.event.manual_receivable_cancelled': '手入力売掛 取消',
   'audit.event.dunning_sent': '督促送信',
   'audit.event.dunning_paused': '督促停止',
   'audit.event.dunning_resumed': '督促再開',
@@ -313,6 +316,7 @@ export const ja = {
   'audit.event.organization_deleted': '組織削除',
   'audit.event.login_succeeded': 'ログイン成功',
   'audit.event.login_failed': 'ログイン失敗',
+  'audit.event.clear_settings_updated': '設定変更',
 
   // ── Keyboard shortcuts / command palette ──
   'shortcuts.title': 'キーボードショートカット',

--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -18,6 +18,9 @@ const EVENT_META: Record<AuditEventType, StatusMeta> = {
   reconciliation_confirmed:    { v: 'ok',   labelKey: 'audit.event.reconciliation_confirmed' },
   reconciliation_reversed:     { v: 'bad',  labelKey: 'audit.event.reconciliation_reversed' },
   client_credit_applied:       { v: 'ok',   labelKey: 'audit.event.client_credit_applied' },
+  manual_receivable_created:   { v: 'ok',   labelKey: 'audit.event.manual_receivable_created' },
+  manual_receivable_updated:   { v: 'info', labelKey: 'audit.event.manual_receivable_updated' },
+  manual_receivable_cancelled: { v: 'bad',  labelKey: 'audit.event.manual_receivable_cancelled' },
   dunning_sent:                { v: 'info', labelKey: 'audit.event.dunning_sent' },
   dunning_paused:              { v: 'warn', labelKey: 'audit.event.dunning_paused' },
   dunning_resumed:             { v: 'ok',   labelKey: 'audit.event.dunning_resumed' },
@@ -28,6 +31,7 @@ const EVENT_META: Record<AuditEventType, StatusMeta> = {
   organization_deleted:        { v: 'bad',  labelKey: 'audit.event.organization_deleted' },
   login_succeeded:             { v: 'ok',   labelKey: 'audit.event.login_succeeded' },
   login_failed:                { v: 'bad',  labelKey: 'audit.event.login_failed' },
+  clear_settings_updated:      { v: 'info', labelKey: 'audit.event.clear_settings_updated' },
 }
 
 const EVENT_TYPES = Object.keys(EVENT_META) as AuditEventType[]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -160,6 +160,9 @@ export type AuditEventType =
   | 'reconciliation_confirmed'
   | 'reconciliation_reversed'
   | 'client_credit_applied'
+  | 'manual_receivable_created'
+  | 'manual_receivable_updated'
+  | 'manual_receivable_cancelled'
   | 'dunning_sent'
   | 'dunning_paused'
   | 'dunning_resumed'
@@ -170,6 +173,7 @@ export type AuditEventType =
   | 'organization_deleted'
   | 'login_succeeded'
   | 'login_failed'
+  | 'clear_settings_updated'
 
 export interface AuditEvent {
   audit_event_id: number


### PR DESCRIPTION
First slice of the Adoption Readiness milestone (#196 — review-surfaced UI polish).

## What

- **Audit-log raw slugs.** The frontend `AuditEventType` union was missing four event types the backend emits and `terminology.md` §2 registers (`clear_settings_updated`, `manual_receivable_{created,updated,cancelled}`), so `EVENT_META` wasn't required to cover them and they rendered as raw slugs via the fallback. Added them to the union (now `EVENT_META` is compile-time exhaustive), to `EVENT_META`, and to the ja/en catalogs. They are now also selectable in the event-type filter.
- **Misleading dashboard subtitle.** The 未消込 KPI card sub was the static string `残高合計取得中` / `Total balance loading` — it always read as perpetually loading. Replaced with `消込待ち` / `Awaiting reconciliation`.

## Notes

- No new terminology: the four event types are already registered.
- Verified: `npm run check` (type-check + lint + 46 tests incl. ja/en parity) green, and visually against the live UI (audit log now shows 設定変更 / 手入力売掛 作成 / …; dashboard shows 消込待ち).
- **Follow-up observed (not in this PR):** the other dashboard KPI subs (`overdueSub` "最長 31 日経過", `clearedSub` "前月比 +8.2%", `creditSub` "適用待ち 2 件") are hardcoded placeholder values, not real aggregates. Wiring real figures needs backend aggregate endpoints — tracked under #196.

Refs #196