### PR TITLE
Tier A serving: Authorization-header fallback + front-controller .htaccess

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -122,8 +122,15 @@ async function request<T>(
     Accept: 'application/json',
   }
 
+  // The token goes to both headers: some shared-hosting front proxies (Tier A;
+  // observed on HETEML) strip the standard `Authorization` header before it
+  // reaches PHP, so the backend falls back to the `X-Authorization` mirror
+  // when the standard header is missing (#265).
   const token = getToken()
-  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+    headers['X-Authorization'] = `Bearer ${token}`
+  }
 
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json'

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,0 +1,25 @@
+RewriteEngine On
+
+# Some CGI/FastCGI shared hosts have Apache itself drop the Authorization
+# header; re-deliver it as an env var so PHP still sees it. Hosts whose *front
+# proxy* strips the header before Apache (e.g. HETEML) are covered separately
+# by the SPA's X-Authorization mirror + AuthorizationHeaderFallback (#265).
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+# Front controller: real files (SPA assets, install.php) are served directly;
+# everything else routes through index.php (API + SPA shell fallback).
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]
+
+# Minimal hardening at the Apache layer. Dynamic responses already carry the
+# full security-header set from the NENE2 baseline pipeline — deliberately not
+# duplicated here (a second CSP would be enforced as the intersection);
+# setifempty only fills the gap on statically served asset files.
+<IfModule mod_headers.c>
+    Header always unset X-Powered-By
+    Header unset X-Powered-By
+    Header setifempty X-Content-Type-Options "nosniff"
+    Header setifempty Referrer-Policy "strict-origin-when-cross-origin"
+</IfModule>
+ServerSignature Off

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -16,6 +16,7 @@ use NeneClear\Database\ApplicationDatabaseIdentity;
 use NeneClear\Database\CandidateProfiles;
 use NeneClear\Database\MigrationVersions;
 use NeneClear\Http\ApplicationFactory;
+use NeneClear\Http\AuthorizationHeaderFallback;
 use NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture;
 use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -151,6 +152,10 @@ $application = ApplicationFactory::create(
 
 $psr17 = new Psr17Factory();
 $request = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
+
+// Shared-hosting front proxies (HETEML) strip the Authorization header; adopt
+// the SPA's X-Authorization mirror when the standard header is absent (#265).
+$request = AuthorizationHeaderFallback::apply($request);
 
 // fromGlobals() fills parsedBody from $_POST (form/multipart) only. The SPA
 // posts application/json, so decode it once here; handlers keep reading

--- a/src/Http/AuthorizationHeaderFallback.php
+++ b/src/Http/AuthorizationHeaderFallback.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Recovers the Bearer token on shared hosting whose front proxy strips the
+ * standard `Authorization` header before it reaches PHP (Tier A concern,
+ * observed on HETEML — custom headers pass through, `Authorization` does not,
+ * so neither `.htaccess` tricks nor `CGIPassAuth` can help; #265, proven by
+ * the sibling invoice deployment). The admin SPA mirrors the token into
+ * `X-Authorization`; that value is adopted only when `Authorization` is
+ * absent, so environments that deliver the standard header are unaffected.
+ */
+final class AuthorizationHeaderFallback
+{
+    public const string FALLBACK_HEADER = 'X-Authorization';
+
+    public static function apply(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if ($request->getHeaderLine('Authorization') !== '') {
+            return $request;
+        }
+
+        $fallback = $request->getHeaderLine(self::FALLBACK_HEADER);
+
+        if ($fallback === '') {
+            return $request;
+        }
+
+        return $request->withHeader('Authorization', $fallback);
+    }
+}

--- a/tests/Http/AuthorizationHeaderFallbackTest.php
+++ b/tests/Http/AuthorizationHeaderFallbackTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\AuthorizationHeaderFallback;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AuthorizationHeaderFallbackTest extends TestCase
+{
+    private function request(): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', '/admin/auth/me');
+    }
+
+    public function test_standard_header_wins_over_the_mirror(): void
+    {
+        $request = $this->request()
+            ->withHeader('Authorization', 'Bearer standard')
+            ->withHeader('X-Authorization', 'Bearer mirror');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertSame('Bearer standard', $result->getHeaderLine('Authorization'));
+    }
+
+    public function test_mirror_is_adopted_when_standard_header_is_absent(): void
+    {
+        $request = $this->request()->withHeader('X-Authorization', 'Bearer mirror');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertSame('Bearer mirror', $result->getHeaderLine('Authorization'));
+    }
+
+    public function test_empty_standard_header_counts_as_absent(): void
+    {
+        $request = $this->request()
+            ->withHeader('Authorization', '')
+            ->withHeader('X-Authorization', 'Bearer mirror');
+
+        $result = AuthorizationHeaderFallback::apply($request);
+
+        self::assertSame('Bearer mirror', $result->getHeaderLine('Authorization'));
+    }
+
+    public function test_no_headers_leaves_the_request_unchanged(): void
+    {
+        $result = AuthorizationHeaderFallback::apply($this->request());
+
+        self::assertSame('', $result->getHeaderLine('Authorization'));
+        self::assertFalse($result->hasHeader('Authorization'));
+    }
+}

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -37,6 +37,7 @@ echo "==> Build the admin UI into public_html/assets/"
 required_paths=(
   public_html/index.php
   public_html/install.php
+  public_html/.htaccess
   public_html/assets/index.html
   vendor/autoload.php
   vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php


### PR DESCRIPTION
Prereq for the clear.ayane.co.jp demo deployment (#260 GO). Mirrors nene-invoice's proven HETEML fix (its #596/#597).

- SPA sends the Bearer token in both `Authorization` and `X-Authorization` — HETEML's front proxy strips the former before PHP; custom headers pass.
- `AuthorizationHeaderFallback` at the config boundary adopts the mirror **only when `Authorization` is absent** — standard environments unaffected.
- New `public_html/.htaccess`: front-controller rewrite (repo had none — Apache would 404 everything but `/index.php`), `E=HTTP_AUTHORIZATION` for hosts where Apache itself drops the header, minimal hardening (`setifempty` for static assets; no CSP duplication — the NENE2 pipeline already emits the full set on dynamic responses).

Verification: 4 unit tests; `composer check` green (365 backend tests); 46 vitest; live smoke `GET /admin/auth/me` with only `X-Authorization` → 200 authenticated.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)