### PR TITLE
fix(tooling): load .env in phinx.php so migrate targets the app's database

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -6,6 +6,17 @@ declare(strict_types=1);
 // access is allowed here (docs/development/nene2-compliance.md §15).
 // `composer check` does not run migrations; tests create their own schema.
 
+// Load .env — the same file public_html/index.php reads — so `composer
+// migrations:migrate` targets the DB the app actually uses. Without this the
+// getenv() calls below miss .env and fall back to sqlite, so a MySQL/pgsql
+// setup migrates the wrong database and leaves the real one empty (#226).
+// createUnsafeImmutable uses putenv() so the getenv() calls see it; Immutable
+// means a real exported env var still wins.
+require_once __DIR__ . '/vendor/autoload.php';
+if (is_file(__DIR__ . '/.env')) {
+    Dotenv\Dotenv::createUnsafeImmutable(__DIR__)->safeLoad();
+}
+
 $adapter = getenv('DB_ADAPTER') ?: 'sqlite';
 
 $environment = match ($adapter) {


### PR DESCRIPTION
## Problem

`composer migrations:migrate` did not respect `.env`. `phinx.php` read config via `getenv()` only and never loaded `.env`, while `public_html/index.php` loads it via Dotenv. On MySQL/pgsql: migrate fell back to the default **sqlite** adapter and migrated `database/nene_clear.sqlite3`, leaving the configured MySQL/pgsql database empty. `/health` returned 200 but any DB-touching request (e.g. login) returned **500**.

## Fix

Load `.env` at the top of `phinx.php` (config/tooling boundary, same file the app reads) with `createUnsafeImmutable()->safeLoad()` — putenv mode so the existing `getenv()` calls see it, Immutable so a real exported env var still wins.

## Verification

- **Fresh MySQL clone, no env export** (verbatim article commands): migrate now reports `using adapter mysql` / `using database <configured>` and creates all 20 tables in the configured DB; a subsequent login goes 500 → 401.
- **SQLite dev flow**: still resolves to `database/nene_clear.sqlite3` (no-op when up to date).
- `php -l` clean; `php-cs-fixer` clean; no impact on `composer check` (tests build their own schema).

Also makes the README MySQL/pgsql instructions and the Qiita article's MySQL walkthrough (#224 / PR #225) correct as written.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)