### PR TITLE
feat(security): encrypt bank account number at rest (libsodium, opt-in key)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,11 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_FROM_ADDRESS=noreply@nene-clear.dev
 SMTP_FROM_NAME="NeNe Clear"
+
+# Encryption at rest (optional, #195). When set, sensitive fields (bank account
+# number) are encrypted on write; reads transparently handle both encrypted and
+# legacy plaintext. Generate base64 of 32 random bytes:
+#   php -r 'echo base64_encode(random_bytes(32)), "\n";'
+# Leave empty to store as-is. Do NOT lose this key — encrypted values cannot be
+# read without it.
+NENE_CLEAR_ENCRYPTION_KEY=

--- a/database/migrations/20260627120000_widen_bank_account_number_for_encryption.php
+++ b/database/migrations/20260627120000_widen_bank_account_number_for_encryption.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class WidenBankAccountNumberForEncryption extends AbstractMigration
+{
+    /**
+     * Encryption-at-rest (#192 / #195) stores `account_number` as
+     * `enc:v1:` + base64(nonce + ciphertext), which is longer than the plain
+     * value (a ~10-char number becomes ~75 chars; the 64-char max becomes
+     * ~147). Widen the column so ciphertext fits. Legacy plaintext is
+     * unaffected, and SQLite stores TEXT with no length limit so it is skipped.
+     */
+    public function up(): void
+    {
+        if ($this->getAdapter()->getAdapterType() === 'sqlite') {
+            return;
+        }
+
+        $this->table('bank_accounts')
+            ->changeColumn('account_number', 'string', ['limit' => 255, 'null' => false])
+            ->update();
+    }
+
+    public function down(): void
+    {
+        if ($this->getAdapter()->getAdapterType() === 'sqlite') {
+            return;
+        }
+
+        $this->table('bank_accounts')
+            ->changeColumn('account_number', 'string', ['limit' => 64, 'null' => false])
+            ->update();
+    }
+}

--- a/database/schema/bank_accounts.sql
+++ b/database/schema/bank_accounts.sql
@@ -6,7 +6,7 @@ CREATE TABLE bank_accounts (
     bank_name                VARCHAR(255) NOT NULL,
     bank_branch              VARCHAR(255) NOT NULL DEFAULT '',
     account_type             VARCHAR(32) NOT NULL,
-    account_number           VARCHAR(64) NOT NULL,
+    account_number           VARCHAR(255) NOT NULL,  -- holds encryption-at-rest ciphertext (enc:v1:…) as well as plaintext
     csv_encoding             VARCHAR(32) NOT NULL DEFAULT 'utf8',
     csv_date_format          VARCHAR(32) NOT NULL,
     csv_date_column          INT NOT NULL,

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -104,6 +104,9 @@ $application = ApplicationFactory::create(
     // Absolute base for invitation e-mail links. Same-origin in production; the
     // dev frontend (Vite) runs on a separate port, so default to it locally.
     appBaseUrl: $env('NENE_CLEAR_APP_URL', 'http://localhost:5383'),
+    // Optional encryption-at-rest key (base64 of 32 bytes). When unset, sensitive
+    // fields are stored as-is; when set, they are encrypted on write (#192/#195).
+    encryptionKey: $env('NENE_CLEAR_ENCRYPTION_KEY'),
 );
 
 $psr17 = new Psr17Factory();

--- a/src/BankImport/BankImportServiceProvider.php
+++ b/src/BankImport/BankImportServiceProvider.php
@@ -15,6 +15,7 @@ use NeneClear\Audit\AuditRecorderInterface;
 use NeneClear\Audit\PdoAuditEventRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\Security\Encryptor;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -30,6 +31,7 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
                 BankAccountRepositoryInterface::class,
                 static fn (ContainerInterface $c): BankAccountRepositoryInterface => new PdoBankAccountRepository(
                     ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    ServiceResolver::get($c, Encryptor::class),
                 ),
             )
             ->set(
@@ -48,7 +50,7 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
                 ImportBankCsvUseCaseInterface::class,
                 static fn (ContainerInterface $c): ImportBankCsvUseCaseInterface => new ImportBankCsvUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx, ServiceResolver::get($c, Encryptor::class)),
                     static fn (DatabaseQueryExecutorInterface $tx): BankImportBatchRepositoryInterface => new PdoBankImportBatchRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): BankTransactionRepositoryInterface => new PdoBankTransactionRepository($tx),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),

