### PR TITLE
docs(handoff): add 2026-07-03 session journal + handoff; point current.md at it

### DIFF
--- a/docs/journal/2026-07-03.md
+++ b/docs/journal/2026-07-03.md
@@ -1,0 +1,77 @@
+# Daily log — 2026-07-03
+
+Daily work log for NeNe Clear. English per [ADR 0008](../adr/0008-english-only-repository-documentation.md).
+See also the cycle [handoff](../todo/handoff-2026-07-03.md) and [`current.md`](../todo/current.md).
+
+## Summary
+
+Produced the **screenshots for the Qiita article** (#224 /
+`docs/articles/qiita-payment-reconciliation-dunning.md`): shots **1, 2 and 6**
+of the 7 placeholders, including one retake after an article correction. Built a
+**reusable two-track screenshot pipeline** (terminal-style SVG renders for CLI
+shots; real-browser captures for UI shots) so the remaining shots are cheap to
+take. **No code changes, no PRs** — all deliverables live outside the repo in
+`/home/xi/docker/_work/assets/`.
+
+## Screenshots delivered
+
+| # | Article anchor | File (`_work/assets/`) | How it was made |
+| --- | --- | --- | --- |
+| 1 | §1 Docker services (after the port table) | `qiita-clear-01-docker-services.png` | Recreated `mysql` + `mailpit` containers for a genuine first-run `docker compose up -d` / `docker compose ps` output (both healthy; ports 3383 / 1383 / 8383), re-rendered as a terminal-style SVG → PNG. |
+| 2 | §2 after `curl /health` | `qiita-clear-02-backend-health.png` | Two stacked terminals: dev-server startup + `curl` health JSON. **Retaken** after the article switched to the front-controller command `php -S localhost:8384 -t public_html public_html/index.php`; the retake reflects that router-script mode logs no per-request `[200]` line (verified live). |
+| 6 | §7 dunning | `qiita-clear-06-dunning-ui.png`, `qiita-clear-06-mailpit.png` | Real captures. Dunning page shows 6 open upstream invoices (overdue badges, days elapsed) + send history whose top 3 rows are dunning notices actually sent this session; Mailpit shows the received dunning mail body (real `DunningMessageRenderer` template). Client emails / client names pixelated per the article's masking instruction. |
+
+SVG sources for shots 1–2 sit next to the PNGs so future corrections are
+re-renders, not re-shoots.
+
+## The pipeline (what makes the remaining shots cheap)
+
+- **Terminal shots** — hand-built SVG in the established dark-terminal style,
+  rendered with `rsvg-convert -z 1.5`. Content is always *captured real output*
+  (commands actually run), only re-typeset.
+- **Browser shots** — WSL has no browser, but Windows Chrome is driven headless:
+  single-shot captures via `chrome.exe --headless --screenshot`, scripted flows
+  via **puppeteer-core executed by Windows `node.exe`** (CDP from WSL is blocked:
+  Chrome binds its debug port to Windows loopback only). Auth is injected by
+  minting an HS256 JWT with the dev `NENE_CLEAR_JWT_SECRET` (claims
+  `sub`/`org`/`role`) into `sessionStorage['nene_clear_token']`.
+- **Upstream data** — the dev backend falls back to an *empty*
+  `FakeInvoiceUpstreamClient`, so a ~70-line **stub of the Invoice upstream API**
+  (3 endpoints of `invoice-upstream-contract.md`) now serves 6 open invoices on
+  `127.0.0.1:8390`, consistent with the existing demo data; `.env` temporarily
+  points `NENE_INVOICE_API_BASE_URL` at it. Dunning sends went through the real
+  `POST /admin/dunning-notices` flow (notices #111–#113 + audit events + SMTP →
+  Mailpit).
+- **Masking** — ImageMagick regional pixelation (crop → scale 10% → resize back
+  → composite).
+
+Kit persisted at `_work/assets/nene-clear-screenshot-kit/` (stub + puppeteer
+script); details and revert checklist in the
+[handoff](../todo/handoff-2026-07-03.md).
+
+## Notes / gotchas recorded
+
+- `POST /admin/dunning-notices` reads `getParsedBody()` → send
+  **form-encoded**, not JSON, when driving it with `curl`.
+- `php -S` with a router script does **not** log per-request status lines —
+  screenshot 2's first version (old `-t public_html/` form) showed a green
+  `[200]: GET /health` that the corrected command genuinely does not print.
+- `/health` intentionally has no version field; the installed version is on the
+  auth-gated `GET /machine/health` (#182). The article's plain
+  `{"status":"ok","service":"NENE2"}` is correct.
+- Recreating the Mailpit container wipes its (in-memory) store — done knowingly
+  for shot 1; prior captured mail was disposable.
+
+## Numbers
+
+- Screenshots delivered: **4 PNGs** (article shots 1, 2, 6) + 2 SVG sources.
+- PRs merged: **0** (no repo changes this session).
+
+## Next / open
+
+1. **Remaining article shots 3, 4, 5, 7** (placeholders in the article around
+   lines 222 / 254 / 294 / 392) — the pipeline above covers all of them.
+2. After the last shot: **revert the `.env` upstream vars, stop the stub, clean
+   `C:\Users\Public\claude-shots\`** (checklist in the handoff §3).
+3. Dev work resumes at **installer Slice 3** (unchanged; see
+   [handoff-2026-07-02 §3](../todo/handoff-2026-07-02.md)).

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,13 +2,17 @@
 
 Last updated: 2026-07-03
 
-> **Latest handoff: [`handoff-2026-07-02.md`](handoff-2026-07-02.md)** — this
-> session shipped the bootstrap `create-admin` CLI (#228), a `phinx` `.env` fix
-> (#226), the Qiita article (#224), the **Tier A web-installer PoC** (#232) and
-> its **release-build** (#236), and reconciled the Tier A stance (#234). The
-> installer effort is mid-flight: Slices 1–2 done, **Slice 3 (install.php fetches
-> the release from `nene-origin.dev`) is next** — see the handoff §3. Cross-repo
-> and business context: `_work/discussion-log/2026-07-01.md` (議題2).
+> **Latest handoff: [`handoff-2026-07-03.md`](handoff-2026-07-03.md)** — a
+> screenshot-production session for the Qiita article (#224): shots 1, 2, 6
+> done (assets + reusable pipeline in `_work/assets/`), **shots 3, 4, 5, 7
+> remaining**, and the local env is deliberately non-default (upstream stub on
+> 8390 + `.env` pointing at it — **read the handoff §3 revert checklist before
+> running backend tests**). No code changes. Dev work still resumes at
+> **installer Slice 3 (install.php fetches the release from `nene-origin.dev`)**
+> — actionable spec in [handoff-2026-07-02 §3](handoff-2026-07-02.md); that
+> session shipped `create-admin` (#228), the phinx `.env` fix (#226), the
+> installer PoC (#232), the release build (#236) and the Tier A stance (#234).
+> Cross-repo / business context: `_work/discussion-log/2026-07-01.md` (議題2).
 
 ## Status
 

--- a/docs/todo/handoff-2026-07-03.md
+++ b/docs/todo/handoff-2026-07-03.md
@@ -1,0 +1,104 @@
+# Handoff — NeNe Clear (2026-07-03)
+
+Snapshot of a **Qiita-article screenshot production** session. **Nothing was
+merged; no repo code changed.** Pairs with [`current.md`](current.md), the
+[daily log](../journal/2026-07-03.md), and the prior
+[handoff-2026-07-02](handoff-2026-07-02.md) — whose next dev step (**installer
+Slice 3**) is untouched and still the next coding task.
+
+> ⚠️ **This session left the local environment in a deliberate non-default
+> state** so the remaining screenshots are cheap to take. Read §3 (revert
+> checklist) before running backend tests or resuming dev work.
+
+---
+
+## 1. Screenshot status (article `docs/articles/qiita-payment-reconciliation-dunning.md`)
+
+| Shot | Anchor | Status | Asset (`/home/xi/docker/_work/assets/`) |
+| --- | --- | --- | --- |
+| 1 | §1 Docker services | ✅ done | `qiita-clear-01-docker-services.png` (+ `.svg` source) |
+| 2 | §2 backend + `/health` | ✅ done (retaken for the front-controller command) | `qiita-clear-02-backend-health.png` (+ `.svg` source) |
+| 3 | ~line 222 | ⬜ TODO | — |
+| 4 | ~line 254 | ⬜ TODO | — |
+| 5 | ~line 294 | ⬜ TODO | — |
+| 6 | §7 dunning + Mailpit | ✅ done | `qiita-clear-06-dunning-ui.png`, `qiita-clear-06-mailpit.png` |
+| 7 | ~line 392 (optional) | ⬜ TODO | — |
+
+Specs for each remaining shot are HTML comments in the article itself
+(`スクリーンショット N（必須）`). The article text is the source of truth for
+commands — shot 2 was retaken because the body switched to
+`php -S localhost:8384 -t public_html public_html/index.php`.
+
+Masking rule used for shot 6 (keep for the rest): pixelate client emails and
+client names; the product's own `noreply@nene-clear.dev` stays visible.
+
+---
+
+## 2. The screenshot pipeline (reuse it for shots 3–5, 7)
+
+Kit: **`/home/xi/docker/_work/assets/nene-clear-screenshot-kit/`**
+(`invoice-upstream-stub.php`, `shot-dunning.js`).
+
+**a. Terminal-style shots (1, 2).** Run the real command, capture output, then
+typeset it into the dark-terminal SVG template (copy
+`qiita-clear-02-backend-health.svg`; palette: bg `#0a0e14`, window `#10151d`,
+prompt path `#6cb6ff`, `$`/success `#3fb950`, text `#c9d1d9`, dim `#8b949e`;
+DejaVu Sans Mono 22px, 36px line height, char width 13.245px). Render:
+`rsvg-convert -z 1.5 -o out.png in.svg`.
+
+**b. Browser shots (UI / Mailpit).** WSL has no browser; use Windows Chrome:
+
+- One-shot: `"/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+  --headless --disable-gpu --window-size=1600,1000 --hide-scrollbars
+  --virtual-time-budget=6000 --screenshot='C:\Users\Public\claude-shots\x.png' <URL>`
+  (Windows reaches WSL services on `localhost`).
+- Scripted (login, waits, DPR 1.5): edit `shot-dunning.js` (already deployed at
+  `C:\Users\Public\claude-shots\drive\` with `node_modules`) and run
+  `cd /mnt/c/Users/Public/claude-shots/drive && "/mnt/c/Program Files/nodejs/node.exe" shot-dunning.js`.
+  Do **not** try CDP from WSL — Chrome binds the debug port to Windows loopback
+  only (NAT-mode WSL cannot reach it); running node on Windows is the workaround.
+
+**c. Auth.** Mint an HS256 JWT with `NENE_CLEAR_JWT_SECRET` from `.env`, claims
+`{sub: 20, org: 0, role: "admin", iat, exp}` (user 20 = `tanaka@demo.example`),
+e.g. via `php -r` + `Firebase\JWT\JWT::encode` with the repo's vendor autoload.
+Frontend session: `sessionStorage['nene_clear_token'] = <jwt>` then full reload
+(see `shot-dunning.js`). The same bearer works for `curl` against `/admin/*`.
+
+**d. Upstream demo data.** The stub serves invoices 2056–2061 / clients 156–161
+(consistent with the seeded demo DB). Restart if dead:
+`php -S 127.0.0.1:8390 /home/xi/docker/_work/assets/nene-clear-screenshot-kit/invoice-upstream-stub.php &`
+
+**e. API-driven actions.** Dunning send: `curl -H "Authorization: Bearer $T"
+-d 'invoice_id=2056&stage=initial' http://localhost:8384/admin/dunning-notices`
+— **form-encoded, not JSON** (`getParsedBody()`).
+
+**f. Masking.** ImageMagick pixelation per region:
+`convert in.png \( +clone -crop WxH+X+Y +repage -scale 10% -resize 'WxH!' \) -geometry +X+Y -composite out.png`.
+
+---
+
+## 3. Environment state / revert checklist
+
+Current (verified 2026-07-03): backend `php -S` on **8384**, Vite on **5383**,
+Docker `nene-clear-db` + `nene-clear-mail` healthy, upstream stub on **8390**,
+Mailpit holding the 3 dunning mails.
+
+| What | State | Action when screenshots are done |
+| --- | --- | --- |
+| `.env` (gitignored) | `NENE_INVOICE_API_BASE_URL=http://127.0.0.1:8390`, `NENE_INVOICE_BEARER_TOKEN=dev-stub` | **Set both back to empty.** ⚠️ While set, the 6 skipped Invoice **contract tests auto-activate** and would run against the stub — unset before `composer check`. App-wise, reverting is safe (empty vars → fake client; degraded mode is handled). |
+| Upstream stub (8390) | running (session-started `php -S`) | Kill it (`ps aux | grep 8390`). Kit copy persists for restarts. |
+| Dev DB (`database/nene_clear.sqlite3`) | +3 dunning notices (#111–#113, sent_by 20) + audit events | Keep — coherent demo data. |
+| Mailpit store | wiped 2026-07-03 (container recreate for shot 1), now 3 dunning mails | Keep until shots done; disposable. |
+| `C:\Users\Public\claude-shots\` | puppeteer drive dir, headless profile, raw/unmasked PNGs | Delete the whole folder when done (raw PNGs contain unmasked demo emails). |
+
+---
+
+## 4. Next
+
+1. Take **shots 3, 4, 5, 7** with §2's pipeline (specs = article comments).
+2. Run §3's revert checklist; then publish the article with assets from
+   `_work/assets/`.
+3. Resume dev at **installer Slice 3** — actionable spec in
+   [handoff-2026-07-02 §3](handoff-2026-07-02.md): install.php acquires the
+   release ZIP from `nene-origin.dev` (`NENE_ORIGIN_URL`), sha256-verify, safe
+   extract.


### PR DESCRIPTION
## Summary

- `docs/journal/2026-07-03.md` — daily log for the Qiita article (#224) screenshot session: shots 1, 2, 6 delivered (assets in the workspace `_work/assets/`), reusable two-track screenshot pipeline, recorded gotchas.
- `docs/todo/handoff-2026-07-03.md` — handoff: remaining shots 3/4/5/7 with reuse instructions, and the **environment revert checklist** (Invoice-upstream stub on 8390 + temporary `.env` vars — unset before `composer check`, since the 6 skipped contract tests auto-activate).
- `docs/todo/current.md` — latest-handoff banner now points at 2026-07-03; installer Slice 3 remains the next dev step.

Docs only; no code changes.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)