### PR TITLE
feat(machine): adopt the candidate-database preflight (#183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,19 @@ SMTP_FROM_NAME="NeNe Clear"
 # machine surface ungated (local dev); the public /health is unaffected.
 NENE2_MACHINE_API_KEY=
 
+# Candidate-database preflight allowlist (optional, #183). Each candidate an
+# operator/deploy tool may preflight via POST /machine/database/preflight is
+# declared here by id — connection details are never accepted from the request
+# (SSRF prevention). A SELECT-only credential is recommended; the inspector
+# additionally enforces a read-only transaction. Example (id "legacy"):
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_ADAPTER=mysql
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_HOST=127.0.0.1
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_PORT=3306
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_NAME=nene_clear_old
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_USER=readonly
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_PASSWORD=
+#   NENE_CLEAR_DB_CANDIDATE_LEGACY_MULTI_TENANT=false
+
 # Encryption at rest (optional, #195). When set, sensitive fields (bank account
 # number) are encrypted on write; reads transparently handle both encrypted and
 # legacy plaintext. Generate base64 of 32 random bytes:

--- a/database/migrations/20260703000000_stamp_application_identity.php
+++ b/database/migrations/20260703000000_stamp_application_identity.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use NeneClear\Database\ApplicationDatabaseIdentity;
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Stamps this database with NeNe Clear's application identity marker
+ * (`nene2_app_identity`, NENE2#1420) so a candidate-database preflight can
+ * verify "is this database mine?" (issue #183). Running this migration on an
+ * existing database is the backfill; fresh installs get it as part of the
+ * normal migrate. Idempotent: the single marker row is replaced.
+ *
+ * The table shape mirrors `Nene2\Database\Preflight\ApplicationIdentityMarker`
+ * (VARCHAR(190) columns, no primary key). The marker class itself is not used
+ * here because it opens its own transaction, which conflicts with the
+ * transaction Phinx already holds around a migration.
+ */
+final class StampApplicationIdentity extends AbstractMigration
+{
+    private const TABLE = 'nene2_app_identity';
+
+    public function up(): void
+    {
+        if (!$this->hasTable(self::TABLE)) {
+            $this->table(self::TABLE, ['id' => false])
+                ->addColumn('application_id', 'string', ['limit' => 190, 'null' => false])
+                ->addColumn('tenant_id', 'string', ['limit' => 190, 'null' => true])
+                ->create();
+        }
+
+        $this->execute(sprintf('DELETE FROM %s', self::TABLE));
+        $this->table(self::TABLE)
+            ->insert([
+                ['application_id' => ApplicationDatabaseIdentity::APPLICATION_ID, 'tenant_id' => null],
+            ])
+            ->saveData();
+    }
+
+    public function down(): void
+    {
+        if ($this->hasTable(self::TABLE)) {
+            $this->table(self::TABLE)->drop()->save();
+        }
+    }
+}

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -23,7 +23,7 @@ Last updated: 2026-07-03
 
 | Layer | Count | Tool |
 | --- | --- | --- |
-| Backend | 342 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
+| Backend | 352 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
 | Frontend unit | 27 | Vitest |
 | Browser E2E | 43 | Playwright (API mocked) |
 
@@ -117,6 +117,15 @@ Business/owner levers (not code; see review doc): managed/SaaS supply, pricing
 
 ## Recently completed
 
+- **Candidate-database preflight adopted** (#183): opt-in
+  `POST /machine/database/preflight` is live — `DefaultDatabaseCandidateInspector`
+  wired with this app's Phinx versions (`MigrationVersions`), the **`phinxlog`**
+  ledger name, and `ApplicationDatabaseIdentity` (`nene-clear`, single-tenant DB
+  lineage). Migration `20260703000000` stamps / backfills the
+  `nene2_app_identity` marker idempotently. Candidates come only from the
+  `NENE_CLEAR_DB_CANDIDATE_*` env allowlist (SSRF-safe; documented in
+  `.env.example`). Tests cover fresh / migrated-own-DB (compatible + identity
+  match) / unknown-id 422 / key gating / endpoint absent without the inspector.
 - **Machine surface: installed version on `GET /machine/health`** (#182): the
   repo `VERSION` is injected as `appVersion` into both `RuntimeApplicationFactory`
   sites (health-only and full), `NENE2_MACHINE_API_KEY` gates the machine surface

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -8,9 +8,13 @@ use Nene2\Database\DatabaseConnectionFactoryInterface;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
 use Nene2\Http\ResponseEmitter;
 use NeneClear\Database\AdapterAwareQueryExecutor;
 use NeneClear\Database\AdapterAwareTransactionManager;
+use NeneClear\Database\ApplicationDatabaseIdentity;
+use NeneClear\Database\CandidateProfiles;
+use NeneClear\Database\MigrationVersions;
 use NeneClear\Http\ApplicationFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
@@ -93,6 +97,18 @@ $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
 $machineApiKey = $env('NENE2_MACHINE_API_KEY') ?: null;
 $appVersion = is_file($root . '/VERSION') ? trim((string) file_get_contents($root . '/VERSION')) : '';
 
+// Candidate-database preflight (issue #183): the inspector knows this app's
+// migration versions + identity; candidates come only from the env allowlist
+// (NENE_CLEAR_DB_CANDIDATE_*), never from the request body (SSRF prevention).
+$candidateInspector = new DefaultDatabaseCandidateInspector(
+    applicationMigrationVersions: MigrationVersions::fromDirectory($root . '/database/migrations'),
+    // This app's Phinx ledger is `phinxlog` (phinx.php default_migration_table),
+    // not the inspector's `phinx_log` default — required for schema recognition.
+    ledgerTable: 'phinxlog',
+    applicationIdentity: ApplicationDatabaseIdentity::identity(),
+);
+$candidateProfiles = CandidateProfiles::fromEnv($_ENV);
+
 $application = ApplicationFactory::create(
     debug: $debug,
     allowedOrigins: [],
@@ -115,6 +131,8 @@ $application = ApplicationFactory::create(
     encryptionKey: $env('NENE_CLEAR_ENCRYPTION_KEY'),
     machineApiKey: $machineApiKey,
     appVersion: $appVersion !== '' ? $appVersion : null,
+    databaseCandidateInspector: $candidateInspector,
+    databaseCandidateProfiles: $candidateProfiles,
 );
 
 $psr17 = new Psr17Factory();

--- a/src/Database/ApplicationDatabaseIdentity.php
+++ b/src/Database/ApplicationDatabaseIdentity.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Database;
+
+use Nene2\Database\Preflight\ApplicationIdentity;
+
+/**
+ * The stable identity NeNe Clear stamps into its own database and expects to
+ * find again when preflighting a candidate database (issue #183, NENE2#1420).
+ *
+ * The application id identifies this database lineage as NeNe Clear's (vs any
+ * other NENE2 application sharing the same ledger conventions). The tenant id
+ * stays null: a Clear deployment keeps all of its organizations in one
+ * database, so the database itself is not per-tenant.
+ */
+final readonly class ApplicationDatabaseIdentity
+{
+    public const APPLICATION_ID = 'nene-clear';
+
+    public static function identity(): ApplicationIdentity
+    {
+        return new ApplicationIdentity(self::APPLICATION_ID, null);
+    }
+}

--- a/src/Database/CandidateProfiles.php
+++ b/src/Database/CandidateProfiles.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Database;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\Preflight\CandidateProfile;
+
+/**
+ * Builds the candidate-database profiles for `POST /machine/database/preflight`
+ * from the application's own environment (issue #183).
+ *
+ * Candidates are declared as env allowlist entries — connection details are
+ * never accepted from the request body (SSRF prevention, NENE2#1419):
+ *
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_ADAPTER=sqlite|mysql|pgsql
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_NAME=…        # database name / sqlite path
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_HOST=…        # mysql/pgsql (default 127.0.0.1)
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_PORT=…        # default 3306 / 5432
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_USER=…        # SELECT-only credential recommended
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_PASSWORD=…
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_CHARSET=…     # default utf8mb4 (ignored by pgsql)
+ *     NENE_CLEAR_DB_CANDIDATE_<ID>_MULTI_TENANT= # "true" for multi-tenant deployments
+ *
+ * The caller references the candidate as the lowercased `<ID>` segment.
+ * A malformed entry is skipped (never fails the boot) — the candidate is then
+ * simply unknown to the endpoint (422).
+ */
+final readonly class CandidateProfiles
+{
+    private const PREFIX = 'NENE_CLEAR_DB_CANDIDATE_';
+
+    /**
+     * @param array<array-key, mixed> $env Typically `$_ENV` at the config boundary.
+     *
+     * @return array<string, CandidateProfile> keyed by candidate id
+     */
+    public static function fromEnv(array $env): array
+    {
+        $profiles = [];
+
+        foreach (self::candidateKeys($env) as $key) {
+            $key = (string) $key; // PHP array keys coerce numeric-looking ids to int
+            $value = static fn (string $suffix, string $default = ''): string => is_string($env[self::PREFIX . $key . '_' . $suffix] ?? null)
+                ? (string) $env[self::PREFIX . $key . '_' . $suffix]
+                : $default;
+
+            $adapter = $value('ADAPTER', 'sqlite');
+            $id = strtolower($key);
+
+            try {
+                $config = match ($adapter) {
+                    'mysql', 'pgsql' => new DatabaseConfig(
+                        url: null,
+                        environment: 'candidate',
+                        adapter: $adapter,
+                        host: $value('HOST', '127.0.0.1'),
+                        port: (int) $value('PORT', $adapter === 'mysql' ? '3306' : '5432'),
+                        name: $value('NAME'),
+                        user: $value('USER'),
+                        password: $value('PASSWORD'),
+                        charset: $value('CHARSET', $adapter === 'mysql' ? 'utf8mb4' : 'utf8'),
+                    ),
+                    'sqlite' => DatabaseConfig::sqlite($value('NAME'), 'candidate'),
+                    default => null,
+                };
+            } catch (\Throwable) {
+                continue; // malformed entry — skip, never fail the boot
+            }
+
+            if ($config === null || $id === '') {
+                continue;
+            }
+
+            $profiles[$id] = new CandidateProfile(
+                id: $id,
+                connectionFactory: new PdoConnectionFactory($config),
+                multiTenant: $value('MULTI_TENANT') === 'true',
+            );
+        }
+
+        return $profiles;
+    }
+
+    /**
+     * @param array<array-key, mixed> $env
+     *
+     * @return list<string> distinct `<ID>` segments that declare an adapter or name
+     */
+    private static function candidateKeys(array $env): array
+    {
+        $keys = [];
+        foreach (array_keys($env) as $envKey) {
+            if (!is_string($envKey) || !str_starts_with($envKey, self::PREFIX)) {
+                continue;
+            }
+            if (preg_match('/^' . self::PREFIX . '([A-Z0-9_]+)_(ADAPTER|NAME)$/', $envKey, $matches) === 1) {
+                $keys[$matches[1]] = true;
+            }
+        }
+
+        return array_keys($keys);
+    }
+}

--- a/src/Database/MigrationVersions.php
+++ b/src/Database/MigrationVersions.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Database;
+
+/**
+ * Reads the migration version ids this application knows about from the Phinx
+ * migrations directory. Fed to the candidate-database preflight inspector
+ * (issue #183) so it can classify a candidate's ledger as
+ * fresh / compatible / ahead / foreign / partial — with an empty list the
+ * inspector can never return `safe` (`migration_versions_unknown`).
+ */
+final readonly class MigrationVersions
+{
+    /**
+     * @return list<string> Phinx version ids (the leading 14-digit timestamp of
+     *                      each migration filename), ascending.
+     */
+    public static function fromDirectory(string $directory): array
+    {
+        $files = glob($directory . '/*.php');
+        if ($files === false) {
+            return [];
+        }
+
+        $versions = [];
+        foreach ($files as $file) {
+            if (preg_match('/^(\d{14})_/', basename($file), $matches) === 1) {
+                $versions[] = $matches[1];
+            }
+        }
+
+        sort($versions, SORT_STRING);
+
+        return $versions;
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -8,6 +8,8 @@ use LogicException;
 use Nene2\Auth\TokenVerifierInterface;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
+use Nene2\Database\Preflight\CandidateProfile;
+use Nene2\Database\Preflight\DatabaseCandidateInspector;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -65,6 +67,11 @@ final class ApplicationFactory
      * @param string|null $appVersion This application's own release version (the repo `VERSION`
      *        file), surfaced as `version` on the auth-gated `GET /machine/health` — distinct from
      *        the framework version. Null omits the field (consumers treat it as unknown).
+     * @param DatabaseCandidateInspector|null $databaseCandidateInspector Opt-in candidate-database
+     *        preflight (issue #183): when provided, registers the auth-gated
+     *        `POST /machine/database/preflight`. Null keeps the endpoint absent (404).
+     * @param array<string, CandidateProfile> $databaseCandidateProfiles Env-declared candidates the
+     *        preflight may inspect, keyed by id ({@see \NeneClear\Database\CandidateProfiles}).
      */
     public static function create(
         bool $debug = false,
@@ -86,6 +93,8 @@ final class ApplicationFactory
         string $encryptionKey = '',
         ?string $machineApiKey = null,
         ?string $appVersion = null,
+        ?DatabaseCandidateInspector $databaseCandidateInspector = null,
+        array $databaseCandidateProfiles = [],
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
 
@@ -100,6 +109,8 @@ final class ApplicationFactory
                 debug: $debug,
                 allowedOrigins: $allowedOrigins,
                 appVersion: $appVersion,
+                databaseCandidateInspector: $databaseCandidateInspector,
+                databaseCandidateProfiles: $databaseCandidateProfiles,
             ))->create();
         }
 
@@ -143,6 +154,8 @@ final class ApplicationFactory
             debug: $debug,
             allowedOrigins: $allowedOrigins,
             appVersion: $appVersion,
+            databaseCandidateInspector: $databaseCandidateInspector,
+            databaseCandidateProfiles: $databaseCandidateProfiles,
         ))->create();
     }
 

--- a/tests/Database/CandidateProfilesTest.php
+++ b/tests/Database/CandidateProfilesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use NeneClear\Database\CandidateProfiles;
+use PHPUnit\Framework\TestCase;
+
+final class CandidateProfilesTest extends TestCase
+{
+    public function test_builds_profiles_from_the_env_allowlist(): void
+    {
+        $profiles = CandidateProfiles::fromEnv([
+            'NENE_CLEAR_DB_CANDIDATE_LEGACY_ADAPTER' => 'mysql',
+            'NENE_CLEAR_DB_CANDIDATE_LEGACY_HOST' => 'db.internal',
+            'NENE_CLEAR_DB_CANDIDATE_LEGACY_NAME' => 'nene_clear_old',
+            'NENE_CLEAR_DB_CANDIDATE_LEGACY_USER' => 'readonly',
+            'NENE_CLEAR_DB_CANDIDATE_LEGACY_PASSWORD' => 'secret',
+            'NENE_CLEAR_DB_CANDIDATE_RESTORE_2026_ADAPTER' => 'sqlite',
+            'NENE_CLEAR_DB_CANDIDATE_RESTORE_2026_NAME' => '/tmp/restore.sqlite3',
+            'NENE_CLEAR_DB_CANDIDATE_RESTORE_2026_MULTI_TENANT' => 'true',
+            'UNRELATED_KEY' => 'ignored',
+        ]);
+
+        self::assertSame(['legacy', 'restore_2026'], array_keys($profiles));
+        self::assertSame('legacy', $profiles['legacy']->id);
+        self::assertFalse($profiles['legacy']->multiTenant);
+        self::assertTrue($profiles['restore_2026']->multiTenant);
+    }
+
+    public function test_skips_malformed_entries_instead_of_failing_the_boot(): void
+    {
+        $profiles = CandidateProfiles::fromEnv([
+            // mysql candidate without a database name → invalid DatabaseConfig
+            'NENE_CLEAR_DB_CANDIDATE_BROKEN_ADAPTER' => 'mysql',
+            'NENE_CLEAR_DB_CANDIDATE_OK_ADAPTER' => 'sqlite',
+            'NENE_CLEAR_DB_CANDIDATE_OK_NAME' => ':memory:',
+        ]);
+
+        self::assertSame(['ok'], array_keys($profiles));
+    }
+
+    public function test_returns_no_profiles_when_nothing_is_declared(): void
+    {
+        self::assertSame([], CandidateProfiles::fromEnv(['DB_ADAPTER' => 'sqlite']));
+    }
+}

--- a/tests/Database/MigrationVersionsTest.php
+++ b/tests/Database/MigrationVersionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use NeneClear\Database\MigrationVersions;
+use PHPUnit\Framework\TestCase;
+
+final class MigrationVersionsTest extends TestCase
+{
+    public function test_reads_version_ids_from_the_real_migrations_directory(): void
+    {
+        $versions = MigrationVersions::fromDirectory(dirname(__DIR__, 2) . '/database/migrations');
+
+        self::assertNotEmpty($versions);
+        self::assertContains('20260530120000', $versions, 'first shipped migration must be known');
+        self::assertContains('20260703000000', $versions, 'identity-marker migration must be known');
+
+        foreach ($versions as $version) {
+            self::assertMatchesRegularExpression('/^\d{14}$/', $version);
+        }
+
+        $sorted = $versions;
+        sort($sorted, SORT_STRING);
+        self::assertSame($sorted, $versions, 'versions are returned ascending');
+    }
+
+    public function test_returns_an_empty_list_for_a_missing_directory(): void
+    {
+        self::assertSame([], MigrationVersions::fromDirectory('/nonexistent/path'));
+    }
+}

--- a/tests/Http/DatabasePreflightTest.php
+++ b/tests/Http/DatabasePreflightTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\Preflight\CandidateProfile;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+use NeneClear\Database\ApplicationDatabaseIdentity;
+use NeneClear\Database\MigrationVersions;
+use NeneClear\Http\ApplicationFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Candidate-database preflight adoption (issue #183): the opt-in
+ * `POST /machine/database/preflight` inspects an env-declared candidate
+ * read-only and returns a structured verdict.
+ */
+final class DatabasePreflightTest extends TestCase
+{
+    private const MACHINE_KEY = 'test-machine-key';
+
+    private string $candidatePath;
+
+    protected function setUp(): void
+    {
+        $this->candidatePath = tempnam(sys_get_temp_dir(), 'clear-candidate-') . '.sqlite3';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->candidatePath);
+    }
+
+    public function test_preflights_a_fresh_sqlite_candidate(): void
+    {
+        $response = $this->post(['candidate' => 'fresh']);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['reachable'] ?? null);
+        self::assertContains(
+            $data['recommendation'] ?? null,
+            ['safe', 'needs_migration', 'needs_review', 'refuse'],
+        );
+        self::assertSame('fresh', $data['migration_state'] ?? null);
+    }
+
+    public function test_recognizes_a_migrated_clear_database_as_its_own(): void
+    {
+        // Simulate a fully-migrated Clear database: the phinxlog ledger holds
+        // every known migration version and the identity marker is stamped.
+        $pdo = new \PDO('sqlite:' . $this->candidatePath);
+        $pdo->exec('CREATE TABLE phinxlog (version BIGINT NOT NULL, migration_name TEXT, breakpoint INTEGER)');
+        $insert = $pdo->prepare('INSERT INTO phinxlog (version) VALUES (:version)');
+        foreach (MigrationVersions::fromDirectory(dirname(__DIR__, 2) . '/database/migrations') as $version) {
+            $insert->execute([':version' => $version]);
+        }
+        $pdo->exec('CREATE TABLE nene2_app_identity (application_id TEXT NOT NULL, tenant_id TEXT NULL)');
+        $pdo->exec("INSERT INTO nene2_app_identity (application_id, tenant_id) VALUES ('nene-clear', NULL)");
+        unset($pdo);
+
+        $response = $this->post(['candidate' => 'fresh']);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertTrue($data['reachable'] ?? null);
+        self::assertTrue($data['schema_recognized'] ?? null);
+        self::assertSame('compatible', $data['migration_state'] ?? null);
+        self::assertSame('match', $data['app_identity'] ?? null);
+    }
+
+    public function test_rejects_an_unknown_candidate_id(): void
+    {
+        $response = $this->post(['candidate' => 'nope']);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_requires_the_machine_api_key(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('POST', '/machine/database/preflight')
+            ->withHeader('Content-Type', 'application/json');
+        $request->getBody()->write((string) json_encode(['candidate' => 'fresh']));
+
+        $response = $this->app()->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_endpoint_is_absent_without_the_inspector(): void
+    {
+        $app = ApplicationFactory::create(
+            debug: false,
+            allowedOrigins: [],
+            machineApiKey: self::MACHINE_KEY,
+        );
+        $request = (new Psr17Factory())
+            ->createServerRequest('POST', '/machine/database/preflight')
+            ->withHeader('X-NENE2-API-Key', self::MACHINE_KEY)
+            ->withHeader('Content-Type', 'application/json');
+        $request->getBody()->write((string) json_encode(['candidate' => 'fresh']));
+
+        $response = $app->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string, string> $body
+     */
+    private function post(array $body): ResponseInterface
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('POST', '/machine/database/preflight')
+            ->withHeader('X-NENE2-API-Key', self::MACHINE_KEY)
+            ->withHeader('Content-Type', 'application/json');
+        $request->getBody()->write((string) json_encode($body));
+
+        return $this->app()->handle($request);
+    }
+
+    private function app(): RequestHandlerInterface
+    {
+        // Mirrors public_html/index.php: inspector = app migration versions +
+        // identity; candidates resolved only from the application's own config.
+        return ApplicationFactory::create(
+            debug: false,
+            allowedOrigins: [],
+            machineApiKey: self::MACHINE_KEY,
+            databaseCandidateInspector: new DefaultDatabaseCandidateInspector(
+                applicationMigrationVersions: MigrationVersions::fromDirectory(
+                    dirname(__DIR__, 2) . '/database/migrations',
+                ),
+                ledgerTable: 'phinxlog',
+                applicationIdentity: ApplicationDatabaseIdentity::identity(),
+            ),
+            databaseCandidateProfiles: [
+                'fresh' => new CandidateProfile(
+                    id: 'fresh',
+                    connectionFactory: new PdoConnectionFactory(
+                        DatabaseConfig::sqlite($this->candidatePath, 'candidate'),
+                    ),
+                ),
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adopts the NENE2 candidate-database preflight (NENE2#1419 A + #1420 B) — the opt-in `POST /machine/database/preflight` that inspects a candidate database **read-only** and returns a structured verdict before anyone points the app at it.

### Wiring (issue #183 の3点)

1. **Inspector** — `DefaultDatabaseCandidateInspector` on both `RuntimeApplicationFactory` sites:
   - `applicationMigrationVersions`: scanned from `database/migrations` (`MigrationVersions`) — never empty, so `safe` is reachable.
   - `ledgerTable: 'phinxlog'` — ⚠ this app's `default_migration_table` is `phinxlog`, not the inspector's `phinx_log` default; without this the inspector would never recognize a Clear schema.
   - `applicationIdentity`: `ApplicationDatabaseIdentity` (`nene-clear`, tenant **null** — one Clear deployment keeps all organizations in a single database, so the DB lineage is not per-tenant).
2. **Identity marker** — migration `20260703000000_stamp_application_identity` creates/backfills `nene2_app_identity` idempotently (single-row replace). Implemented with plain Phinx ops because `ApplicationIdentityMarker` opens its own transaction, which conflicts with the transaction Phinx already holds (verified by an actual failed run, then a green full migrate on scratch sqlite with the marker row present).
3. **Candidate profiles** — env allowlist `NENE_CLEAR_DB_CANDIDATE_<ID>_{ADAPTER,HOST,PORT,NAME,USER,PASSWORD,CHARSET,MULTI_TENANT}` (`CandidateProfiles::fromEnv`, documented in `.env.example`). Connection details are never read from the request body (SSRF prevention); malformed entries are skipped so boot never fails.

## Acceptance (issue #183)

- ✅ `POST /machine/database/preflight {"candidate":"<id>"}`（machine key auth）→ verdict（`reachable / schema_recognized / migration_state / populated / recommendation / reason_codes / app_identity / tenant`）
- ✅ read-only は機構強制（NENE2 inspector が enforce・SELECT-only credential も `.env.example` で推奨）
- ✅ 未知の candidate id → 422 / key 無し → 401 / inspector 未配線 → 404（opt-in）
- ✅ migrated な Clear DB → `compatible` ＋ `app_identity: match`（テストで検証）

## Tests

- `composer check` green — PHPUnit **352**（342 → +10）, PHPStan L8, PHP-CS-Fixer.
- Full `phinx migrate` verified on a scratch sqlite: all 25 migrations green, marker row `('nene-clear', NULL)` present.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)