--- a/src/BankImport/PdoBankAccountRepository.php
+++ b/src/BankImport/PdoBankAccountRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\BankImport;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\Security\Encryptor;
 
 final readonly class PdoBankAccountRepository implements BankAccountRepositoryInterface
 {
@@ -13,6 +14,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ?Encryptor $encryptor = null,
     ) {
     }
 
@@ -54,7 +56,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
                 $account->bankName,
                 $account->bankBranch,
                 $account->accountType->value,
-                $account->accountNumber,
+                $this->encryptor?->encrypt($account->accountNumber) ?? $account->accountNumber,
                 $account->csvEncoding,
                 $account->csvDateFormat,
                 $account->csvDateColumn,
@@ -75,7 +77,7 @@ final readonly class PdoBankAccountRepository implements BankAccountRepositoryIn
             bankName: (string) $row['bank_name'],
             bankBranch: (string) $row['bank_branch'],
             accountType: AccountType::from((string) $row['account_type']),
-            accountNumber: (string) $row['account_number'],
+            accountNumber: $this->encryptor?->decrypt((string) $row['account_number']) ?? (string) $row['account_number'],
             csvEncoding: (string) $row['csv_encoding'],
             csvDateFormat: (string) $row['csv_date_format'],
             csvDateColumn: (int) $row['csv_date_column'],

--- a/src/ClearSettings/ClearSettingsServiceProvider.php
+++ b/src/ClearSettings/ClearSettingsServiceProvider.php
@@ -17,6 +17,7 @@ use NeneClear\BankImport\BankAccountRepositoryInterface;
 use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Security\Encryptor;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -39,8 +40,8 @@ final readonly class ClearSettingsServiceProvider implements ServiceProviderInte
                 UpdateClearSettingsUseCaseInterface::class,
                 static fn (ContainerInterface $c): UpdateClearSettingsUseCaseInterface => new UpdateClearSettingsUseCase(
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
-                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
-                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx, ServiceResolver::get($c, Encryptor::class))),
+                    static fn (DatabaseQueryExecutorInterface $tx): BankAccountRepositoryInterface => new PdoBankAccountRepository($tx, ServiceResolver::get($c, Encryptor::class)),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),
                     ServiceResolver::get($c, ClockInterface::class),
                 ),

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -20,6 +20,7 @@ use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Security\Encryptor;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -50,7 +51,7 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                     ServiceResolver::get($c, DatabaseTransactionManagerInterface::class),
                     ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): DunningNoticeRepositoryInterface => new PdoDunningNoticeRepository($tx),
-                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx)),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx, ServiceResolver::get($c, Encryptor::class))),
                     ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                     ServiceResolver::get($c, DunningMailerInterface::class),
                     static fn (DatabaseQueryExecutorInterface $tx): AuditRecorderInterface => new AuditRecorder(new PdoAuditEventRepository($tx)),

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -26,6 +26,7 @@ use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamHttpClient;
+use NeneClear\Security\Encryptor;
 use NeneClear\User\InvitationLinkBuilder;
 use NeneClear\User\InvitationMailerInterface;
 use NeneClear\User\LogOnlyInvitationMailer;
@@ -75,6 +76,7 @@ final class ApplicationFactory
         string $invoiceBearerToken = '',
         string $appBaseUrl = '',
         ?InvitationMailerInterface $invitationMailer = null,
+        string $encryptionKey = '',
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
 
@@ -103,6 +105,7 @@ final class ApplicationFactory
             self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
             $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
             $appBaseUrl,
+            $encryptionKey,
         );
 
         $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
@@ -140,6 +143,7 @@ final class ApplicationFactory
         DunningMailerInterface $mailer,
         InvitationMailerInterface $invitationMailer,
         string $appBaseUrl,
+        string $encryptionKey,
     ): ContainerInterface {
         $langDir = dirname(__DIR__, 2) . '/lang';
 
@@ -174,6 +178,7 @@ final class ApplicationFactory
             ->set(DunningMailerInterface::class, static fn (ContainerInterface $c): DunningMailerInterface => $mailer)
             ->set(InvitationMailerInterface::class, static fn (ContainerInterface $c): InvitationMailerInterface => $invitationMailer)
             ->set(InvitationLinkBuilder::class, static fn (ContainerInterface $c): InvitationLinkBuilder => new InvitationLinkBuilder($appBaseUrl))
+            ->set(Encryptor::class, static fn (ContainerInterface $c): Encryptor => new Encryptor($encryptionKey !== '' ? $encryptionKey : null))
             ->addProvider(new ApplicationServiceProvider())
             ->build();
     }

