### PR TITLE
Demo enablement: T-relative seeder, demo upstream fixture, runbook (+ CSV unit & JSON body fixes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 APP_ENV=local
 
+# JWT signing secret — REQUIRED for the admin surface (fail-close: when empty,
+# the app boots with /health only and registers no authenticated routes).
+# Generate: php -r 'echo bin2hex(random_bytes(32)), "\n";'
+NENE_CLEAR_JWT_SECRET=
+
 # PHP backend port (used by Vite proxy). Fixed: 8384 (nene-clear local port scheme).
 NENE_CLEAR_PORT=8384
 
@@ -65,3 +70,16 @@ NENE2_MACHINE_API_KEY=
 # Leave empty to store as-is. Do NOT lose this key — encrypted values cannot be
 # read without it.
 NENE_CLEAR_ENCRYPTION_KEY=
+
+# --- Demo deployment (#260, docs/demo.md) --------------------------------------
+# NENE_CLEAR_DEMO_UPSTREAM=1 pre-populates the standalone fake Invoice upstream
+# with T-relative demo invoices (upstream match suggestions + live dunning sends
+# work without a real NeNe Invoice). Only effective while
+# NENE_INVOICE_API_BASE_URL is empty; never enable on a production install.
+NENE_CLEAR_DEMO_UPSTREAM=
+
+# Fixed hand-out credentials used by tools/seed-demo.php (reset = rerun).
+# Keep them here so nightly resets don't rotate the passwords. 12+ chars;
+# QUOTE values containing # (dotenv treats an unquoted # as a comment).
+NENE_CLEAR_DEMO_ADMIN_PASSWORD=
+NENE_CLEAR_DEMO_VIEWER_PASSWORD=

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,113 @@
+# Demo Environment Runbook
+
+One page for running, showing, and resetting the NeNe Clear prospect demo
+(#260). The demo is a **fixed, pre-seeded organization** with hand-out
+credentials — no self-signup, no auth-code changes. Reset = rerun the seeder.
+
+## 1. Prepare
+
+```bash
+composer install
+composer migrations:migrate
+docker compose up -d mailpit          # local: catches dunning mail on :8383
+```
+
+`.env` (see `.env.example` for the full comments):
+
+```dotenv
+NENE_CLEAR_JWT_SECRET=<64 hex chars>            # required — fail-close without it
+NENE_CLEAR_DEMO_UPSTREAM=1                      # live upstream suggestions + dunning
+NENE_CLEAR_DEMO_ADMIN_PASSWORD="…12+ chars…"    # quote values containing #
+NENE_CLEAR_DEMO_VIEWER_PASSWORD="…12+ chars…"
+SMTP_HOST=127.0.0.1                             # local Mailpit; empty = log-only mailer
+SMTP_PORT=1383
+```
+
+## 2. Seed / reset
+
+```bash
+php tools/seed-demo.php --force
+```
+
+Reads the demo passwords from `.env` (or `--admin-password` / `--viewer-password`).
+**Destructive for the demo org only**: deletes every record of the org with slug
+`demo` (including its audit trail) and reseeds ~280 bank transactions, 12 monthly
+import batches, reconciliations, credits, manual receivables, dunning history and
+an audit trail — all dated relative to the run date, so the demo never looks
+stale. Rerunning it at any time (or nightly via cron) is the reset mechanism.
+
+It also rewrites `var/demo-bank-import.csv` — the file you import live during
+the demo.
+
+## 3. Run
+
+```bash
+php -S 0.0.0.0:8384 -t public_html public_html/index.php
+```
+
+- URL: `http://localhost:8384/` (built SPA is served from `public_html/assets/`)
+- Sign-in: `demo-admin@nene-clear.dev` (full flow) / `demo-viewer@nene-clear.dev`
+  (read-only screens) with the passwords from `.env`
+- Mailpit UI (sent dunning mail): `http://localhost:8383/`
+
+## 4. Showcase walkthrough (the 見せ場)
+
+1. **Dashboard** — unmatched count and recent dunning are non-zero out of the box.
+2. **Bank import** — upload `var/demo-bank-import.csv` against the みずほ銀行
+   account. 6 deposits import; the withdrawal row is filtered out.
+3. **Name-mismatch match (名義ズレ)** — open the new unmatched deposit
+   `ヤマダコウムテン（カ` (¥423,500) and propose: the engine suggests manual
+   receivable **MR-2026-012 / 株式会社山田工務店** on *exact amount + due soon*
+   even though the transfer name doesn't contain the client name. Confirm — the
+   receivable flips to `paid`, the transaction to `matched`, and the audit log
+   records the confirmation.
+4. **Upstream suggestion** — deposit `ヤマカワショウジ（カ` (¥660,000) proposes
+   upstream invoice **INV-2026-058** (from the demo Invoice fixture).
+5. **Dunning** — the eligible list shows the fixture invoices. Send an initial
+   notice for overdue **INV-2026-056**; the mail lands in Mailpit. Sending again
+   for **INV-2026-057** is rejected with *dunning-too-frequent* (a notice went
+   out 2 days ago — the 7-day minimum interval at work). **INV-2026-059** is
+   paused ("支払計画合意済み") to show the pause feature.
+6. **Audit log** — every step above appears immediately at the top.
+7. **Reset** — rerun `php tools/seed-demo.php --force`; everything is clean again.
+
+## 5. Known limitations
+
+- **The Invoice upstream is a fixture, not a live NeNe Invoice.**
+  `NENE_CLEAR_DEMO_UPSTREAM=1` fills the in-memory fake client per request:
+  confirming a match against an *upstream* invoice does not reduce that
+  invoice's outstanding on the next screen load (Clear's own reconciliation
+  records are persistent and correct). Prefer the manual-receivable matches for
+  the confirm showcase; treat upstream rows as "connected to Invoice" texture.
+- **MFA stays off** for the demo org — the opt-in flow's frontend + break-glass
+  CLI are still open (slice 4 of #195); do not enroll TOTP on demo accounts.
+- **Re-importing the same CSV the same day** returns a duplicate-import 409 —
+  by design (dedupe by file hash). After a reset the import works again.
+- The bearer token lives in the SPA session; a hard reload keeps the session
+  per tab (sessionStorage) but a new tab needs a fresh sign-in.
+
+## 6. Shared-hosting (HETEML) deployment sketch
+
+Target: `clear.ayane.co.jp` (same shape as invoice; decided 2026-07-09; DB
+`_nene_clear` on the shared MySQL — one product = one database, no table
+sharing). Publishing itself is a separate owner decision; the pieces are ready:
+
+1. Build the artifact on the dev machine: `composer release:zip`
+   (`tools/build-release.sh` — vendor `--no-dev`, SPA built into
+   `public_html/assets/`, installer included).
+2. Upload/rsync so that only the app's `public_html/` is inside the docroot
+   (vendor one level above, like invoice).
+3. Run `public_html/install.php` once (requirements → DB → migrate → first
+   admin), then **delete it**.
+4. `.env` on the host: MySQL `_nene_clear` credentials, `APP_DEBUG=false`,
+   real `NENE_CLEAR_JWT_SECRET`, demo variables as above; HETEML SMTP or leave
+   `SMTP_HOST` empty (log-only) until deliverability is decided.
+5. Seed: `php8.4 tools/seed-demo.php --force` over SSH; add a daily cron with
+   the same command as the reset.
+
+The repo's "shared hosting is not recommended" stance (roadmap Phase 3, #193)
+is a **data-sensitivity judgment for production deployments** (receivables /
+bank / PII: no root, throttled SMTP, weak backup story) — not a technical
+blocker. A demo org holds only fictional seed data, is reset nightly, and sends
+mail to `.example` addresses, so none of those risks apply to this deployment.
+Production installs should still go to VPS + Docker (Tier B).

--- a/docs/journal/2026-07-09.md
+++ b/docs/journal/2026-07-09.md
@@ -1,0 +1,65 @@
+# 2026-07-09 — Demo enablement (#260, #261, #262)
+
+Work order: `_work/handoff-clear-demo-2026-07-09-work-order.md` (cross-repo
+demo plan `_work/handoff-demo-trio-2026-07-09.md`, due 2026-07-12).
+
+## Shipped
+
+- **`tools/seed-demo.php`** — one-command drop-and-reseed of the `demo`
+  organization, every date relative to the run day: 12 monthly import batches
+  (~285 deposits, status spread incl. a reversed batch), reconciliations with
+  upstream + manual allocations, overpayment credits, 18 manual receivables,
+  ~57 dunning notices, a chronologically ordered audit trail (canonical #258
+  shape), 19 operators, fixed hand-out admin/viewer credentials (12+ chars via
+  env/flags), and `var/demo-bank-import.csv` for the live import showcase.
+  Deterministic (fixed mt_srand); adapter-aware via the same `.env` wiring as
+  `create-admin.php`; org/users created through the real use cases.
+- **`DemoInvoiceUpstreamFixture`** + `NENE_CLEAR_DEMO_UPSTREAM=1` (config
+  boundary, `public_html/index.php`): pre-populates the standalone fake
+  Invoice client with 6 T-relative invoices/clients so upstream suggestions
+  and **live dunning sends** work with no real upstream. Needed because
+  dunning is upstream-only (manual-receivable dunning = ADR 0014 issues 4–5,
+  unimplemented) and the default fake client is empty.
+- **`docs/demo.md`** — runbook: prepare → seed/reset → run → showcase
+  walkthrough → known limitations → HETEML deployment sketch.
+- `.env.example`: documented `NENE_CLEAR_JWT_SECRET` (was missing entirely)
+  and the demo variables.
+
+## Bugs found by walking the showcase (both fixed)
+
+1. **#261 — CSV amounts ×100 off.** `BankCsvParser` stored bank-CSV yen as
+   `amount_cents` ×1 while the UI, dunning renderer and manual-receivable form
+   all use ¥1=100. Live imports displayed ÷100 and could never exact-match a
+   receivable. Fixed in the parser; test fixtures updated.
+2. **#262 — JSON bodies unparsed.** `fromGlobals()` fills `parsedBody` from
+   `$_POST` only; the SPA posts JSON, so every `getParsedBody()` handler
+   (propose/confirm/reverse/dunning) 422'd against the real backend. Masked by
+   `withParsedBody()` in tests, API-mocked E2E, and form-encoded curl in the
+   07-03 screenshot session. Fixed with a JSON decode at the entry point.
+
+## Verified
+
+`composer check` green (361 backend tests, 6 skipped contract tests; PHPStan
+L8; CS; conformance). Frontend: 46 vitest, lint clean. Full showcase walked
+twice over HTTP against the seeded sqlite (reset in between): login → CSV
+import (6 deposits, withdrawal filtered) → 名義ズレ propose (MR-2026-012,
+score 0.7, "exact amount match; due soon") → confirm (receivable `paid`,
+outstanding 0) → dunning send INV-2026-056 (mail observed in Mailpit) →
+INV-2026-057 rejected `dunning-too-frequent`. `tools/build-release.sh`
+produced `nene-clear-0.1.0.zip` (16 MB) containing the installer, the seeder
+and the freshly built SPA.
+
+## Notes / follow-ups
+
+- Phase 0 discrepancies vs the work order (minor, reported): dev sqlite is
+  git-ignored, not "bundled"; users were 22 not 20; and the `.env` still
+  pointed at the dead screenshot stub (now reverted).
+- Registry/code drift spotted, not addressed here: terminology registry lists
+  `client_credit.status = open | partially_applied | applied` but
+  `ClientCreditStatus` implements `open | voided`.
+- Demo upstream fixture is stateless per request: confirming against an
+  *upstream* invoice does not reduce its outstanding on the next load
+  (documented in `docs/demo.md` known limitations; manual receivables are the
+  recommended confirm showcase).
+- Publication to `clear.ayane.co.jp` = owner decision; steps ready in
+  `docs/demo.md` §6.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,18 +1,20 @@
 # Current Work
 
-Last updated: 2026-07-03
+Last updated: 2026-07-09
 
-> **Latest handoff: [`handoff-2026-07-03.md`](handoff-2026-07-03.md)** — a
-> screenshot-production session for the Qiita article (#224): shots 1, 2, 6
-> done (assets + reusable pipeline in `_work/assets/`), **shots 3, 4, 5, 7
-> remaining**, and the local env is deliberately non-default (upstream stub on
-> 8390 + `.env` pointing at it — **read the handoff §3 revert checklist before
-> running backend tests**). No code changes. Dev work still resumes at
-> **installer Slice 3 (install.php fetches the release from `nene-origin.dev`)**
-> — actionable spec in [handoff-2026-07-02 §3](handoff-2026-07-02.md); that
-> session shipped `create-admin` (#228), the phinx `.env` fix (#226), the
-> installer PoC (#232), the release build (#236) and the Tier A stance (#234).
-> Cross-repo / business context: `_work/discussion-log/2026-07-01.md` (議題2).
+> **Latest: demo enablement shipped (#260–#262, 2026-07-09)** — one-command
+> T-relative demo seeder (`tools/seed-demo.php`), env-gated demo upstream
+> fixture (`NENE_CLEAR_DEMO_UPSTREAM=1`), and the demo runbook
+> **[`docs/demo.md`](../demo.md)**. Two real product bugs found and fixed on
+> the way: the bank CSV parser stored yen ×1 while everything else is ¥1=100
+> (#261), and JSON POST bodies were never parsed at the entry point, so the
+> SPA's propose/confirm/dunning-send failed against the real backend (#262).
+> The 2026-07-03 screenshot session's `.env` (dead stub on 8390) has been
+> reverted. Publication target `clear.ayane.co.jp` is prepared owner-side
+> (subdomain + `_nene_clear` DB exist); actual deploy awaits the owner's
+> go — steps in `docs/demo.md` §6. Qiita shots 3, 4, 5, 7 are still open
+> ([handoff-2026-07-03](handoff-2026-07-03.md)); dev work otherwise resumes at
+> **installer Slice 3** ([handoff-2026-07-02 §3](handoff-2026-07-02.md)).
 
 ## Status
 

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -16,6 +16,8 @@ use NeneClear\Database\ApplicationDatabaseIdentity;
 use NeneClear\Database\CandidateProfiles;
 use NeneClear\Database\MigrationVersions;
 use NeneClear\Http\ApplicationFactory;
+use NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 
@@ -91,6 +93,17 @@ $transactionManager = $connectionFactory !== null
 $smtpHost = $env('SMTP_HOST') ?: null;
 $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
 
+// Demo upstream fixture (#260): when NENE_CLEAR_DEMO_UPSTREAM=1 and no real
+// upstream is configured, pre-populate the standalone fake client with
+// T-relative demo invoices/clients so upstream match suggestions and live
+// dunning sends work in a standalone demo. Off by default; a configured real
+// upstream always wins. See NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture.
+$invoiceClient = null;
+if ($env('NENE_CLEAR_DEMO_UPSTREAM') === '1' && $invoiceApiBaseUrl === null) {
+    $invoiceClient = new FakeInvoiceUpstreamClient();
+    DemoInvoiceUpstreamFixture::populate($invoiceClient, new DateTimeImmutable('today'));
+}
+
 // Machine surface (issue #182): the repo VERSION file is this app's release
 // version, surfaced on the auth-gated GET /machine/health so deployment tooling
 // (e.g. NeNe Suite update tracking) can read the installed version.
@@ -115,6 +128,7 @@ $application = ApplicationFactory::create(
     query: $query,
     transactionManager: $transactionManager,
     jwtSecret: $jwtSecret,
+    invoiceClient: $invoiceClient,
     smtpHost: $smtpHost,
     smtpPort: (int) $env('SMTP_PORT', '1025'),
     smtpUsername: $env('SMTP_USERNAME'),
@@ -137,6 +151,18 @@ $application = ApplicationFactory::create(
 
 $psr17 = new Psr17Factory();
 $request = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+
+// fromGlobals() fills parsedBody from $_POST (form/multipart) only. The SPA
+// posts application/json, so decode it once here; handlers keep reading
+// getParsedBody() and serve form and JSON clients alike (#262). Handlers that
+// parse the raw body themselves (JsonRequestBodyParser) are unaffected — the
+// body stream stays readable.
+if (str_contains($request->getHeaderLine('Content-Type'), 'application/json')) {
+    $decodedBody = json_decode((string) $request->getBody(), associative: true);
+    if (is_array($decodedBody)) {
+        $request = $request->withParsedBody($decodedBody);
+    }
+}
 
 // SPA fallback: serve the built index.html for browser navigation requests.
 // Browsers send Accept: text/html,... — API clients send Accept: application/json

--- a/src/BankImport/BankCsvParser.php
+++ b/src/BankImport/BankCsvParser.php
@@ -10,8 +10,10 @@ use DateTimeImmutable;
  * Parses a bank CSV into deposit lines using a {@see BankAccount}'s profile.
  *
  * Only credits (deposits) are kept: rows whose amount column is empty or not a
- * positive value are skipped (they are withdrawals). The amount is read as an
- * integer in the smallest currency unit (¥1 = 1). Deposit rows with an
+ * positive value are skipped (they are withdrawals). Bank CSV cells carry
+ * integer yen; the parsed amount is stored in the app-wide `_cents` unit
+ * (1 yen = 100 cents, terminology registry §3), so imported deposits compare
+ * directly against receivable `outstanding_cents` (#261). Deposit rows with an
  * unparseable value date fail the whole import rather than being dropped
  * silently (compliance §3.1 — no silent loss of evidence).
  */
@@ -72,7 +74,7 @@ final readonly class BankCsvParser
 
         $digits = preg_replace('/[^\d-]/', '', $raw) ?? '';
 
-        return $digits === '' || $digits === '-' ? 0 : (int) $digits;
+        return $digits === '' || $digits === '-' ? 0 : (int) $digits * 100;
     }
 
     /**

--- a/src/InvoiceUpstream/DemoInvoiceUpstreamFixture.php
+++ b/src/InvoiceUpstream/DemoInvoiceUpstreamFixture.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\InvoiceUpstream;
+
+use DateTimeImmutable;
+
+/**
+ * Populates a {@see FakeInvoiceUpstreamClient} with a small, T-relative set of
+ * demo invoices/clients so a standalone demo deployment (no live NeNe Invoice)
+ * can walk the full showcase — upstream match suggestions and live dunning
+ * sends — without touching auth or the real upstream client (#260).
+ *
+ * Enabled from the config boundary (`public_html/index.php`) via the
+ * `NENE_CLEAR_DEMO_UPSTREAM` env flag; never active by default. Due dates are
+ * computed relative to "today" at request time, so the fixture never goes
+ * stale. The client is rebuilt per request (in-memory), which means payments
+ * written back on a confirmed match do not persist across requests — Clear's
+ * own reconciliation records do. `tools/seed-demo.php` seeds dunning history
+ * against the same invoice ids/numbers so both views stay coherent.
+ *
+ * Statuses use the registered upstream `invoice.status` vocabulary only
+ * (`issued`, `partially_paid` — terminology registry §2); "overdue" is a
+ * computed condition (`issued` + past due), matching dunning eligibility.
+ */
+final readonly class DemoInvoiceUpstreamFixture
+{
+    /**
+     * Rows: invoiceId, invoiceNumber, clientId, clientName, contactName,
+     * recipientEmail, totalCents, outstandingCents, dueInDays (relative to T),
+     * status.
+     *
+     * @return list<array{int, string, int, string, string, string, int, int, int, string}>
+     */
+    public static function rows(): array
+    {
+        return [
+            [2056, 'INV-2026-056', 156, 'アクメ株式会社', '経理部 佐藤様', 'billing@acme.example', 193000000, 193000000, -24, 'issued'],
+            [2057, 'INV-2026-057', 157, '株式会社テストコーポレーション', '経理部 高橋様', 'billing@testcorp.example', 84700000, 35000000, -10, 'partially_paid'],
+            [2058, 'INV-2026-058', 158, '山川商事株式会社', '経理課 田村様', 'billing@yamakawa.example', 66000000, 66000000, 6, 'issued'],
+            [2059, 'INV-2026-059', 159, 'グリーンフィールド株式会社', '管理部 中野様', 'billing@greenfield.example', 209000000, 209000000, 20, 'issued'],
+            [2060, 'INV-2026-060', 160, 'あおぞら建設株式会社', '経理部 藤井様', 'billing@aozora.example', 55000000, 33000000, -31, 'partially_paid'],
+            [2061, 'INV-2026-061', 161, '株式会社スターリング', '経理担当 大森様', 'billing@sterling.example', 96800000, 96800000, 45, 'issued'],
+        ];
+    }
+
+    public static function populate(FakeInvoiceUpstreamClient $client, DateTimeImmutable $today): void
+    {
+        foreach (self::rows() as [$invoiceId, $invoiceNumber, $clientId, , $contactName, $recipientEmail, $totalCents, $outstandingCents, $dueInDays, $status]) {
+            $client->addClient(new InvoiceClientInfo(
+                clientId: $clientId,
+                contactName: $contactName,
+                recipientEmail: $recipientEmail,
+            ));
+            $client->addInvoice(new InvoiceItem(
+                invoiceId: $invoiceId,
+                invoiceNumber: $invoiceNumber,
+                clientId: $clientId,
+                outstandingCents: $outstandingCents,
+                totalCents: $totalCents,
+                dueAt: $today->modify(sprintf('%+d days', $dueInDays))->format('Y-m-d'),
+                status: $status,
+                currency: 'JPY',
+            ));
+        }
+    }
+}

--- a/tests/BankImport/BankCsvParserBoundaryTest.php
+++ b/tests/BankImport/BankCsvParserBoundaryTest.php
@@ -75,8 +75,8 @@ final class BankCsvParserBoundaryTest extends TestCase
         $lines = $this->parse($csv);
 
         self::assertCount(2, $lines);
-        self::assertSame(1000, $lines[0]->amountCents);
-        self::assertSame(2000, $lines[1]->amountCents);
+        self::assertSame(100000, $lines[0]->amountCents);
+        self::assertSame(200000, $lines[1]->amountCents);
     }
 
     public function test_multiple_header_rows_are_skipped(): void
@@ -107,7 +107,7 @@ final class BankCsvParserBoundaryTest extends TestCase
         $lines = $this->parse($csv);
 
         self::assertCount(1, $lines);
-        self::assertSame(1234567, $lines[0]->amountCents);
+        self::assertSame(123456700, $lines[0]->amountCents);
     }
 
     public function test_missing_amount_cell_is_skipped(): void
@@ -147,6 +147,6 @@ final class BankCsvParserBoundaryTest extends TestCase
         $lines = $this->parse($csv);
 
         self::assertCount(1, $lines);
-        self::assertSame(1000, $lines[0]->amountCents);
+        self::assertSame(100000, $lines[0]->amountCents);
     }
 }

--- a/tests/BankImport/BankCsvParserTest.php
+++ b/tests/BankImport/BankCsvParserTest.php
@@ -42,10 +42,10 @@ final class BankCsvParserTest extends TestCase
 
         self::assertCount(2, $lines); // the withdrawal row is skipped
         self::assertSame('2026-04-20', $lines[0]->valueDate);
-        self::assertSame(110000, $lines[0]->amountCents);
+        self::assertSame(11000000, $lines[0]->amountCents); // ¥110,000 → cents (#261)
         self::assertSame('カ）アクメ', $lines[0]->counterpartyText);
         self::assertSame('2026-04-22', $lines[1]->valueDate);
-        self::assertSame(50000, $lines[1]->amountCents); // quoted "50,000"
+        self::assertSame(5000000, $lines[1]->amountCents); // quoted "50,000" → cents
         self::assertSame('フリコミ タロウ', $lines[1]->counterpartyText);
     }
 

--- a/tests/Database/ImportBankCsvPdoTest.php
+++ b/tests/Database/ImportBankCsvPdoTest.php
@@ -94,7 +94,7 @@ final class ImportBankCsvPdoTest extends TestCase
         $rows = (new PdoBankTransactionRepository($this->query))->findByBatch($output->bankImportBatchId);
         self::assertCount(2, $rows);
         self::assertSame('2026-04-20', $rows[0]->valueDate);
-        self::assertSame(110000, $rows[0]->amountCents);
+        self::assertSame(11000000, $rows[0]->amountCents); // ¥110,000 → cents (#261)
         self::assertSame('unmatched', $rows[0]->status->value);
 
         $audit = $this->query->fetchOne('SELECT action, actor_id FROM audit_events WHERE action = ?', ['bank_import']);

--- a/tests/Http/BankImportHttpTest.php
+++ b/tests/Http/BankImportHttpTest.php
@@ -145,10 +145,10 @@ final class BankImportHttpTest extends TestCase
         self::assertSame(1, $byCounterparty['total'] ?? null);
         self::assertSame('ACME', $byCounterparty['items'][0]['counterparty_text'] ?? null);
 
-        // Amount range filter (TARO 50,000 < ACME 110,000).
-        $byAmount = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?amount_max_cents=100000'));
+        // Amount range filter (TARO ¥50,000 < ACME ¥110,000, in cents).
+        $byAmount = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?amount_max_cents=10000000'));
         self::assertSame(1, $byAmount['total'] ?? null);
-        self::assertSame(50000, $byAmount['items'][0]['amount_cents'] ?? null);
+        self::assertSame(5000000, $byAmount['items'][0]['amount_cents'] ?? null);
 
         // Sort by amount ascending → smallest (TARO 50,000) first.
         $sorted = $this->decode($this->get($token, '/admin/bank-transactions/unmatched?sort_by=amount_cents&sort_dir=asc'));

--- a/tests/Http/ReconciliationHttpTest.php
+++ b/tests/Http/ReconciliationHttpTest.php
@@ -175,7 +175,7 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000, 'INV-001'); // exact amount + invoice number in counterparty
+        $this->addInvoice(1, 11000000, 'INV-001'); // exact amount (¥110,000 in cents, #261) + invoice number in counterparty
 
         $response = $this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]);
 
@@ -190,11 +190,11 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $response = $this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]);
 
         self::assertSame(201, $response->getStatusCode());
