### PR TITLE
docs: retract Tier A shared-hosting recommendation; recommend VPS+Docker + managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Operators who need both install **two sibling apps** connected via HTTP.
 - **Bank reconciliation** — CSV import, human-confirmed match, audit trail
 - **Dunning** — operator-controlled overdue reminders with send history
 - **Compliance** — binding rules for reconciliation and dunning ([compliance doc](./docs/explanation/payment-reconciliation-dunning-compliance.md))
-- **Self-hosted OSS** — MIT; Tier A shared hosting or Tier B Docker/VPS
+- **Self-hosted OSS** — MIT; recommended on **VPS + Docker** (Tier B). Shared hosting is **not recommended** for receivables/bank/PII data (no root, throttled SMTP, limited DKIM & backups); a managed / install-service option is planned
 - **AI-readable** — OpenAPI + MCP; human confirms, AI proposes
 - **Optional upstream: NeNe Invoice** — when connected, invoice/payment truth via HTTP API (not a shared DB); without it, Clear reconciles and duns directly-entered / CSV-imported receivables ([ADR 0014](./docs/adr/0014-accept-manual-receivables.md))
 
@@ -57,8 +57,8 @@ Operators who need both install **two sibling apps** connected via HTTP.
 - Login throttling; security assessment in
   [`docs/security/assessment-2026-05.md`](./docs/security/assessment-2026-05.md).
 
-Next: Phase 3 (Tier A shared-hosting installer / release ZIP) and Phase 4
-(MCP tools, accounting-software CSV export). See [`docs/roadmap.md`](./docs/roadmap.md).
+Next: Phase 3 (distribution — managed / install-service on VPS + Docker) and
+Phase 4 (MCP tools, accounting-software CSV export). See [`docs/roadmap.md`](./docs/roadmap.md).
 
 **Billing documents (見積・請求・入金):** [`nene-invoice`](https://github.com/hideyukiMORI/nene-invoice) — not this repo.
 

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -93,12 +93,16 @@ skips straight to bank import.
    reconciliation link and audit entry.
 6. For overdue invoices, operator sends **dunning email** from Clear; send is logged.
 
-## Dual deployment (planned)
+## Deployment (planned)
 
-| Tier | Path | Notes |
+| Target | Path | Notes |
 | --- | --- | --- |
-| **Tier A — shared hosting** | Release ZIP + web installer + MySQL | Beside Invoice on same server; separate DB |
-| **Tier B — Docker / VPS** | `docker compose up` | Invoice + Clear as two services |
+| **VPS + Docker (Tier B, recommended)** | `docker compose up` | Run receivables / bank / PII data on infrastructure you control |
+| **Managed / install-service** | Hosted, or set up for you | For operators without ops capacity (see adoption review) |
+
+> Shared hosting (Tier A) is **not recommended** for this data — no root,
+> throttled SMTP, limited DKIM/backup. See
+> [`adoption-review-2026-06.md`](./adoption-review-2026-06.md).
 
 ## Philosophy (summary)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,11 +40,17 @@ Operators self-host Clear beside NeNe Invoice to:
 - Dashboard (unmatched count, recent dunning) ✅
 - React + TypeScript SPA (`frontend/`); Vitest + Playwright E2E; CI ✅
 
-## Phase 3: Tier A Shared Hosting — 🔲 Next
+## Phase 3: Distribution (managed / install-service) — 🔲 Next
 
-- Web installer + release ZIP
-- Operator guide for the Invoice + Clear two-app setup
-- Same-origin or subdomain admin
+Reframed from "Tier A shared hosting": the 2026-06 adoption review
+([`explanation/adoption-review-2026-06.md`](./explanation/adoption-review-2026-06.md))
+found shared hosting unsuitable for receivables / bank / PII data (no root,
+throttled SMTP, limited DKIM and backups). The recommended target is **VPS +
+Docker (Tier B)** with a managed / install-service option for operators without
+ops capacity.
+
+- Official Docker image + managed / install-service offering
+- Operator deployment guide (VPS + Docker; Invoice + Clear as two apps)
 - Operator-editable dunning templates per organization
 
 ## Phase 4: Ecosystem — 🔲


### PR DESCRIPTION
The 2026-06 adoption review (#190) found **shared hosting (ヘテムル / サクラ) unsuitable** for a product holding receivables / bank / PII data — no root, throttled/blocked outbound SMTP, limited DKIM & DB backups. This retracts the Tier A recommendation (owner-authorized).

## Changes

- **README** — recommend **VPS + Docker (Tier B)**; shared hosting marked **not recommended** for this data; managed / install-service planned. Phase 3 reframed in the "Next" line.
- **roadmap** — Phase 3 reframed from "Tier A Shared Hosting" to **"Distribution (managed / install-service)"** on VPS + Docker, with rationale + review link.
- **product-vision** — deployment table recommends Tier B + managed, with a shared-hosting "not recommended" note.

Docs only. Pairs with the deliverability guide (#205) which already flags shared-hosting SMTP limits.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)