### PR TITLE
docs: reposition NeNe Clear as standalone-capable (NeNe Invoice optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Payment reconciliation and dunning — self-hosted for Japan SMB.**
 
-**NeNe Clear** is a **separate product** from [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice). It does **not** issue quotes or invoices. It **clears bank deposits against billed receivables** and **sends professional overdue reminders** — on [NENE2](https://github.com/hideyukiMORI/NENE2), shared hosting or Docker.
+**NeNe Clear** is a **separate product** from [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice). It does **not** issue quotes or invoices. It **clears bank deposits against billed receivables** and **sends professional overdue reminders** — on [NENE2](https://github.com/hideyukiMORI/NENE2), shared hosting or Docker. Receivables come from **NeNe Invoice (optional upstream)** or are **entered / CSV-imported directly** ([manual receivables, ADR 0014](./docs/adr/0014-accept-manual-receivables.md)), so Clear runs **standalone** — no NeNe Invoice required.
 
 > **Not upper compatible with `nene-invoice`.** Different domain, different repo, different database. See [ADR 0009](./docs/adr/0009-separate-from-nene-invoice.md).
 
@@ -26,7 +26,7 @@ Operators who need both install **two sibling apps** connected via HTTP.
 - **Compliance** — binding rules for reconciliation and dunning ([compliance doc](./docs/explanation/payment-reconciliation-dunning-compliance.md))
 - **Self-hosted OSS** — MIT; Tier A shared hosting or Tier B Docker/VPS
 - **AI-readable** — OpenAPI + MCP; human confirms, AI proposes
-- **Upstream: NeNe Invoice** — invoice and payment truth via HTTP API, not shared DB
+- **Optional upstream: NeNe Invoice** — when connected, invoice/payment truth via HTTP API (not a shared DB); without it, Clear reconciles and duns directly-entered / CSV-imported receivables ([ADR 0014](./docs/adr/0014-accept-manual-receivables.md))
 
 ## Documentation
 

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -59,10 +59,12 @@ sibling applications**.
 
 ## Target operators
 
-**Primary — Japan SMB office manager** already using NeNe Invoice (or any
-billing source that exposes invoice/payment data via future adapters). They
-receive bank CSV weekly, spend hours in Excel matching deposits, and send
-overdue emails manually.
+**Primary — Japan SMB office manager** using NeNe Invoice **or** another billing
+tool (freee / マネーフォワード / 弥生 / Misoca / spreadsheet). Receivables come
+from the NeNe Invoice upstream API when connected, or are entered / CSV-imported
+directly ([manual receivables, ADR 0014](../adr/0014-accept-manual-receivables.md)),
+so Clear runs standalone. They receive bank CSV weekly, spend hours in Excel
+matching deposits, and send overdue emails manually.
 
 **Secondary — Tier B developers** running Invoice + Clear on Docker Compose on
 one VPS — two apps, HTTP between them, no shared database.
@@ -77,6 +79,11 @@ one VPS — two apps, HTTP between them, no shared database.
 > without moving invoice data out of Invoice.
 
 ## Primary use case
+
+Clear works **with or without NeNe Invoice**. With it, step 1 connects the
+upstream; without it, the operator enters or CSV-imports receivables directly
+([manual receivables, ADR 0014](../adr/0014-accept-manual-receivables.md)) and
+skips straight to bank import.
 
 1. Operator configures **NeNe Invoice API** connection in Clear.
 2. Operator imports **bank CSV** into Clear.


### PR DESCRIPTION
Closes the repositioning part of #191 (Adoption Readiness milestone).

## Why

The review's #1 blocker: non-NeNe-Invoice users perceived the product as requiring it. Manual receivables (ADR 0014) + the receivables CSV import (now alias-aware, PR #203) let Clear run standalone — the docs should say so.

## What

- **README** intro + Goals: receivables come from NeNe Invoice (optional upstream) **or** are entered / CSV-imported directly; Clear runs standalone — no NeNe Invoice required.
- **product-vision**: broaden Target operators to freee / MF / 弥生 / Misoca / spreadsheet users; note the Primary use case works **with or without** NeNe Invoice.

Accurate per ADR 0014 (manual receivables are reconciliation references, not invoices — scope X1 unchanged). Intentionally does **not** touch the Tier A / shared-hosting wording — that's #193 (owner sign-off).

Refs #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)