### PR TITLE
fix(observability): LogOnly メーラーの error_log を PSR-3 経由に置換 (#248)

### DIFF
--- a/src/Dunning/LogOnlyDunningMailer.php
+++ b/src/Dunning/LogOnlyDunningMailer.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace NeneClear\Dunning;
 
+use Psr\Log\LoggerInterface;
+
+/**
+ * Fallback mailer used when no SMTP host is configured. The dunning notice is
+ * written to the PSR-3 logger so the flow is exercisable in dev without an SMTP
+ * server, correlated to the request like every other framework log record.
+ */
 final readonly class LogOnlyDunningMailer implements DunningMailerInterface
 {
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
     public function channel(): string
     {
         return 'log';
@@ -13,13 +24,12 @@ final readonly class LogOnlyDunningMailer implements DunningMailerInterface
 
     public function send(DunningMailPayload $payload): void
     {
-        error_log(sprintf(
-            '[DunningNotice #%d] org=%d invoice=%d to=%s subject=%s',
-            $payload->dunningNoticeId,
-            $payload->organizationId,
-            $payload->invoiceId,
-            $payload->to,
-            $payload->subject,
-        ));
+        $this->logger->info('Dunning notice delivered to the log channel (no SMTP configured).', [
+            'dunningNoticeId' => $payload->dunningNoticeId,
+            'organizationId' => $payload->organizationId,
+            'invoiceId' => $payload->invoiceId,
+            'to' => $payload->to,
+            'subject' => $payload->subject,
+        ]);
     }
 }

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -139,8 +139,8 @@ final class ApplicationFactory
             $jwtSecret,
             $psr17,
             self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
-            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
-            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName, $logger),
+            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName, $logger),
             $appBaseUrl,
             $encryptionKey,
             $logger,
@@ -212,8 +212,8 @@ final class ApplicationFactory
             $jwtSecret,
             new Psr17Factory(),
             self::resolveInvoiceClient($invoiceClient, $invoiceApiBaseUrl, $invoiceBearerToken),
-            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
-            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName),
+            self::resolveMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName, $logger),
+            $invitationMailer ?? self::resolveInvitationMailer($smtpHost, $smtpPort, $smtpUsername, $smtpPassword, $smtpFromAddress, $smtpFromName, $logger),
             $appBaseUrl,
             $encryptionKey,
             $logger,
@@ -301,12 +301,13 @@ final class ApplicationFactory
         string $smtpPassword,
         string $smtpFromAddress,
         string $smtpFromName,
+        LoggerInterface $logger,
     ): DunningMailerInterface {
         if ($smtpHost !== null && $smtpHost !== '') {
             return new SmtpDunningMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword);
         }
 
-        return new LogOnlyDunningMailer();
+        return new LogOnlyDunningMailer($logger);
     }
 
     private static function resolveInvitationMailer(
@@ -316,11 +317,12 @@ final class ApplicationFactory
         string $smtpPassword,
         string $smtpFromAddress,
         string $smtpFromName,
+        LoggerInterface $logger,
     ): InvitationMailerInterface {
         if ($smtpHost !== null && $smtpHost !== '') {
             return new SmtpInvitationMailer($smtpHost, $smtpPort, $smtpFromAddress, $smtpFromName, $smtpUsername, $smtpPassword);
         }
 
-        return new LogOnlyInvitationMailer();
+        return new LogOnlyInvitationMailer($logger);
     }
 }

--- a/src/User/LogOnlyInvitationMailer.php
+++ b/src/User/LogOnlyInvitationMailer.php
@@ -4,22 +4,27 @@ declare(strict_types=1);
 
 namespace NeneClear\User;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Fallback mailer used when no SMTP host is configured. The invitation link is
- * written to the error log so the onboarding flow is exercisable in dev
+ * written to the PSR-3 logger so the onboarding flow is exercisable in dev
  * (and visible in Mailpit once SMTP is configured).
  */
 final readonly class LogOnlyInvitationMailer implements InvitationMailerInterface
 {
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
     public function send(InvitationMailPayload $payload): void
     {
-        error_log(sprintf(
-            '[UserInvitation user=%d org=%s] to=%s subject=%s body=%s',
-            $payload->userId,
-            $payload->organizationId ?? 'null',
-            $payload->to,
-            $payload->subject,
-            $payload->body,
-        ));
+        $this->logger->info('User invitation delivered to the log channel (no SMTP configured).', [
+            'userId' => $payload->userId,
+            'organizationId' => $payload->organizationId,
+            'to' => $payload->to,
+            'subject' => $payload->subject,
+            'body' => $payload->body,
+        ]);
     }
 }


### PR DESCRIPTION
## 目的

PSR-3/Monolog ロガーは #244/#245 で `ApplicationFactory` に配線済みだが、SMTP 未設定時のフォールバックメーラー 2 本が引き続き `error_log()` を直呼びしており、フレームワークのログ経路（構造化 JSON・チャンネル `nene-clear`・request-id 相関・秘匿情報の redaction）を素通りしていた。2026-07-05 NENE2 バックエンド監査（nene-clear「Logging PSR-3 非配線」）由来。

## 変更

- `LogOnlyDunningMailer` / `LogOnlyInvitationMailer` に `Psr\Log\LoggerInterface` をコンストラクタ注入（nene-records `AccessLogMiddleware` と同じ注入パターン）。
- `error_log(sprintf(...))` を `$this->logger->info(message, context)` に置換（**2 箇所**）。ペイロード各フィールドを構造化 context として出力。
- `ApplicationFactory::resolveMailer` / `resolveInvitationMailer` にコンテナの logger を引き回し。

## 揃えた sibling パターン

nene-records `src/Analytics/AccessLogMiddleware.php`（`LoggerInterface` コンストラクタ注入 + `$this->logger->...(message, context)`）。ログ出力先・フォーマット・レベル制御は `Nene2\Log\MonologLoggerFactory`（channel `nene-clear`・JSON to `php://stderr`・`APP_DEBUG` で Debug/Warning）に一元化済みで、独自方式は追加していない。

## 追加 env

なし。ログレベルは既存の `APP_DEBUG`（`.env.example` 記載済み）駆動。LogOnly は SMTP 未設定の dev 経路のため `info` で可視。

## 検証

- `composer test`: 352 passed（緑・deprecations/skipped は既存）。
- `php -l`: 変更 3 ファイル構文エラーなし。
- スモーク: `LogOnlyDunningMailer` を実 Monolog logger で send → stderr に構造化 JSON INFO レコードが出ることを確認。

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)