### PR TITLE
Serve the built SPA correctly from the backend /assets mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@
 /database/*.sqlite3
 /frontend/node_modules/
 /frontend/apps/*/dist/
+/frontend/dist-e2e/
 /sec-router.php

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -9,7 +9,8 @@ credentials — no self-signup, no auth-code changes. Reset = rerun the seeder.
 ```bash
 composer install
 composer migrations:migrate
-docker compose up -d mailpit          # local: catches dunning mail on :8383
+(cd frontend && npm ci && npm run build)   # SPA into public_html/assets/ (git-ignored)
+docker compose up -d mailpit               # local: catches dunning mail on :8383
 ```
 
 `.env` (see `.env.example` for the full comments):

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   // Load env from project root (one level up from frontend/) so .env values
   // are available without duplicating them in frontend/.env.
   const projectEnv = loadEnv(mode, resolve(__dirname, '..'), '')
@@ -20,6 +20,12 @@ export default defineConfig(({ mode }) => {
   const frontendPort = parseInt(projectEnv['NENE_CLEAR_FRONTEND_PORT'] ?? '5380', 10)
 
   return {
+    // The build lands in public_html/assets/ and is served by the PHP backend
+    // under the /assets/ mount, so asset URLs must carry that prefix (#268).
+    // The dev server keeps base '/' (it mounts the app at the root), and the
+    // E2E suite builds with `--base=/` because `vite preview` also serves the
+    // outDir at the root (tests/e2e/playwright.config.ts).
+    base: command === 'build' ? '/assets/' : '/',
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: { '@': resolve(__dirname, 'src') },

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -22,6 +22,17 @@ use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 
+// php -S with a router script routes EVERY request here, including existing
+// static files (SPA assets, favicon). Returning false hands those back to the
+// built-in server for direct serving — mirroring Apache's `-f` short-circuit
+// in .htaccess (#268). No effect outside the CLI server.
+if (PHP_SAPI === 'cli-server') {
+    $staticPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+    if (is_string($staticPath) && $staticPath !== '/' && is_file(__DIR__ . $staticPath)) {
+        return false;
+    }
+}
+
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 $root = dirname(__DIR__);

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -26,8 +26,9 @@ export default defineConfig({
   webServer: {
     // --base=/ overrides the backend-serving default ('/assets/', #268):
     // `vite preview` mounts the outDir at the root, so the root base is the
-    // self-consistent one here.
-    command: 'npm run build -- --base=/ && npm run preview -- --port 4174 --strictPort',
+    // self-consistent one here. The E2E build goes to its own outDir so it
+    // never clobbers public_html/assets/ (the backend-served build).
+    command: 'npm run build -- --base=/ --outDir=dist-e2e && npm run preview -- --outDir=dist-e2e --port 4174 --strictPort',
     cwd: '../../frontend',
     url: 'http://localhost:4174',
     reuseExistingServer: !process.env.CI,

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'npm run build && npm run preview -- --port 4174 --strictPort',
+    // --base=/ overrides the backend-serving default ('/assets/', #268):
+    // `vite preview` mounts the outDir at the root, so the root base is the
+    // self-consistent one here.
+    command: 'npm run build -- --base=/ && npm run preview -- --port 4174 --strictPort',
     cwd: '../../frontend',
     url: 'http://localhost:4174',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Found deploying the demo (#260): hashed JS/CSS 401'd on clear.ayane.co.jp (and equally under local `php -S`) because the Vite build assumed a root mount while the backend serves `public_html/assets/` under `/assets/`. Dev and E2E never noticed — both mount the app at the root.

- `base: command === 'build' ? '/assets/' : '/'`; E2E builds with `--base=/` for `vite preview`.
- `php -S` router script now `return false`s existing static files (Apache's `-f` rewrite short-circuit already covers this in production).
- `docs/demo.md`: added the missing frontend build step.

Verification: composer check green, 46 vitest, **54 Playwright E2E passed locally**, and live `php -S` smoke — shell 200, hashed JS/CSS 200, favicon 200.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)