### PR TITLE
feat(reconciliation): surface the manual-receivable path when no match candidates exist

### DIFF
--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -157,6 +157,7 @@ export const en: Record<MessageKey, string> = {
   'reconciliation.suggestions': 'Match candidates',
   'reconciliation.searchingSuggestions': 'Searching candidates…',
   'reconciliation.noSuggestions': 'No candidates found',
+  'reconciliation.noSuggestionsCta': 'Not using NeNe Invoice? Register receivables under Manual receivables (entry / CSV import) →',
   'reconciliation.useSuggestion': 'Use',
   'reconciliation.dueLabel': 'Due',
   'reconciliation.allocation': 'Allocation',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -153,6 +153,7 @@ export const ja = {
   'reconciliation.suggestions': 'マッチ候補',
   'reconciliation.searchingSuggestions': '候補を検索中…',
   'reconciliation.noSuggestions': '候補が見つかりませんでした',
+  'reconciliation.noSuggestionsCta': 'NeNe Invoice 未使用の場合は「手入力売掛」で売掛を登録／CSV取込できます →',
   'reconciliation.useSuggestion': '選択',
   'reconciliation.dueLabel': '期限',
   'reconciliation.allocation': '配賦',

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listUnmatchedTransactions, listReconciliations,
@@ -97,7 +98,12 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
         {suggestQ.data?.upstream_unavailable && (
           <Notice variant="warn">{t('reconciliation.upstreamUnavailable')}</Notice>
         )}
-        {suggestQ.data?.suggestions.length === 0 && <p className="muted" style={{ fontSize: 12, margin: 0 }}>{t('reconciliation.noSuggestions')}</p>}
+        {suggestQ.data?.suggestions.length === 0 && (
+          <p className="muted" style={{ fontSize: 12, margin: 0 }}>
+            {t('reconciliation.noSuggestions')}{' '}
+            <Link to="/admin/manual-receivables">{t('reconciliation.noSuggestionsCta')}</Link>
+          </p>
+        )}
         {suggestQ.data?.suggestions.map((s, i) => (
           <div key={`${s.source}-${s.invoice_id ?? s.manual_receivable_id}-${i}`} className="sugg-row">
             <Badge variant={s.source === 'manual' ? 'neut' : 'info'}>{t(s.source === 'manual' ? 'reconciliation.source.manual' : 'reconciliation.source.invoice')}</Badge>


### PR DESCRIPTION
First discoverability slice of #191 (Adoption Readiness milestone).

## Why

The review's #1 blocker: operators who don't use NeNe Invoice perceived the product as requiring it. Standalone operation already exists (`importManualReceivables`, ADR 0014) but is easy to miss. This surfaces it at the exact dead-end moment.

## What

When a reconciliation match has **no candidates**, the suggestions panel now links to **Manual receivables** with a localized prompt — "Not using NeNe Invoice? Register receivables (entry / CSV import) →" — so the standalone path is discoverable in context.

- Adds `reconciliation.noSuggestionsCta` (ja/en) + a react-router `Link` to `/admin/manual-receivables`.

## Verification

`npm run check` — type-check + lint + 46 tests (incl. ja/en parity) green.

## Next in #191

Remaining: broader repositioning copy (login / README / product-vision, coordinated with #193) and per-tool CSV import presets (needs the real export formats of freee / MF / 弥生 / MISOCA).

Refs #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)