### PR TITLE
feat(export): CSV 出力を Nene2\Export\CsvWriter へ一元化し formula injection を閉塞する

### DIFF
--- a/src/Export/ExportBankTransactionsCsvHandler.php
+++ b/src/Export/ExportBankTransactionsCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Export;
 
+use Nene2\Export\CsvWriter;
 use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\BankTransactionFilter;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
@@ -46,28 +47,28 @@ final readonly class ExportBankTransactionsCsvHandler
             $offset += self::BATCH;
         } while (count($batch) === self::BATCH);
 
-        $csv = $this->buildCsv(
-            ['bank_transaction_id', 'bank_import_batch_id', 'value_date', 'amount_cents',
-                'counterparty_text', 'status', 'line_key'],
-            $rows,
+        return $this->csvResponse(
+            $this->render(
+                ['bank_transaction_id', 'bank_import_batch_id', 'value_date', 'amount_cents',
+                    'counterparty_text', 'status', 'line_key'],
+                $rows,
+            ),
+            'bank-transactions.csv',
         );
-
-        return $this->csvResponse($csv, 'bank-transactions.csv');
     }
 
     /**
+     * Renders rows to a CSV string via the framework writer, which neutralises
+     * formula injection in string cells and prepends a UTF-8 BOM by default.
+     *
      * @param list<string> $headers
-     * @param list<list<mixed>> $rows
+     * @param iterable<list<string|int|float|bool|null>> $rows
      */
-    private function buildCsv(array $headers, array $rows): string
+    private function render(array $headers, iterable $rows): string
     {
         $handle = fopen('php://temp', 'r+');
         assert($handle !== false);
-        fwrite($handle, "\xEF\xBB\xBF");
-        fputcsv($handle, $headers);
-        foreach ($rows as $row) {
-            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
-        }
+        (new CsvWriter($handle, $headers))->writeAll($rows);
         rewind($handle);
         $content = stream_get_contents($handle);
         fclose($handle);

--- a/src/Export/ExportClientCreditsCsvHandler.php
+++ b/src/Export/ExportClientCreditsCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Export;
 
+use Nene2\Export\CsvWriter;
 use NeneClear\Auth\AuthContext;
 use NeneClear\Reconciliation\ClientCreditFilter;
 use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
@@ -48,28 +49,28 @@ final readonly class ExportClientCreditsCsvHandler
             $offset += self::BATCH;
         } while (count($batch) === self::BATCH);
 
-        $csv = $this->buildCsv(
-            ['client_credit_id', 'client_id', 'status', 'amount_cents', 'remaining_cents',
-                'source_bank_transaction_id', 'reconciliation_id', 'created_at', 'created_by'],
-            $rows,
+        return $this->csvResponse(
+            $this->render(
+                ['client_credit_id', 'client_id', 'status', 'amount_cents', 'remaining_cents',
+                    'source_bank_transaction_id', 'reconciliation_id', 'created_at', 'created_by'],
+                $rows,
+            ),
+            'client-credits.csv',
         );
-
-        return $this->csvResponse($csv, 'client-credits.csv');
     }
 
     /**
+     * Renders rows to a CSV string via the framework writer, which neutralises
+     * formula injection in string cells and prepends a UTF-8 BOM by default.
+     *
      * @param list<string> $headers
-     * @param list<list<mixed>> $rows
+     * @param iterable<list<string|int|float|bool|null>> $rows
      */
-    private function buildCsv(array $headers, array $rows): string
+    private function render(array $headers, iterable $rows): string
     {
         $handle = fopen('php://temp', 'r+');
         assert($handle !== false);
-        fwrite($handle, "\xEF\xBB\xBF");
-        fputcsv($handle, $headers);
-        foreach ($rows as $row) {
-            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
-        }
+        (new CsvWriter($handle, $headers))->writeAll($rows);
         rewind($handle);
         $content = stream_get_contents($handle);
         fclose($handle);

--- a/src/Export/ExportDunningNoticesCsvHandler.php
+++ b/src/Export/ExportDunningNoticesCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Export;
 
+use Nene2\Export\CsvWriter;
 use NeneClear\Auth\AuthContext;
 use NeneClear\Dunning\DunningNoticeFilter;
 use NeneClear\Dunning\DunningNoticeRepositoryInterface;
@@ -50,28 +51,28 @@ final readonly class ExportDunningNoticesCsvHandler
             $offset += self::BATCH;
         } while (count($batch) === self::BATCH);
 
