### PR TITLE
fix(invoice-upstream): match Invoice's payment response + status filter contract (#214)

### DIFF
--- a/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamHttpClient.php
@@ -37,7 +37,15 @@ final readonly class InvoiceUpstreamHttpClient implements InvoiceUpstreamClientI
         $offset = 0;
 
         for ($page = 0; $page < self::MAX_PAGES; ++$page) {
-            $query = http_build_query(['status' => $statuses, 'limit' => self::PAGE_LIMIT, 'offset' => $offset]);
+            // Invoice's read filter expects `status` as a comma-joined string
+            // (status=issued,partially_paid), parsed via explode(','). A PHP array
+            // (status[]=…) is not a string there, so the filter is silently dropped
+            // and drafts/paid leak in — send the comma form.
+            $params = ['limit' => self::PAGE_LIMIT, 'offset' => $offset];
+            if ($statuses !== []) {
+                $params['status'] = implode(',', $statuses);
+            }
+            $query = http_build_query($params);
             $body = $this->request('GET', '/api/invoices?' . $query);
             $items = (array) ($body['items'] ?? []);
 
@@ -101,12 +109,19 @@ final readonly class InvoiceUpstreamHttpClient implements InvoiceUpstreamClientI
             resourceId: $invoiceId,
         );
 
+        // Invoice returns RecordPaymentResult: the payment is nested under
+        // `payment` (alongside `invoice` + `total_paid_cents`), per service-api.yaml.
+        $payment = $body['payment'] ?? [];
+        if (!is_array($payment)) {
+            $payment = [];
+        }
+
         return new InvoicePaymentCreated(
-            paymentId: (int) $body['payment_id'],
+            paymentId: (int) ($payment['payment_id'] ?? 0),
             invoiceId: $invoiceId,
-            amountCents: (int) $body['amount_cents'],
-            paidAt: (string) $body['paid_at'],
-            externalReference: (string) $body['external_reference'],
+            amountCents: (int) ($payment['amount_cents'] ?? 0),
+            paidAt: (string) ($payment['paid_at'] ?? ''),
+            externalReference: (string) ($payment['external_reference'] ?? ''),
         );
     }
 


### PR DESCRIPTION
Closes #214

## What

Live contract verification against a **running NeNe Invoice** (issued a `read:invoices`+`write:payments` service token, set `NENE_INVOICE_API_BASE_URL`/`NENE_INVOICE_BEARER_TOKEN`, ran `tests/Contract/InvoiceUpstreamContractTest`) surfaced two **consumer-side** mismatches in `InvoiceUpstreamHttpClient`. NeNe Invoice (the SSOT, per `service-api.yaml`) is correct; this PR fixes Clear's client.

1. **createPayment response shape** — read the 201 body as flat (`payment_id`, `amount_cents`, …), but the contract returns `RecordPaymentResult` = nested `{ payment, invoice, total_paid_cents }`. Now reads from the nested `payment` object (null-safe), matching `service-api.yaml`.
2. **status filter serialization** — `listInvoices` sent `status` as a PHP array (`status[]=issued&status[]=partially_paid`) via `http_build_query`, but Invoice's read filter expects a **comma-joined string** (`status=issued,partially_paid`, parsed with `explode(',')`). The array form was ignored, so the filter silently dropped and drafts/paid invoices leaked in (empty `invoice_number`). Now sends the comma form.

## Verification

All **6** `InvoiceUpstreamContractTest` tests pass against a live Invoice (63 assertions). Without env vars they still skip (CI unaffected). No change to the `FakeInvoiceUpstreamClient` path or unit tests.

## Scope note

Only `src/InvoiceUpstream/InvoiceUpstreamHttpClient.php` is touched. (The working tree also contained unrelated in-progress MFA work by a concurrent session — deliberately **not** included here.)