### PR TITLE
feat(audit)!: 監査ログスキーマを canonical 形へ収斂（段階②・列化＋backfill＋rename）

### DIFF
--- a/database/migrations/20260708120000_canonicalize_audit_events.php
+++ b/database/migrations/20260708120000_canonicalize_audit_events.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\PdoAdapter;
+use Phinx\Db\Adapter\WrapperInterface;
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Canonicalizes the audit trail to the framework-canonical table shape
+ * (`Nene2\Audit\AuditTableConfig::canonical()`, NENE2 ADR 0014) — stage 2 of
+ * the audit framework adoption (Issue #258; stage 1 was #254 / PR #255).
+ *
+ * 1. Splits `payload_json` into the canonical `before_json` / `after_json` /
+ *    `metadata_json` columns. Both stored shapes are converted losslessly:
+ *    - legacy *flat* rows `{…context, before, after}` — context keys move to
+ *      `metadata_json`;
+ *    - stage-1 *folded* rows `{before, after, metadata:{…}}` — direct mapping.
+ *    Every payload key lands in exactly one of the three columns, so no audit
+ *    information is dropped. The append-only contract is respected: this is a
+ *    format normalization only; the recorded content is unchanged.
+ * 2. Drops `payload_json` once every row is converted.
+ * 3. Renames `event_type` → `action` and `actor_user_id` → `actor_id`.
+ *
+ * Every step is guarded (hasColumn), so a partially-applied run is re-run safe.
+ * A row whose payload is not a JSON object aborts the migration loudly rather
+ * than risking silent trail corruption.
+ */
+final class CanonicalizeAuditEvents extends AbstractMigration
+{
+    public function up(): void
+    {
+        if (!$this->table('audit_events')->hasColumn('before_json')) {
+            $this->table('audit_events')
+                ->addColumn('before_json', 'text', ['null' => true, 'default' => null])
+                ->addColumn('after_json', 'text', ['null' => true, 'default' => null])
+                ->addColumn('metadata_json', 'text', ['null' => true, 'default' => null])
+                ->update();
+        }
+
+        if ($this->table('audit_events')->hasColumn('payload_json')) {
+            $this->backfill();
+            $this->table('audit_events')->removeColumn('payload_json')->update();
+        }
+
+        if ($this->table('audit_events')->hasColumn('event_type')) {
+            $this->table('audit_events')->renameColumn('event_type', 'action')->update();
+        }
+
+        if ($this->table('audit_events')->hasColumn('actor_user_id')) {
+            $this->table('audit_events')->renameColumn('actor_user_id', 'actor_id')->update();
+        }
+    }
+
+    public function down(): void
+    {
+        if ($this->table('audit_events')->hasColumn('action')) {
+            $this->table('audit_events')->renameColumn('action', 'event_type')->update();
+        }
+
+        if ($this->table('audit_events')->hasColumn('actor_id')) {
+            $this->table('audit_events')->renameColumn('actor_id', 'actor_user_id')->update();
+        }
+
+        if (!$this->table('audit_events')->hasColumn('payload_json')) {
+            $this->table('audit_events')
+                ->addColumn('payload_json', 'text', ['null' => true, 'default' => null])
+                ->update();
+            $this->refold();
+            $this->table('audit_events')
+                ->changeColumn('payload_json', 'text', ['null' => false])
+                ->update();
+        }
+
+        if ($this->table('audit_events')->hasColumn('before_json')) {
+            $this->table('audit_events')
+                ->removeColumn('before_json')
+                ->removeColumn('after_json')
+                ->removeColumn('metadata_json')
+                ->update();
+        }
+    }
+
+    /** Converts every `payload_json` row into the three canonical columns. */
+    private function backfill(): void
+    {
+        $pdo = $this->pdo();
+
+        /** @var list<array{id: int|string, payload_json: string|null}> $rows */
+        $rows = $pdo->query('SELECT id, payload_json FROM audit_events')->fetchAll(PDO::FETCH_ASSOC);
+        $update = $pdo->prepare(
+            'UPDATE audit_events SET before_json = ?, after_json = ?, metadata_json = ? WHERE id = ?',
+        );
+
+        foreach ($rows as $row) {
+            [$before, $after, $metadata] = self::split((string) $row['payload_json'], (int) $row['id']);
+            $update->execute([$before, $after, $metadata, $row['id']]);
+        }
+    }
+
+    /** Folds the three canonical columns back into the stage-1 folded payload. */
+    private function refold(): void
+    {
+        $pdo = $this->pdo();
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $pdo
+            ->query('SELECT id, before_json, after_json, metadata_json FROM audit_events')
+            ->fetchAll(PDO::FETCH_ASSOC);
+        $update = $pdo->prepare('UPDATE audit_events SET payload_json = ? WHERE id = ?');
+
+        foreach ($rows as $row) {
+            $folded = [];
+            foreach (['before' => 'before_json', 'after' => 'after_json', 'metadata' => 'metadata_json'] as $key => $column) {
+                if (is_string($row[$column]) && $row[$column] !== '') {
+                    $folded[$key] = json_decode($row[$column], true, 512, JSON_THROW_ON_ERROR);
+                }
+            }
+            $update->execute([
+                $folded === [] ? '{}' : json_encode($folded, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE),
+                $row['id'],
+            ]);
+        }
+    }
+
+    /**
+     * Splits one stored payload into `[before, after, metadata]` JSON strings.
+     *
+     * Mirrors the read-side normalization this migration retires: a folded
+     * row's `metadata` object is lifted to the top level first, then `before` /
+     * `after` snapshots are extracted, and every remaining top-level key —
+     * legacy context such as `invoice_id` or `email` — becomes metadata.
+     *
+     * @return array{?string, ?string, ?string}
+     */
+    private static function split(string $payloadJson, int $id): array
+    {
+        try {
+            $payload = json_decode($payloadJson, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException(sprintf('audit_events.id=%d: payload_json is not valid JSON.', $id), 0, $e);
+        }
+
+        if (!is_array($payload)) {
+            throw new RuntimeException(sprintf('audit_events.id=%d: payload_json is not a JSON object.', $id));
+        }
+
+        if (isset($payload['metadata']) && is_array($payload['metadata'])) {
+            /** @var array<string, mixed> $folded */
+            $folded = $payload['metadata'];
+            unset($payload['metadata']);
+            $payload = array_merge($folded, $payload);
+        }
+
+        $before = null;
+        if (array_key_exists('before', $payload) && is_array($payload['before'])) {
+            $before = $payload['before'];
+            unset($payload['before']);
+        }
+
+        $after = null;
+        if (array_key_exists('after', $payload) && is_array($payload['after'])) {
+            $after = $payload['after'];
+            unset($payload['after']);
+        }
+
+        return [self::encode($before), self::encode($after), self::encode($payload === [] ? null : $payload)];
+    }
+
+    /**
+     * @param array<mixed>|null $value
+     */
+    private static function encode(?array $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+
+    /** The raw PDO connection, for parameterised backfill statements. */
+    private function pdo(): PDO
+    {
+        $adapter = $this->getAdapter();
+
+        // The CLI runner hands migrations a decorated adapter (timed output);
+        // unwrap to the real PDO-backed adapter.
+        while ($adapter instanceof WrapperInterface) {
+            $adapter = $adapter->getAdapter();
+        }
+
+        if (!$adapter instanceof PdoAdapter) {
+            throw new RuntimeException('The audit canonicalization backfill requires a PDO adapter.');
+        }
+
+        $connection = $adapter->getConnection();
+
+        if (!$connection instanceof PDO) {
+            throw new RuntimeException('The PDO adapter returned no PDO connection.');
+        }
+
+        return $connection;
+    }
+}

--- a/database/schema/audit_events.sql
+++ b/database/schema/audit_events.sql
@@ -1,12 +1,20 @@
 -- Schema snapshot (reference). Source of truth: database/migrations/.
 -- Immutable audit trail (compliance §6). Append-only.
+-- Framework-canonical shape (Nene2\Audit\AuditTableConfig::canonical(), stage 2
+-- of the audit adoption — Issue #258); Clear keeps integer ids and NOT NULL
+-- actor/organization (actor_id 0 = system).
 CREATE TABLE audit_events (
     id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     organization_id  BIGINT UNSIGNED NOT NULL,
-    event_type       VARCHAR(64) NOT NULL,
-    actor_user_id    BIGINT UNSIGNED NOT NULL,
+    action           VARCHAR(64) NOT NULL,
+    entity_type      VARCHAR(64) NOT NULL DEFAULT '',
+    entity_id        BIGINT UNSIGNED NULL DEFAULT NULL,
+    actor_id         BIGINT UNSIGNED NOT NULL,
     occurred_at      DATETIME NOT NULL,
-    payload_json     TEXT NOT NULL,
+    before_json      TEXT NULL DEFAULT NULL,
+    after_json       TEXT NULL DEFAULT NULL,
+    metadata_json    TEXT NULL DEFAULT NULL,
     PRIMARY KEY (id),
-    KEY idx_audit_events_org_type (organization_id, event_type)
+    KEY idx_audit_events_org_action (organization_id, action),
+    KEY idx_audit_events_entity (entity_type, entity_id)
 );

--- a/docs/explanation/operator-guide.md
+++ b/docs/explanation/operator-guide.md
@@ -74,7 +74,7 @@ Dunning notices are **immutable** once created. No deletion.
 
 Every mutating operation is recorded in `audit_events`:
 
-| Event type | Trigger |
+| Action | Trigger |
 | --- | --- |
 | `bank_import` | CSV imported |
 | `bank_import_batch_reversed` | Import batch reversed |
@@ -83,8 +83,9 @@ Every mutating operation is recorded in `audit_events`:
 | `client_credit_applied` | Credit applied to invoice |
 | `dunning_sent` | Dunning notice sent |
 
-Each record contains: organization, event type, actor user ID, timestamp, and a
-JSON payload with before/after snapshots of the relevant data.
+Each record contains: organization, action, actor ID, timestamp, before/after
+JSON snapshots of the relevant data, and extra context metadata where the event
+carries it (e.g. the targeted `invoice_id`).
 
 ---
 
@@ -117,7 +118,7 @@ The following search and filter operations are available via the API and (in Pha
 
 Audit events are stored in `audit_events` and are queryable by:
 - `organization_id` (always scoped to caller's org)
-- `event_type`
+- `action`
 - `occurred_at` range (SQL-level; no REST endpoint in Phase 1/2)
 
 ---

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -98,14 +98,16 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 Do not invent `cancelled`, `void`, `pending`, `unpaid`, etc. without registering
 them here first.
 
-### Audit event types (`audit_events.event_type`, exact strings)
+### Audit actions (`audit_events.action`, exact strings)
 
 Append-only audit trail (`AuditEvent`, compliance §6). Every state-changing
 operation records exactly one event from this closed set. New mutating
-operations MUST register their `event_type` here **before** first use; spelling
-follows `{entity}_{past-tense-verb}` in lowercase snake_case.
+operations MUST register their `action` here **before** first use; spelling
+follows `{entity}_{past-tense-verb}` in lowercase snake_case. (The column was
+renamed from `event_type` in the stage-2 canonicalization, Issue #258; the
+action strings themselves are unchanged.)
 
-| `event_type` | Operation | Payload shape |
+| `action` | Operation | Snapshots |
 | --- | --- | --- |
 | `bank_import` | Bank CSV imported | `after` |
 | `bank_import_batch_reversed` | Import batch reversed | `before` + `after` |
@@ -131,8 +133,10 @@ follows `{entity}_{past-tense-verb}` in lowercase snake_case.
 | `login_failed` | Authentication rejected | `after` (attempted `email` + `failure_reason`) |
 
 Mutations that create a resource carry only `after`; deletions carry only
-`before`; in-place changes carry both. Payload keys reuse canonical field names
-(§3); booleans follow the `is_` rule (e.g. `is_paused`).
+`before`; in-place changes carry both. Context beyond the snapshots (e.g. the
+`invoice_id` a dunning pause targets) is recorded in `metadata`. Snapshot and
+metadata keys reuse canonical field names (§3); booleans follow the `is_` rule
+(e.g. `is_paused`).
 
 ### Audit entity types (`audit_events.entity_type`, exact strings)
 
@@ -193,11 +197,12 @@ login). New events MUST map to one of these registered `entity_type` values:
 | Upstream client id | `client_id` | `upstream_client_id`, `clientId` |
 | Upstream payment id | `payment_id` | `upstream_payment_id`, `paymentId` |
 | Foreign keys (Clear-owned) | `bank_transaction_id`, `bank_import_batch_id`, `bank_account_id`, `payment_reconciliation_id`, `client_credit_id`, `manual_receivable_id` | camelCase, abbreviations |
-| Actor / timestamps | `imported_by`, `imported_at`, `confirmed_by`, `confirmed_at`, `reversed_at`, `sent_by`, `sent_at`, `created_by`, `created_at` | `issue_date`, `paidAt`, `actor_id` (use role-specific names above) |
-| Audit event type | `event_type` | `type`, `action` |
+| Actor / timestamps | `imported_by`, `imported_at`, `confirmed_by`, `confirmed_at`, `reversed_at`, `sent_by`, `sent_at`, `created_by`, `created_at` | `issue_date`, `paidAt`; `actor_id` outside the audit trail (use role-specific names above) |
+| Audit action | `action` | `event_type` (pre-#258), `type` |
 | Audit subject type | `entity_type` | `entity`, `target_type`, `resource` |
 | Audit subject id | `entity_id` | `target_id`, `resource_id` |
-| Audit actor / time | `actor_user_id`, `occurred_at` | `user_id`, `actor_id`, `created_at` (on audit rows) |
+| Audit actor / time | `actor_id`, `occurred_at` (audit rows only) | `actor_user_id` (pre-#258), `user_id`, `created_at` (on audit rows) |
+| Audit snapshots / context | `before`, `after`, `metadata` (JSON columns `before_json`, `after_json`, `metadata_json`) | `payload`, `payload_json` (pre-#258), `diff`, `context` |
 | Login failure reason (audit) | `failure_reason` | `reason`, `error`, `code` |
 | List envelope | `items`, `limit`, `offset` | `data`, `results`, `count` |
 
@@ -297,7 +302,7 @@ exact spellings; do not invent variants per endpoint.
 | `sort_dir` | `asc` or `desc` (default `desc`) |
 
 Other single-value filters use the canonical field name itself (`status`,
-`client_id`, `event_type`, `entity_type`, `entity_id`, `counterparty`).
+`client_id`, `action`, `entity_type`, `entity_id`, `counterparty`).
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1573,9 +1573,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/Offset'
-        - name: event_type
+        - name: action
           in: query
-          description: Filter by exact event type (see terminology registry §audit event types).
+          description: Filter by exact action string (see terminology registry §audit actions).
           schema:
             type: string
         - name: entity_type
@@ -1589,7 +1589,7 @@ paths:
           schema:
             type: integer
             format: int64
-        - name: actor_user_id
+        - name: actor_id
           in: query
           schema: { type: integer, format: int64 }
         - name: occurred_from
@@ -1602,7 +1602,7 @@ paths:
           schema: { type: string, format: date }
         - name: sort_by
           in: query
-          description: "Sort column: occurred_at | event_type | entity_type | actor_user_id."
+          description: "Sort column: occurred_at | action | entity_type | actor_id."
           schema: { type: string }
         - name: sort_dir
           in: query
@@ -2596,7 +2596,7 @@ components:
 
     AuditEvent:
       type: object
-      required: [audit_event_id, organization_id, event_type, entity_type, occurred_at, payload]
+      required: [audit_event_id, organization_id, action, entity_type, occurred_at, before, after, metadata]
       properties:
         audit_event_id:
           type: integer
@@ -2604,9 +2604,9 @@ components:
         organization_id:
           type: integer
           format: int64
-        event_type:
+        action:
           type: string
-          description: Exact event type string (see terminology registry §audit event types).
+          description: Exact action string (see terminology registry §audit actions).
         entity_type:
           type: string
           description: Subject record type (see terminology registry §audit entity types).
@@ -2615,16 +2615,27 @@ components:
           format: int64
           nullable: true
           description: Subject record id; null when there is no single subject (e.g. failed login).
-        actor_user_id:
+        actor_id:
           type: integer
           format: int64
           nullable: true
         occurred_at:
           type: string
           format: date-time
-        payload:
+        before:
           type: object
-          description: Event detail, including before/after snapshots for state changes.
+          nullable: true
+          description: Sanitized snapshot before the change; null for creates.
+          additionalProperties: true
+        after:
+          type: object
+          nullable: true
+          description: Sanitized snapshot after the change; null for deletes.
+          additionalProperties: true
+        metadata:
+          type: object
+          nullable: true
+          description: Extra event context (e.g. invoice_id on dunning pause/resume); null when the event recorded none.
           additionalProperties: true
 
     AuditEventListResponse:

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -413,8 +413,8 @@ export function dunningNoticesExportPath(params: DunningNoticeQuery): string {
 
 // --- Audit trail (admin) ---
 export interface AuditQuery {
-  eventType?: string
-  actorUserId?: string
+  action?: string
+  actorId?: string
   occurredFrom?: string
   occurredTo?: string
   sortBy?: string
@@ -425,8 +425,8 @@ export interface AuditQuery {
 
 export function listAuditEvents(params: AuditQuery, signal?: AbortSignal) {
   const q = new URLSearchParams({ limit: String(params.limit ?? 50), offset: String(params.offset ?? 0) })
-  if (params.eventType) q.set('event_type', params.eventType)
-  if (params.actorUserId) q.set('actor_user_id', params.actorUserId)
+  if (params.action) q.set('action', params.action)
+  if (params.actorId) q.set('actor_id', params.actorId)
   if (params.occurredFrom) q.set('occurred_from', params.occurredFrom)
   if (params.occurredTo) q.set('occurred_to', params.occurredTo)
   if (params.sortBy) q.set('sort_by', params.sortBy)

--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { listAuditEvents } from '@/api/endpoints'
-import type { AuditEvent, AuditEventType } from '@/types'
+import type { AuditEvent, AuditAction } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Pager, FilterBar, FilterField, PageHead, DatePicker, SortableTh, nextSort } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -10,9 +10,9 @@ import { formatDateTime } from '@/utils/format'
 
 const PAGE = 20
 
-// Every registered event_type (terminology §2) with its display label key and a
+// Every registered action (terminology §2) with its display label key and a
 // badge tone: green for value-creating, red for reversing/deleting/failing.
-const EVENT_META: Record<AuditEventType, StatusMeta> = {
+const EVENT_META: Record<AuditAction, StatusMeta> = {
   bank_import:                 { v: 'info', labelKey: 'audit.event.bank_import' },
   bank_import_batch_reversed:  { v: 'bad',  labelKey: 'audit.event.bank_import_batch_reversed' },
   reconciliation_confirmed:    { v: 'ok',   labelKey: 'audit.event.reconciliation_confirmed' },
@@ -36,9 +36,9 @@ const EVENT_META: Record<AuditEventType, StatusMeta> = {
   mfa_disabled:                { v: 'warn', labelKey: 'audit.event.mfa_disabled' },
 }
 
-const EVENT_TYPES = Object.keys(EVENT_META) as AuditEventType[]
+const ACTIONS = Object.keys(EVENT_META) as AuditAction[]
 
-/** Pretty-print one before/after block, or any payload value, as stable JSON. */
+/** Pretty-print one before/after/metadata block as stable JSON. */
 function StateBlock({ label, value }: { label: string; value: unknown }) {
   return (
     <div className="audit-state">
@@ -50,43 +50,36 @@ function StateBlock({ label, value }: { label: string; value: unknown }) {
 
 function EventDetail({ event }: { event: AuditEvent }) {
   const { t } = useTranslation()
-  const payload = event.payload
-  const before = payload['before']
-  const after = payload['after']
-  // Context keys are everything in the payload that is not the before/after diff.
-  const context = Object.fromEntries(
-    Object.entries(payload).filter(([k]) => k !== 'before' && k !== 'after'),
-  )
-  const hasContext = Object.keys(context).length > 0
+  const { before, after, metadata } = event
 
-  if (before === undefined && after === undefined && !hasContext) {
+  if (before === null && after === null && metadata === null) {
     return <span className="muted">{t('audit.noChange')}</span>
   }
 
   return (
     <div className="audit-detail">
-      {hasContext && <StateBlock label="—" value={context} />}
-      {before !== undefined && <StateBlock label={t('audit.before')} value={before} />}
-      {after !== undefined && <StateBlock label={t('audit.after')} value={after} />}
+      {metadata !== null && <StateBlock label="—" value={metadata} />}
+      {before !== null && <StateBlock label={t('audit.before')} value={before} />}
+      {after !== null && <StateBlock label={t('audit.after')} value={after} />}
     </div>
   )
 }
 
 export default function AuditLogPage() {
   const { t } = useTranslation()
-  const [eventType, setEventType] = useState('')
+  const [action, setAction] = useState('')
   const [actor, setActor] = useState('')
   const [from, setFrom] = useState('')
   const [to, setTo] = useState('')
-  const [applied, setApplied] = useState<{ eventType: string; actor: string; from: string; to: string; offset: number }>({ eventType: '', actor: '', from: '', to: '', offset: 0 })
+  const [applied, setApplied] = useState<{ action: string; actor: string; from: string; to: string; offset: number }>({ action: '', actor: '', from: '', to: '', offset: 0 })
   const [sort, setSort] = useState<SortState>({ by: 'occurred_at', dir: 'desc' })
   const [expanded, setExpanded] = useState<ReadonlySet<number>>(new Set())
 
   const auditQ = useQuery({
     queryKey: ['audit-events', applied, sort],
     queryFn: ({ signal }) => listAuditEvents({
-      eventType: applied.eventType || undefined,
-      actorUserId: applied.actor || undefined,
+      action: applied.action || undefined,
+      actorId: applied.actor || undefined,
       occurredFrom: applied.from ? applied.from.replace(/\//g, '-') : undefined,
       occurredTo: applied.to ? applied.to.replace(/\//g, '-') : undefined,
       sortBy: sort.by,
@@ -96,8 +89,8 @@ export default function AuditLogPage() {
     }, signal),
   })
 
-  function search() { setApplied({ eventType, actor, from, to, offset: 0 }) }
-  function clear() { setEventType(''); setActor(''); setFrom(''); setTo(''); setApplied({ eventType: '', actor: '', from: '', to: '', offset: 0 }) }
+  function search() { setApplied({ action, actor, from, to, offset: 0 }) }
+  function clear() { setAction(''); setActor(''); setFrom(''); setTo(''); setApplied({ action: '', actor: '', from: '', to: '', offset: 0 }) }
   function goPage(off: number) { setApplied(p => ({ ...p, offset: off })) }
   function onSort(col: string) { setSort(s => nextSort(s, col)); setApplied(p => ({ ...p, offset: 0 })) }
 
@@ -110,10 +103,10 @@ export default function AuditLogPage() {
     })
   }
 
-  function actorLabel(actorUserId: number): string {
-    return actorUserId === 0
+  function actorLabel(actorId: number): string {
+    return actorId === 0
       ? t('audit.actor.system')
-      : t('audit.actor.user', { id: actorUserId })
+      : t('audit.actor.user', { id: actorId })
   }
 
   const total = auditQ.data?.total ?? 0
@@ -131,10 +124,10 @@ export default function AuditLogPage() {
 
       <FilterBar>
         <FilterField label={t('audit.filter.event')}>
-          <select className="inp" value={eventType} onChange={e => setEventType(e.target.value)}>
+          <select className="inp" value={action} onChange={e => setAction(e.target.value)}>
             <option value="">{t('audit.filter.all')}</option>
-            {EVENT_TYPES.map(type => (
-              <option key={type} value={type}>{t(EVENT_META[type].labelKey)}</option>
+            {ACTIONS.map(a => (
+              <option key={a} value={a}>{t(EVENT_META[a].labelKey)}</option>
             ))}
           </select>
         </FilterField>
@@ -160,8 +153,8 @@ export default function AuditLogPage() {
           <thead>
             <tr>
               <SortableTh column="occurred_at" sort={sort} onSort={onSort}>{t('audit.table.time')}</SortableTh>
-              <SortableTh column="event_type" sort={sort} onSort={onSort}>{t('audit.table.event')}</SortableTh>
-              <SortableTh column="actor_user_id" sort={sort} onSort={onSort}>{t('audit.table.actor')}</SortableTh>
+              <SortableTh column="action" sort={sort} onSort={onSort}>{t('audit.table.event')}</SortableTh>
+              <SortableTh column="actor_id" sort={sort} onSort={onSort}>{t('audit.table.actor')}</SortableTh>
               <th>{t('audit.table.detail')}</th>
             </tr>
           </thead>
@@ -173,8 +166,8 @@ export default function AuditLogPage() {
                 <Fragment key={event.audit_event_id}>
                   <tr data-kbd-row={index} className={cursor === index ? 'is-cursor' : undefined}>
                     <td className="muted">{formatDateTime(event.occurred_at)}</td>
-                    <td><StatusBadge map={EVENT_META} value={event.event_type} dot fallback={event.event_type} /></td>
-                    <td>{actorLabel(event.actor_user_id)}</td>
+                    <td><StatusBadge map={EVENT_META} value={event.action} dot fallback={event.action} /></td>
+                    <td>{actorLabel(event.actor_id)}</td>
                     <td className="row-act">
                       <Button variant="ghost" size="sm" onClick={() => toggle(event.audit_event_id)}>
                         {isOpen ? t('audit.hideDetail') : t('audit.viewDetail')}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -152,9 +152,10 @@ export interface ListEnvelope<T> {
   total: number
 }
 
-// Append-only audit trail (terminology §2). `payload` is an open record whose
-// shape depends on `event_type`; it commonly carries `before` / `after` blocks.
-export type AuditEventType =
+// Append-only audit trail (terminology §2). `before` / `after` are the
+// sanitized snapshots; `metadata` carries extra context keys (e.g. the
+// targeted `invoice_id`) — each null when the event recorded none.
+export type AuditAction =
   | 'bank_import'
   | 'bank_import_batch_reversed'
   | 'reconciliation_confirmed'
@@ -180,13 +181,15 @@ export type AuditEventType =
 export interface AuditEvent {
   audit_event_id: number
   organization_id: number
-  event_type: AuditEventType
+  action: AuditAction
   // Subject record the event changed (terminology §audit entity types).
   entity_type: string
   entity_id: number | null
-  actor_user_id: number
+  actor_id: number
   occurred_at: string
-  payload: Record<string, unknown>
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+  metadata: Record<string, unknown> | null
 }
 
 // Invoice upstream read models (read-only from Clear's perspective)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,8 @@ parameters:
     - tests
     - public_html
     - tools
+  # Phinx migration classes are file-loaded (not autoloaded); discover their
+  # symbols so migration tests can reference them.
+  scanDirectories:
+    - database/migrations
   tmpDir: .phpstan.cache

--- a/src/Audit/AuditEvent.php
+++ b/src/Audit/AuditEvent.php
@@ -7,10 +7,12 @@ namespace NeneClear\Audit;
 /**
  * Read-side view of one audit record (compliance §6).
  *
- * Writes now go through the framework recorder (`Nene2\Audit\AuditEvent`, ADR
+ * Writes go through the framework recorder (`Nene2\Audit\AuditEvent`, ADR
  * 0014); this product value object is the shape the read layer hydrates from
- * `audit_events` and hands to {@see AuditEventResponse}. `payload` is the
- * normalized flat payload (see {@see PdoAuditReadRepository}).
+ * the canonical `audit_events` columns (stage 2, Issue #258) and hands to
+ * {@see AuditEventResponse}: `before` / `after` are the sanitized snapshots,
+ * `metadata` carries the event's extra context keys (e.g. `invoice_id` on
+ * dunning pauses) — each null when the event recorded none.
  *
  * `entityType` / `entityId` identify the record the operation changed, so a
  * single record's history is queryable. `entityId` is null when the subject has
@@ -19,16 +21,20 @@ namespace NeneClear\Audit;
 final readonly class AuditEvent
 {
     /**
-     * @param array<string, mixed> $payload
+     * @param array<string, mixed>|null $before
+     * @param array<string, mixed>|null $after
+     * @param array<string, mixed>|null $metadata
      */
     public function __construct(
         public int $organizationId,
-        public string $eventType,
+        public string $action,
         public string $entityType,
         public ?int $entityId,
-        public int $actorUserId,
+        public int $actorId,
         public string $occurredAt,
-        public array $payload,
+        public ?array $before,
+        public ?array $after,
+        public ?array $metadata,
         public ?int $id = null,
     ) {
     }

--- a/src/Audit/AuditEventFilter.php
+++ b/src/Audit/AuditEventFilter.php
@@ -15,10 +15,10 @@ namespace NeneClear\Audit;
 final readonly class AuditEventFilter
 {
     public function __construct(
-        public ?string $eventType = null,
+        public ?string $action = null,
         public ?string $entityType = null,
         public ?int $entityId = null,
-        public ?int $actorUserId = null,
+        public ?int $actorId = null,
         public ?string $occurredFrom = null,
         public ?string $occurredTo = null,
         public string $sortColumn = 'occurred_at',

--- a/src/Audit/AuditEventResponse.php
+++ b/src/Audit/AuditEventResponse.php
@@ -14,12 +14,14 @@ final readonly class AuditEventResponse
         return [
             'audit_event_id' => $event->id,
             'organization_id' => $event->organizationId,
-            'event_type' => $event->eventType,
+            'action' => $event->action,
             'entity_type' => $event->entityType,
             'entity_id' => $event->entityId,
-            'actor_user_id' => $event->actorUserId,
+            'actor_id' => $event->actorId,
             'occurred_at' => $event->occurredAt,
-            'payload' => $event->payload,
+            'before' => $event->before,
+            'after' => $event->after,
+            'metadata' => $event->metadata,
         ];
     }
 }

--- a/src/Audit/AuditReadRepositoryInterface.php
+++ b/src/Audit/AuditReadRepositoryInterface.php
@@ -8,14 +8,14 @@ namespace NeneClear\Audit;
  * Product-owned read side of the audit trail.
  *
  * The write side is the framework recorder (`Nene2\Audit`, ADR 0014); reads stay
- * in the product because they carry two concerns the framework read contract
- * intentionally leaves out: tenant (organization) scoping and Clear's own sort
- * whitelist (which includes `actor_user_id`, a column `Nene2\Audit\AuditQuery`
- * does not model).
+ * in the product because they carry concerns the framework read contract
+ * intentionally leaves out: tenant (organization) scoping, Clear's own sort
+ * whitelist (which includes `actor_id`, a column `Nene2\Audit\AuditQuery` does
+ * not model), and inclusive `DATE(occurred_at)` range bounds.
  *
- * Rows are read from `audit_events` verbatim (raw `payload_json`) and normalized
- * so a framework-folded row (`{before, after, metadata:{…}}`) and a legacy flat
- * row (`{…context, before, after}`) yield the same API payload shape.
+ * Rows are stored in the framework-canonical shape (stage 2, Issue #258):
+ * `before_json` / `after_json` / `metadata_json` hydrate straight into the
+ * product {@see AuditEvent} view.
  */
 interface AuditReadRepositoryInterface
 {

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace NeneClear\Audit;
 
-use Nene2\Audit\AuditPayloadMode;
 use Nene2\Audit\AuditRecorder;
 use Nene2\Audit\AuditRecorderFactory;
 use Nene2\Audit\AuditRecorderFactoryInterface;
@@ -21,19 +20,21 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Wires the append-only audit trail onto the framework audit module
- * (`Nene2\Audit`, ADR 0014) without re-migrating (stage ①).
+ * (`Nene2\Audit`, ADR 0014).
  *
- * The write side is the framework's transaction-atomic
- * {@see AuditRecorderFactoryInterface::forExecutor()} plus
- * {@see PdoAuditEventRepository}, pointed at Clear's existing `audit_events`
- * table via {@see AuditTableConfig} in SinglePayload mode — physical column
- * names (`event_type`, `actor_user_id`, `payload_json`) are absorbed by config,
- * so no column is renamed. A non-transactional {@see AuditRecorderInterface} is
- * also provided for the login auditing path, which carries no business mutation.
+ * Stage 2 (Issue #258): `audit_events` is the framework-canonical table
+ * ({@see AuditTableConfig::canonical()} — `action` / `actor_id` /
+ * `before_json` / `after_json` / `metadata_json`), so the config seam carries
+ * no name mapping any more. The write side is the framework's
+ * transaction-atomic {@see AuditRecorderFactoryInterface::forExecutor()} plus
+ * {@see PdoAuditEventRepository}; a non-transactional
+ * {@see AuditRecorderInterface} is also provided for the login auditing path,
+ * which carries no business mutation.
  *
- * The read side stays product-owned ({@see AuditReadRepositoryInterface}) because
- * it keeps tenant scoping and Clear's `actor_user_id` sort, which the framework
- * read contract deliberately omits.
+ * The read side stays product-owned ({@see AuditReadRepositoryInterface})
+ * because it keeps tenant scoping, Clear's `actor_id` sort, and inclusive
+ * `DATE(occurred_at)` bounds, which the framework read contract deliberately
+ * omits.
  */
 final readonly class AuditServiceProvider implements ServiceProviderInterface
 {
@@ -83,32 +84,17 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
     }
 
     /**
-     * Points the framework audit module at Clear's existing `audit_events` table
-     * (ADR 0014) — the single seam for stage-① adoption. SinglePayload mode folds
-     * `before`/`after`/`metadata` into the existing `payload_json` column; the
-     * `event_type` / `actor_user_id` physical names are kept (no rename), so the
-     * binding terminology and API contract are unchanged.
+     * The framework-canonical mapping for Clear's `audit_events` table (ADR
+     * 0014). Since the stage-2 migration (Issue #258) the physical schema *is*
+     * the convergence target — before/after payload mode, a `metadata_json`
+     * column, `action` / `actor_id` names, auto-increment integer id — so this
+     * is {@see AuditTableConfig::canonical()} with no knob turned.
      *
      * Public so integration tests can build a real framework recorder against the
      * same mapping.
      */
     public static function tableConfig(): AuditTableConfig
     {
-        return new AuditTableConfig(
-            table: 'audit_events',
-            mode: AuditPayloadMode::SinglePayload,
-            idColumn: 'id',
-            actionColumn: 'event_type',
-            entityTypeColumn: 'entity_type',
-            entityIdColumn: 'entity_id',
-            actorColumn: 'actor_user_id',
-            organizationColumn: 'organization_id',
-            occurredAtColumn: 'occurred_at',
-            metadataColumn: null,
-            beforeColumn: null,
-            afterColumn: null,
-            payloadColumn: 'payload_json',
-            idIsAutoIncrement: true,
-        );
+        return AuditTableConfig::canonical();
     }
 }

--- a/src/Audit/ListAuditEventsHandler.php
+++ b/src/Audit/ListAuditEventsHandler.php
@@ -29,10 +29,10 @@ final readonly class ListAuditEventsHandler
         $int = static fn (string $k): ?int => isset($q[$k]) && is_numeric($q[$k]) ? (int) $q[$k] : null;
 
         $filter = new AuditEventFilter(
-            eventType: $str('event_type'),
+            action: $str('action'),
             entityType: $str('entity_type'),
             entityId: $int('entity_id'),
-            actorUserId: $int('actor_user_id'),
+            actorId: $int('actor_id'),
             occurredFrom: $str('occurred_from'),
             occurredTo: $str('occurred_to'),
             sortColumn: $str('sort_by') ?? 'occurred_at',

--- a/src/Audit/PdoAuditReadRepository.php
+++ b/src/Audit/PdoAuditReadRepository.php
@@ -9,16 +9,16 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 /**
  * Read side of the audit trail (write is the framework recorder, ADR 0014).
  *
- * Reads `audit_events` directly so Clear keeps its own tenant scoping and sort
- * whitelist (including `actor_user_id`). The raw `payload_json` is normalized on
- * hydration: a framework-folded row `{before, after, metadata:{…}}` is flattened
- * back to Clear's historical flat shape `{…context, before, after}`, so folded
- * (post-adoption) and legacy flat rows return an identical payload to the API and
- * the frontend's before/after + context-key rendering.
+ * Reads the canonical `audit_events` columns (stage 2, Issue #258) directly so
+ * Clear keeps its own tenant scoping, its `actor_id` sort, and its inclusive
+ * `DATE(occurred_at)` bounds — read concerns the framework `AuditQuery`
+ * deliberately omits. The stage-1 payload-normalization layer is gone: every
+ * row is stored canonically (`before_json` / `after_json` / `metadata_json`),
+ * so hydration is a straight column read.
  */
 final readonly class PdoAuditReadRepository implements AuditReadRepositoryInterface
 {
-    private const string COLUMNS = 'id, organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json';
+    private const string COLUMNS = 'id, organization_id, action, entity_type, entity_id, actor_id, occurred_at, before_json, after_json, metadata_json';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -58,9 +58,9 @@ final readonly class PdoAuditReadRepository implements AuditReadRepositoryInterf
         /** @var list<string|int> $params */
         $params = [$organizationId];
 
-        if ($filter->eventType !== null) {
-            $clauses[] = 'event_type = ?';
-            $params[] = $filter->eventType;
+        if ($filter->action !== null) {
+            $clauses[] = 'action = ?';
+            $params[] = $filter->action;
         }
         if ($filter->entityType !== null) {
             $clauses[] = 'entity_type = ?';
@@ -70,9 +70,9 @@ final readonly class PdoAuditReadRepository implements AuditReadRepositoryInterf
             $clauses[] = 'entity_id = ?';
             $params[] = $filter->entityId;
         }
-        if ($filter->actorUserId !== null) {
-            $clauses[] = 'actor_user_id = ?';
-            $params[] = $filter->actorUserId;
+        if ($filter->actorId !== null) {
+            $clauses[] = 'actor_id = ?';
+            $params[] = $filter->actorId;
         }
         if ($filter->occurredFrom !== null) {
             $clauses[] = 'DATE(occurred_at) >= ?';
@@ -90,9 +90,9 @@ final readonly class PdoAuditReadRepository implements AuditReadRepositoryInterf
     private static function orderBy(AuditEventFilter $filter): string
     {
         $column = match ($filter->sortColumn) {
-            'event_type' => 'event_type',
+            'action' => 'action',
             'entity_type' => 'entity_type',
-            'actor_user_id' => 'actor_user_id',
+            'actor_id' => 'actor_id',
             default => 'occurred_at',
         };
         $direction = strtolower($filter->sortDirection) === 'asc' ? 'ASC' : 'DESC';
@@ -105,42 +105,32 @@ final readonly class PdoAuditReadRepository implements AuditReadRepositoryInterf
      */
     private function hydrate(array $row): AuditEvent
     {
-        /** @var array<string, mixed> $payload */
-        $payload = json_decode((string) $row['payload_json'], true, 512, JSON_THROW_ON_ERROR);
-
         return new AuditEvent(
             organizationId: (int) $row['organization_id'],
-            eventType: (string) $row['event_type'],
+            action: (string) $row['action'],
             entityType: (string) $row['entity_type'],
             entityId: $row['entity_id'] !== null ? (int) $row['entity_id'] : null,
-            actorUserId: (int) $row['actor_user_id'],
+            actorId: (int) $row['actor_id'],
             occurredAt: (string) $row['occurred_at'],
-            payload: self::normalize($payload),
+            before: self::decode($row['before_json'] ?? null),
+            after: self::decode($row['after_json'] ?? null),
+            metadata: self::decode($row['metadata_json'] ?? null),
             id: (int) $row['id'],
         );
     }
 
     /**
-     * Flattens a framework-folded payload back to Clear's flat shape.
-     *
-     * The framework's SinglePayload writer stores `{before, after, metadata:{…}}`;
-     * Clear's historical rows are flat `{…context, before, after}`. Lifting the
-     * `metadata` object's keys to the top level makes both indistinguishable to
-     * the API and the frontend (which reads any non-before/after key as context).
-     * Legacy flat rows have no top-level `metadata` key and pass through unchanged.
-     *
-     * @param array<string, mixed> $payload
-     * @return array<string, mixed>
+     * @return array<string, mixed>|null
      */
-    private static function normalize(array $payload): array
+    private static function decode(mixed $json): ?array
     {
-        if (isset($payload['metadata']) && is_array($payload['metadata'])) {
-            /** @var array<string, mixed> $metadata */
-            $metadata = $payload['metadata'];
-            unset($payload['metadata']);
-            $payload = array_merge($metadata, $payload);
+        if (!is_string($json) || $json === '') {
+            return null;
         }
 
-        return $payload;
+        /** @var array<string, mixed>|null $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : null;
     }
 }

--- a/tests/Database/CanonicalizeAuditEventsMigrationTest.php
+++ b/tests/Database/CanonicalizeAuditEventsMigrationTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use PDO;
+use Phinx\Db\Adapter\SQLiteAdapter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Backfill coverage for the stage-2 audit canonicalization migration
+ * (Issue #258): the pre-canonical `audit_events` table (with `payload_json`)
+ * is converted in place, and **every** stored payload shape lands losslessly
+ * in the canonical `before_json` / `after_json` / `metadata_json` columns.
+ *
+ * Inputs mirror the real rows observed in the dev database plus the stage-1
+ * folded shape:
+ * - flat, after-only (`login_succeeded`, `login_failed`)
+ * - flat, before-only (`user_deleted`)
+ * - flat with a context key alongside before/after (`dunning_resumed` + `invoice_id`)
+ * - flat before+after with no context (`invitation_accepted`)
+ * - stage-1 folded `{before, after, metadata:{…}}` (`dunning_paused`)
+ * - stage-1 folded without metadata (`clear_settings_updated`)
+ */
+final class CanonicalizeAuditEventsMigrationTest extends TestCase
+{
+    private const int VERSION = 20260708120000;
+
+    private string $dbPath;
+    private SQLiteAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../database/migrations/20260530130300_create_audit_events_table.php';
+        require_once __DIR__ . '/../../database/migrations/20260606120000_add_entity_to_audit_events.php';
+        require_once __DIR__ . '/../../database/migrations/20260708120000_canonicalize_audit_events.php';
+
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-audit-migration-', true) . '.sqlite';
+        $this->adapter = new SQLiteAdapter(['name' => $this->dbPath, 'suffix' => '']);
+
+        // Build the pre-canonical schema by running the real original
+        // migrations, so the table's stored DDL matches what a production
+        // database actually carries (Phinx-quoted identifiers — the SQLite
+        // copy-alter path depends on them).
+        foreach ([new \CreateAuditEventsTable('testing', 20260530130300), new \AddEntityToAuditEvents('testing', 20260606120000)] as $migration) {
+            $migration->setAdapter($this->adapter);
+            $migration->change();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->adapter->disconnect();
+
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    private function pdo(): PDO
+    {
+        $connection = $this->adapter->getConnection();
+        self::assertInstanceOf(PDO::class, $connection);
+
+        return $connection;
+    }
+
+    private function query(string $sql): \PDOStatement
+    {
+        $statement = $this->pdo()->query($sql);
+        self::assertNotFalse($statement);
+
+        return $statement;
+    }
+
+    private function migration(): \CanonicalizeAuditEvents
+    {
+        $migration = new \CanonicalizeAuditEvents('testing', self::VERSION);
+        $migration->setAdapter($this->adapter);
+
+        return $migration;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function insertLegacy(string $eventType, array $payload, int $actor = 1, ?int $entityId = null): void
+    {
+        $statement = $this->pdo()->prepare(
+            'INSERT INTO audit_events (organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json) '
+            . 'VALUES (7, ?, \'subject\', ?, ?, \'2026-07-01 09:00:00\', ?)',
+        );
+        $statement->execute([$eventType, $entityId, $actor, json_encode($payload, JSON_THROW_ON_ERROR)]);
+    }
+
+    /**
+     * @return array<string, array{before: ?string, after: ?string, metadata: ?string}>
+     */
+    private function convertedByAction(): array
+    {
+        $rows = $this->query('SELECT action, before_json, after_json, metadata_json FROM audit_events ORDER BY id')
+            ->fetchAll(PDO::FETCH_ASSOC);
+
+        $byAction = [];
+        foreach ($rows as $row) {
+            $byAction[(string) $row['action']] = [
+                'before' => $row['before_json'],
+                'after' => $row['after_json'],
+                'metadata' => $row['metadata_json'],
+            ];
+        }
+
+        return $byAction;
+    }
+
+    public function test_backfill_converts_every_stored_payload_shape_losslessly(): void
+    {
+        $this->insertLegacy('login_succeeded', ['after' => ['user_id' => 20, 'email' => 'tanaka@demo.example']]);
+        $this->insertLegacy('login_failed', ['after' => ['email' => 'admin@nene-clear.dev', 'failure_reason' => 'invalid_credentials']], 0);
+        $this->insertLegacy('user_deleted', ['before' => ['user_id' => 38, 'email' => 'gone@dev.local', 'role' => 'member']], 1, 38);
+        $this->insertLegacy('dunning_resumed', ['invoice_id' => 2104, 'before' => ['is_paused' => true], 'after' => ['is_paused' => false]], 1, 2104);
+        $this->insertLegacy('invitation_accepted', ['before' => ['status' => 'invited'], 'after' => ['status' => 'active']], 40, 40);
+        // Stage-1 folded rows (framework SinglePayload shape).
+        $this->insertLegacy('dunning_paused', ['before' => ['is_paused' => false], 'after' => ['is_paused' => true], 'metadata' => ['invoice_id' => 2104]], 1, 2104);
+        $this->insertLegacy('clear_settings_updated', ['before' => ['dunning_min_interval_days' => 14], 'after' => ['dunning_min_interval_days' => 7]], 1, 7);
+
+        $this->migration()->up();
+
+        // Schema is canonical: renamed columns exist, payload_json is gone.
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'action'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'actor_id'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'before_json'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'after_json'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'metadata_json'));
+        self::assertFalse($this->adapter->hasColumn('audit_events', 'payload_json'));
+        self::assertFalse($this->adapter->hasColumn('audit_events', 'event_type'));
+        self::assertFalse($this->adapter->hasColumn('audit_events', 'actor_user_id'));
+
+        $converted = $this->convertedByAction();
+        self::assertCount(7, $converted, 'every inserted row survives the migration');
+
+        // Flat after-only: snapshot moves, nothing else appears.
+        self::assertNull($converted['login_succeeded']['before']);
+        self::assertSame(['user_id' => 20, 'email' => 'tanaka@demo.example'], self::decode($converted['login_succeeded']['after']));
+        self::assertNull($converted['login_succeeded']['metadata']);
+
+        // Flat before-only.
+        self::assertSame(['user_id' => 38, 'email' => 'gone@dev.local', 'role' => 'member'], self::decode($converted['user_deleted']['before']));
+        self::assertNull($converted['user_deleted']['after']);
+        self::assertNull($converted['user_deleted']['metadata']);
+
+        // Flat with a context key: the context lands in metadata — no information lost.
+        self::assertSame(['is_paused' => true], self::decode($converted['dunning_resumed']['before']));
+        self::assertSame(['is_paused' => false], self::decode($converted['dunning_resumed']['after']));
+        self::assertSame(['invoice_id' => 2104], self::decode($converted['dunning_resumed']['metadata']));
+
+        // Flat before+after with no context: metadata stays null.
+        self::assertSame(['status' => 'invited'], self::decode($converted['invitation_accepted']['before']));
+        self::assertSame(['status' => 'active'], self::decode($converted['invitation_accepted']['after']));
+        self::assertNull($converted['invitation_accepted']['metadata']);
+
+        // Stage-1 folded: direct mapping, metadata preserved.
+        self::assertSame(['is_paused' => false], self::decode($converted['dunning_paused']['before']));
+        self::assertSame(['is_paused' => true], self::decode($converted['dunning_paused']['after']));
+        self::assertSame(['invoice_id' => 2104], self::decode($converted['dunning_paused']['metadata']));
+
+        // Stage-1 folded without metadata.
+        self::assertSame(['dunning_min_interval_days' => 14], self::decode($converted['clear_settings_updated']['before']));
+        self::assertNull($converted['clear_settings_updated']['metadata']);
+
+        // No row is left unconverted: every row has at least one canonical
+        // payload column populated (all inputs carried a snapshot).
+        $unconverted = $this->query('SELECT COUNT(*) FROM audit_events WHERE before_json IS NULL AND after_json IS NULL AND metadata_json IS NULL')
+            ->fetchColumn();
+        self::assertSame(0, (int) $unconverted, 'backfill must convert every row');
+
+        // Non-payload columns are untouched by the backfill.
+        $row = $this->query("SELECT organization_id, entity_type, entity_id, actor_id, occurred_at FROM audit_events WHERE action = 'dunning_resumed'")
+            ->fetch(PDO::FETCH_ASSOC);
+        self::assertIsArray($row);
+        self::assertSame(7, (int) $row['organization_id']);
+        self::assertSame('subject', $row['entity_type']);
+        self::assertSame(2104, (int) $row['entity_id']);
+        self::assertSame(1, (int) $row['actor_id']);
+        self::assertSame('2026-07-01 09:00:00', $row['occurred_at']);
+    }
+
+    public function test_up_is_rerun_safe_after_completion(): void
+    {
+        $this->insertLegacy('login_succeeded', ['after' => ['user_id' => 1]]);
+
+        $this->migration()->up();
+        // A second run must be a no-op (every step is hasColumn-guarded).
+        $this->migration()->up();
+
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'action'));
+        self::assertFalse($this->adapter->hasColumn('audit_events', 'payload_json'));
+        self::assertSame(
+            ['user_id' => 1],
+            self::decode((string) $this->query('SELECT after_json FROM audit_events')->fetchColumn()),
+        );
+    }
+
+    public function test_down_restores_the_stage1_shape(): void
+    {
+        $this->insertLegacy('dunning_resumed', ['invoice_id' => 9, 'before' => ['is_paused' => true], 'after' => ['is_paused' => false]]);
+
+        $this->migration()->up();
+        $this->migration()->down();
+
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'event_type'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'actor_user_id'));
+        self::assertTrue($this->adapter->hasColumn('audit_events', 'payload_json'));
+        self::assertFalse($this->adapter->hasColumn('audit_events', 'before_json'));
+
+        // Content survives the round trip in the stage-1 folded shape.
+        self::assertSame(
+            ['before' => ['is_paused' => true], 'after' => ['is_paused' => false], 'metadata' => ['invoice_id' => 9]],
+            self::decode((string) $this->query('SELECT payload_json FROM audit_events')->fetchColumn()),
+        );
+    }
+
+    public function test_backfill_aborts_loudly_on_a_non_object_payload(): void
+    {
+        $this->pdo()->exec(
+            'INSERT INTO audit_events (organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json) '
+            . "VALUES (7, 'login_succeeded', 'user', NULL, 1, '2026-07-01 09:00:00', '\"scalar\"')",
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('payload_json is not a JSON object');
+
+        $this->migration()->up();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private static function decode(?string $json): ?array
+    {
+        if ($json === null || $json === '') {
+            return null;
+        }
+
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/tests/Database/ImportBankCsvPdoTest.php
+++ b/tests/Database/ImportBankCsvPdoTest.php
@@ -97,9 +97,9 @@ final class ImportBankCsvPdoTest extends TestCase
         self::assertSame(110000, $rows[0]->amountCents);
         self::assertSame('unmatched', $rows[0]->status->value);
 
-        $audit = $this->query->fetchOne('SELECT event_type, actor_user_id FROM audit_events WHERE event_type = ?', ['bank_import']);
+        $audit = $this->query->fetchOne('SELECT action, actor_id FROM audit_events WHERE action = ?', ['bank_import']);
         self::assertNotNull($audit);
-        self::assertSame(42, (int) $audit['actor_user_id']);
+        self::assertSame(42, (int) $audit['actor_id']);
     }
 
     public function test_reimporting_same_file_is_blocked(): void

--- a/tests/Database/PdoAuditReadRepositoryTest.php
+++ b/tests/Database/PdoAuditReadRepositoryTest.php
@@ -13,13 +13,13 @@ use NeneClear\Tests\Support\SchemaFixture;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Read side of the audit trail after the framework recorder adoption (stage ①).
+ * Read side of the audit trail on the canonical schema (stage 2, Issue #258).
  *
- * The framework writes new rows in SinglePayload *folded* shape
- * (`{before, after, metadata:{…}}`), while historical rows are *flat*
- * (`{…context, before, after}`). This proves both shapes read back as the same
- * flat API payload, and that Clear's `actor_user_id` sort (absent from the
- * framework's `AuditQuery`) still works.
+ * Every row is stored canonically (`before_json` / `after_json` /
+ * `metadata_json`), so hydration is a straight column read — the stage-1
+ * flat/folded normalization layer is gone. Clear-specific read concerns are
+ * covered here: tenant scoping, the `actor_id` sort (absent from the framework
+ * `AuditQuery`), and the inclusive `DATE(occurred_at)` bounds.
  */
 final class PdoAuditReadRepositoryTest extends TestCase
 {
@@ -43,18 +43,20 @@ final class PdoAuditReadRepositoryTest extends TestCase
     }
 
     private function insertRaw(
-        string $eventType,
+        string $action,
         string $entityType,
         ?int $entityId,
         int $actor,
         string $at,
-        string $payloadJson,
+        ?string $beforeJson,
+        ?string $afterJson,
+        ?string $metadataJson = null,
         int $orgId = 7,
     ): void {
         $this->query->execute(
-            'INSERT INTO audit_events (organization_id, event_type, entity_type, entity_id, actor_user_id, occurred_at, payload_json) '
-            . 'VALUES (?, ?, ?, ?, ?, ?, ?)',
-            [$orgId, $eventType, $entityType, $entityId, $actor, $at, $payloadJson],
+            'INSERT INTO audit_events (organization_id, action, entity_type, entity_id, actor_id, occurred_at, before_json, after_json, metadata_json) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [$orgId, $action, $entityType, $entityId, $actor, $at, $beforeJson, $afterJson, $metadataJson],
         );
     }
 
@@ -66,11 +68,7 @@ final class PdoAuditReadRepositoryTest extends TestCase
         return $rows[0];
     }
 
-    /**
-     * A legacy flat row (context key alongside before/after) is returned verbatim:
-     * the context key stays at the top level for the frontend's context panel.
-     */
-    public function test_legacy_flat_row_is_returned_verbatim(): void
+    public function test_hydrates_before_after_and_metadata_from_canonical_columns(): void
     {
         $this->insertRaw(
             'dunning_paused',
@@ -78,89 +76,63 @@ final class PdoAuditReadRepositoryTest extends TestCase
             5,
             2,
             '2026-04-20 12:00:00',
-            (string) json_encode(['invoice_id' => 5, 'before' => ['is_paused' => false], 'after' => ['is_paused' => true]]),
+            (string) json_encode(['is_paused' => false]),
+            (string) json_encode(['is_paused' => true]),
+            (string) json_encode(['invoice_id' => 5]),
         );
 
-        $event = $this->find(new AuditEventFilter(eventType: 'dunning_paused'));
+        $event = $this->find(new AuditEventFilter(action: 'dunning_paused'));
 
-        self::assertSame(
-            ['invoice_id' => 5, 'before' => ['is_paused' => false], 'after' => ['is_paused' => true]],
-            $event->payload,
-        );
+        self::assertSame('dunning_paused', $event->action);
+        self::assertSame('invoice', $event->entityType);
+        self::assertSame(5, $event->entityId);
+        self::assertSame(2, $event->actorId);
+        self::assertSame(['is_paused' => false], $event->before);
+        self::assertSame(['is_paused' => true], $event->after);
+        self::assertSame(['invoice_id' => 5], $event->metadata);
     }
 
-    /**
-     * A framework-folded row is normalized back to the flat shape: the metadata
-     * object's keys are lifted to the top level and the `metadata` wrapper is
-     * dropped, so it is indistinguishable from a legacy flat row.
-     */
-    public function test_folded_row_is_normalized_to_flat_shape(): void
+    public function test_null_columns_hydrate_as_null(): void
     {
         $this->insertRaw(
-            'dunning_resumed',
-            'invoice',
-            5,
+            'user_created',
+            'user',
+            10,
             1,
             '2026-04-10 09:00:00',
-            (string) json_encode(['before' => ['is_paused' => true], 'after' => ['is_paused' => false], 'metadata' => ['invoice_id' => 5]]),
+            null,
+            (string) json_encode(['email' => 'a@acme.example']),
         );
 
-        $event = $this->find(new AuditEventFilter(eventType: 'dunning_resumed'));
+        $event = $this->find(new AuditEventFilter(action: 'user_created'));
 
-        self::assertArrayNotHasKey('metadata', $event->payload);
-        self::assertSame(5, $event->payload['invoice_id']);
-        self::assertSame(['is_paused' => true], $event->payload['before']);
-        self::assertSame(['is_paused' => false], $event->payload['after']);
+        self::assertNull($event->before);
+        self::assertSame(['email' => 'a@acme.example'], $event->after);
+        self::assertNull($event->metadata);
     }
 
-    /**
-     * The whole point of stage ①: a folded row and a flat row carrying the same
-     * logical content expose an identical payload to the API (same context key at
-     * the top level, same before/after, no `metadata` wrapper on either).
-     */
-    public function test_folded_and_flat_rows_expose_identical_payload_shape(): void
+    /** `actor_id` sort — a column the framework `AuditQuery` cannot express. */
+    public function test_sort_by_actor_id(): void
     {
-        $flat = ['invoice_id' => 9, 'before' => ['is_paused' => false], 'after' => ['is_paused' => true]];
-        $this->insertRaw('dunning_paused', 'invoice', 9, 3, '2026-05-01 08:00:00', (string) json_encode($flat));
-        $this->insertRaw(
-            'dunning_paused',
-            'invoice',
-            9,
-            3,
-            '2026-05-02 08:00:00',
-            (string) json_encode(['before' => ['is_paused' => false], 'after' => ['is_paused' => true], 'metadata' => ['invoice_id' => 9]]),
-        );
+        $this->insertRaw('user_created', 'user', 1, 9, '2026-04-10 09:00:00', null, '{}');
+        $this->insertRaw('user_created', 'user', 2, 3, '2026-04-11 09:00:00', null, '{}');
+        $this->insertRaw('user_created', 'user', 3, 6, '2026-04-12 09:00:00', null, '{}');
 
-        $rows = $this->repo->findByOrganization(7, new AuditEventFilter(eventType: 'dunning_paused'), 50, 0);
-        self::assertCount(2, $rows);
-
-        // Both rows normalize to the same flat payload regardless of stored shape.
-        self::assertSame($rows[0]->payload, $rows[1]->payload);
-        self::assertSame($flat, $rows[0]->payload);
-    }
-
-    /** `actor_user_id` sort — a column the framework `AuditQuery` cannot express. */
-    public function test_sort_by_actor_user_id(): void
-    {
-        $this->insertRaw('user_created', 'user', 1, 9, '2026-04-10 09:00:00', (string) json_encode(['after' => []]));
-        $this->insertRaw('user_created', 'user', 2, 3, '2026-04-11 09:00:00', (string) json_encode(['after' => []]));
-        $this->insertRaw('user_created', 'user', 3, 6, '2026-04-12 09:00:00', (string) json_encode(['after' => []]));
-
-        $rows = $this->repo->findByOrganization(7, new AuditEventFilter(sortColumn: 'actor_user_id', sortDirection: 'asc'), 50, 0);
-        $actors = array_map(static fn (AuditEvent $e): int => $e->actorUserId, $rows);
+        $rows = $this->repo->findByOrganization(7, new AuditEventFilter(sortColumn: 'actor_id', sortDirection: 'asc'), 50, 0);
+        $actors = array_map(static fn (AuditEvent $e): int => $e->actorId, $rows);
         self::assertSame([3, 6, 9], $actors);
     }
 
     public function test_tenant_scoping_and_filters(): void
     {
-        $this->insertRaw('user_created', 'user', 10, 1, '2026-04-10 09:00:00', (string) json_encode(['after' => []]));
-        $this->insertRaw('login_failed', 'user', null, 0, '2026-04-25 23:00:00', (string) json_encode(['after' => []]));
-        $this->insertRaw('user_created', 'user', 11, 1, '2026-05-02 09:00:00', (string) json_encode(['after' => []]), 99);
+        $this->insertRaw('user_created', 'user', 10, 1, '2026-04-10 09:00:00', null, '{}');
+        $this->insertRaw('login_failed', 'user', null, 0, '2026-04-25 23:00:00', null, '{}');
+        $this->insertRaw('user_created', 'user', 11, 1, '2026-05-02 09:00:00', null, '{}', null, 99);
 
         self::assertCount(2, $this->repo->findByOrganization(7, new AuditEventFilter(), 50, 0));
         self::assertSame(2, $this->repo->countByOrganization(7, new AuditEventFilter()));
-        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(eventType: 'user_created'), 50, 0));
-        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(actorUserId: 1), 50, 0));
+        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(action: 'user_created'), 50, 0));
+        self::assertCount(1, $this->repo->findByOrganization(7, new AuditEventFilter(actorId: 1), 50, 0));
 
         $range = new AuditEventFilter(occurredFrom: '2026-04-20', occurredTo: '2026-04-30');
         self::assertCount(1, $this->repo->findByOrganization(7, $range, 50, 0));

--- a/tests/Http/AuditHttpTest.php
+++ b/tests/Http/AuditHttpTest.php
@@ -115,24 +115,25 @@ final class AuditHttpTest extends TestCase
         $body = $this->decode($list);
 
         self::assertArrayHasKey('items', $body);
-        $types = array_column($body['items'], 'event_type');
-        self::assertContains('user_created', $types);
-        self::assertContains('login_succeeded', $types);
+        $actions = array_column($body['items'], 'action');
+        self::assertContains('user_created', $actions);
+        self::assertContains('login_succeeded', $actions);
 
         $userCreated = null;
         foreach ($body['items'] as $item) {
-            if ($item['event_type'] === 'user_created') {
+            if ($item['action'] === 'user_created') {
                 $userCreated = $item;
                 break;
             }
         }
         self::assertNotNull($userCreated);
-        self::assertSame('new@acme.example', $userCreated['payload']['after']['email']);
+        self::assertNull($userCreated['before']);
+        self::assertSame('new@acme.example', $userCreated['after']['email']);
         // No password material ever reaches the audit trail.
         self::assertStringNotContainsStringIgnoringCase('a-strong-password', (string) json_encode($userCreated));
     }
 
-    public function test_event_type_filter_narrows_results(): void
+    public function test_action_filter_narrows_results(): void
     {
         $token = $this->tokenFor('admin@acme.example');
         $this->request('POST', '/admin/users', $token, [
@@ -141,9 +142,9 @@ final class AuditHttpTest extends TestCase
             'password' => 'a-strong-password',
         ]);
 
-        $body = $this->decode($this->request('GET', '/admin/audit-events?event_type=user_created', $token));
-        $types = array_unique(array_column($body['items'], 'event_type'));
-        self::assertSame(['user_created'], array_values($types));
+        $body = $this->decode($this->request('GET', '/admin/audit-events?action=user_created', $token));
+        $actions = array_unique(array_column($body['items'], 'action'));
+        self::assertSame(['user_created'], array_values($actions));
     }
 
     public function test_entity_type_is_recorded_and_filterable(): void
@@ -157,7 +158,7 @@ final class AuditHttpTest extends TestCase
         $newUserId = $created['user_id'];
 
         // The user_created event carries entity_type=user and entity_id=<new id>.
-        $body = $this->decode($this->request('GET', '/admin/audit-events?event_type=user_created', $token));
+        $body = $this->decode($this->request('GET', '/admin/audit-events?action=user_created', $token));
         self::assertSame('user', $body['items'][0]['entity_type']);
         self::assertSame($newUserId, $body['items'][0]['entity_id']);
 

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -144,12 +144,14 @@ final class SchemaFixture
             'CREATE TABLE audit_events (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 organization_id INTEGER NOT NULL,
-                event_type TEXT NOT NULL,
+                action TEXT NOT NULL,
                 entity_type TEXT NOT NULL DEFAULT \'\',
                 entity_id INTEGER,
-                actor_user_id INTEGER NOT NULL,
+                actor_id INTEGER NOT NULL,
                 occurred_at TEXT NOT NULL,
-                payload_json TEXT NOT NULL
+                before_json TEXT,
+                after_json TEXT,
+                metadata_json TEXT
             )'
         );
     }

--- a/tests/e2e/capture-screens.mjs
+++ b/tests/e2e/capture-screens.mjs
@@ -38,7 +38,7 @@ const dunning = (o) => ({ dunning_notice_id: 1, organization_id: 7, invoice_id: 
 const invoice = (o) => ({ invoice_id: 123, invoice_number: 'INV-2026-009', client_id: 45, issued_at: '2026-03-31', due_at: '2026-04-30', total_cents: 110000, outstanding_cents: 110000, status: 'overdue', currency: 'JPY', ...o })
 const usr = (o) => ({ user_id: 1, organization_id: 7, email: 'member@acme.example', role: 'member', status: 'active', ...o })
 const settings = { organization_id: 7, upstream_base_url: 'https://invoice.example.com', upstream_token_ref: 'NENE_INVOICE_BEARER_TOKEN', dunning_min_interval_days: 7, bank_accounts: [{ bank_account_id: 1, bank_name: 'みずほ銀行', bank_branch: '本店', account_type: 'ordinary', account_number: '1234567' }] }
-const audit = (o) => ({ audit_event_id: 1, organization_id: 7, event_type: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1, actor_user_id: 1, occurred_at: '2026-04-21 10:00:00', payload: { before: { bank_transaction_status: 'unmatched' }, after: { bank_transaction_status: 'matched', total_allocated_cents: 110000 } }, ...o })
+const audit = (o) => ({ audit_event_id: 1, organization_id: 7, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1, actor_id: 1, occurred_at: '2026-04-21 10:00:00', before: { bank_transaction_status: 'unmatched' }, after: { bank_transaction_status: 'matched', total_allocated_cents: 110000 }, metadata: null, ...o })
 
 const txs = [
   tx({ bank_transaction_id: 1, status: 'unmatched' }),
@@ -56,11 +56,11 @@ const users = [
   usr({ user_id: 3, email: 'sato@acme.example', role: 'viewer', status: 'invited' }),
 ]
 const audits = [
-  audit({ audit_event_id: 5, event_type: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1 }),
-  audit({ audit_event_id: 4, event_type: 'dunning_sent', entity_type: 'dunning_notice', entity_id: 7, payload: { after: { invoice_number: 'INV-2026-001', recipient_email: 'accounts@acme.example', channel: 'log' } } }),
-  audit({ audit_event_id: 3, event_type: 'user_updated', entity_type: 'user', entity_id: 2, payload: { before: { role: 'viewer' }, after: { role: 'member' } } }),
-  audit({ audit_event_id: 2, event_type: 'clear_settings_updated', entity_type: 'clear_settings', entity_id: 7, payload: { before: { dunning_min_interval_days: 14 }, after: { dunning_min_interval_days: 7 } } }),
-  audit({ audit_event_id: 1, event_type: 'login_succeeded', entity_type: 'user', entity_id: 1, payload: { after: { email: 'admin@acme.example' } } }),
+  audit({ audit_event_id: 5, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1 }),
+  audit({ audit_event_id: 4, action: 'dunning_sent', entity_type: 'dunning_notice', entity_id: 7, before: null, after: { invoice_number: 'INV-2026-001', recipient_email: 'accounts@acme.example', channel: 'log' } }),
+  audit({ audit_event_id: 3, action: 'user_updated', entity_type: 'user', entity_id: 2, before: { role: 'viewer' }, after: { role: 'member' }, metadata: { user_id: 2, email: 'member@acme.example' } }),
+  audit({ audit_event_id: 2, action: 'clear_settings_updated', entity_type: 'clear_settings', entity_id: 7, before: { dunning_min_interval_days: 14 }, after: { dunning_min_interval_days: 7 } }),
+  audit({ audit_event_id: 1, action: 'login_succeeded', entity_type: 'user', entity_id: 1, before: null, after: { email: 'admin@acme.example' } }),
 ]
 
 function payloadFor(pathname, method, empty) {


### PR DESCRIPTION
## 目的

段階①（#254 / PR #255）が施主判断待ちとして残した canonical 化を実施する（**施主決裁 2026-07-08**）。新旧二重形（`payload_json` 内の folded/flat）の二重サポートをやめ、テーブル・API・FE を NENE2 framework canonical 形（`AuditTableConfig::canonical()`、ADR 0014 の収斂ターゲット）に一本化する。参照正 = nene-invoice の canonical 実装（invoice PR #588）。

Closes #258

## 変更点

### スキーマ（migration `20260708120000`）

`audit_events` を canonical 形へ:

| 旧 | 新 |
| --- | --- |
| `event_type` | `action`（値の文字列は不変） |
| `actor_user_id` | `actor_id` |
| `payload_json`（folded/flat 混在） | `before_json` / `after_json` / `metadata_json` |

- **backfill は無損失**: flat 行 `{…context, before, after}` の context キーは `metadata_json` へ、段階① folded 行 `{before, after, metadata:{…}}` は直写像。全 payload キーが三列のいずれかに必ず着地する（**監査情報量は不減**・append-only 尊重＝形式の正規化のみ）。
- 各ステップ hasColumn ガードで**再実行安全**。非オブジェクト payload は fail-loud（migration 中断・`payload_json` は無傷）。`down()` は段階① folded 形へ復元。

### write 側

- `AuditServiceProvider::tableConfig()` → ノブなしの `AuditTableConfig::canonical()`。record call site（framework `Nene2\Audit\AuditEvent` 構築・TX 原子性 `forExecutor()`）は段階①のまま無変更。

### read 側（正規化レイヤ撤去）

- `PdoAuditReadRepository::normalize()`（新旧両形→flat の正規化）を撤去し、canonical 三列を直接 hydrate。
- read repo は**製品所有のまま**: org スコープ・`actor_id` ソート・inclusive `DATE(occurred_at)` 境界は framework `AuditQuery` が表現できないため（段階①と同じ判断・invoice との構成差分は下記）。

### API / OpenAPI / 用語レジストリ / FE（同一 PR で追随）

- `GET /admin/audit-events`: レスポンスは `payload` に代えて `before` / `after` / `metadata`（各 nullable object）。query params `event_type`→`action`・`actor_user_id`→`actor_id`、`sort_by` は `occurred_at | action | entity_type | actor_id`。
- `terminology.md`: §2 見出しを Audit actions（`audit_events.action`）へ、§3 の canonical/Never を反転登録（`event_type`・`actor_user_id`・`payload_json` は pre-#258 の rejected synonym に）。§5 filter 一覧も追随。
- FE: `types`（`AuditAction`・`AuditEvent.before/after/metadata`）・`endpoints`・`AuditLogPage`（ソート列・詳細パネルは metadata/before/after 表示）・e2e スクリーンショット mock。i18n ラベルキーは不変。

## invoice（参照正）との差分

- invoice は transition config のまま（テーブル `audit_logs`・`actor_user_id`・`created_at`・**metadata 列なし**）。clear は decision「metadata は捨てない」のため、framework canonical そのもの（`metadata_json` 列あり・`actor_id`・`occurred_at`）に収斂した。framework の canonical() ドキュメントに施主要件として明記されている収斂先そのもの。
- invoice の read は framework `AuditQuery` への薄い写像だが、clear の read は直接 SQL を維持（`actor_id` ソートと `DATE()` 境界を API から落とさないため）。Recorder / TableConfig / ServiceProvider の構成は同型。
- NENE2 参照スキーマとの adaptation: id 系は clear の整数のまま（VARCHAR ULID 対応は不要）、`organization_id` / `actor_id` は NOT NULL 維持（actor 0 = system）。インデックスは既存（org+action 複合・entity 複合）を維持。

## 実査結果

- **本番デプロイ**: なし。ライブ運用は records / suite のみ（横断 board・daily 確認）。clear は LP 未公開・Invoice 実接続 live 化も未了（`docs/todo/current.md`）。backfill リスクは dev/テストデータのみ。第三者インストール（release ZIP）が仮にあっても Phinx 経由で同 migration が適用され、ガード＋fail-loud で証跡は壊れない。
- **旧形式行の実形**: dev DB（sqlite・58 行）を実査し backfill テスト入力に反映（after-only / before-only / context 付き flat / before+after flat / folded±metadata）。
- **dev DB で実 migration 検証**: 58 行全変換・未変換 0・context→metadata 保持 10 行・非 payload 列は不変。

## 検証

- `composer check` 緑（phpunit 361 tests / PHPStan L8 / cs / conformance）。
- `npm run check`（frontend: tsc + eslint + vitest 46 tests）緑。
- 新規テスト: `CanonicalizeAuditEventsMigrationTest`（実 migration を SQLite adapter で駆動 — 全 shape 変換網羅・全行変換担保・up 再実行安全・down 往復・fail-loud）、`PdoAuditReadRepositoryTest`（canonical read 契約: hydration・filter・`actor_id` ソート・tenant scoping・日付境界）、`AuditHttpTest`（HTTP 契約: `action`/`before`/`after`）。
- 付随変更: `phpstan.neon` に `scanDirectories: database/migrations`（migration クラスは file-load のためシンボル発見用）。

Self-review: backend-api, database, openapi-contract, frontend

## 残リスク

- 破壊的 API 変更（フィールド名 rename）だが、本番デプロイ・外部コンシューマなしを実査済み。FE は同一 PR で追随。

🤖 Generated with [Claude Code](https://claude.com/claude-code)