### PR TITLE
feat(health): report the installed version on the machine surface (#182)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ SMTP_PASSWORD=
 SMTP_FROM_ADDRESS=noreply@nene-clear.dev
 SMTP_FROM_NAME="NeNe Clear"
 
+# Machine API key (NENE2 machine surface, #182). When set, GET /machine/health is
+# auth-gated by the X-NENE2-API-Key header and reports this app's VERSION so
+# deployment tooling can track the installed version (NeNe Suite pairs the same
+# value as NENE_SUITE_APP_NENE_CLEAR_MACHINE_KEY). Leave empty to keep the
+# machine surface ungated (local dev); the public /health is unaffected.
+NENE2_MACHINE_API_KEY=
+
 # Encryption at rest (optional, #195). When set, sensitive fields (bank account
 # number) are encrypted on write; reads transparently handle both encrypted and
 # legacy plaintext. Generate base64 of 32 random bytes:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-07-02
+Last updated: 2026-07-03
 
 > **Latest handoff: [`handoff-2026-07-02.md`](handoff-2026-07-02.md)** — this
 > session shipped the bootstrap `create-admin` CLI (#228), a `phinx` `.env` fix
@@ -23,7 +23,7 @@ Last updated: 2026-07-02
 
 | Layer | Count | Tool |
 | --- | --- | --- |
-| Backend | 236 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
+| Backend | 342 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
 | Frontend unit | 27 | Vitest |
 | Browser E2E | 43 | Playwright (API mocked) |
 
@@ -117,6 +117,12 @@ Business/owner levers (not code; see review doc): managed/SaaS supply, pricing
 
 ## Recently completed
 
+- **Machine surface: installed version on `GET /machine/health`** (#182): the
+  repo `VERSION` is injected as `appVersion` into both `RuntimeApplicationFactory`
+  sites (health-only and full), `NENE2_MACHINE_API_KEY` gates the machine surface
+  (`.env.example` documented; NeNe Suite pairs it as
+  `NENE_SUITE_APP_NENE_CLEAR_MACHINE_KEY`), and the public `/health` stays
+  version-free. HTTP tests cover key gating and version reporting.
 - **MFA (TOTP) backend** (slices 1–3, PR #213 / #216 / #217): RFC 6238 generator,
   encrypted secret + hashed recovery codes, lockout + replay, self-service
   enrolment endpoints, and a login challenge for enrolled users. Frontend +

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -87,6 +87,12 @@ $transactionManager = $connectionFactory !== null
 $smtpHost = $env('SMTP_HOST') ?: null;
 $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
 
+// Machine surface (issue #182): the repo VERSION file is this app's release
+// version, surfaced on the auth-gated GET /machine/health so deployment tooling
+// (e.g. NeNe Suite update tracking) can read the installed version.
+$machineApiKey = $env('NENE2_MACHINE_API_KEY') ?: null;
+$appVersion = is_file($root . '/VERSION') ? trim((string) file_get_contents($root . '/VERSION')) : '';
+
 $application = ApplicationFactory::create(
     debug: $debug,
     allowedOrigins: [],
@@ -107,6 +113,8 @@ $application = ApplicationFactory::create(
     // Optional encryption-at-rest key (base64 of 32 bytes). When unset, sensitive
     // fields are stored as-is; when set, they are encrypted on write (#192/#195).
     encryptionKey: $env('NENE_CLEAR_ENCRYPTION_KEY'),
+    machineApiKey: $machineApiKey,
+    appVersion: $appVersion !== '' ? $appVersion : null,
 );
 
 $psr17 = new Psr17Factory();

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -59,6 +59,12 @@ final class ApplicationFactory
 {
     /**
      * @param list<string> $allowedOrigins CORS allowlist; empty disables CORS (set explicitly in production).
+     * @param string|null $machineApiKey When set, auth-gates the NENE2 machine surface
+     *        (`GET /machine/health`) via `X-NENE2-API-Key`. Suite update tracking pairs this
+     *        value as `NENE_SUITE_APP_NENE_CLEAR_MACHINE_KEY` (issue #182).
+     * @param string|null $appVersion This application's own release version (the repo `VERSION`
+     *        file), surfaced as `version` on the auth-gated `GET /machine/health` — distinct from
+     *        the framework version. Null omits the field (consumers treat it as unknown).
      */
     public static function create(
         bool $debug = false,
@@ -78,16 +84,22 @@ final class ApplicationFactory
         string $appBaseUrl = '',
         ?InvitationMailerInterface $invitationMailer = null,
         string $encryptionKey = '',
+        ?string $machineApiKey = null,
+        ?string $appVersion = null,
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
 
         // Public/health-only surface: no database or JWT secret → no admin routes.
+        // The machine surface stays available so deployment tooling can read the
+        // app version even before the database is configured.
         if ($query === null || $jwtSecret === null || $jwtSecret === '') {
             return (new RuntimeApplicationFactory(
                 responseFactory: $psr17,
                 streamFactory: $psr17,
+                machineApiKey: $machineApiKey,
                 debug: $debug,
                 allowedOrigins: $allowedOrigins,
+                appVersion: $appVersion,
             ))->create();
         }
 
@@ -124,11 +136,13 @@ final class ApplicationFactory
         return (new RuntimeApplicationFactory(
             responseFactory: $psr17,
             streamFactory: $psr17,
+            machineApiKey: $machineApiKey,
             domainExceptionHandlers: $exceptionHandlers,
             routeRegistrars: $routeRegistrars,
             authMiddleware: $authMiddleware,
             debug: $debug,
             allowedOrigins: $allowedOrigins,
+            appVersion: $appVersion,
         ))->create();
     }
 

--- a/tests/Http/MachineHealthTest.php
+++ b/tests/Http/MachineHealthTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\ApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Machine surface wiring (issue #182): the auth-gated GET /machine/health
+ * reports this application's own release version so deployment tooling can
+ * track the installed version. The public GET /health must not expose it.
+ */
+final class MachineHealthTest extends TestCase
+{
+    private const MACHINE_KEY = 'test-machine-key';
+    private const APP_VERSION = '0.1.0-test';
+
+    public function test_machine_health_reports_app_version_with_valid_key(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', '/machine/health')
+            ->withHeader('X-NENE2-API-Key', self::MACHINE_KEY);
+
+        $response = $this->app()->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertSame('ok', $data['status'] ?? null);
+        self::assertSame(self::APP_VERSION, $data['version'] ?? null);
+        self::assertArrayHasKey('framework_version', $data);
+    }
+
+    public function test_machine_health_rejects_a_missing_key(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('GET', '/machine/health');
+
+        $response = $this->app()->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_public_health_does_not_expose_the_app_version(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('GET', '/health');
+
+        $response = $this->app()->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertArrayNotHasKey('version', $data);
+    }
+
+    public function test_machine_health_omits_version_when_not_injected(): void
+    {
+        $app = ApplicationFactory::create(
+            debug: false,
+            allowedOrigins: [],
+            machineApiKey: self::MACHINE_KEY,
+        );
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', '/machine/health')
+            ->withHeader('X-NENE2-API-Key', self::MACHINE_KEY);
+
+        $response = $app->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertArrayNotHasKey('version', $data);
+    }
+
+    private function app(): \Psr\Http\Server\RequestHandlerInterface
+    {
+        // Health-only surface (no DB / JWT) — the machine surface must work even
+        // before the database is configured, mirroring public_html/index.php.
+        return ApplicationFactory::create(
+            debug: false,
+            allowedOrigins: [],
+            machineApiKey: self::MACHINE_KEY,
+            appVersion: self::APP_VERSION,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adopts the NENE2 machine-surface version reporting (NENE2#1414, framework ≥ v1.5.330 — the path dependency already tracks it) so deployment tooling can read this app's installed version.

- **`appVersion` injection**: the repo `VERSION` file (already maintained by the release build, #236) is read at the config boundary (`public_html/index.php`) and passed to **both** `RuntimeApplicationFactory` sites in `ApplicationFactory` — the health-only surface included, so the version stays readable even before the database is configured.
- **`NENE2_MACHINE_API_KEY`**: read at the config boundary and passed as `machineApiKey`, auth-gating `GET /machine/health` via `X-NENE2-API-Key`. Documented in `.env.example`; NeNe Suite pairs the same value as `NENE_SUITE_APP_NENE_CLEAR_MACHINE_KEY` for its update-diff probe.
- The public `GET /health` remains version-free (machine-only exposure, per the framework design).
- No behavior change when the env var is unset (surface stays ungated; `version` omitted when the file is absent — consumers keep treating it as unknown).

## Acceptance (issue #182)

- ✅ `GET /machine/health` + `X-NENE2-API-Key` → `{ status, service, version: "0.1.0", framework_version, ... }`
- ✅ 未対応時と同じく defensive: version 未注入なら field 省略（Suite は unknown 維持）

## Tests

- `MachineHealthTest` (4 tests): version reported with a valid key · 401 without a key · `/health` does not leak the version · field omitted when not injected.
- `composer check` green — PHPUnit **342** (338 → +4), PHPStan L8, PHP-CS-Fixer.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)