### PR TITLE
feat(tooling): bootstrap CLI to create the first organization + admin user

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -10,6 +10,7 @@ $finder = Finder::create()
         __DIR__ . '/public_html',
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/tools',
     ])
     ->name('*.php');
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ cp .env.example .env            # adjust DB_*, NENE_CLEAR_JWT_SECRET as needed
 # 2. Backend (PHP 8.4 with ext-curl — required by the Invoice upstream client).
 composer install
 composer migrations:migrate     # apply schema
+
+# First run only: create the first organization + admin so you can log in
+# (prompts for a password; or pass --password / ADMIN_PASSWORD). See --help.
+php tools/create-admin.php --org-name "My Company" --email admin@example.com
+
 php -S localhost:8384 -t public_html/    # or your preferred SAPI (NENE_CLEAR_PORT=8384)
 
 # 3. Frontend admin UI (Node 22)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,5 @@ parameters:
     - src
     - tests
     - public_html
+    - tools
   tmpDir: .phpstan.cache

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -133,6 +133,45 @@ final class ApplicationFactory
     }
 
     /**
+     * Builds and returns the fully-wired DI container, without the HTTP runtime.
+     *
+     * This is the composition root reused by non-HTTP entry points (e.g. the
+     * `tools/create-admin.php` bootstrap CLI) so they resolve the exact same
+     * use cases the HTTP app does, instead of hand-wiring a partial container
+     * that would drift. Domain services are lazy factories, so only what the
+     * caller resolves is constructed.
+     */
+    public static function container(
+        DatabaseQueryExecutorInterface $query,
+        DatabaseTransactionManagerInterface $transactionManager,
+        string $jwtSecret,
+        ?InvoiceUpstreamClientInterface $invoiceClient = null,
+        ?string $smtpHost = null,
+        int $smtpPort = 1025,
+        string $smtpUsername = '',
+        string $smtpPassword = '',
+        string $smtpFromAddress = 'noreply@nene-clear.dev',
+        string $smtpFromName = 'NeNe Clear',
+        ?string $invoiceApiBaseUrl = null,
+        string $invoiceBearerToken = '',
+        string $appBaseUrl = '',
+        ?InvitationMailerInterface $invitationMailer = null,
+        string $encryptionKey = '',
+    ): ContainerInterface {
+        return self::buildContainer(
+            $query,
+            $transactionManager,
+            $jwtSecret,
+            new Psr17Factory(),
+            self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
+            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            $appBaseUrl,
+            $encryptionKey,
+        );
+    }
+
+    /**
      * Registers framework + config-derived services, then every domain provider.
      */
     private static function buildContainer(

--- a/tests/Http/BootstrapAdminTest.php
+++ b/tests/Http/BootstrapAdminTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Auth\LoginInput;
+use NeneClear\Auth\LoginUseCaseInterface;
+use NeneClear\Auth\Role;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\Tests\Support\SchemaFixture;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCaseInterface;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * The bootstrap path used by tools/create-admin.php: resolve the domain use
+ * cases from ApplicationFactory::container(), create the first organization +
+ * admin, and confirm the account can immediately log in (proves bcrypt hashing,
+ * Active status, and the wiring all line up).
+ */
+final class BootstrapAdminTest extends TestCase
+{
+    private const string SECRET = 'test-secret-test-secret-32chars!';
+    private const string PASSWORD = 'correct horse battery staple';
+
+    private string $dbPath;
+    private ContainerInterface $container;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-bootstrap-', true) . '.sqlite';
+        $kit = DatabaseTestKit::sqlite($this->dbPath);
+        SchemaFixture::createOrganizations($kit->queryExecutor);
+        SchemaFixture::createUsers($kit->queryExecutor);
+        SchemaFixture::createAuditEvents($kit->queryExecutor);
+        SchemaFixture::createTotpTables($kit->queryExecutor);
+
+        $this->container = ApplicationFactory::container($kit->queryExecutor, $kit->transactionManager, self::SECRET);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testCreatesFirstOrgAndAdminThatCanLogIn(): void
+    {
+        $organization = ServiceResolver::get($this->container, CreateOrganizationUseCaseInterface::class)
+            ->execute(new CreateOrganizationInput(slug: 'acme', name: 'ACME Inc', actorUserId: 0));
+
+        $user = ServiceResolver::get($this->container, CreateUserUseCaseInterface::class)
+            ->execute(new CreateUserInput(
+                organizationId: $organization->id,
+                email: 'admin@acme.example',
+                role: Role::Admin,
+                password: self::PASSWORD,
+                actorUserId: 0,
+            ));
+
+        self::assertNotNull($user->id);
+        self::assertSame(UserStatus::Active, $user->status);
+        self::assertSame(Role::Admin, $user->role);
+        self::assertSame($organization->id, $user->organizationId);
+
+        $login = ServiceResolver::get($this->container, LoginUseCaseInterface::class)
+            ->execute(new LoginInput('admin@acme.example', self::PASSWORD));
+
+        self::assertIsString($login->token);
+        self::assertFalse($login->mfaRequired);
+        self::assertSame('admin', $login->role);
+        self::assertSame($organization->id, $login->organizationId);
+    }
+
+    public function testCreatesCrossTenantSuperadminWithoutAnOrganization(): void
+    {
+        $user = ServiceResolver::get($this->container, CreateUserUseCaseInterface::class)
+            ->execute(new CreateUserInput(
+                organizationId: null,
+                email: 'root@example.test',
+                role: Role::Superadmin,
+                password: self::PASSWORD,
+                actorUserId: 0,
+            ));
+
+        self::assertNull($user->organizationId);
+        self::assertSame(UserStatus::Active, $user->status);
+
+        $login = ServiceResolver::get($this->container, LoginUseCaseInterface::class)
+            ->execute(new LoginInput('root@example.test', self::PASSWORD));
+
+        self::assertIsString($login->token);
+        self::assertSame('superadmin', $login->role);
+        self::assertNull($login->organizationId);
+    }
+}

--- a/tools/create-admin.php
+++ b/tools/create-admin.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bootstrap CLI: create the first organization + admin user on a fresh install.
+ *
+ * A fresh database has no accounts, and every user-creating endpoint requires an
+ * already-authenticated admin — a chicken-and-egg. This one-off, audited command
+ * breaks it by reusing the same domain use cases the HTTP app uses, so bcrypt
+ * hashing, email/slug uniqueness, the atomic write+audit, and the registered
+ * roles/status all behave identically. Run it once after
+ * `composer migrations:migrate`.
+ *
+ * Usage:
+ *   php tools/create-admin.php --org-name "ACME Inc" --email admin@acme.example
+ *   php tools/create-admin.php --org-name "ACME Inc" --org-slug acme \
+ *       --email admin@acme.example --password '…'
+ *   ADMIN_PASSWORD='…' php tools/create-admin.php --org-name "ACME" --email …
+ *   php tools/create-admin.php --role superadmin --email root@example  # no org
+ *
+ * The password comes from --password, else the ADMIN_PASSWORD env var, else an
+ * interactive hidden prompt. Database config is read from .env, like the app.
+ *
+ * Config-boundary entry point (docs/development/nene2-compliance.md §15): raw env
+ * access and the DB wiring below mirror public_html/index.php on purpose.
+ */
+
+use Dotenv\Dotenv;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use NeneClear\Auth\Role;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\Organization\OrganizationAlreadyExistsException;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCaseInterface;
+use NeneClear\User\UserAlreadyExistsException;
+use NeneClear\User\UserRepositoryInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, 'This script must be run from the command line.' . PHP_EOL);
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+};
+
+$usage = static function (int $code): never {
+    $lines = [
+        'Create the first organization + admin user for a fresh NeNe Clear install.',
+        '',
+        'Usage:',
+        '  php tools/create-admin.php --org-name NAME --email EMAIL [options]',
+        '',
+        'Options:',
+        '  --org-name NAME   Organization display name (required unless --role superadmin)',
+        '  --org-slug SLUG   URL-safe org id (default: derived from --org-name)',
+        '  --email EMAIL     Admin login email (required)',
+        '  --password PASS   Admin password (default: ADMIN_PASSWORD env, else hidden prompt)',
+        '  --role ROLE       admin (default) | superadmin | member | viewer',
+        '  -h, --help        Show this help',
+    ];
+    fwrite($code === 0 ? STDOUT : STDERR, implode(PHP_EOL, $lines) . PHP_EOL);
+    exit($code);
+};
+
+$slugify = static function (string $name): string {
+    $slug = (string) preg_replace('/[^a-z0-9]+/', '-', strtolower($name));
+
+    return trim($slug, '-');
+};
+
+$promptPassword = static function () use ($fail): string {
+    if (!stream_isatty(STDIN)) {
+        $fail('No --password given and no interactive terminal to prompt. Set --password or ADMIN_PASSWORD.');
+    }
+
+    fwrite(STDOUT, 'Admin password: ');
+    $sttyState = shell_exec('stty -g');
+    shell_exec('stty -echo');
+    $input = fgets(STDIN);
+    if (is_string($sttyState)) {
+        shell_exec('stty ' . trim($sttyState));
+    }
+    fwrite(STDOUT, PHP_EOL);
+
+    return is_string($input) ? trim($input) : '';
+};
+
+// --- Parse arguments (--key value or --key=value) ------------------------------
+$rawArgv = $_SERVER['argv'] ?? [];
+$args = array_slice(is_array($rawArgv) ? array_values($rawArgv) : [], 1);
+$count = count($args);
+/** @var array<string, string> $opts */
+$opts = [];
+for ($i = 0; $i < $count; $i++) {
+    $arg = (string) $args[$i];
+    if ($arg === '-h' || $arg === '--help') {
+        $usage(0);
+    }
+    if (!str_starts_with($arg, '--')) {
+        fwrite(STDERR, sprintf('Unexpected argument: %s', $arg) . PHP_EOL);
+        $usage(1);
+    }
+    $body = substr($arg, 2);
+    if (str_contains($body, '=')) {
+        [$key, $value] = explode('=', $body, 2);
+    } else {
+        $key = $body;
+        $next = $i + 1 < $count ? (string) $args[$i + 1] : '';
+        if ($next !== '' && !str_starts_with($next, '--')) {
+            $value = $next;
+            $i++;
+        } else {
+            $value = '';
+        }
+    }
+    $opts[$key] = $value;
+}
+
+// --- Load .env and resolve inputs ---------------------------------------------
+if (is_file($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
+
+$role = Role::tryFrom($opts['role'] ?? 'admin');
+if ($role === null) {
+    $fail('Invalid --role. Valid values: superadmin, admin, member, viewer.');
+}
+
+$email = trim($opts['email'] ?? '');
+if ($email === '' || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+    $fail('A valid --email is required.');
+}
+
+$isSuperadmin = $role === Role::Superadmin;
+$orgName = trim($opts['org-name'] ?? '');
+$orgSlug = trim($opts['org-slug'] ?? '');
+
+if (!$isSuperadmin) {
+    if ($orgName === '') {
+        $fail('--org-name is required (omit only with --role superadmin).');
+    }
+    if ($orgSlug === '') {
+        $orgSlug = $slugify($orgName);
+    }
+    if ($orgSlug === '') {
+        $fail('Could not derive a slug from --org-name; pass --org-slug explicitly (a-z, 0-9, hyphen).');
+    }
+}
+
+$password = $opts['password'] ?? ($env('ADMIN_PASSWORD') ?: null);
+if ($password === null || $password === '') {
+    $password = $promptPassword();
+}
+if (strlen($password) < 12) {
+    $fail('Password must be at least 12 characters.');
+}
+
+// --- Database wiring (mirrors public_html/index.php) ---------------------------
+$adapter = $env('DB_ADAPTER', 'sqlite');
+$connectionFactory = (static function () use ($env, $adapter, $root): ?DatabaseConnectionFactoryInterface {
+    try {
+        $config = match ($adapter) {
+            'mysql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'mysql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '3306'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8mb4'),
+            ),
+            'pgsql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'pgsql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '5432'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8'),
+            ),
+            default => DatabaseConfig::sqlite($env('DB_NAME') ?: $root . '/database/nene_clear.sqlite3'),
+        };
+
+        return new PdoConnectionFactory($config);
+    } catch (\Throwable) {
+        return null;
+    }
+})();
+
+if ($connectionFactory === null) {
+    $fail('Database is not configured or unreachable. Check .env (DB_ADAPTER, DB_*).');
+}
+
+$query = new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter);
+$transactionManager = new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter);
+
+// --- Create org + admin via the same use cases the HTTP app uses ---------------
+$container = ApplicationFactory::container($query, $transactionManager, $env('NENE_CLEAR_JWT_SECRET'));
+
+// Fail before creating an organization if the email is taken, so a re-run does
+// not leave an orphan organization behind (the create-user step guards it too).
+if (ServiceResolver::get($container, UserRepositoryInterface::class)->existsByEmail($email)) {
+    $fail(sprintf("A user with email '%s' already exists.", $email));
+}
+
+$organizationId = null;
+if (!$isSuperadmin) {
+    try {
+        $organization = ServiceResolver::get($container, CreateOrganizationUseCaseInterface::class)
+            ->execute(new CreateOrganizationInput(slug: $orgSlug, name: $orgName, actorUserId: 0));
+        $organizationId = $organization->id;
+        fwrite(STDOUT, sprintf('Created organization #%d (%s / %s)', $organization->id, $organization->slug, $organization->name) . PHP_EOL);
+    } catch (OrganizationAlreadyExistsException) {
+        $fail(sprintf("An organization with slug '%s' already exists; pass a different --org-slug.", $orgSlug));
+    }
+}
+
+try {
+    $user = ServiceResolver::get($container, CreateUserUseCaseInterface::class)
+        ->execute(new CreateUserInput(
+            organizationId: $organizationId,
+            email: $email,
+            role: $role,
+            password: $password,
+            actorUserId: 0,
+        ));
+} catch (UserAlreadyExistsException) {
+    $fail(sprintf("A user with email '%s' already exists.", $email));
+}
+
+fwrite(STDOUT, sprintf(
+    'Created %s user #%d <%s>%s. You can now log in to the admin UI.',
+    $role->value,
+    $user->id ?? 0,
+    $user->email,
+    $organizationId !== null ? sprintf(' in organization #%d', $organizationId) : '',
+) . PHP_EOL);
+
+exit(0);


