### PR TITLE
feat(settings): mask bank account number in the UI + in the audit snapshot

### DIFF
--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -240,6 +240,8 @@ export const en: Record<MessageKey, string> = {
   'settings.accountType.ordinary': 'Ordinary',
   'settings.accountType.current': 'Current',
   'settings.accountNumber': 'Account number',
+  'settings.revealNumber': 'Show',
+  'settings.hideNumber': 'Hide',
   'settings.csvMapping': 'CSV column mapping',
   'settings.csv.dateCol': 'Date col',
   'settings.csv.amountCol': 'Amount col',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -236,6 +236,8 @@ export const ja = {
   'settings.accountType.ordinary': '普通',
   'settings.accountType.current': '当座',
   'settings.accountNumber': '口座番号',
+  'settings.revealNumber': '表示',
+  'settings.hideNumber': '隠す',
   'settings.csvMapping': 'CSVマッピング設定',
   'settings.csv.dateCol': '日付列',
   'settings.csv.amountCol': '金額列',

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -17,6 +17,15 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
   const [dunningInterval, setDunningInterval] = useState(settings.dunning_min_interval_days)
   const [fiscalMonth, setFiscalMonth] = useState<number | null>(settings.fiscal_year_end_month ?? null)
   const [accounts, setAccounts] = useState<BankAccount[]>(settings.bank_accounts)
+  // Account numbers are masked by default; revealing one is an explicit per-row
+  // action so the number isn't shown in plaintext on screen-share / over a
+  // shoulder (#192). True server-side withholding is tracked separately.
+  const [revealedAccounts, setRevealedAccounts] = useState<Set<number>>(new Set())
+  const toggleReveal = (i: number) => setRevealedAccounts(prev => {
+    const next = new Set(prev)
+    if (next.has(i)) { next.delete(i) } else { next.add(i) }
+    return next
+  })
   const [testResult, setTestResult] = useState<'ok' | 'fail' | null>(null)
   const [testing, setTesting] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -127,7 +136,13 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
                   <option value="current">{t('settings.accountType.current')}</option>
                 </select>
               </div>
-              <div className="field" style={{ flex: 1, minWidth: 140 }}><label>{t('settings.accountNumber')}</label><input className="inp mono" value={acc.account_number} onChange={e => updateAccount(i, 'account_number', e.target.value)} /></div>
+              <div className="field" style={{ flex: 1, minWidth: 140 }}>
+                <label>{t('settings.accountNumber')}</label>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <input className="inp mono" style={{ flex: 1, minWidth: 0 }} type={revealedAccounts.has(i) ? 'text' : 'password'} value={acc.account_number} onChange={e => updateAccount(i, 'account_number', e.target.value)} />
+                  <Button variant="ghost" size="sm" onClick={() => toggleReveal(i)}>{t(revealedAccounts.has(i) ? 'settings.hideNumber' : 'settings.revealNumber')}</Button>
+                </div>
+              </div>
             </div>
             <details style={{ marginTop: 12 }}>
               <summary style={{ cursor: 'pointer', fontSize: 12, color: 'var(--navy-500)', fontWeight: 600 }}>{t('settings.csvMapping')}</summary>

--- a/src/ClearSettings/UpdateClearSettingsUseCase.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCase.php
@@ -104,9 +104,24 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
             'dunning_min_interval_days' => $settings->dunningMinIntervalDays,
             'fiscal_year_end_month' => $settings->fiscalYearEndMonth,
             'bank_account_numbers' => array_map(
-                static fn ($account): string => $account->accountNumber,
+                static fn ($account): string => self::maskAccountNumber($account->accountNumber),
                 $settings->bankAccounts,
             ),
         ];
+    }
+
+    /**
+     * Mask a bank account number for the audit payload: keep only the last four
+     * digits so the trail still shows *which* account changed without persisting
+     * the full number in plaintext in every settings-change event (#192).
+     */
+    private static function maskAccountNumber(string $number): string
+    {
+        $length = strlen($number);
+        if ($length <= 4) {
+            return $number;
+        }
+
+        return str_repeat('*', $length - 4) . substr($number, -4);
     }
 }


### PR DESCRIPTION
Part of the Adoption Readiness milestone (#192 — every persona flagged the plaintext bank account number in Settings).

## What

- **UI:** the Settings → 銀行口座 account number is now masked (`type=password`) by default with a per-row **表示 / 隠す** toggle, mirroring the existing API-token field. Value binding, edit, and save are unchanged, so the replace-all settings update is untouched.
- **Audit:** the `clear_settings_updated` snapshot masked account numbers (keep last 4) so settings-change payloads no longer persist full numbers in plaintext.

## Scope / what's deferred

GET `clear-settings` still returns the full number (the replace-all save round-trips it), so this removes the **on-screen plaintext** the review flagged but is not yet a hard server-side boundary. Server-side withholding (masked GET) + an audited reveal endpoint (`bank_account_number_revealed`) require reworking the settings update and are deferred to a follow-up tied to #195. Tracked in #192.

## Verification

- `composer check` — 296 tests / 1063 assertions, PHPStan level 8 clean, CS-Fixer no changes.
- `npm run check` — type-check + lint + 46 tests (incl. ja/en parity).
- Visual: account number shows `•••••••` + 表示; clicking reveals `1234567` and the button becomes 隠す.

Refs #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)