-        $csv = $this->buildCsv(
-            ['dunning_notice_id', 'invoice_id', 'invoice_number', 'client_id', 'recipient_email',
-                'outstanding_at_send_cents', 'due_at', 'channel', 'template_version', 'sent_by', 'sent_at'],
-            $rows,
+        return $this->csvResponse(
+            $this->render(
+                ['dunning_notice_id', 'invoice_id', 'invoice_number', 'client_id', 'recipient_email',
+                    'outstanding_at_send_cents', 'due_at', 'channel', 'template_version', 'sent_by', 'sent_at'],
+                $rows,
+            ),
+            'dunning-notices.csv',
         );
-
-        return $this->csvResponse($csv, 'dunning-notices.csv');
     }
 
     /**
+     * Renders rows to a CSV string via the framework writer, which neutralises
+     * formula injection in string cells and prepends a UTF-8 BOM by default.
+     *
      * @param list<string> $headers
-     * @param list<list<mixed>> $rows
+     * @param iterable<list<string|int|float|bool|null>> $rows
      */
-    private function buildCsv(array $headers, array $rows): string
+    private function render(array $headers, iterable $rows): string
     {
         $handle = fopen('php://temp', 'r+');
         assert($handle !== false);
-        fwrite($handle, "\xEF\xBB\xBF");
-        fputcsv($handle, $headers);
-        foreach ($rows as $row) {
-            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
-        }
+        (new CsvWriter($handle, $headers))->writeAll($rows);
         rewind($handle);
         $content = stream_get_contents($handle);
         fclose($handle);

--- a/src/Export/ExportReconciliationsCsvHandler.php
+++ b/src/Export/ExportReconciliationsCsvHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Export;
 
+use Nene2\Export\CsvWriter;
 use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationFilter;
@@ -83,31 +84,30 @@ final readonly class ExportReconciliationsCsvHandler
             $offset += self::BATCH;
         } while (count($batch) === self::BATCH);
 
-        $csv = $this->buildCsv(
-            ['reconciliation_id', 'allocation_id', 'status', 'invoice_id', 'amount_cents',
-                'external_reference', 'bank_transaction_id', 'value_date', 'bank_amount_cents',
-                'counterparty_text', 'confirmed_at', 'confirmed_by', 'reversed_at', 'reversal_reason',
-                'source', 'manual_receivable_id'],
-            $rows,
+        return $this->csvResponse(
+            $this->render(
+                ['reconciliation_id', 'allocation_id', 'status', 'invoice_id', 'amount_cents',
+                    'external_reference', 'bank_transaction_id', 'value_date', 'bank_amount_cents',
+                    'counterparty_text', 'confirmed_at', 'confirmed_by', 'reversed_at', 'reversal_reason',
+                    'source', 'manual_receivable_id'],
+                $rows,
+            ),
+            'reconciliations.csv',
         );
-
-        return $this->csvResponse($csv, 'reconciliations.csv');
     }
 
     /**
+     * Renders rows to a CSV string via the framework writer, which neutralises
+     * formula injection in string cells and prepends a UTF-8 BOM by default.
+     *
      * @param list<string> $headers
-     * @param list<list<mixed>> $rows
+     * @param iterable<list<string|int|float|bool|null>> $rows
      */
-    private function buildCsv(array $headers, array $rows): string
+    private function render(array $headers, iterable $rows): string
     {
         $handle = fopen('php://temp', 'r+');
         assert($handle !== false);
-        // UTF-8 BOM for Excel compatibility
-        fwrite($handle, "\xEF\xBB\xBF");
-        fputcsv($handle, $headers);
-        foreach ($rows as $row) {
-            fputcsv($handle, array_map(static fn ($v): string => (string) $v, $row));
-        }
+        (new CsvWriter($handle, $headers))->writeAll($rows);
         rewind($handle);
         $content = stream_get_contents($handle);
         fclose($handle);

--- a/tests/Http/ExportCsvHttpTest.php
+++ b/tests/Http/ExportCsvHttpTest.php
@@ -192,6 +192,37 @@ final class ExportCsvHttpTest extends TestCase
         self::assertStringContainsString('110000', $body);
     }
 
