### PR TITLE
fix(install): .env を EnvironmentWriter で 0640・値エスケープして書き込む (#250)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -27,6 +27,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
+use Nene2\Install\EnvironmentWriter;
 use NeneClear\Auth\Role;
 use NeneClear\Database\AdapterAwareQueryExecutor;
 use NeneClear\Database\AdapterAwareTransactionManager;
@@ -205,7 +206,7 @@ function run_install(string $root, string $envFile, string $marker): void
     migrate($root, $adapter, $db, $sqlitePath);
 
     // 2) Persist config so the app connects to the same database.
-    $jwtSecret = bin2hex(random_bytes(32));
+    $jwtSecret = EnvironmentWriter::generateSecret(32);
     write_env($envFile, $adapter, $db, $sqlitePath, $jwtSecret);
 
     // 3) Create the first organization + admin via the app's own use cases.
@@ -249,27 +250,28 @@ function migrate(string $root, string $adapter, array $db, string $sqlitePath): 
  */
 function write_env(string $envFile, string $adapter, array $db, string $sqlitePath, string $jwtSecret): void
 {
-    $lines = [
-        'APP_ENV=production',
-        'APP_DEBUG=false',
-        'DB_ADAPTER=' . $adapter,
+    // .env は toolkit の EnvironmentWriter で原子書き込みする（chmod 0640 で fail-closed・
+    // 値を \\ " $ escape・改行/NUL 拒否）。従来の生連結 + rename と違い、DB パスワードに
+    // " $ # 空白・改行が含まれても .env が壊れず、同ホスト全ユーザからの読み取り（穴 #1）と
+    // .env インジェクション（穴 #2）を塞ぐ。KEY 順序と名前は既存のまま維持する。
+    $values = [
+        'APP_ENV' => 'production',
+        'APP_DEBUG' => 'false',
+        'DB_ADAPTER' => $adapter,
     ];
     if ($adapter === 'mysql') {
-        $lines[] = 'DB_HOST=' . (string) $db['host'];
-        $lines[] = 'DB_PORT=' . (string) $db['port'];
-        $lines[] = 'DB_NAME=' . (string) $db['name'];
-        $lines[] = 'DB_USER=' . (string) $db['user'];
-        $lines[] = 'DB_PASSWORD=' . (string) $db['pass'];
-        $lines[] = 'DB_CHARSET=utf8mb4';
+        $values['DB_HOST'] = (string) $db['host'];
+        $values['DB_PORT'] = (string) $db['port'];
+        $values['DB_NAME'] = (string) $db['name'];
+        $values['DB_USER'] = (string) $db['user'];
+        $values['DB_PASSWORD'] = (string) $db['pass'];
+        $values['DB_CHARSET'] = 'utf8mb4';
     } else {
-        $lines[] = 'DB_NAME=' . $sqlitePath;
+        $values['DB_NAME'] = $sqlitePath;
     }
-    $lines[] = 'NENE_CLEAR_JWT_SECRET=' . $jwtSecret;
+    $values['NENE_CLEAR_JWT_SECRET'] = $jwtSecret;
 
-    $tmp = $envFile . '.tmp';
-    if (file_put_contents($tmp, implode("\n", $lines) . "\n") === false || !rename($tmp, $envFile)) {
-        throw new RuntimeException('.env の書き込みに失敗しました。パーミッションを確認してください。');
-    }
+    (new EnvironmentWriter())->write($envFile, $values);
 }
 
 /**

--- a/tests/Install/EnvFileWriteSecurityTest.php
+++ b/tests/Install/EnvFileWriteSecurityTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Install;
+
+use Nene2\Install\EnvironmentWriter;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Guards the security properties the installer relies on when it persists `.env`
+ * (public_html/install.php → write_env → EnvironmentWriter): the file must never be
+ * world-readable and hostile values (`$`, quotes, spaces) must survive a phpdotenv
+ * round-trip without breaking the file or injecting extra lines.
+ *
+ * Mirrors the ordered key map clear's installer writes so a regression in the map or
+ * a drift back to a raw `file_put_contents` writer is caught here rather than in prod.
+ */
+final class EnvFileWriteSecurityTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/nene-clear-env-' . bin2hex(random_bytes(6));
+
+        if (!mkdir($this->dir, 0770, true) && !is_dir($this->dir)) {
+            self::fail('could not create the temp directory for the test');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $env = $this->dir . '/.env';
+
+        if (is_file($env)) {
+            @unlink($env);
+        }
+
+        @rmdir($this->dir);
+    }
+
+    /**
+     * The clear installer's mysql env map, mirroring write_env() key order.
+     *
+     * @return array<string, string>
+     */
+    private static function clearMysqlEnv(string $dbPassword, string $jwtSecret): array
+    {
+        return [
+            'APP_ENV' => 'production',
+            'APP_DEBUG' => 'false',
+            'DB_ADAPTER' => 'mysql',
+            'DB_HOST' => '127.0.0.1',
+            'DB_PORT' => '3306',
+            'DB_NAME' => 'nene_clear',
+            'DB_USER' => 'nene_clear',
+            'DB_PASSWORD' => $dbPassword,
+            'DB_CHARSET' => 'utf8mb4',
+            'NENE_CLEAR_JWT_SECRET' => $jwtSecret,
+        ];
+    }
+
+    public function testEnvFileIsNotWorldReadable(): void
+    {
+        $path = $this->dir . '/.env';
+
+        (new EnvironmentWriter())->write(
+            $path,
+            self::clearMysqlEnv('plain-password', EnvironmentWriter::generateSecret(32)),
+        );
+
+        self::assertFileExists($path);
+
+        $perms = fileperms($path);
+        self::assertNotFalse($perms);
+        // No permission bits for "other"; 0640 is what EnvironmentWriter targets.
+        self::assertSame(0, $perms & 0007, sprintf('.env is world-accessible: %o', $perms & 0777));
+        self::assertSame(0640, $perms & 0777, sprintf('.env mode is %o, expected 0640', $perms & 0777));
+    }
+
+    public function testHostilePasswordIsEscapedAndSurvivesRoundTrip(): void
+    {
+        $path = $this->dir . '/.env';
+        // Contains the three characters phpdotenv treats specially inside quotes ($, ", \),
+        // plus a space, a '#' and a `${...}` expansion attempt.
+        $password = 'a b"c$d\\e#f${DB_USER}';
+
+        (new EnvironmentWriter())->write(
+            $path,
+            self::clearMysqlEnv($password, EnvironmentWriter::generateSecret(32)),
+        );
+
+        $contents = (string) file_get_contents($path);
+
+        // The raw password must not appear unescaped, and its `$` must be backslash-escaped
+        // so phpdotenv does not expand ${DB_USER} into the value.
+        self::assertStringContainsString('DB_PASSWORD="', $contents);
+        self::assertStringContainsString('\\$', $contents);
+        self::assertStringNotContainsString('DB_PASSWORD=a b"c$d', $contents);
+
+        // Round-trip through the same loader the app uses (phpdotenv) to confirm the value
+        // is read back verbatim with no injected lines.
+        $env = \Dotenv\Dotenv::parse($contents);
+        self::assertSame($password, $env['DB_PASSWORD'] ?? null);
+        self::assertSame('nene_clear', $env['DB_USER'] ?? null);
+        self::assertArrayHasKey('NENE_CLEAR_JWT_SECRET', $env);
+        // Exactly the 10 keys we wrote — no extra lines injected via the value.
+        self::assertCount(10, $env);
+    }
+
+    public function testNewlineInValueIsRefused(): void
+    {
+        $path = $this->dir . '/.env';
+
+        $this->expectException(RuntimeException::class);
+
+        (new EnvironmentWriter())->write(
+            $path,
+            self::clearMysqlEnv("secret\nADMIN_OVERRIDE=1", EnvironmentWriter::generateSecret(32)),
+        );
+    }
+}


### PR DESCRIPTION
## 目的

Closes #250

検品 C レーン先行セキュリティ **S3**。上流化設計 `_work/reports/2026-07-06/upstream-design/08-installer.md`（監査 #21）が指摘した、clear の自前 `.env` 書き込みのセキュリティ穴 #1・#2 を塞ぐ。

## 背景（自前 .env 書き込みの実箇所）

`public_html/install.php` の `write_env()`（旧 `:250-273`）:

- `.env` を **world-readable のまま** `file_put_contents` + `rename`（`chmod` なし）
- 値を無加工で `KEY=value` 連結（エスケープ・改行/NUL 拒否なし）

→ DB パスワード・JWT secret が同ホスト全ユーザから読める（穴 #1）／値に改行が入れば別行注入・`$` は phpdotenv 変数展開で破損/漏洩（穴 #2）。

## 変更点

invoice `public_html/install.php`（フル配線の参照形・`EnvironmentWriter::write` + `generateSecret(32)`）に厳密に揃え、NENE2 `Nene2\Install\EnvironmentWriter` を採用:

- `write_env()` を EnvironmentWriter への薄いオーケストレーションに置換。順序付き `KEY => value` map を製品側で構築（**既存キー名・順序・hex32 secret 形式を維持**＝後方互換）。
- `chmod 0640` に落とせなければ **書き込み拒否**（fail-closed）・値の `\ " $` エスケープ・改行/NUL 拒否・atomic write。
- jwt secret を `EnvironmentWriter::generateSecret(32)` に統一（従来の `bin2hex(random_bytes(32))` と同形式）。

migrate・要件チェック・org/admin 作成・再設置ガードの載せ替えは範囲外（P2、08-installer.md §7）。

## 検証結果

- 新規 `tests/Install/EnvFileWriteSecurityTest.php`（3 tests / 12 assertions・緑）:
  - `.env` mode が **0640**（other ビット 0）
  - `$`/`"`/`\`/空白/`${DB_USER}` を含むパスワードがエスケープされ、phpdotenv `Dotenv::parse` の round-trip で復元・**注入行なし（key 数 10 で固定）**
  - 値に改行が入ると `RuntimeException`
- 実出力: `mode=640` / `DB_PASSWORD="a b\"c\$d\\e#f\${DB_USER}"`
- `composer test` 355 tests OK（既存 deprecation/skip のみ）・`composer analyse` No errors・`composer cs` clean
- `php -l` 変更 2 ファイル OK

Self-review: backend-api, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)