@@ -228,14 +228,14 @@ final class ReconciliationHttpTest extends TestCase
     public function test_confirm_against_a_manual_receivable(): void
     {
         $token = $this->tokenFor('admin@acme.example');
-        $txId = $this->importCsv($token); // 110000 deposit
+        $txId = $this->importCsv($token); // ¥110,000 deposit (11000000 cents)
 
         // A receivable entered directly in Clear (no upstream invoice).
-        $mrId = $this->seedManualReceivable(110000);
+        $mrId = $this->seedManualReceivable(11000000);
 
         $response = $this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['source' => 'manual', 'manual_receivable_id' => $mrId, 'amount_cents' => 110000]],
+            'allocations' => [['source' => 'manual', 'manual_receivable_id' => $mrId, 'amount_cents' => 11000000]],
         ]);
 
         self::assertSame(201, $response->getStatusCode());
@@ -258,8 +258,8 @@ final class ReconciliationHttpTest extends TestCase
     public function test_propose_includes_manual_receivable_candidates(): void
     {
         $token = $this->tokenFor('admin@acme.example');
-        $txId = $this->importCsv($token); // 110000 deposit
-        $mrId = $this->seedManualReceivable(110000);
+        $txId = $this->importCsv($token); // ¥110,000 deposit (11000000 cents)
+        $mrId = $this->seedManualReceivable(11000000);
 
         $body = $this->decode($this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]));
 
