### PR TITLE
feat(receivable-import): recognize common Japanese export headers + Shift-JIS + ¥/comma amounts

### DIFF
--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -347,7 +347,7 @@ export const en: Record<MessageKey, string> = {
   'manualReceivables.createSub': 'Register a reference by number, payer, and amount.',
   'manualReceivables.import': 'Import CSV',
   'manualReceivables.importSub': 'Bulk-register receivables from a CSV.',
-  'manualReceivables.importColumns': 'CSV header columns: reference_number, client_name, total_cents (optional: recipient_email, due_at, issued_at, currency). Duplicate reference numbers are skipped.',
+  'manualReceivables.importColumns': 'CSV header columns: reference_number, client_name, total_cents (optional: recipient_email, due_at, issued_at, currency). Common Japanese export headers from freee / MoneyForward / Yayoi / Misoca (請求書番号 / 取引先名 / 金額 / 期日, etc.) are auto-recognized, and Shift-JIS files and ¥/comma-formatted amounts are handled. Duplicate reference numbers are skipped.',
   'manualReceivables.importResult': 'Created {created} / skipped {skipped} / errors {errors}',
   'manualReceivables.csvRow': 'CSV row',
   'manualReceivables.referenceNumber': 'Reference number',

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -343,7 +343,7 @@ export const ja = {
   'manualReceivables.createSub': '請求書番号・請求先・金額で参照情報を登録します。',
   'manualReceivables.import': 'CSV取込',
   'manualReceivables.importSub': '売掛をCSVで一括登録します。',
-  'manualReceivables.importColumns': 'CSVのヘッダー列: reference_number, client_name, total_cents（任意: recipient_email, due_at, issued_at, currency）。重複する請求書番号はスキップされます。',
+  'manualReceivables.importColumns': 'CSVのヘッダー列: reference_number, client_name, total_cents（任意: recipient_email, due_at, issued_at, currency）。freee・マネーフォワード・弥生・Misoca 等のよくある日本語ヘッダー（請求書番号・取引先名・金額・期日 など）も自動認識し、Shift-JIS や ¥・カンマ付きの金額にも対応します。重複する請求書番号はスキップされます。',
   'manualReceivables.importResult': '作成 {created} 件 / スキップ {skipped} 件 / エラー {errors} 件',
   'manualReceivables.csvRow': 'CSV行',
   'manualReceivables.referenceNumber': '請求書番号',

--- a/src/Receivable/ManualReceivableCsvParser.php
+++ b/src/Receivable/ManualReceivableCsvParser.php
@@ -5,26 +5,75 @@ declare(strict_types=1);
 namespace NeneClear\Receivable;
 
 /**
- * Parses a receivables CSV by header name (not fixed column positions — unlike
- * the bank CSV, which is per-account). Recognized columns map to the same field
- * names the API uses; unknown columns are ignored. Amounts are integers in the
- * smallest currency unit (¥1 = 1), like the bank importer. Validation of each
- * row's values is the import use case's job (it reuses ManualReceivableValidator).
+ * Parses a receivables CSV by header name (not fixed column positions). Each
+ * column header is matched against a dictionary of aliases — including the
+ * common Japanese headers that freee / マネーフォワード / 弥生 / Misoca exports
+ * use — and mapped to the canonical API field names; the first column matching a
+ * field wins, and unknown columns are ignored. Shift-JIS (CP932) input is
+ * detected and transcoded to UTF-8, and amount cells are normalized (¥ / commas
+ * / 円 / full-width digits stripped) so real exports import without manual
+ * remapping. Amounts are integers in the smallest currency unit (¥1 = 1).
+ * Validation of each row's values is the import use case's job (it reuses
+ * {@see ManualReceivableValidator}).
  */
 final readonly class ManualReceivableCsvParser
 {
-    private const array RECOGNIZED = [
-        'reference_number', 'client_name', 'total_cents',
-        'recipient_email', 'due_at', 'issued_at', 'currency',
+    /**
+     * Canonical field => recognized header aliases (matched case-insensitively).
+     * Keep the canonical English name in each list so existing/templated CSVs
+     * keep working.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array ALIASES = [
+        'reference_number' => [
+            'reference_number', 'invoice_number', 'document_number', 'reference', 'ref', 'no',
+            '番号', '請求書番号', '請求番号', '請求no', '伝票番号', '文書番号', '帳票番号',
+        ],
+        'client_name' => [
+            'client_name', 'customer_name', 'customer', 'client', 'payer',
+            '取引先', '取引先名', '取引先名称', '得意先', '得意先名', '顧客', '顧客名', '宛名', '会社名', '請求先', '請求先名',
+        ],
+        'total_cents' => [
+            'total_cents', 'total_amount', 'amount', 'total',
+            '金額', '合計', '合計金額', '請求金額', '請求額', '請求合計', '税込金額', '税込合計', '総額', 'ご請求金額',
+        ],
+        'recipient_email' => [
+            'recipient_email', 'email', 'e-mail', 'mail',
+            'メール', 'メールアドレス', '宛先メール', '送信先',
+        ],
+        'due_at' => [
+            'due_at', 'due_date', 'payment_due', 'due',
+            '支払期日', '支払期限', '入金期日', '期日', 'お支払期限', '振込期限', '支払予定日',
+        ],
+        'issued_at' => [
+            'issued_at', 'issue_date', 'invoice_date', 'issued', 'date',
+            '発行日', '請求日', '請求年月日', '発行年月日', '取引日', '日付',
+        ],
+        'currency' => [
+            'currency', '通貨',
+        ],
     ];
+
+    /** Fields whose values are numeric amounts and get separator/symbol stripping. */
+    private const array AMOUNT_FIELDS = ['total_cents'];
 
     public function parse(string $contents): ParsedReceivableRows
     {
+        // Accept Shift-JIS (CP932) exports (弥生 et al.): if the bytes are not
+        // valid UTF-8, transcode from CP932. ASCII-only content is already valid
+        // UTF-8, so this only kicks in for non-UTF-8 multibyte files.
+        if (!mb_check_encoding($contents, 'UTF-8')) {
+            $contents = mb_convert_encoding($contents, 'UTF-8', 'SJIS-win') ?: $contents;
+        }
+
         // Strip a UTF-8 BOM if present, then split on any newline style.
         $contents = preg_replace('/^\xEF\xBB\xBF/', '', $contents) ?? $contents;
         $lines = preg_split('/\r\n|\r|\n/', $contents) ?: [];
 
-        $headerMap = null; // column index => recognized field name
+        $lookup = self::aliasLookup();
+
+        $headerMap = null; // column index => canonical field name
         $headers = [];
         $rows = [];
         $lineNumber = 0;
@@ -38,23 +87,66 @@ final readonly class ManualReceivableCsvParser
 
             if ($headerMap === null) {
                 $headerMap = [];
+                $claimed = [];
                 foreach ($cells as $index => $name) {
-                    $key = strtolower(trim((string) $name));
-                    if (in_array($key, self::RECOGNIZED, true)) {
-                        $headerMap[$index] = $key;
-                        $headers[] = $key;
+                    $field = $lookup[self::normalizeHeader((string) $name)] ?? null;
+                    if ($field === null || isset($claimed[$field])) {
+                        continue; // unknown column, or this field already taken (first wins)
                     }
+                    $headerMap[$index] = $field;
+                    $claimed[$field] = true;
+                    $headers[] = $field;
                 }
                 continue;
             }
 
             $data = [];
             foreach ($headerMap as $index => $field) {
-                $data[$field] = trim((string) ($cells[$index] ?? ''));
+                $value = trim((string) ($cells[$index] ?? ''));
+                if (in_array($field, self::AMOUNT_FIELDS, true)) {
+                    $value = self::normalizeAmount($value);
+                }
+                $data[$field] = $value;
             }
             $rows[] = ['row' => $lineNumber, 'data' => $data];
         }
 
         return new ParsedReceivableRows($headers, $rows);
+    }
+
+    /**
+     * Lower-cased alias => canonical field, for O(1) header matching.
+     *
+     * @return array<string, string>
+     */
+    private static function aliasLookup(): array
+    {
+        $lookup = [];
+        foreach (self::ALIASES as $field => $aliases) {
+            foreach ($aliases as $alias) {
+                $lookup[mb_strtolower($alias, 'UTF-8')] = $field;
+            }
+        }
+
+        return $lookup;
+    }
+
+    /** Trim ASCII + full-width whitespace and surrounding quotes, then lower-case. */
+    private static function normalizeHeader(string $name): string
+    {
+        $name = preg_replace('/^[\s\x{3000}"\']+|[\s\x{3000}"\']+$/u', '', $name) ?? $name;
+
+        return mb_strtolower($name, 'UTF-8');
+    }
+
+    /**
+     * Normalize an amount cell to a bare integer string: full-width digits to
+     * half-width, then strip currency symbols, separators, spaces, and 円.
+     */
+    private static function normalizeAmount(string $value): string
+    {
+        $value = mb_convert_kana($value, 'n', 'UTF-8');
+
+        return preg_replace('/[¥￥,，、\s\x{3000}円]/u', '', $value) ?? $value;
     }
 }

--- a/tests/Receivable/ManualReceivableCsvParserTest.php
+++ b/tests/Receivable/ManualReceivableCsvParserTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Receivable;
+
+use NeneClear\Receivable\ManualReceivableCsvParser;
+use PHPUnit\Framework\TestCase;
+
+final class ManualReceivableCsvParserTest extends TestCase
+{
+    public function testRecognizesCanonicalHeaders(): void
+    {
+        $csv = "reference_number,client_name,total_cents\nINV-1,Acme,110000\n";
+
+        $parsed = (new ManualReceivableCsvParser())->parse($csv);
+
+        self::assertSame(['reference_number', 'client_name', 'total_cents'], $parsed->headers);
+        self::assertSame('110000', $parsed->rows[0]['data']['total_cents']);
+        self::assertSame('Acme', $parsed->rows[0]['data']['client_name']);
+    }
+
+    public function testRecognizesJapaneseAliasesFromTypicalExport(): void
+    {
+        $csv = "請求書番号,取引先名,請求金額,支払期日\nINV-9,株式会社アクメ,\"￥110,000\",2026/04/30\n";
+
+        $parsed = (new ManualReceivableCsvParser())->parse($csv);
+
+        self::assertContains('reference_number', $parsed->headers);
+        self::assertContains('client_name', $parsed->headers);
+        self::assertContains('total_cents', $parsed->headers);
+        self::assertContains('due_at', $parsed->headers);
+
+        $data = $parsed->rows[0]['data'];
+        self::assertSame('INV-9', $data['reference_number']);
+        self::assertSame('株式会社アクメ', $data['client_name']);
+        self::assertSame('110000', $data['total_cents']); // ¥ and comma stripped
+        self::assertSame('2026/04/30', $data['due_at']);
+    }
+
+    public function testNormalizesFullWidthAmountAndYenSuffix(): void
+    {
+        $csv = "請求書番号,取引先,金額\nA,B,１１０，０００円\n";
+
+        $data = (new ManualReceivableCsvParser())->parse($csv)->rows[0]['data'];
+
+        self::assertSame('110000', $data['total_cents']);
+    }
+
+    public function testReadsShiftJisInput(): void
+    {
+        $utf8 = "請求書番号,取引先名,合計金額\nINV-3,みどり商事,50000\n";
+        $sjis = mb_convert_encoding($utf8, 'SJIS-win', 'UTF-8');
+
+        $parsed = (new ManualReceivableCsvParser())->parse($sjis);
+
+        self::assertContains('client_name', $parsed->headers);
+        self::assertSame('みどり商事', $parsed->rows[0]['data']['client_name']);
+        self::assertSame('50000', $parsed->rows[0]['data']['total_cents']);
+    }
+
+    public function testFirstColumnWinsWhenTwoMapToTheSameField(): void
+    {
+        // Both 金額 and 合計金額 map to total_cents; the first column wins.
+        $csv = "請求書番号,取引先,金額,合計金額\nA,B,100,999\n";
+
+        $parsed = (new ManualReceivableCsvParser())->parse($csv);
+
+        self::assertSame(1, array_count_values($parsed->headers)['total_cents']);
+        self::assertSame('100', $parsed->rows[0]['data']['total_cents']);
+    }
+
+    public function testIgnoresUnknownColumns(): void
+    {
+        $csv = "請求書番号,メモ,取引先,金額\nINV-7,社内用,Acme,1000\n";
+
+        $parsed = (new ManualReceivableCsvParser())->parse($csv);
+
+        self::assertSame(['reference_number', 'client_name', 'total_cents'], $parsed->headers);
+        self::assertArrayNotHasKey('メモ', $parsed->rows[0]['data']);
+    }
+}


### PR DESCRIPTION
Second slice of #191 (Adoption Readiness milestone) — the receivables "入口" for non-NeNe-Invoice users.

## Why (research finding)

Manual-receivable CSV import (`importManualReceivables`, already implemented) only recognized canonical English headers, so freee / マネーフォワード / 弥生 / Misoca exports didn't import without hand-editing. Researching the formats showed they are **user-customizable and version-dependent** (freee lets you pick columns; Misoca exports in multiple selectable formats; MF changed its spec in 2025; 弥生 is Shift-JIS, PDF-documented), so **fixed per-tool column presets would be brittle**. An **alias dictionary** is the robust, low-maintenance approach (chosen direction).

## What

`ManualReceivableCsvParser` now:
- **Header alias dictionary** — maps common Japanese headers (請求書番号 / 取引先名 / 金額 / 期日 / メール …) and English synonyms to the canonical fields; first column matching a field wins; unknown columns ignored.
- **Shift-JIS (CP932)** — non-UTF-8 input is detected and transcoded to UTF-8 (弥生 et al.).
- **Amount normalization** — full-width digits → half-width; strip ¥ / commas / 円 / spaces, so the strict `ctype_digit` validator accepts `￥110,000` and `１１０，０００円`.

No new terminology (aliases map to existing registered fields). Canonical-header CSVs keep working. Import-modal guidance copy updated (ja/en).

## Verification

- `composer check` — 302 tests (incl. 6 new `ManualReceivableCsvParserTest`), 1082 assertions, PHPStan level 8 clean, CS-Fixer no changes.
- `npm run check` — type-check + lint + 46 tests (ja/en parity).

## Next in #191

Repositioning copy (login / README / product-vision, coordinated with #193). Aliases can be extended as more real export samples surface.

Refs #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)