--- a/src/Security/Encryptor.php
+++ b/src/Security/Encryptor.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Security;
+
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Application-level authenticated encryption for sensitive fields at rest
+ * (libsodium secretbox). Stored ciphertext is prefixed `enc:v1:` so reads can
+ * tell encrypted values from legacy plaintext and decrypt only the former —
+ * making a partial rollout and lazy re-encryption (on the next write) safe.
+ *
+ * When no key is configured the encryptor is a **passthrough**: `encrypt()`
+ * returns the plaintext unchanged and `decrypt()` returns stored values as-is.
+ * This keeps existing deployments working; set `NENE_CLEAR_ENCRYPTION_KEY`
+ * (base64 of 32 random bytes) to turn encryption on. Do **not** lose the key —
+ * values written while it was set cannot be read without it.
+ */
+final readonly class Encryptor
+{
+    private const string PREFIX = 'enc:v1:';
+
+    private ?string $key;
+
+    public function __construct(?string $base64Key = null)
+    {
+        if ($base64Key === null || $base64Key === '') {
+            $this->key = null;
+
+            return;
+        }
+
+        $key = base64_decode($base64Key, true);
+        if ($key === false || strlen($key) !== SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+            throw new InvalidArgumentException(sprintf(
+                'NENE_CLEAR_ENCRYPTION_KEY must be base64 of exactly %d bytes.',
+                SODIUM_CRYPTO_SECRETBOX_KEYBYTES,
+            ));
+        }
+
+        $this->key = $key;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->key !== null;
+    }
+
+    public function encrypt(string $plaintext): string
+    {
+        if ($this->key === null) {
+            return $plaintext;
+        }
+
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = sodium_crypto_secretbox($plaintext, $nonce, $this->key);
+
+        return self::PREFIX . base64_encode($nonce . $cipher);
+    }
+
+    public function decrypt(string $stored): string
+    {
+        if (!str_starts_with($stored, self::PREFIX)) {
+            return $stored; // legacy plaintext, or encryption was off at write time
+        }
+
+        if ($this->key === null) {
+            throw new RuntimeException('Encrypted value found but no encryption key is configured.');
+        }
+
+        $raw = base64_decode(substr($stored, strlen(self::PREFIX)), true);
+        if ($raw === false || strlen($raw) < SODIUM_CRYPTO_SECRETBOX_NONCEBYTES) {
+            throw new RuntimeException('Corrupt encrypted value.');
+        }
+
+        $nonce = substr($raw, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = substr($raw, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plain = sodium_crypto_secretbox_open($cipher, $nonce, $this->key);
+        if ($plain === false) {
+            throw new RuntimeException('Decryption failed (wrong key or tampered data).');
+        }
+
+        return $plain;
+    }
+}

--- a/tests/Database/PdoBankAccountRepositoryEncryptionTest.php
+++ b/tests/Database/PdoBankAccountRepositoryEncryptionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\BankImport\AccountType;
+use NeneClear\BankImport\BankAccount;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\Security\Encryptor;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoBankAccountRepositoryEncryptionTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-bank-enc-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createBankAccounts($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function account(string $number): BankAccount
+    {
+        return new BankAccount(
+            organizationId: 7,
+            bankName: 'みずほ銀行',
+            bankBranch: '本店',
+            accountType: AccountType::Ordinary,
+            accountNumber: $number,
+            csvEncoding: 'utf8',
+            csvDateFormat: 'Y/m/d',
+            csvDateColumn: 0,
+            csvAmountColumn: 1,
+            csvCounterpartyColumn: 3,
+            csvHeaderRows: 1,
+        );
+    }
+
+    private function storedNumber(int $id): string
+    {
+        $row = $this->query->fetchOne('SELECT account_number FROM bank_accounts WHERE id = ?', [$id]);
+        self::assertIsArray($row);
+
+        return (string) $row['account_number'];
+    }
+
+    public function testAccountNumberIsEncryptedAtRestAndDecryptedOnRead(): void
+    {
+        $repo = new PdoBankAccountRepository($this->query, new Encryptor(self::key("\x02")));
+
+        $id = $repo->save($this->account('1234567'));
+
+        $stored = $this->storedNumber($id);
+        self::assertStringStartsWith('enc:v1:', $stored);
+        self::assertStringNotContainsString('1234567', $stored);
+
+        $loaded = $repo->findById($id);
+        self::assertNotNull($loaded);
+        self::assertSame('1234567', $loaded->accountNumber);
+    }
+
+    public function testPlaintextWithoutKeyAndLegacyValuesStayReadable(): void
+    {
+        $plain = new PdoBankAccountRepository($this->query); // no encryptor
+        $id = $plain->save($this->account('7654321'));
+
+        self::assertSame('7654321', $this->storedNumber($id)); // stored as-is
+
+        // A repo configured with a key still reads legacy plaintext (passthrough).
+        $withKey = new PdoBankAccountRepository($this->query, new Encryptor(self::key("\x03")));
+        $loaded = $withKey->findById($id);
+        self::assertNotNull($loaded);
+        self::assertSame('7654321', $loaded->accountNumber);
+    }
+
+    private static function key(string $byte): string
+    {
+        return base64_encode(str_repeat($byte, SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
+    }
+}

--- a/tests/Security/EncryptorTest.php
+++ b/tests/Security/EncryptorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Security;
+
+use InvalidArgumentException;
+use NeneClear\Security\Encryptor;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class EncryptorTest extends TestCase
+{
+    private static function key(string $byte = "\x01"): string
+    {
+        return base64_encode(str_repeat($byte, SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
+    }
+
+    public function testRoundTripWithKey(): void
+    {
+        $enc = new Encryptor(self::key());
+
+        self::assertTrue($enc->isEnabled());
+        $cipher = $enc->encrypt('1234567');
+        self::assertStringStartsWith('enc:v1:', $cipher);
+        self::assertStringNotContainsString('1234567', $cipher);
+        self::assertSame('1234567', $enc->decrypt($cipher));
+    }
+
+    public function testEachEncryptionUsesAFreshNonce(): void
+    {
+        $enc = new Encryptor(self::key());
+
+        self::assertNotSame($enc->encrypt('x'), $enc->encrypt('x'));
+    }
+
+    public function testPassthroughWhenDisabled(): void
+    {
+        $enc = new Encryptor(null);
+
+        self::assertFalse($enc->isEnabled());
+        self::assertSame('1234567', $enc->encrypt('1234567'));
+        self::assertSame('1234567', $enc->decrypt('1234567'));
+    }
+
+    public function testDecryptLeavesLegacyPlaintextAlone(): void
+    {
+        $enc = new Encryptor(self::key());
+
+        self::assertSame('plain-legacy', $enc->decrypt('plain-legacy'));
+    }
+
+    public function testRejectsKeyOfWrongLength(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Encryptor(base64_encode('too-short'));
+    }
+
+    public function testDecryptFailsOnTamperedCiphertext(): void
+    {
+        $enc = new Encryptor(self::key());
+        $tampered = $enc->encrypt('secret') . 'AA';
+
+        $this->expectException(RuntimeException::class);
+        $enc->decrypt($tampered);
+    }
+
+    public function testEncryptedValueIsUnreadableWithTheWrongKey(): void
+    {
+        $cipher = (new Encryptor(self::key("\x01")))->encrypt('secret');
+
+        $this->expectException(RuntimeException::class);
+        (new Encryptor(self::key("\x02")))->decrypt($cipher);
+    }
+}


### PR DESCRIPTION
The encryption-at-rest half of #195 (Adoption Readiness milestone). #192 masked the bank account number in the UI + audit payload, but the database still stored it in plaintext. This encrypts it at rest.

## What

- **`Encryptor`** (libsodium `secretbox`): authenticated encryption with an `enc:v1:` prefix. Reads tell ciphertext from legacy plaintext and decrypt only the former.
  - **No key → passthrough** (existing deployments unchanged). Set `NENE_CLEAR_ENCRYPTION_KEY` (base64 of 32 bytes) to enable.
  - Reads handle both → **lazy rollout** (re-encrypted on the next settings save) and **partial-coverage safe**.
- Injected into `PdoBankAccountRepository` (encrypt on save / decrypt on read), wired through `ApplicationFactory` + the BankImport / ClearSettings / Dunning providers; key read from env in `index.php`.
- **Migration** widens `bank_accounts.account_number` 64 → 255 (ciphertext is longer); skips SQLite (TEXT). Reference schema updated.

## Verification

- `composer check` — 311 tests (+9: `EncryptorTest`, `PdoBankAccountRepositoryEncryptionTest`), 1103 assertions, PHPStan level 8 clean, CS-Fixer no changes.
- The repo test proves the **stored column is `enc:v1:` ciphertext** (no plaintext) and **reads decrypt** back.
- `composer migrations:migrate` applies cleanly on dev SQLite.

## Scope / deferred

MFA (TOTP, the auth-flow-changing half of #195) is intentionally deferred to a separate change — it alters the login contract (frontend + backend). Encryption here covers the account number; recipient emails are displayed/searched and would be more invasive (separate follow-up).

Refs #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)