### PR TITLE
fix(observability): wire PSR-3/Monolog logging into ApplicationFactory

### DIFF
--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -17,6 +17,8 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Http\UtcClock;
+use Nene2\Log\MonologLoggerFactory;
+use Nene2\Log\RequestIdHolder;
 use NeneClear\Auth\AuthServiceProvider;
 use NeneClear\Auth\JwtTokenService;
 use NeneClear\Auth\MfaChallengeTokens;
@@ -40,6 +42,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Builds the NeNe Clear HTTP application on top of the NENE2 runtime.
@@ -50,6 +53,12 @@ use Psr\Http\Server\RequestHandlerInterface;
  * via {@see ApplicationServiceProvider}. This factory only assembles the
  * container and hands the resolved route registrars, exception handlers and
  * auth middleware to {@see RuntimeApplicationFactory}.
+ *
+ * A {@see MonologLoggerFactory}-built PSR-3 logger (channel `nene-clear`, JSON to
+ * `php://stderr`, correlated to the request via {@see RequestIdHolder}) is always
+ * passed to {@see RuntimeApplicationFactory}, in both the health-only and the full
+ * branch below — without it the framework silently falls back to `NullLogger` and
+ * `RequestLoggingMiddleware`/`ErrorHandlerMiddleware` discard everything.
  *
  * The framework baseline pipeline (error handling, request id, security headers,
  * CORS, request size limit) and the built-in `/health` route are always present.
@@ -97,6 +106,8 @@ final class ApplicationFactory
         array $databaseCandidateProfiles = [],
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
+        $requestIdHolder = new RequestIdHolder();
+        $logger = (new MonologLoggerFactory())->create('nene-clear', $debug, $requestIdHolder);
 
         // Public/health-only surface: no database or JWT secret → no admin routes.
         // The machine surface stays available so deployment tooling can read the
