### PR TITLE
docs: record the clear.ayane.co.jp demo deployment

### DIFF
--- a/docs/journal/2026-07-09.md
+++ b/docs/journal/2026-07-09.md
@@ -63,3 +63,37 @@ and the freshly built SPA.
   recommended confirm showcase).
 - Publication to `clear.ayane.co.jp` = owner decision; steps ready in
   `docs/demo.md` §6.
+
+## Evening session — deployed to clear.ayane.co.jp (owner GO)
+
+Owner approved publication; deployed per `docs/demo.md` §6 (invoice-shaped
+HETEML layout). Web PHP verified **8.4.23** with a throwaway version probe
+(deleted immediately). Release ZIP staged to `~/deploy-staging/nene-clear/`
+(sha256 verified), rsynced to `~/web/domain/ayane_co_jp/clear/` (docroot =
+`clear/public_html`, vendor above the docroot), installer completed by the
+owner in the browser (MySQL `_nene_clear`; DB password never left the panel),
+demo env vars appended, seeder run over SSH against MySQL (same counts as
+sqlite), `install.php` deleted. Nightly-reset wrapper installed at
+`~/bin/reseed-clear-demo.sh` — cron registration in the panel is the owner's
+step (HETEML crontab is panel-only).
+
+Two more product bugs surfaced and fixed during the deployment:
+
+3. **#265 — HETEML's front proxy strips `Authorization`** (predicted from the
+   invoice deployment log, then reproduced live: standard header → 401, mirror
+   → 200). Fixed with the SPA `X-Authorization` mirror + entry-point fallback +
+   a new `public_html/.htaccess` (the repo shipped none — Apache had no front
+   controller at all).
+4. **#268 — the built SPA could not be served by the backend anywhere**: the
+   Vite build assumed a root mount while the backend serves the bundle under
+   `/assets/` — hashed JS/CSS 401'd (locally under `php -S` too). Fixed with a
+   command-conditional `base`, an isolated E2E outDir (`dist-e2e`), and a
+   CLI-server static-file short-circuit in `index.php`. 54 Playwright E2E green.
+
+Live verification (all over HTTPS): login page fully rendered (headless Chrome
+screenshot), demo credentials sign in, CSV import → 名義ズレ propose
+(MR-2026-012, 0.7) → confirm (`paid`, outstanding 0), dunning INV-2026-056
+recorded (`channel: log` — no SMTP configured yet), INV-2026-057 throttled
+(`dunning-too-frequent`), viewer sign-in OK, deep-link shell 200. Issue #264
+filed for the `client_credit.status` registry/enum drift (cross-repo issues
+#40); #267 (installer UX papercut) filed by the owner during install.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -10,9 +10,15 @@ Last updated: 2026-07-09
 > (#261), and JSON POST bodies were never parsed at the entry point, so the
 > SPA's propose/confirm/dunning-send failed against the real backend (#262).
 > The 2026-07-03 screenshot session's `.env` (dead stub on 8390) has been
-> reverted. Publication target `clear.ayane.co.jp` is prepared owner-side
-> (subdomain + `_nene_clear` DB exist); actual deploy awaits the owner's
-> go — steps in `docs/demo.md` §6. Qiita shots 3, 4, 5, 7 are still open
+> reverted. **The demo is live at `https://clear.ayane.co.jp` (deployed
+> 2026-07-09 evening, owner GO)** — HETEML, MySQL `_nene_clear`, invoice-shaped
+> docroot; the deployment surfaced and fixed two more Tier A bugs (#265
+> Authorization stripped by the front proxy, #268 SPA asset base). Remaining
+> owner step: register the nightly reset cron (`~/bin/reseed-clear-demo.sh`)
+> in the HETEML panel. SMTP is unset (dunning channel `log`), and the
+> `client_credit.status` registry/enum drift is #264. Details:
+> [`docs/journal/2026-07-09.md`](../journal/2026-07-09.md).
+> Qiita shots 3, 4, 5, 7 are still open
 > ([handoff-2026-07-03](handoff-2026-07-03.md)); dev work otherwise resumes at
 > **installer Slice 3** ([handoff-2026-07-02 §3](handoff-2026-07-02.md)).
 


### PR DESCRIPTION
Journal + current.md update for the 2026-07-09 evening deployment of the demo to https://clear.ayane.co.jp (owner GO on #260; Tier A fixes #265/#268 landed separately). Docs only.

Refs #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)