+    public function test_export_neutralizes_formula_injection_in_counterparty(): void
+    {
+        // A bank statement whose memo (counterparty) column carries an attacker
+        // controlled spreadsheet formula. The export must render it as text.
+        $csv = "date,deposit,withdrawal,memo\n2026/04/20,110000,,=SUM(1+2)\n";
+        $token = $this->tokenFor('admin@acme.example');
+
+        $file = $this->psr17->createUploadedFile(
+            $this->psr17->createStream($csv),
+            strlen($csv),
+            UPLOAD_ERR_OK,
+            'april.csv',
+            'text/csv',
+        );
+        $this->app->handle(
+            $this->psr17->createServerRequest('POST', '/admin/bank-import-batches')
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withUploadedFiles(['file' => $file])
+                ->withParsedBody(['bank_account_id' => 1]),
+        );
+
+        $body = (string) $this->get($token, '/admin/export/bank-transactions')->getBody();
+
+        // Neutralised: the formula cell is prefixed with a single quote so a
+        // spreadsheet treats it as text rather than executing it.
+        self::assertStringContainsString("'=SUM(1+2)", $body);
+        self::assertStringNotContainsString(',=SUM(1+2)', $body);
+        // Numeric column stays numeric (type-based sanitisation, not quoted).
+        self::assertStringContainsString('110000', $body);
+    }
+
     public function test_export_reconciliations_returns_csv(): void
     {
         $this->importCsvAndConfirm();


### PR DESCRIPTION
## 目的

Clear の CSV 出力は手組み `buildCsv` が Export ハンドラ 4 つに同型コピーされ、いずれも `fputcsv` を直呼びして**振込名義（`counterparty_text`）・宛先メール（`recipient_email`）等のユーザ制御テキストを formula injection 無防備で出力**していた（設計レポート `_work/reports/2026-07-06/upstream-design/03-csv-helper.md`）。

NENE2 v1.8.0（ADR 0015）で追加された `Nene2\Export\CsvWriter`（injection 中和 既定 ON・型ベース・RFC4180 escape・BOM 既定 ON）に一元化し、injection を機構的に閉塞する。

## 変更点

- 4 ハンドラの手組み `buildCsv`（`fputcsv` + 手書き BOM + `(string)` 一括キャスト）を削除し、`Nene2\Export\CsvWriter` へ委譲（invoice の使い方が参照形。独自ラッパクラスは新設しない）
  - `ExportBankTransactionsCsvHandler.php`
  - `ExportReconciliationsCsvHandler.php`
  - `ExportClientCreditsCsvHandler.php`
  - `ExportDunningNoticesCsvHandler.php`
- ヘッダ・列順・出力先（`csvResponse`）は据え置き
- injection 中和のテストを追加（`counterparty_text` に `=SUM(1+2)` を仕込み、出力が `'=SUM(1+2)` へ中和され、数値列は数値のまま）

## 出力変化あり（意図したセキュリティ是正）

- **injection 中和**: formula トリガ（`=` `+` `-` `@` TAB CR）で始まる**文字列**セルに先頭 `'` が付与される。`CsvWriter` は**型ベース**中和のため、`amount_cents` 等の数値列（負数含む）はそのまま数値で出力され壊れない。
- **BOM**: 既存も UTF-8 BOM を付与済のため不変。
- **escape**: 旧実装は `fputcsv` 既定（backslash escape）、`CsvWriter` は RFC4180（`escape=''`）。PHP 8.4 の非空 escape deprecation も回避。

## 検証

clean env（`env -i`）で実行:

- `composer test` … OK (356 tests, 1313 assertions, 6 skipped)
- `composer analyse` … PHPStan No errors
- `composer cs` … 0 fixable
- `php -l` 変更 5 ファイル … syntax OK

Self-review: backend-api

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)