@@ -105,7 +116,9 @@ final class ApplicationFactory
             return (new RuntimeApplicationFactory(
                 responseFactory: $psr17,
                 streamFactory: $psr17,
+                logger: $logger,
                 machineApiKey: $machineApiKey,
+                requestIdHolder: $requestIdHolder,
                 debug: $debug,
                 allowedOrigins: $allowedOrigins,
                 appVersion: $appVersion,
@@ -130,6 +143,8 @@ final class ApplicationFactory
             $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
             $appBaseUrl,
             $encryptionKey,
+            $logger,
+            $requestIdHolder,
         );
 
         $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
@@ -147,8 +162,10 @@ final class ApplicationFactory
         return (new RuntimeApplicationFactory(
             responseFactory: $psr17,
             streamFactory: $psr17,
+            logger: $logger,
             machineApiKey: $machineApiKey,
             domainExceptionHandlers: $exceptionHandlers,
+            requestIdHolder: $requestIdHolder,
             routeRegistrars: $routeRegistrars,
             authMiddleware: $authMiddleware,
             debug: $debug,
@@ -184,7 +201,11 @@ final class ApplicationFactory
         string $appBaseUrl = '',
         ?InvitationMailerInterface $invitationMailer = null,
         string $encryptionKey = '',
+        bool $debug = false,
     ): ContainerInterface {
+        $requestIdHolder = new RequestIdHolder();
+        $logger = (new MonologLoggerFactory())->create('nene-clear', $debug, $requestIdHolder);
+
         return self::buildContainer(
             $query,
             $transactionManager,
@@ -195,6 +216,8 @@ final class ApplicationFactory
             $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
             $appBaseUrl,
             $encryptionKey,
+            $logger,
+            $requestIdHolder,
         );
     }
 
@@ -211,11 +234,15 @@ final class ApplicationFactory
         InvitationMailerInterface $invitationMailer,
         string $appBaseUrl,
         string $encryptionKey,
+        LoggerInterface $logger,
+        RequestIdHolder $requestIdHolder,
     ): ContainerInterface {
         $langDir = dirname(__DIR__, 2) . '/lang';
 
         return (new ContainerBuilder())
             ->set(Psr17Factory::class, static fn (ContainerInterface $c): Psr17Factory => $psr17)
+            ->set(LoggerInterface::class, static fn (ContainerInterface $c): LoggerInterface => $logger)
+            ->set(RequestIdHolder::class, static fn (ContainerInterface $c): RequestIdHolder => $requestIdHolder)
             ->set(ResponseFactoryInterface::class, static fn (ContainerInterface $c): ResponseFactoryInterface => $psr17)
             ->set(StreamFactoryInterface::class, static fn (ContainerInterface $c): StreamFactoryInterface => $psr17)
             ->set(JsonResponseFactory::class, static fn (ContainerInterface $c): JsonResponseFactory => new JsonResponseFactory($psr17, $psr17))


### PR DESCRIPTION
## Why

`src/Http/ApplicationFactory.php` never built or passed a `Psr\Log\LoggerInterface`/`RequestIdHolder` to `Nene2\Http\RuntimeApplicationFactory` — neither in the health-only early-return branch nor the full authenticated branch. `RuntimeApplicationFactory` defaults to `NullLogger` when no logger is supplied, so `RequestLoggingMiddleware` and `ErrorHandlerMiddleware` silently discarded everything (request summaries, unhandled exceptions). The only real logging in the codebase was `error_log()` inside `LogOnlyDunningMailer`/`LogOnlyInvitationMailer` — mailer fallback UX, not a general logging path.

Closes #244

## What changed

`src/Http/ApplicationFactory.php` only:
- Build one `RequestIdHolder` + one `LoggerInterface` (`Nene2\Log\MonologLoggerFactory`, channel `nene-clear`, JSON to `php://stderr`, `Level::Debug` when `APP_DEBUG=true` else `Level::Warning`) per `create()`/`container()` call.
- Pass `logger:`/`requestIdHolder:` into **both** `RuntimeApplicationFactory` constructions (health-only and full).
- Register `LoggerInterface::class`/`RequestIdHolder::class` as container services in `buildContainer()` (also exposed via the public `container()` entry point used by `tools/create-admin.php` / `public_html/install.php`, which gained an optional `bool $debug = false` param, backward compatible).

Mirrors the existing `nene-records`/`nene-vault` `RuntimeServiceProvider` pattern verbatim. No new logging call sites were added to domain code — this only connects the existing framework pipeline, which already redacts secrets/Authorization/cookies/raw body by construction (`RequestLoggingMiddleware` logs only method/path/status/duration/request_id; `ErrorHandlerMiddleware` logs only exception class + location + request_id, full exception only in debug mode).

`LogOnlyDunningMailer`/`LogOnlyInvitationMailer` `error_log()` calls are untouched (out of scope — mail UX, not the logging path).

## Verification

- `composer check` green: PHPUnit 352 tests / 1297 assertions OK (pre-existing 7 deprecations, 6 skips, unrelated to this change), PHPStan level clean, CS Fixer clean.
- Manually booted the app (`php -S … public_html/index.php`) with `APP_DEBUG=true` and hit `GET /health` and an unmatched path. Confirmed real JSON logs now land on stderr, correlated to the response's `X-Request-Id`, with no secrets/body/Authorization present:

```json
{"message":"HTTP request handled.","context":{"request_id":"47560c...","method":"GET","path":"/health","status":200,"duration_ms":0.354},"level":200,"level_name":"INFO","channel":"nene-clear", ...,"extra":{"request_id":"47560c..."}}
```

The `request_id` in the log line matches the `X-Request-Id` response header exactly.

## Self-review

Self-review: backend-api, middleware-security

## Remaining risk

None identified — additive wiring only, no behavior change to responses/routes; `container()`'s new `$debug` param is optional/trailing so existing callers (`tools/create-admin.php`, `public_html/install.php`) are unaffected (they simply keep getting `Level::Warning`-only logging until/if they're updated to pass debug too, which is out of scope here).