@@ -272,11 +272,11 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]);
 
         $response = $this->get($token, '/admin/reconciliations');
@@ -288,11 +288,11 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $reconBody = $this->decode($this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]));
         $reconId = $reconBody['payment_reconciliation_id'];
 
@@ -305,11 +305,11 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $reconId = $this->decode($this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]))['payment_reconciliation_id'];
 
         $reverseResponse = $this->post($token, '/admin/reconciliations/' . $reconId . '/reverse', [
@@ -326,12 +326,12 @@ final class ReconciliationHttpTest extends TestCase
     {
         $adminToken = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($adminToken);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $viewerToken = $this->tokenFor('viewer@acme.example');
         $response = $this->post($viewerToken, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]);
 
         self::assertSame(403, $response->getStatusCode());
@@ -349,17 +349,17 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 50000); // only 50k outstanding, tx is 110k
+        $this->addInvoice(1, 5000000); // only ¥50,000 outstanding, tx is ¥110,000
 
         $response = $this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]);
 
         self::assertSame(422, $response->getStatusCode());
         $body = $this->decode($response);
         self::assertSame(1, $body['invoice_id'] ?? null);
-        self::assertSame(50000, $body['outstanding_cents'] ?? null);
+        self::assertSame(5000000, $body['outstanding_cents'] ?? null);
     }
 
     public function test_upstream_unavailable_degrades_to_manual_candidates(): void
