### PR TITLE
docs: reconcile Tier A stance — possible via install.php but not recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Operators who need both install **two sibling apps** connected via HTTP.
 - **Bank reconciliation** — CSV import, human-confirmed match, audit trail
 - **Dunning** — operator-controlled overdue reminders with send history
 - **Compliance** — binding rules for reconciliation and dunning ([compliance doc](./docs/explanation/payment-reconciliation-dunning-compliance.md))
-- **Self-hosted OSS** — MIT; recommended on **VPS + Docker** (Tier B). Shared hosting is **not recommended** for receivables/bank/PII data (no root, throttled SMTP, limited DKIM & backups); a managed / install-service option is planned
+- **Self-hosted OSS** — MIT; recommended on **VPS + Docker** (Tier B). Shared hosting (Tier A) is **possible** via the web installer (`public_html/install.php`) but **not recommended** for receivables/bank/PII data (no root, throttled SMTP, limited DKIM & backups) — **use at your own risk**; a managed / install-service option is planned
 - **AI-readable** — OpenAPI + MCP; human confirms, AI proposes
 - **Optional upstream: NeNe Invoice** — when connected, invoice/payment truth via HTTP API (not a shared DB); without it, Clear reconciles and duns directly-entered / CSV-imported receivables ([ADR 0014](./docs/adr/0014-accept-manual-receivables.md))
 

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -44,7 +44,7 @@ Canonical English terms for NeNe Clear public docs, OpenAPI, and code comments.
 | **cents** | Integer amount in the **smallest currency unit**. For JPY (the only Phase 1–3 currency) one "cent" is one 円, so `amount_cents = 1000` means ¥1,000. The suffix is a fixed internal convention, not a sub-yen unit | float or DECIMAL money; reading `_cents` as 1/100 yen |
 | **overdue** | An upstream invoice past `due_at` with unpaid balance — a computed flag owned by Invoice, mirrored read-only for dunning eligibility | treating it as a Clear-owned stored status |
 | **audit event** | An immutable record of an import, match, reversal, dunning send, or credit creation (who / when / what) | "log line" without actor/timestamp |
-| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL), beside NeNe Invoice on the same server | "rental server" in code |
+| **Tier A** | Shared hosting deployment (ZIP + web installer + MySQL), beside NeNe Invoice on the same server — available but **not recommended** for bank/PII data (at your own risk) | "rental server" in code |
 | **Tier B** | Docker / VPS deployment — Invoice + Clear as two services | "cloud tier" |
 | **handler** | HTTP entry point class | "controller" |
 | **use case** | Business logic class with `execute()` | "service" (UseCase sense) |

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -99,9 +99,11 @@ skips straight to bank import.
 | --- | --- | --- |
 | **VPS + Docker (Tier B, recommended)** | `docker compose up` | Run receivables / bank / PII data on infrastructure you control |
 | **Managed / install-service** | Hosted, or set up for you | For operators without ops capacity (see adoption review) |
+| **Shared hosting (Tier A, discouraged)** | `public_html/install.php` | Possible but **not recommended** for bank/PII — at your own risk |
 
-> Shared hosting (Tier A) is **not recommended** for this data — no root,
-> throttled SMTP, limited DKIM/backup. See
+> Shared hosting (Tier A) is **possible** via the web installer
+> (`public_html/install.php`) but **not recommended** for this data — no root,
+> throttled SMTP, limited DKIM/backup; **use at your own risk**. See
 > [`adoption-review-2026-06.md`](./adoption-review-2026-06.md).
 
 ## Philosophy (summary)

--- a/docs/explanation/requirements.md
+++ b/docs/explanation/requirements.md
@@ -89,10 +89,10 @@ Binding detail: [`payment-reconciliation-dunning-compliance.md`](./payment-recon
 - [x] ja + en admin UI (ADR 0005)
 - [x] Dashboard: unmatched count, recent dunning
 
-### Phase 3 — Tier A 🔲
+### Phase 3 — Tier A 🔲 (possible but not recommended for bank/PII — at your own risk)
 
-- [ ] Web installer (MySQL, admin user, Invoice API config)
-- [ ] Release ZIP
+- [x] Web installer PoC (MySQL/SQLite, tenancy, admin) — #232, at-your-own-risk warning
+- [ ] Release ZIP + GitHub-download acquire
 - [ ] Operator guide
 
 ---

--- a/docs/explanation/scope-boundary.md
+++ b/docs/explanation/scope-boundary.md
@@ -38,7 +38,7 @@ Clear MVP = Phase 1–3 in [`roadmap.md`](../roadmap.md):
 1. Bank import + Invoice upstream integration
 2. Human-confirmed matching + audit
 3. Dunning + send log
-4. Tier A installer
+4. Tier A installer (available; not recommended for bank/PII — at your own risk)
 
 Post-MVP Clear improvements (same domain only): additional bank CSV formats,
 stronger match suggestions, optional postal dunning log — each via Issue + ADR

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,10 +44,12 @@ Operators self-host Clear beside NeNe Invoice to:
 
 Reframed from "Tier A shared hosting": the 2026-06 adoption review
 ([`explanation/adoption-review-2026-06.md`](./explanation/adoption-review-2026-06.md))
-found shared hosting unsuitable for receivables / bank / PII data (no root,
+found shared hosting a poor fit for receivables / bank / PII data (no root,
 throttled SMTP, limited DKIM and backups). The recommended target is **VPS +
 Docker (Tier B)** with a managed / install-service option for operators without
-ops capacity.
+ops capacity. Tier A is **possible but not recommended** — a web installer
+(`public_html/install.php`) ships as a PoC (#232) with an explicit
+at-your-own-risk warning; it is not the recommended path for this data.
 
 - Official Docker image + managed / install-service offering
 - Operator deployment guide (VPS + Docker; Invoice + Clear as two apps)


### PR DESCRIPTION
Makes the docs coherent with the shipped Tier A web installer (#232): Tier A shared hosting is **possible** via `public_html/install.php` but **not recommended** for bank/PII data — use at your own risk. VPS+Docker (Tier B) recommended; managed option planned.

Updated living/normative docs: README, roadmap (Phase 3), product-vision (targets table + note), glossary (Tier A def), requirements (Phase 3 checklist — installer PoC marked done), scope-boundary. Point-in-time records (adoption-review, milestone, handoff, current.md) left as history.

Docs-only. Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)