### PR DESCRIPTION
## What

Adds `tools/create-admin.php`, an audited one-off command to create the **first organization + admin user** on a fresh install — the last gap that made a clean install unusable (nobody could log in; every user-creating endpoint needs an authenticated admin, and there was no seeder).

It reuses the existing `CreateOrganizationUseCase` / `CreateUserUseCase`, so bcrypt hashing, email/slug uniqueness, the atomic write+audit, and the terminology-registered roles/status behave exactly like the HTTP path.

- Password from `--password`, `ADMIN_PASSWORD`, or an interactive hidden prompt.
- `--role` defaults to `admin`; `superadmin` creates a cross-tenant user with no org.
- Slug auto-derived from `--org-name` (or `--org-slug`).
- Fails **before** creating an org if the email is taken → a re-run leaves no orphan org.
- New `ApplicationFactory::container()` exposes the exact composition root for non-HTTP entry points (no hand-wired partial container).
- `tools/` brought under PHPStan L8 + PHP-CS-Fixer.

## Verification

- `composer check` green: **338 tests** (+2), PHPStan L8 no errors, CS-Fixer clean.
- Integration test (`tests/Http/BootstrapAdminTest.php`): bootstrap org + admin → login issues a token; plus the cross-tenant superadmin path.
- End-to-end on **MySQL** and **SQLite**: `--help`, missing-email error, migrate, create (org + active admin, audit events with system actor `0`), duplicate-email re-run fails with no orphan org, and the created admin logs in and receives a token.

No new Problem Details slugs / field names / status values / operationIds.

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)