@@ -369,8 +369,8 @@ final class ReconciliationHttpTest extends TestCase
         $this->invoiceClient->makeUnavailable();
 
         $token = $this->tokenFor('admin@acme.example');
-        $txId = $this->importCsv($token); // 110000 deposit
-        $this->seedManualReceivable(110000);
+        $txId = $this->importCsv($token); // ¥110,000 deposit (11000000 cents)
+        $this->seedManualReceivable(11000000);
 
         $response = $this->post($token, '/admin/reconciliations/propose', ['bank_transaction_id' => $txId]);
 
@@ -385,11 +385,11 @@ final class ReconciliationHttpTest extends TestCase
     {
         $token = $this->tokenFor('admin@acme.example');
         $txId = $this->importCsv($token);
-        $this->addInvoice(1, 110000);
+        $this->addInvoice(1, 11000000);
 
         $reconId = $this->decode($this->post($token, '/admin/reconciliations', [
             'bank_transaction_id' => $txId,
-            'allocations' => [['invoice_id' => 1, 'amount_cents' => 110000]],
+            'allocations' => [['invoice_id' => 1, 'amount_cents' => 11000000]],
         ]))['payment_reconciliation_id'];
 
         $this->post($token, '/admin/reconciliations/' . $reconId . '/reverse', ['reversal_reason' => 'first']);

--- a/tools/seed-demo.php
+++ b/tools/seed-demo.php
@@ -1,0 +1,763 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Demo-org seeder (#260): drop and re-seed the fixed demo organization with
+ * realistic, T-relative data in one command, so the hosted demo never goes
+ * stale and can be reset at any time (rerun = reset).
+ *
+ * What it produces (all dates relative to the run date T):
+ *  - the demo organization + fixed hand-out credentials (1 admin, 1 viewer)
+ *    and a believable operator cast (active/invited, mixed roles);
+ *  - 12 months of bank import batches (~280 deposits) with a spread of
+ *    unmatched / partially_matched / matched / voided lines;
+ *  - confirmed and reversed reconciliations with allocations (upstream +
+ *    manual sources), overpayment client credits;
+ *  - manual receivables (ADR 0014), including open ones that pair with the
+ *    emitted live-import CSV for the name-mismatch matching showcase;
+ *  - dunning history aligned with {@see \NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture}
+ *    invoice ids, so the live dunning screen (NENE_CLEAR_DEMO_UPSTREAM=1) and
+ *    the seeded history tell one coherent story;
+ *  - an audit trail mirroring the registered actions for all of the above;
+ *  - `var/demo-bank-import.csv` — a T-relative bank CSV to import during the
+ *    demo (contains the 名義ズレ exact-amount match showcase).
+ *
+ * DESTRUCTIVE: every row belonging to the demo organization (and the whole
+ * `login_attempts` table, so stale lockouts never survive a reset) is deleted
+ * first. The demo org's audit trail is part of the demo data and is reset with
+ * it — do not point this tool at a database holding real records.
+ *
+ * Usage:
+ *   php tools/seed-demo.php --force \
+ *     --admin-password '…12+ chars…' --viewer-password '…12+ chars…'
+ *   NENE_CLEAR_DEMO_ADMIN_PASSWORD=… NENE_CLEAR_DEMO_VIEWER_PASSWORD=… \
+ *     php tools/seed-demo.php --force
+ *
+ * Database config comes from .env like the app (sqlite / mysql / pgsql).
+ * Deterministic: the same T yields the same dataset (fixed mt_srand seed).
+ *
+ * Config-boundary entry point (docs/development/nene2-compliance.md §15): raw
+ * env access and the DB wiring mirror public_html/index.php on purpose.
+ */
+
+use Dotenv\Dotenv;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use NeneClear\Auth\Role;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture;
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCaseInterface;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, 'This script must be run from the command line.' . PHP_EOL);
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+};
+
+// --- Parse arguments (--key value or --key=value) ------------------------------
+$rawArgv = $_SERVER['argv'] ?? [];
+$args = array_slice(is_array($rawArgv) ? array_values($rawArgv) : [], 1);
+$count = count($args);
+/** @var array<string, string> $opts */
+$opts = [];
+for ($i = 0; $i < $count; $i++) {
+    $arg = (string) $args[$i];
+    if ($arg === '-h' || $arg === '--help') {
+        $lines = [
+            'Drop and re-seed the demo organization with T-relative demo data.',
+            '',
+            'Usage:',
+            '  php tools/seed-demo.php --force --admin-password PASS --viewer-password PASS',
+            '',
+            'Options:',
+            '  --org-slug SLUG        Demo org slug (default: demo)',
+            '  --org-name NAME        Demo org display name (default: デモ商事株式会社)',
+            '  --admin-email EMAIL    Hand-out admin login (default: demo-admin@nene-clear.dev)',
+            '  --viewer-email EMAIL   Hand-out viewer login (default: demo-viewer@nene-clear.dev)',
+            '  --admin-password PASS  Admin password (default: NENE_CLEAR_DEMO_ADMIN_PASSWORD env)',
+            '  --viewer-password PASS Viewer password (default: NENE_CLEAR_DEMO_VIEWER_PASSWORD env)',
+            '  --force                Skip the interactive confirmation (required for cron)',
+            '  -h, --help             Show this help',
+        ];
+        fwrite(STDOUT, implode(PHP_EOL, $lines) . PHP_EOL);
+        exit(0);
+    }
+    if (!str_starts_with($arg, '--')) {
+        $fail(sprintf('Unexpected argument: %s (see --help)', $arg));
+    }
+    $body = substr($arg, 2);
+    if (str_contains($body, '=')) {
+        [$key, $value] = explode('=', $body, 2);
+    } else {
+        $key = $body;
+        $next = $i + 1 < $count ? (string) $args[$i + 1] : '';
+        if ($next !== '' && !str_starts_with($next, '--')) {
+            $value = $next;
+            $i++;
+        } else {
+            $value = '';
+        }
+    }
+    $opts[$key] = $value;
+}
+
+// --- Load .env and resolve inputs ---------------------------------------------
+if (is_file($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
+
+$optOr = static function (string $key, string $default) use ($opts): string {
+    $value = trim($opts[$key] ?? '');
+
+    return $value !== '' ? $value : $default;
+};
+
+$orgSlug = $optOr('org-slug', 'demo');
+$orgName = $optOr('org-name', 'デモ商事株式会社');
+$adminEmail = $optOr('admin-email', 'demo-admin@nene-clear.dev');
+$viewerEmail = $optOr('viewer-email', 'demo-viewer@nene-clear.dev');
+$adminPassword = $opts['admin-password'] ?? ($env('NENE_CLEAR_DEMO_ADMIN_PASSWORD') ?: '');
+$viewerPassword = $opts['viewer-password'] ?? ($env('NENE_CLEAR_DEMO_VIEWER_PASSWORD') ?: '');
+
+foreach ([[$adminEmail, '--admin-email'], [$viewerEmail, '--viewer-email']] as [$email, $flag]) {
+    if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+        $fail(sprintf('%s is not a valid email address (%s).', $email, $flag));
+    }
+}
+if (strlen($adminPassword) < 12 || strlen($viewerPassword) < 12) {
+    $fail('Demo passwords are required and must be at least 12 characters. '
+        . 'Pass --admin-password/--viewer-password or set NENE_CLEAR_DEMO_ADMIN_PASSWORD / '
+        . 'NENE_CLEAR_DEMO_VIEWER_PASSWORD in .env (keeps credentials stable across resets).');
+}
+
+// --- Database wiring (mirrors public_html/index.php) ---------------------------
+$adapter = $env('DB_ADAPTER', 'sqlite');
+$connectionFactory = (static function () use ($env, $adapter, $root): ?DatabaseConnectionFactoryInterface {
+    try {
+        $config = match ($adapter) {
+            'mysql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'mysql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '3306'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8mb4'),
+            ),
+            'pgsql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'pgsql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '5432'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8'),
+            ),
+            default => DatabaseConfig::sqlite($env('DB_NAME') ?: $root . '/database/nene_clear.sqlite3'),
+        };
+
+        return new PdoConnectionFactory($config);
+    } catch (\Throwable) {
+        return null;
+    }
+})();
+
+if ($connectionFactory === null) {
+    $fail('Database is not configured or unreachable. Check .env (DB_ADAPTER, DB_*).');
+}
+
+$query = new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter);
+$transactionManager = new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter);
+
+try {
+    $query->fetchOne('SELECT id FROM organizations LIMIT 1');
+} catch (\Throwable $e) {
+    $fail('Schema is missing or outdated — run `composer migrations:migrate` first. (' . $e->getMessage() . ')');
+}
+
+// --- Confirm the destructive reset ---------------------------------------------
+if (!isset($opts['force'])) {
+    if (!stream_isatty(STDIN)) {
+        $fail('Refusing to reset without confirmation. Pass --force (e.g. from cron).');
+    }
+    fwrite(STDOUT, sprintf(
+        "This DELETES every record of organization '%s' (including its audit trail)\n"
+        . 'and reseeds it with fresh demo data. Type the org slug to continue: ',
+        $orgSlug,
+    ));
+    $answer = trim((string) fgets(STDIN));
+    if ($answer !== $orgSlug) {
+        $fail('Aborted.');
+    }
+}
+
+$today = new DateTimeImmutable('today');
+mt_srand(20260712); // deterministic content; only T moves between runs
+
+$d = static fn (DateTimeImmutable $x): string => $x->format('Y-m-d');
+$days = static fn (int $offset): DateTimeImmutable => $today->modify(sprintf('%+d days', $offset));
+/** Random business-hours timestamp on the given day. */
+$at = static fn (DateTimeImmutable $day): string => $day->format('Y-m-d') . sprintf(' %02d:%02d:%02d', mt_rand(9, 17), mt_rand(0, 59), mt_rand(0, 59));
+$json = static fn (array $value): string => (string) json_encode($value, JSON_UNESCAPED_UNICODE);
+
+// --- 1) Delete the previous demo org, children first ---------------------------
+$existing = $query->fetchOne('SELECT id FROM organizations WHERE slug = ?', [$orgSlug]);
+$transactionManager->transactional(static function (DatabaseQueryExecutorInterface $ex) use ($existing): void {
+    if (is_array($existing)) {
+        $orgId = (int) $existing['id'];
+        foreach ([
+            'dunning_pauses', 'dunning_notices', 'reconciliation_allocations',
+            'payment_reconciliations', 'client_credits', 'bank_transactions',
+            'bank_import_batches', 'bank_accounts', 'manual_receivables',
+            'clear_settings', 'audit_events', 'user_invitations',
+        ] as $table) {
+            $ex->execute(sprintf('DELETE FROM %s WHERE organization_id = ?', $table), [$orgId]);
+        }
+        foreach (['used_totp_steps', 'recovery_codes', 'totp_secrets'] as $table) {
+            $ex->execute(
+                sprintf('DELETE FROM %s WHERE user_id IN (SELECT id FROM users WHERE organization_id = ?)', $table),
+                [$orgId],
+            );
+        }
+        $ex->execute('DELETE FROM users WHERE organization_id = ?', [$orgId]);
+        $ex->execute('DELETE FROM organizations WHERE id = ?', [$orgId]);
+    }
+
+    // Throttle state is keyed by identifier hash, not org — wipe it so a reset
+    // also clears any demo-account lockout (login_attempts is audit-exempt).
+    $ex->execute('DELETE FROM login_attempts');
+});
+fwrite(STDOUT, ($existing !== null ? "Deleted previous demo organization.\n" : "No previous demo organization found.\n"));
+
+// --- 2) Recreate org + hand-out users via the app's own use cases --------------
+$container = ApplicationFactory::container($query, $transactionManager, $env('NENE_CLEAR_JWT_SECRET'));
+
+$organization = ServiceResolver::get($container, CreateOrganizationUseCaseInterface::class)
+    ->execute(new CreateOrganizationInput(slug: $orgSlug, name: $orgName, actorUserId: 0));
+$orgId = $organization->id;
+
+$createUser = ServiceResolver::get($container, CreateUserUseCaseInterface::class);
+$admin = $createUser->execute(new CreateUserInput(
+    organizationId: $orgId,
+    email: $adminEmail,
+    role: Role::Admin,
+    password: $adminPassword,
+    actorUserId: 0,
+));
+$viewer = $createUser->execute(new CreateUserInput(
+    organizationId: $orgId,
+    email: $viewerEmail,
+    role: Role::Viewer,
+    password: $viewerPassword,
+    actorUserId: 0,
+));
+$adminId = (int) ($admin->id ?? 0);
+$viewerId = (int) ($viewer->id ?? 0);
+
+// --- 3) Bulk demo data, one transaction ----------------------------------------
+/** @var array<string, int> $counts */
+$counts = [];
+/** @var list<string> $openRefs */
+$openRefs = [];
+
+$transactionManager->transactional(static function (DatabaseQueryExecutorInterface $ex) use (
+    $orgId,
+    $adminId,
+    $viewerId,
+    $today,
+    $d,
+    $days,
+    $at,
+    $json,
+    &$counts,
+    &$openRefs,
+): void {
+    /** @var list<array{string, string, string, int, ?string, ?string, ?string}> $auditRows action, entityType, occurredAt, entityId, before, after, metadata */
+    $auditRows = [];
+
+    // Operator cast: realistic member list behind the two hand-out accounts.
+    $cast = [
+        ['tanaka@demo.example', 'admin', 'active'],
+        ['suzuki@demo.example', 'member', 'active'],
+        ['sato@demo.example', 'member', 'active'],
+        ['takahashi@demo.example', 'viewer', 'active'],
+        ['ito@demo.example', 'member', 'invited'],
+        ['watanabe@demo.example', 'viewer', 'active'],
+        ['yamamoto@demo.example', 'admin', 'active'],
+        ['nakamura@demo.example', 'member', 'active'],
+        ['kobayashi@demo.example', 'viewer', 'active'],
+        ['kato@demo.example', 'member', 'invited'],
+        ['yoshida@demo.example', 'member', 'active'],
+        ['yamada@demo.example', 'viewer', 'active'],
+        ['sasaki@demo.example', 'admin', 'active'],
+        ['matsumoto@demo.example', 'member', 'active'],
+        ['inoue@demo.example', 'viewer', 'invited'],
+        ['kimura@demo.example', 'member', 'active'],
+        ['hayashi@demo.example', 'member', 'active'],
+    ];
+    $memberIds = [];
+    foreach ($cast as $i => [$email, $role, $status]) {
+        $createdAt = $at($days(-200 + $i * 9));
+        $userId = $ex->insert(
+            'INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted, created_at, updated_at)'
+            . ' VALUES (?, ?, ?, ?, ?, 0, ?, ?)',
+            [$orgId, $email, $role, $status, password_hash(bin2hex(random_bytes(12)), PASSWORD_BCRYPT), $createdAt, $createdAt],
+        );
+        if ($role !== 'viewer' && $status === 'active') {
+            $memberIds[] = $userId;
+        }
+        $auditRows[] = ['user_created', 'user', $createdAt, $userId, null,
+            $json(['user_id' => $userId, 'email' => $email, 'role' => $role, 'status' => $status]), null];
+    }
+    $counts['users'] = count($cast) + 2;
+    $actors = [...$memberIds, $adminId];
+
+    // Org settings (upstream config is display-only in the demo).
+    $settingsAt = $at($days(-180));
+    $ex->insert(
+        'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, created_at, updated_at)'
+        . ' VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [$orgId, 'https://invoice.example', 'NENE_INVOICE_BEARER_TOKEN', 7, 3, $settingsAt, $settingsAt],
+    );
+    $auditRows[] = ['clear_settings_updated', 'clear_settings', $settingsAt, $orgId,
+        $json([]), $json(['upstream_base_url' => 'https://invoice.example', 'dunning_min_interval_days' => 7]), null];
+
+    // Bank accounts (CSV profile: date,deposit,withdrawal,counterparty; header row).
+    $accounts = [
+        ['みずほ銀行', '渋谷支店', '1234567'],
+        ['三菱UFJ銀行', '新宿支店', '7654321'],
+        ['三井住友銀行', '本店営業部', '2468013'],
+    ];
+    $accountIds = [];
+    foreach ($accounts as [$bank, $branch, $number]) {
+        $createdAt = $at($days(-190));
+        $accountIds[] = $ex->insert(
+            'INSERT INTO bank_accounts (organization_id, bank_name, bank_branch, account_type, account_number,'
+            . ' csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows,'
+            . ' is_deleted, created_at, updated_at)'
+            . " VALUES (?, ?, ?, 'ordinary', ?, 'utf8', 'Y/m/d', 0, 1, 3, 1, 0, ?, ?)",
+            [$orgId, $bank, $branch, $number, $createdAt, $createdAt],
+        );
+    }
+    $counts['bank_accounts'] = count($accountIds);
+
+    // Payers: katakana transfer name / registered client name / mail slug.
+    $companies = [
+        ['（カ）テストコーポレーション', '株式会社テストコーポレーション', 'testcorp'],
+        ['カ）アクメ', 'アクメ株式会社', 'acme'],
+        ['ヤマカワショウジ（カ', '山川商事株式会社', 'yamakawa'],
+        ['グリーンフィールド（カ', 'グリーンフィールド株式会社', 'greenfield'],
+        ['アオゾラケンセツ（カ', 'あおぞら建設株式会社', 'aozora'],
+        ['（カ）スターリング', '株式会社スターリング', 'sterling'],
+        ['フジサワデンキ（カ', '藤沢電機株式会社', 'fujisawa-denki'],
+        ['ヤマダコウムテン（カ', '株式会社山田工務店', 'yamada-koumuten'],
+        ['タカハシケンセツ（カ', '高橋建設株式会社', 'takahashi-kensetsu'],
+        ['（カ）ホシノブッサン', '星野物産株式会社', 'hoshino'],
+        ['ミナトロジスティクス（カ', 'ミナトロジスティクス株式会社', 'minato-logi'],
+        ['カ）サクラフーズ', 'さくらフーズ株式会社', 'sakura-foods'],
+        ['（カ）ワタナベセイサクショ', '渡辺製作所株式会社', 'watanabe-ss'],
+        ['ヒガシヤマショウテン（カ', '東山商店株式会社', 'higashiyama'],
+        ['カ）ニシムラウンユ', '西村運輸株式会社', 'nishimura-unyu'],
+        ['（カ）オオタケミライ', 'オオタケミライ株式会社', 'otake-mirai'],
+    ];
+    $persons = ['ヤマダ タロウ', 'イトウ ユウコ', 'サトウ ケンイチ', 'タナカ ミホ', 'コバヤシ ジュン', 'ナカムラ アヤ'];
+
+    // 12 months of imports. The batch 2 months back is reversed (its lines are
+    // voided) to show the reversal trail.
+    /** @var list<array{id: int, amount: int, date: DateTimeImmutable, company: int, status: string}> $matchable */
+    $matchable = [];
+    $txTotal = 0;
+    $statusTally = ['unmatched' => 0, 'partially_matched' => 0, 'matched' => 0, 'voided' => 0];
+    for ($m = 11; $m >= 0; $m--) {
+        $monthStart = $today->modify(sprintf('-%d months', $m))->modify('first day of this month');
+        $isCurrent = $m === 0;
+        $lastDay = $isCurrent
+            ? max(1, (int) $today->format('j') - 1)
+            : (int) $monthStart->modify('last day of this month')->format('j');
+        $importedDay = $isCurrent ? $today : $monthStart->modify('last day of this month')->modify('+3 days');
+        $reversed = $m === 2;
+        $rows = $isCurrent ? 24 : mt_rand(19, 29);
+        $accountId = $accountIds[$m % 12 < 10 ? 0 : 1];
+        $importedAt = $at($importedDay);
+        $reversedAt = $reversed ? $at($importedDay->modify('+2 days')) : null;
+        $importedBy = $actors[mt_rand(0, count($actors) - 1)];
+
+        $batchId = $ex->insert(
+            'INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, row_count,'
+            . ' status, imported_by, imported_at, reversed_at, reversal_reason, created_at, updated_at)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $orgId, $accountId, hash('sha256', 'demo-batch-' . $m . '-' . $d($monthStart)),
+                'bank_' . $monthStart->format('Ym') . '.csv', $rows,
+                $reversed ? 'reversed' : 'imported', $importedBy, $importedAt,
+                $reversedAt,
+                $reversed ? '取込ファイル誤り（再取込済み）' : null,
+                $importedAt, $importedAt,
+            ],
+        );
+        $auditRows[] = ['bank_import', 'bank_import_batch', $importedAt, $batchId, null,
+            $json(['source_filename' => 'bank_' . $monthStart->format('Ym') . '.csv', 'row_count' => $rows, 'bank_account_id' => $accountId]),
+            $json(['bank_import_batch_id' => $batchId])];
+        if ($reversedAt !== null) {
+            $auditRows[] = ['bank_import_batch_reversed', 'bank_import_batch', $reversedAt, $batchId,
+                $json(['status' => 'imported']), $json(['status' => 'reversed', 'reversal_reason' => '取込ファイル誤り（再取込済み）']), null];
+        }
+
+        for ($r = 0; $r < $rows; $r++) {
+            $isPerson = mt_rand(1, 100) <= 12;
+            $companyIdx = mt_rand(0, count($companies) - 1);
+            $counterparty = $isPerson
+                ? $persons[mt_rand(0, count($persons) - 1)]
+                : $companies[$companyIdx][0];
+            $yen = $isPerson ? mt_rand(8, 120) * 1000 : mt_rand(55, 2950) * 1000;
+            $cents = $yen * 100;
+            $valueDate = $monthStart->modify(sprintf('+%d days', mt_rand(0, max(0, $lastDay - 1))));
+
+            if ($reversed) {
+                $status = 'voided';
+            } elseif ($isPerson) {
+                // Personal transfers are the classic hard-to-match backlog:
+                // they stay unmatched (a matched line always has a matching
+                // reconciliation row below, and those are corporate only).
+                $status = 'unmatched';
+            } else {
+                $roll = mt_rand(1, 100);
+                $status = match (true) {
+                    $m >= 3 => $roll <= 88 ? 'matched' : ($roll <= 93 ? 'partially_matched' : 'unmatched'),
+                    $m >= 1 => $roll <= 60 ? 'matched' : ($roll <= 74 ? 'partially_matched' : 'unmatched'),
+                    default => $roll <= 12 ? 'matched' : ($roll <= 20 ? 'partially_matched' : 'unmatched'),
+                };
+            }
+
+            $txId = $ex->insert(
+                'INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date,'
+                . ' amount_cents, counterparty_text, line_key, status, created_at)'
+                . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $orgId, $batchId, $accountId, $d($valueDate), $cents, $counterparty,
+                    md5($batchId . '|' . $d($valueDate) . '|' . $cents . '|' . $counterparty . '|' . $r),
+                    $status, $importedAt,
+                ],
+            );
+            $txTotal++;
+            $statusTally[$status]++;
+            if ($status === 'matched' || $status === 'partially_matched') {
+                $matchable[] = ['id' => $txId, 'amount' => $cents, 'date' => $valueDate, 'company' => $companyIdx, 'status' => $status];
+            }
+        }
+    }
+    $counts['bank_import_batches'] = 12;
+    $counts['bank_transactions'] = $txTotal;
+
+    // Manual receivables (ADR 0014). The first 11 are settled/partially settled
+    // against real matched deposits below; the last 7 stay open — three of them
+    // pair with the emitted live-import CSV (exact amount / name-in-counterparty
+    // / overdue aging).
+    $mrSettled = array_slice($matchable, 0, 11);
+    $refSeq = 0;
+    $mkRef = static function () use (&$refSeq): string {
+        $refSeq++;
+
+        return sprintf('MR-2026-%03d', $refSeq);
+    };
+    $manualAllocations = [];
+    foreach ($mrSettled as $i => $tx) {
+        $company = $companies[$tx['company']];
+        $partial = $i >= 8; // last three stay partially paid
+        $total = $partial ? $tx['amount'] + mt_rand(150, 900) * 1000 * 100 : $tx['amount'];
+        $issuedAt = $tx['date']->modify(sprintf('-%d days', mt_rand(20, 35)));
+        $createdAt = $at($issuedAt);
+        $mrId = $ex->insert(
+            'INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, total_cents,'
+            . ' outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at, is_deleted)'
+            . " VALUES (?, ?, ?, ?, ?, ?, 'JPY', ?, ?, ?, ?, ?, ?, 0)",
+            [
+                $orgId, $mkRef(), $company[1], 'billing@' . $company[2] . '.example', $total,
+                $total - $tx['amount'], $d($issuedAt), $d($tx['date']->modify(sprintf('%+d days', mt_rand(-8, 6)))),
+                $partial ? 'partially_paid' : 'paid', $adminId, $createdAt, $createdAt,
+            ],
+        );
+        $auditRows[] = ['manual_receivable_created', 'manual_receivable', $createdAt, $mrId, null,
+            $json(['reference_number' => sprintf('MR-2026-%03d', $refSeq), 'client_name' => $company[1], 'total_cents' => $total]),
+            $json(['manual_receivable_id' => $mrId])];
+        $manualAllocations[$tx['id']] = ['mr' => $mrId, 'amount' => $tx['amount']];
+    }
+
+    // Open manual receivables — the live matching targets. Client names are
+    // chosen so the propose screen shows both signal kinds: exact amount only
+    // (kanji name vs katakana transfer name = 名義ズレ) and name-in-counterparty.
+    $openReceivables = [
+        // ref-label, client_name, email slug, yen, due offset (days)
+        ['株式会社山田工務店', 'yamada-koumuten', 423500, 10],  // CSV: ヤマダコウムテン（カ — exact amount
+        ['テストコーポレーション', 'testcorp', 255000, 8],      // CSV: （カ）テストコーポレーション — name + amount
+        ['高橋建設株式会社', 'takahashi-kensetsu', 341000, -15], // overdue aging row
+        ['星野物産株式会社', 'hoshino', 748000, 18],
+        ['渡辺製作所株式会社', 'watanabe-ss', 517000, 25],
+        ['西村運輸株式会社', 'nishimura-unyu', 92400, 5],
+        ['さくらフーズ株式会社', 'sakura-foods', 1265000, 30],
+    ];
+    foreach ($openReceivables as [$client, $slug, $yen, $dueOffset]) {
+        $issuedAt = $days($dueOffset - 30);
+        $createdAt = $at($issuedAt);
+        $ref = $mkRef();
+        $openRefs[] = $ref;
+        $mrId = $ex->insert(
+            'INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, total_cents,'
+            . ' outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at, is_deleted)'
+            . " VALUES (?, ?, ?, ?, ?, ?, 'JPY', ?, ?, 'open', ?, ?, ?, 0)",
+            [
+                $orgId, $ref, $client, 'billing@' . $slug . '.example', $yen * 100,
+                $yen * 100, $d($issuedAt), $d($days($dueOffset)), $adminId, $createdAt, $createdAt,
+            ],
+        );
+        $auditRows[] = ['manual_receivable_created', 'manual_receivable', $createdAt, $mrId, null,
+            $json(['reference_number' => $ref, 'client_name' => $client, 'total_cents' => $yen * 100]),
+            $json(['manual_receivable_id' => $mrId])];
+    }
+    $counts['manual_receivables'] = count($mrSettled) + count($openReceivables);
+
+    // Reconciliations + allocations for every matchable corporate deposit.
+    // Historical upstream invoice ids live in 2000–2055 (they are not resolvable
+    // live — history only); manual allocations point at the receivables above.
+    $upstreamSeq = 0;
+    $creditRows = 0;
+    $reconCount = 0;
+    foreach ($matchable as $i => $tx) {
+        $confirmedAt = $at($tx['date']->modify(sprintf('+%d days', mt_rand(1, 5))));
+        $confirmedBy = $actors[mt_rand(0, count($actors) - 1)];
+        $reconId = $ex->insert(
+            'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code,'
+            . ' confirmed_by, confirmed_at, reversed_at, reversal_reason, created_at, idempotency_key)'
+            . " VALUES (?, ?, 'confirmed', NULL, ?, ?, NULL, NULL, ?, ?)",
+            [$orgId, $tx['id'], $confirmedBy, $confirmedAt, $confirmedAt, 'seed-' . $tx['id']],
+        );
+        $reconCount++;
+
+        $manual = $manualAllocations[$tx['id']] ?? null;
+        $withCredit = $manual === null && $tx['status'] === 'matched' && mt_rand(1, 100) <= 16;
+        $allocated = match (true) {
+            $manual !== null => $manual['amount'],
+            $tx['status'] === 'partially_matched' => (int) (round($tx['amount'] * mt_rand(45, 80) / 100 / 100000) * 100000),
+            $withCredit => $tx['amount'] - mt_rand(5, 60) * 1000 * 100,
+            default => $tx['amount'],
+        };
+        $invoiceId = $manual !== null ? $manual['mr'] : 2000 + ($upstreamSeq % 56);
+        $upstreamSeq++;
+
+        $ex->insert(
+            'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents,'
+            . ' payment_id, external_reference, created_at, source, manual_receivable_id)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $orgId, $reconId, $invoiceId, max($allocated, 100000),
+                $manual !== null ? null : 5000 + $i,
+                sprintf('clear:recon:%d:%d', $reconId, $invoiceId), $confirmedAt,
+                $manual !== null ? 'manual' : 'invoice_upstream',
+                $manual !== null ? $manual['mr'] : null,
+            ],
+        );
+        $auditRows[] = ['reconciliation_confirmed', 'payment_reconciliation', $confirmedAt, $reconId,
+            $json(['status' => 'unmatched']),
+            $json(['status' => 'confirmed', 'amount_cents' => $tx['amount'], 'allocated_cents' => max($allocated, 100000)]),
+            $json(['payment_reconciliation_id' => $reconId, 'bank_transaction_id' => $tx['id']])];
+
+        if ($withCredit) {
+            $creditAmount = $tx['amount'] - $allocated;
+            $voided = mt_rand(1, 100) <= 25;
+            $creditId = $ex->insert(
+                'INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status,'
+                . ' source_bank_transaction_id, reconciliation_id, created_by, created_at, source, manual_receivable_id, client_name)'
+                . " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'invoice_upstream', NULL, ?)",
+                [
+                    $orgId, 100 + $tx['company'], $creditAmount,
+                    $voided ? $creditAmount : ($creditRows % 3 === 0 ? 0 : $creditAmount),
+                    $voided ? 'voided' : 'open',
+                    $tx['id'], $reconId, $confirmedBy, $confirmedAt, $companies[$tx['company']][1],
+                ],
+            );
+            $creditRows++;
+            $auditRows[] = ['client_credit_applied', 'client_credit', $confirmedAt, $creditId, null,
+                $json(['amount_cents' => $creditAmount, 'status' => $voided ? 'voided' : 'open']),
+                $json(['client_credit_id' => $creditId, 'bank_transaction_id' => $tx['id']])];
+        }
+    }
+    $counts['payment_reconciliations'] = $reconCount;
+    $counts['client_credits'] = $creditRows;
+
+    // A few reversed reconciliations (wrong payer, later corrected).
+    $reversedPool = array_slice($matchable, 20, 6);
+    foreach ($reversedPool as $tx) {
+        $confirmedAt = $at($tx['date']->modify('+1 days'));
+        $reversedAt = $at($tx['date']->modify(sprintf('+%d days', mt_rand(3, 9))));
+        $reconId = $ex->insert(
+            'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code,'
+            . ' confirmed_by, confirmed_at, reversed_at, reversal_reason, created_at, idempotency_key)'
+            . " VALUES (?, ?, 'reversed', NULL, ?, ?, ?, ?, ?, ?)",
+            [$orgId, $tx['id'], $adminId, $confirmedAt, $reversedAt, '入金者相違（別請求への充当誤り）', $confirmedAt, 'seed-rev-' . $tx['id']],
+        );
+        $auditRows[] = ['reconciliation_reversed', 'payment_reconciliation', $reversedAt, $reconId,
+            $json(['status' => 'confirmed']), $json(['status' => 'reversed', 'reversal_reason' => '入金者相違（別請求への充当誤り）']),
+            $json(['payment_reconciliation_id' => $reconId, 'bank_transaction_id' => $tx['id']])];
+    }
+    $counts['payment_reconciliations'] += count($reversedPool);
+
+    // Dunning history. Historical invoices (ids 2000–2055) plus the three live
+    // fixture invoices — INV-2026-057 got a notice 2 days ago (shows the
+    // min-interval throttle), INV-2026-056/060 are overdue and freely dunnable.
+    $dunningTargets = [];
+    for ($i = 0; $i < 18; $i++) {
+        $company = $companies[$i % count($companies)];
+        $dunningTargets[] = [
+            'invoice_id' => 2000 + $i,
+            'number' => sprintf('INV-2026-%03d', $i + 1),
+            'client_id' => 100 + ($i % count($companies)),
+            'email' => 'billing@' . $company[2] . '.example',
+            'outstanding' => mt_rand(90, 2200) * 1000 * 100,
+            'stages' => mt_rand(1, 4),
+            'lastSentOffset' => -mt_rand(6, 45),
+        ];
+    }
+    $noticeCount = 0;
+    foreach ($dunningTargets as $t) {
+        $sentDay = $days($t['lastSentOffset']);
+        $dueAt = $sentDay->modify(sprintf('-%d days', 10 + $t['stages'] * 12));
+        for ($stage = $t['stages'] - 1; $stage >= 0; $stage--) {
+            $sentAt = $at($sentDay->modify(sprintf('-%d days', $stage * mt_rand(8, 14))));
+            $noticeId = $ex->insert(
+                'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, recipient_email,'
+                . ' outstanding_cents, due_at, channel, sent_by, sent_at, created_at, template_version)'
+                . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $orgId, $t['invoice_id'], $t['number'], $t['client_id'], $t['email'],
+                    $t['outstanding'], $d($dueAt), mt_rand(1, 100) <= 80 ? 'email' : 'log',
+                    $adminId, $sentAt, $sentAt, '1.0',
+                ],
+            );
+            $noticeCount++;
+            $auditRows[] = ['dunning_sent', 'dunning_notice', $sentAt, $noticeId,
+                $json(['invoice_status' => 'issued', 'invoice_outstanding_cents' => $t['outstanding']]),
+                $json(['invoice_number' => $t['number'], 'recipient_email' => $t['email'], 'outstanding_at_send_cents' => $t['outstanding'], 'channel' => 'email', 'template_version' => '1.0']),
+                $json(['dunning_notice_id' => $noticeId, 'invoice_id' => $t['invoice_id']])];
+        }
+    }
+    foreach (DemoInvoiceUpstreamFixture::rows() as [$invoiceId, $number, $clientId, , , $email, , $outstanding]) {
+        $offset = match ($invoiceId) {
+            2056 => -40,
+            2057 => -2,
+            2060 => -9,
+            default => null,
+        };
+        if ($offset === null) {
+            continue;
+        }
+        $sentAt = $at($days($offset));
+        $noticeId = $ex->insert(
+            'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, recipient_email,'
+            . ' outstanding_cents, due_at, channel, sent_by, sent_at, created_at, template_version)'
+            . " VALUES (?, ?, ?, ?, ?, ?, ?, 'email', ?, ?, ?, '1.0')",
+            [$orgId, $invoiceId, $number, $clientId, $email, $outstanding, $d($days($offset - 20)), $adminId, $sentAt, $sentAt],
+        );
+        $noticeCount++;
+        $auditRows[] = ['dunning_sent', 'dunning_notice', $sentAt, $noticeId,
+            $json(['invoice_status' => 'issued', 'invoice_outstanding_cents' => $outstanding]),
+            $json(['invoice_number' => $number, 'recipient_email' => $email, 'outstanding_at_send_cents' => $outstanding, 'channel' => 'email', 'template_version' => '1.0']),
+            $json(['dunning_notice_id' => $noticeId, 'invoice_id' => $invoiceId])];
+    }
+    $counts['dunning_notices'] = $noticeCount;
+
+    // One active dunning pause on a live fixture invoice (INV-2026-059).
+    $pausedAt = $at($days(-6));
+    $ex->insert(
+        'INSERT INTO dunning_pauses (organization_id, invoice_id, paused_by, paused_at, paused_reason, unpaused_by, unpaused_at)'
+        . ' VALUES (?, 2059, ?, ?, ?, NULL, NULL)',
+        [$orgId, $adminId, $pausedAt, '支払計画合意済み（分割・毎月末）'],
+    );
+    $auditRows[] = ['dunning_paused', 'invoice', $pausedAt, 2059, $json(['is_paused' => false]),
+        $json(['is_paused' => true, 'paused_reason' => '支払計画合意済み（分割・毎月末）']), $json(['invoice_id' => 2059])];
+
+    // Recent sign-ins so the audit page opens on believable activity.
+    foreach ([[-1, $adminId], [-1, $viewerId], [-2, $adminId], [-3, $adminId], [-4, $viewerId]] as [$offset, $userId]) {
+        $auditRows[] = ['login_succeeded', 'user', $at($days($offset)), $userId, null, $json(['user_id' => $userId]), null];
+    }
+
+    // Flush the audit trail in chronological order (append-only shape).
+    usort($auditRows, static fn (array $a, array $b): int => strcmp($a[2], $b[2]));
+    foreach ($auditRows as [$action, $entityType, $occurredAt, $entityId, $before, $after, $metadata]) {
+        $ex->insert(
+            'INSERT INTO audit_events (organization_id, action, actor_id, occurred_at, entity_type, entity_id,'
+            . ' before_json, after_json, metadata_json)'
+            . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [$orgId, $action, $adminId, $occurredAt, $entityType, $entityId, $before, $after, $metadata],
+        );
+    }
+    $counts['audit_events'] = count($auditRows);
+    $counts['status:unmatched'] = $statusTally['unmatched'];
+    $counts['status:partially_matched'] = $statusTally['partially_matched'];
+    $counts['status:matched'] = $statusTally['matched'];
+    $counts['status:voided'] = $statusTally['voided'];
+});
+
+// Backdate the org so it doesn't look created today.
+$orgCreatedAt = $days(-210)->format('Y-m-d') . ' 09:12:00';
+$query->execute('UPDATE organizations SET created_at = ? WHERE id = ?', [$orgCreatedAt, $orgId]);
+
+// --- 4) Live-import CSV ---------------------------------------------------------
+// Amounts are integer yen (the importer converts to cents, #261). Three rows pair
+// with seeded receivables/invoices; the rest exercise no-match and the
+// withdrawal filter.
+$csvPath = $root . '/var/demo-bank-import.csv';
+if (!is_dir($root . '/var')) {
+    mkdir($root . '/var', 0775, true);
+}
+$slash = static fn (int $offset): string => $days($offset)->format('Y/m/d'); // the seeded account profiles parse Y/m/d
+$csvRows = [
+    ['取引日', '入金額', '出金額', '摘要'],
+    [$slash(-2), '423500', '', 'ヤマダコウムテン（カ'],      // exact amount → MR 株式会社山田工務店 (名義ズレ)
+    [$slash(-1), '255000', '', '（カ）テストコーポレーション'], // amount + name → MR テストコーポレーション
+    [$slash(-2), '660000', '', 'ヤマカワショウジ（カ'],      // exact amount → upstream INV-2026-058
+    [$slash(-1), '341000', '', 'タカハシケンセツ（カ'],      // exact amount → overdue MR 高橋建設株式会社
+    [$slash(-3), '', '55000', 'ジドウヒキオトシ'],            // withdrawal — skipped by the importer
+    [$slash(-1), '88000', '', 'フリコミ サトウ ケンイチ'],   // no candidate — manual work stays visible
+    [$slash(-2), '12800', '', 'ヤマダ タロウ'],               // small personal deposit, no candidate
+];
+$csv = implode("\n", array_map(static fn (array $row): string => implode(',', $row), $csvRows)) . "\n";
+file_put_contents($csvPath, $csv);
+
+// --- 5) Summary -----------------------------------------------------------------
+fwrite(STDOUT, PHP_EOL . sprintf('Seeded organization #%d (%s / %s), T = %s', $orgId, $orgSlug, $orgName, $d($today)) . PHP_EOL);
+foreach ($counts as $label => $n) {
+    fwrite(STDOUT, sprintf('  %-26s %d', $label, $n) . PHP_EOL);
+}
+fwrite(STDOUT, PHP_EOL . 'Hand-out credentials:' . PHP_EOL);
+fwrite(STDOUT, sprintf('  admin : %s', $adminEmail) . PHP_EOL);
+fwrite(STDOUT, sprintf('  viewer: %s', $viewerEmail) . PHP_EOL);
+fwrite(STDOUT, PHP_EOL . 'Live-import CSV: ' . $csvPath . PHP_EOL);
+fwrite(STDOUT, 'Open manual receivables: ' . implode(', ', $openRefs) . PHP_EOL);
+fwrite(STDOUT, 'Set NENE_CLEAR_DEMO_UPSTREAM=1 in .env for live upstream suggestions + dunning sends (docs/demo.md).' . PHP_EOL);
+
+exit(0);


