### PR TITLE
chore(conformance): 準拠リンタを composer check に配線しベースライン化 (#256)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,12 @@
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
         "release:zip": "bash tools/build-release.sh",
+        "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=.",
         "check": [
             "@test",
             "@analyse",
-            "@cs"
+            "@cs",
+            "@conformance"
         ]
     }
 }

--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -1,0 +1,24 @@
+{
+    "version": 1,
+    "allow": [],
+    "ignore": [
+        {
+            "rule": "D4",
+            "file": "src/Auth/JwtTokenService.php",
+            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Auth/MfaChallengeTokens.php",
+            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Mfa/TotpGenerator.php",
+            "message": "Raw current-time read time(). Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        }
+    ]
+}


### PR DESCRIPTION
## 目的

検品C の準拠リンタ横展開（pilot・**path-repo 経路のレシピ確定**）。NENE2 v1.8.1 で出荷された `tools/conformance.php`（設計: `_work/reports/2026-07-06/upstream-design/04-conformance-linter.md`）を Clear に配線し、既存ドリフトを baseline 化して**新規混入のみ CI で赤**にする。

Clear は NENE2 を path-repo `@dev`（`../NENE2` symlink＝main）で参照するため、main の linter が vendor 経由でそのまま使える。**composer 依存の変更は不要**（`composer.lock` 無変更を確認）。

## 変更点

- `composer.json`: `scripts.conformance` を追加し `scripts.check` に `@conformance` を組込（D3 充足＝リンタが自己強制）
- `conformance.baseline.json`（新規）: 既存 D4 3件を許容登録

## report-only 採取結果（error 4ルール D1–D4）

| ルール | 件数 | 備考 |
|---|---|---|
| D1 JWT既定secret | 0 | `GuardedJwtSecretResolver` 採用済み |
| D2 依存ブランチ固定 | 0 | `hideyukimori/nene2` は dev-main・feature ブランチ固定なし |
| D3 check自己組込 | 1 | 本 PR で配線し解消 |
| D4 生time API | 3 | `src/Auth/JwtTokenService.php`・`src/Auth/MfaChallengeTokens.php`・`src/Mfa/TotpGenerator.php` |

**真の偽陽性は 0**。D4 3件はいずれも実在の `time()` 直読み（JWT発行 iat/exp・MFAチャレンジ・TOTP time-step）で、将来 `ClockInterface` 注入へ寄せる候補。baseline で許容し新規のみ error にする。

## 検証結果

- `composer conformance` → exit 0（`Conformance OK — no error findings (3 suppressed by baseline/ignore).`）
- `composer check` → **緑**（test 358 / phpstan 457 OK / cs-fixer 0 / conformance OK）
- ゲート実効確認: `src/` に新規 `time()` を1件足すと exit 1（既存3件は baseline で抑制継続）、除去で exit 0 に復帰

## Self-review

release-ci

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