### PR DESCRIPTION
## What

Demo groundwork per `_work/handoff-clear-demo-2026-07-09-work-order.md` (cross-repo plan: pre-seeded fixed demo org + periodic reset, due 2026-07-12).

- **`tools/seed-demo.php`** — drop & reseed the `demo` org in one command, every date relative to the run day: 12 monthly import batches (~285 deposits, unmatched/partial/matched/voided spread incl. a reversed batch), reconciliations with upstream + manual allocations, overpayment credits, 18 manual receivables, dunning history, a canonical (#258) audit trail, 19 operators, fixed hand-out admin/viewer credentials, and `var/demo-bank-import.csv` for the live matching showcase. Deterministic; sqlite/MySQL/pgsql via the same `.env` wiring as `create-admin.php`; org/users go through the real use cases. Rerun = reset (cron-able with `--force`).
- **`DemoInvoiceUpstreamFixture` + `NENE_CLEAR_DEMO_UPSTREAM=1`** (config boundary, `public_html/index.php`) — pre-populates the standalone `FakeInvoiceUpstreamClient` with 6 T-relative invoices/clients so upstream match suggestions and **live dunning sends** work with no real NeNe Invoice. Required for the showcase: dunning is upstream-only (manual-receivable dunning = ADR 0014 issues 4–5, not implemented) and the default fake client is empty. Off by default; a configured real upstream wins.
- **`docs/demo.md`** — 1-page runbook (prepare → seed/reset → run → showcase walkthrough → known limitations → HETEML deployment sketch).
- **`.env.example`** — documents `NENE_CLEAR_JWT_SECRET` (was missing) and the demo variables.

## Product bugs found by actually walking the showcase

- **#261** — `BankCsvParser` stored bank-CSV yen ×1 while the UI, dunning mail renderer and manual-receivable form all treat `_cents` as ¥1=100. Live imports displayed ÷100 and could never exact-amount-match a receivable. Fixed in the parser; test fixtures updated to the cents unit.
- **#262** — JSON POST bodies were never parsed at the HTTP entry point (`fromGlobals()` fills `parsedBody` from `$_POST` only), so the SPA's propose/confirm/dunning-send returned 422 against the real backend. Masked by `withParsedBody()` in tests, API-mocked E2E, and the form-encoded curl workaround in the 07-03 screenshot session. Fixed with a single JSON decode in `public_html/index.php`.

## Verification (real outputs)

- `composer check` green — 361 backend tests (6 skipped = upstream contract tests, env unset), PHPStan L8, CS, conformance. Frontend: 46 vitest passed, lint clean.
- Full showcase over HTTP against the seeded sqlite, **twice with a reset in between**:
  - import `var/demo-bank-import.csv` → `{"bank_import_batch_id": 98, "row_count": 6}` (withdrawal row filtered)
  - propose on `ヤマダコウムテン（カ` ¥423,500 → `MR-2026-012 0.7 | exact amount match; due soon` (名義ズレ)
  - confirm → reconciliation `confirmed`, receivable `{"status":"paid","outstanding_cents":0}`
  - dunning INV-2026-056 → notice recorded, mail in Mailpit: `【お支払いのご案内】請求書 INV-2026-056 のご入金をお願いいたします`
  - dunning INV-2026-057 → `dunning-too-frequent`, `next_allowed_at` +7d (throttle showcase)
- `tools/build-release.sh` → `nene-clear-0.1.0.zip` (16 MB) with installer, seeder and fresh SPA; `.env` excluded.

## Out of scope

Public deployment to `clear.ayane.co.jp` (owner decision; steps in `docs/demo.md` §6), live Invoice connection, MFA on demo accounts, manual-receivable dunning.

Closes #260, Closes #261, Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)