### PR TITLE
Adopt Nene2\Demo v1.9.0: disposable-org demo with a JWT seat page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,13 @@ NENE_CLEAR_DEMO_UPSTREAM=
 # QUOTE values containing # (dotenv treats an unquoted # as a comment).
 NENE_CLEAR_DEMO_ADMIN_PASSWORD=
 NENE_CLEAR_DEMO_VIEWER_PASSWORD=
+
+# --- Disposable demo (#275, Nene2\Demo consumer; docs/demo.md) ------------------
+# DEMO_MODE=1 enables GET /demo/standard: every visit provisions a fresh,
+# seeded, throttled demo organization (TTL-swept by tools/sweep-demo.php from
+# cron). Parses strictly (1/true/yes); anything else keeps the route 404
+# (fail-close — the endpoint creates organizations without authentication).
+# Never enable together with real tenant data unless that is intended.
+DEMO_MODE=
+DEMO_TTL_HOURS=3
+DEMO_MAX_ORGS=200

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -72,6 +72,30 @@ php -S 0.0.0.0:8384 -t public_html public_html/index.php
 6. **Audit log** — every step above appears immediately at the top.
 7. **Reset** — rerun `php tools/seed-demo.php --force`; everything is clean again.
 
+## 4.5 Disposable demo orgs (`/demo/standard`, #275)
+
+With `DEMO_MODE=1` in `.env`, `GET /demo/standard` provisions a **fresh
+throwaway organization per visit** — hand the URL to a prospect and they get
+their own seeded playground (the invoice-style flow, adopted via
+`Nene2\Demo` v1.9.0):
+
+- The visitor lands signed in (a seat page stores a normal 1-hour access token
+  in the SPA session; when it expires, they simply visit the demo URL again).
+- The dataset is a compact T-relative variant of the fixed org's: ~60 deposits
+  over 3 months, dunning history, and the 名義ズレ showcase **pre-staged** —
+  open receivables and their exact-amount deposits already exist, so
+  propose → confirm works immediately with no CSV upload.
+- Protections: per-IP throttle (30 starts/hour → 429 + Retry-After),
+  instance-wide ceiling (`DEMO_MAX_ORGS` → 503), fail-close `DEMO_MODE`
+  (unset/typo → 404). Only `/demo/standard` is public; any other `/demo/*`
+  path stays behind auth.
+- Cleanup: `php tools/sweep-demo.php` (hourly cron) expires orgs past
+  `DEMO_TTL_HOURS` and reaps overflow. Only slugs prefixed `demo-` are ever
+  touched — the fixed `demo` org and real tenants are invisible to it.
+
+The fixed org (§2–4) remains the guided-demo star; disposable orgs are the
+"URL を配るだけ" channel.
+
 ## 5. Known limitations
 
 - **The Invoice upstream is a fixture, not a live NeNe Invoice.**

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -223,6 +223,8 @@ Base URL: `https://nene-clear.dev/problems/`. Slug is **kebab-case**.
 | `unauthorized` | Missing or invalid bearer token (framework `BearerTokenMiddleware`) |
 | `invalid-credentials` | Login failed — wrong email or password |
 | `too-many-login-attempts` | Login throttled — too many failed attempts (HTTP 429) |
+| `too-many-requests` | Disposable-demo start throttled per client (HTTP 429 + Retry-After; framework `Nene2\Demo` handler, #275) |
+| `demo-capacity-exceeded` | Disposable-demo org ceiling reached (HTTP 503; framework `Nene2\Demo` handler, #275) |
 | `mfa-challenge-invalid` | MFA challenge token missing, malformed, or expired (HTTP 401) |
 | `insufficient-capability` | Authenticated but lacks required capability |
 | `role-not-assignable` | Caller may not assign the requested role (e.g. org-admin assigning superadmin) |

--- a/docs/journal/2026-07-10.md
+++ b/docs/journal/2026-07-10.md
@@ -44,3 +44,33 @@ tokens, staggered entrance animation properly gated behind
 whitespace-normalized identity with the delivered files (12/12), plus a
 headless render check (the entrance animation needs virtual time — an empty
 first screenshot was the t=0 frame, not a bug). `composer check` green.
+
+## Nene2\Demo v1.9.0 consumer adoption (#275)
+
+Adopted the disposable-org demo module following the invoice consumer
+(reference: its PR #611): product concretes `DemoOrgProvisioner` (audited use
+cases; random never-disclosed admin password), `DemoOrgReaper`
+(children→parents bulk delete incl. TOTP tables; idempotent; hard-deletes the
+org row since its audit trail dies with it), `DemoDataSeeder` (compact
+T-relative dataset, ~60 deposits/3 months, 名義ズレ propose showcase
+pre-staged so no CSV upload is needed), and the **JWT seater** — the
+Clear-specific design the framework left open: a one-shot seat page whose
+nonce'd inline script stores a normally-issued access token into
+`sessionStorage` and replaces into the SPA. The page carries its own
+per-response CSP (`script-src 'nonce-…'`, rest locked) — the NENE2
+security-headers middleware fills only absent headers, so the invoice #612
+CSP trap is dodged by construction. `FileRateLimitStorage` ported (InMemory
+never fires on per-request-process shared hosting). `/demo/standard` added to
+the auth public paths (exact-match: unknown templates 401 — tighter than
+invoice's 404) and exempted from the SPA fallback. `DEMO_*` parsed fail-close
+at the config boundary; `tools/sweep-demo.php` selects by the `demo-` slug
+prefix (the fixed `demo` org is invisible to it) and prunes stale throttle
+files. PD slugs `too-many-requests` / `demo-capacity-exceeded` registered.
+
+Verified locally (sqlite): composer check green (391 tests, 17 new);
+/demo/standard → seat page (nonce CSP, no-store) → seated `/admin/auth/me` →
+staged 名義ズレ propose 0.7 → dunning history 6 → upstream fixture 6;
+**throttle fired at hit 31 (429 + Retry-After)**; sweep with a lowered
+ceiling reaped 27/30 orgs with zero orphan rows and the fixed org intact;
+DEMO_MODE=0 → 404. Browser-facing HTML for 429/503 deliberately deferred to
+the upstream negotiation proposal.

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+use Nene2\Demo\DemoConfig;
 use Nene2\Http\ResponseEmitter;
 use NeneClear\Database\AdapterAwareQueryExecutor;
 use NeneClear\Database\AdapterAwareTransactionManager;
@@ -116,6 +117,16 @@ if ($env('NENE_CLEAR_DEMO_UPSTREAM') === '1' && $invoiceApiBaseUrl === null) {
     DemoInvoiceUpstreamFixture::populate($invoiceClient, new DateTimeImmutable('today'));
 }
 
+// Disposable-demo config (#275). DEMO_MODE parses strictly (only 1/true/yes
+// enable it) and defaults OFF — the demo route creates organizations without
+// authentication, so a typo must fail closed. Numeric knobs fall back to the
+// framework defaults (3h TTL / 200 orgs / 5 slug attempts) when unset.
+$demoConfig = new DemoConfig(
+    demoMode: in_array(strtolower($env('DEMO_MODE')), ['1', 'true', 'yes'], true),
+    ttlHours: (int) ($env('DEMO_TTL_HOURS') ?: '3'),
+    maxOrgs: (int) ($env('DEMO_MAX_ORGS') ?: '200'),
+);
+
 // Machine surface (issue #182): the repo VERSION file is this app's release
 // version, surfaced on the auth-gated GET /machine/health so deployment tooling
 // (e.g. NeNe Suite update tracking) can read the installed version.
@@ -159,6 +170,7 @@ $application = ApplicationFactory::create(
     appVersion: $appVersion !== '' ? $appVersion : null,
     databaseCandidateInspector: $candidateInspector,
     databaseCandidateProfiles: $candidateProfiles,
+    demoConfig: $demoConfig,
 );
 
 $psr17 = new Psr17Factory();
@@ -191,7 +203,9 @@ $isSpaRoute = $wantHtml
     && $request->getMethod() === 'GET'
     && !str_starts_with($path, '/health')
     && !str_starts_with($path, '/machine')
-    && !str_starts_with($path, '/assets/');
+    && !str_starts_with($path, '/assets/')
+    // The demo start route serves its own HTML (seat page) — never the SPA shell (#275).
+    && !str_starts_with($path, '/demo/');
 
 if ($isSpaRoute) {
     $spaIndex = __DIR__ . '/assets/index.html';

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -47,6 +47,9 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
         '/admin/auth/login/mfa',
         // Invitee has no session yet; the invitation token is the credential.
         '/admin/auth/invitation', '/admin/auth/invitation/accept',
+        // Disposable-demo start (#275): creates the session — no bearer exists yet.
+        // Exact-match blocklist: each DemoTemplate case needs its path listed.
+        '/demo/standard',
     ];
 
     public function register(ContainerBuilder $builder): void

--- a/src/Demo/DemoDataSeeder.php
+++ b/src/Demo/DemoDataSeeder.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Demo\DemoDataSeederInterface;
+use Nene2\Demo\DemoTemplateKeyInterface;
+use Nene2\Http\ClockInterface;
+
+/**
+ * Seeds one disposable demo org with a compact, T-relative reconciliation
+ * dataset (`Nene2\Demo` consumer, #275). Same realism principles as the fixed
+ * demo org's `tools/seed-demo.php` (dates relative to today, status spread,
+ * the 名義ズレ showcase), scaled to per-request creation: ~3 months of
+ * imports, ~60 deposits, 8 manual receivables, dunning history aligned with
+ * the live upstream fixture ({@see \NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture}).
+ *
+ * The propose showcase is **pre-staged**: open manual receivables and their
+ * exact-amount unmatched deposits (kanji client vs katakana transfer name)
+ * already exist, so a visitor lands and can walk 照合 → 消込 → 督促
+ * immediately, without uploading a CSV.
+ *
+ * Contract (framework docblock): every write goes through the ONE injected
+ * executor — a second connection would deadlock the SQLite dev target
+ * ("database is locked", proven on invoice).
+ */
+final readonly class DemoDataSeeder implements DemoDataSeederInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function seed(int $orgId, DemoTemplateKeyInterface $template): void
+    {
+        // Single template today; the narrow keeps future keys explicit.
+        if (!$template instanceof DemoTemplate) {
+            $template = DemoTemplate::tryFromValue($template->value()) ?? DemoTemplate::Standard;
+        }
+
+        $today = $this->clock->now()->setTime(0, 0);
+        mt_srand(20260710 + $orgId); // deterministic content per org
+
+        $adminId = $this->adminId($orgId);
+        $d = static fn (DateTimeImmutable $x): string => $x->format('Y-m-d');
+        $days = static fn (int $offset): DateTimeImmutable => $today->modify(sprintf('%+d days', $offset));
+        $at = static fn (DateTimeImmutable $day): string => $day->format('Y-m-d') . sprintf(' %02d:%02d:%02d', mt_rand(9, 17), mt_rand(0, 59), mt_rand(0, 59));
+        $json = static fn (array $value): string => (string) json_encode($value, JSON_UNESCAPED_UNICODE);
+
+        /** @var list<array{string, string, string, int, ?string, ?string, ?string}> $audit */
+        $audit = [];
+
+        // --- settings + bank account -----------------------------------------
+        $settingsAt = $at($days(-80));
+        $this->query->insert(
+            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, created_at, updated_at)'
+            . ' VALUES (?, ?, ?, 7, 3, ?, ?)',
+            [$orgId, 'https://invoice.example', 'NENE_INVOICE_BEARER_TOKEN', $settingsAt, $settingsAt],
+        );
+
+        $accountAt = $at($days(-85));
+        $accountId = $this->query->insert(
+            'INSERT INTO bank_accounts (organization_id, bank_name, bank_branch, account_type, account_number,'
+            . ' csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows, is_deleted, created_at, updated_at)'
+            . " VALUES (?, 'みずほ銀行', '渋谷支店', 'ordinary', '1234567', 'utf8', 'Y/m/d', 0, 1, 3, 1, 0, ?, ?)",
+            [$orgId, $accountAt, $accountAt],
+        );
+
+        // --- payers ------------------------------------------------------------
+        $companies = [
+            ['（カ）テストコーポレーション', '株式会社テストコーポレーション', 'testcorp'],
+            ['カ）アクメ', 'アクメ株式会社', 'acme'],
+            ['ヤマカワショウジ（カ', '山川商事株式会社', 'yamakawa'],
+            ['グリーンフィールド（カ', 'グリーンフィールド株式会社', 'greenfield'],
+            ['アオゾラケンセツ（カ', 'あおぞら建設株式会社', 'aozora'],
+            ['フジサワデンキ（カ', '藤沢電機株式会社', 'fujisawa-denki'],
+            ['ヒガシヤマショウテン（カ', '東山商店株式会社', 'higashiyama'],
+            ['カ）サクラフーズ', 'さくらフーズ株式会社', 'sakura-foods'],
+        ];
+
+        // --- 3 monthly imports, ~60 deposits ----------------------------------
+        /** @var list<array{id: int, amount: int, date: DateTimeImmutable, company: int, status: string}> $matchable */
+        $matchable = [];
+        for ($m = 2; $m >= 0; $m--) {
+            $monthStart = $today->modify(sprintf('-%d months', $m))->modify('first day of this month');
+            $isCurrent = $m === 0;
+            $lastDay = $isCurrent ? max(1, (int) $today->format('j') - 1) : (int) $monthStart->modify('last day of this month')->format('j');
+            $importedAt = $at($isCurrent ? $today : $monthStart->modify('last day of this month')->modify('+3 days'));
+            $rows = $isCurrent ? 16 : 22;
+
+            $batchId = $this->query->insert(
+                'INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, row_count,'
+                . ' status, imported_by, imported_at, reversed_at, reversal_reason, created_at, updated_at)'
+                . " VALUES (?, ?, ?, ?, ?, 'imported', ?, ?, NULL, NULL, ?, ?)",
+                [$orgId, $accountId, hash('sha256', 'demo-' . $orgId . '-' . $m), 'bank_' . $monthStart->format('Ym') . '.csv', $rows, $adminId, $importedAt, $importedAt, $importedAt],
+            );
+            $audit[] = ['bank_import', 'bank_import_batch', $importedAt, $batchId, null,
+                $json(['source_filename' => 'bank_' . $monthStart->format('Ym') . '.csv', 'row_count' => $rows, 'bank_account_id' => $accountId]),
+                $json(['bank_import_batch_id' => $batchId])];
+
+            for ($r = 0; $r < $rows; $r++) {
+                $companyIdx = mt_rand(0, count($companies) - 1);
+                $cents = mt_rand(55, 2950) * 1000 * 100;
+                $valueDate = $monthStart->modify(sprintf('+%d days', mt_rand(0, max(0, $lastDay - 1))));
+                $roll = mt_rand(1, 100);
+                $status = match (true) {
+                    $m >= 1 => $roll <= 80 ? 'matched' : ($roll <= 90 ? 'partially_matched' : 'unmatched'),
+                    default => $roll <= 15 ? 'matched' : 'unmatched',
+                };
+
+                $txId = $this->query->insert(
+                    'INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date,'
+                    . ' amount_cents, counterparty_text, line_key, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                    [$orgId, $batchId, $accountId, $d($valueDate), $cents, $companies[$companyIdx][0], md5($orgId . '|' . $batchId . '|' . $r), $status, $importedAt],
+                );
+                if ($status === 'matched' || $status === 'partially_matched') {
+                    $matchable[] = ['id' => $txId, 'amount' => $cents, 'date' => $valueDate, 'company' => $companyIdx, 'status' => $status];
+                }
+            }
+        }
+
+        // --- manual receivables ------------------------------------------------
+        // 4 settled against real deposits; 3 open ones pre-stage the showcase:
+        // exact-amount 名義ズレ, name-in-counterparty, and an overdue row.
+        $mrSeq = 0;
+        $mkRef = static function () use (&$mrSeq): string {
+            $mrSeq++;
+
+            return sprintf('MR-2026-%03d', $mrSeq);
+        };
+        /** @var array<int, array{mr: int, amount: int}> $manualAllocations */
+        $manualAllocations = [];
+        foreach (array_slice($matchable, 0, 4) as $tx) {
+            $company = $companies[$tx['company']];
+            $issuedAt = $tx['date']->modify('-25 days');
+            $createdAt = $at($issuedAt);
+            $ref = $mkRef();
+            $mrId = $this->query->insert(
+                'INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, total_cents,'
+                . ' outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at, is_deleted)'
+                . " VALUES (?, ?, ?, ?, ?, 0, 'JPY', ?, ?, 'paid', ?, ?, ?, 0)",
+                [$orgId, $ref, $company[1], 'billing@' . $company[2] . '.example', $tx['amount'], $d($issuedAt), $d($tx['date']->modify('-3 days')), $adminId, $createdAt, $createdAt],
+            );
+            $manualAllocations[$tx['id']] = ['mr' => $mrId, 'amount' => $tx['amount']];
+            $audit[] = ['manual_receivable_created', 'manual_receivable', $createdAt, $mrId, null,
+                $json(['reference_number' => $ref, 'client_name' => $company[1], 'total_cents' => $tx['amount']]),
+                $json(['manual_receivable_id' => $mrId])];
+        }
+
+        $showcase = [
+            // client_name, email slug, yen, due offset, counterparty for the staged unmatched deposit
+            ['株式会社山田工務店', 'yamada-koumuten', 423500, 10, 'ヤマダコウムテン（カ'],   // exact amount only (名義ズレ)
+            ['テストコーポレーション', 'testcorp', 255000, 8, '（カ）テストコーポレーション'], // amount + name signal
+            ['高橋建設株式会社', 'takahashi-kensetsu', 341000, -15, 'タカハシケンセツ（カ'],  // overdue aging
+        ];
+        foreach ($showcase as [$client, $slug, $yen, $dueOffset, $counterparty]) {
+            $issuedAt = $days($dueOffset - 30);
+            $createdAt = $at($issuedAt);
+            $ref = $mkRef();
+            $mrId = $this->query->insert(
+                'INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, total_cents,'
+                . ' outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at, is_deleted)'
+                . " VALUES (?, ?, ?, ?, ?, ?, 'JPY', ?, ?, 'open', ?, ?, ?, 0)",
+                [$orgId, $ref, $client, 'billing@' . $slug . '.example', $yen * 100, $yen * 100, $d($issuedAt), $d($days($dueOffset)), $adminId, $createdAt, $createdAt],
+            );
+            $audit[] = ['manual_receivable_created', 'manual_receivable', $createdAt, $mrId, null,
+                $json(['reference_number' => $ref, 'client_name' => $client, 'total_cents' => $yen * 100]),
+                $json(['manual_receivable_id' => $mrId])];
+
+            // The staged deposit the visitor will match against this receivable.
+            $depositDate = $days(-mt_rand(1, 3));
+            $importedAt = $at($depositDate);
+            $stagedBatch = $this->query->insert(
+                'INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, row_count,'
+                . ' status, imported_by, imported_at, reversed_at, reversal_reason, created_at, updated_at)'
+                . " VALUES (?, ?, ?, ?, 1, 'imported', ?, ?, NULL, NULL, ?, ?)",
+                [$orgId, $accountId, hash('sha256', 'demo-stage-' . $orgId . '-' . $ref), 'bank_' . $depositDate->format('Ymd') . '.csv', $adminId, $importedAt, $importedAt, $importedAt],
+            );
+            $this->query->insert(
+                'INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date,'
+                . " amount_cents, counterparty_text, line_key, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'unmatched', ?)",
+                [$orgId, $stagedBatch, $accountId, $d($depositDate), $yen * 100, $counterparty, md5($orgId . '|stage|' . $ref), $importedAt],
+            );
+            $audit[] = ['bank_import', 'bank_import_batch', $importedAt, $stagedBatch, null,
+                $json(['source_filename' => 'bank_' . $depositDate->format('Ymd') . '.csv', 'row_count' => 1, 'bank_account_id' => $accountId]),
+                $json(['bank_import_batch_id' => $stagedBatch])];
+        }
+
+        // --- reconciliations + allocations + a few credits ---------------------
+        $creditCount = 0;
+        foreach ($matchable as $i => $tx) {
+            $confirmedAt = $at($tx['date']->modify(sprintf('+%d days', mt_rand(1, 5))));
+            $reconId = $this->query->insert(
+                'INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, reason_code,'
+                . ' confirmed_by, confirmed_at, reversed_at, reversal_reason, created_at, idempotency_key)'
+                . " VALUES (?, ?, 'confirmed', NULL, ?, ?, NULL, NULL, ?, ?)",
+                [$orgId, $tx['id'], $adminId, $confirmedAt, $confirmedAt, 'demo-' . $orgId . '-' . $tx['id']],
+            );
+
+            $manual = $manualAllocations[$tx['id']] ?? null;
+            $withCredit = $manual === null && $tx['status'] === 'matched' && mt_rand(1, 100) <= 12;
+            $allocated = match (true) {
+                $manual !== null => $manual['amount'],
+                $tx['status'] === 'partially_matched' => (int) (round($tx['amount'] * 0.6 / 100000) * 100000),
+                $withCredit => $tx['amount'] - mt_rand(5, 40) * 1000 * 100,
+                default => $tx['amount'],
+            };
+
+            $this->query->insert(
+                'INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents,'
+                . ' payment_id, external_reference, created_at, source, manual_receivable_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $orgId, $reconId, $manual !== null ? $manual['mr'] : 2000 + $i, max($allocated, 100000),
+                    $manual !== null ? null : 5000 + $i,
+                    sprintf('clear:recon:%d:%d', $reconId, $manual !== null ? $manual['mr'] : 2000 + $i),
+                    $confirmedAt, $manual !== null ? 'manual' : 'invoice_upstream', $manual !== null ? $manual['mr'] : null,
+                ],
+            );
+            $audit[] = ['reconciliation_confirmed', 'payment_reconciliation', $confirmedAt, $reconId,
+                $json(['status' => 'unmatched']),
+                $json(['status' => 'confirmed', 'amount_cents' => $tx['amount'], 'allocated_cents' => max($allocated, 100000)]),
+                $json(['payment_reconciliation_id' => $reconId, 'bank_transaction_id' => $tx['id']])];
+
+            if ($withCredit) {
+                $creditAmount = $tx['amount'] - $allocated;
+                $creditId = $this->query->insert(
+                    'INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status,'
+                    . ' source_bank_transaction_id, reconciliation_id, created_by, created_at, source, manual_receivable_id, client_name)'
+                    . " VALUES (?, ?, ?, ?, 'open', ?, ?, ?, ?, 'invoice_upstream', NULL, ?)",
+                    [$orgId, 100 + $tx['company'], $creditAmount, $creditCount % 2 === 0 ? $creditAmount : 0, $tx['id'], $reconId, $adminId, $confirmedAt, $companies[$tx['company']][1]],
+                );
+                $creditCount++;
+                $audit[] = ['client_credit_applied', 'client_credit', $confirmedAt, $creditId, null,
+                    $json(['amount_cents' => $creditAmount, 'status' => 'open']),
+                    $json(['client_credit_id' => $creditId, 'bank_transaction_id' => $tx['id']])];
+            }
+        }
+
+        // --- dunning history aligned with the live upstream fixture ------------
+        $notices = [
+            [2056, 'INV-2026-056', 156, 'billing@acme.example', 193000000, -40],
+            [2057, 'INV-2026-057', 157, 'billing@testcorp.example', 35000000, -2],
+            [2060, 'INV-2026-060', 160, 'billing@aozora.example', 33000000, -9],
+            [2001, 'INV-2026-002', 101, 'billing@acme.example', 84800000, -22],
+            [2002, 'INV-2026-003', 102, 'billing@yamakawa.example', 45700000, -15],
+            [2003, 'INV-2026-004', 103, 'billing@greenfield.example', 129000000, -33],
+        ];
+        foreach ($notices as [$invoiceId, $number, $clientId, $email, $outstanding, $offset]) {
+            $sentAt = $at($days($offset));
+            $noticeId = $this->query->insert(
+                'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, recipient_email,'
+                . ' outstanding_cents, due_at, channel, sent_by, sent_at, created_at, template_version)'
+                . " VALUES (?, ?, ?, ?, ?, ?, ?, 'email', ?, ?, ?, '1.0')",
+                [$orgId, $invoiceId, $number, $clientId, $email, $outstanding, $d($days($offset - 20)), $adminId, $sentAt, $sentAt],
+            );
+            $audit[] = ['dunning_sent', 'dunning_notice', $sentAt, $noticeId,
+                $json(['invoice_status' => 'issued', 'invoice_outstanding_cents' => $outstanding]),
+                $json(['invoice_number' => $number, 'recipient_email' => $email, 'outstanding_at_send_cents' => $outstanding, 'channel' => 'email', 'template_version' => '1.0']),
+                $json(['dunning_notice_id' => $noticeId, 'invoice_id' => $invoiceId])];
+        }
+
+        $pausedAt = $at($days(-6));
+        $this->query->insert(
+            'INSERT INTO dunning_pauses (organization_id, invoice_id, paused_by, paused_at, paused_reason, unpaused_by, unpaused_at)'
+            . ' VALUES (?, 2059, ?, ?, ?, NULL, NULL)',
+            [$orgId, $adminId, $pausedAt, '支払計画合意済み（分割・毎月末）'],
+        );
+        $audit[] = ['dunning_paused', 'invoice', $pausedAt, 2059, $json(['is_paused' => false]),
+            $json(['is_paused' => true, 'paused_reason' => '支払計画合意済み（分割・毎月末）']), $json(['invoice_id' => 2059])];
+
+        // --- flush the audit trail chronologically ------------------------------
+        usort($audit, static fn (array $a, array $b): int => strcmp($a[2], $b[2]));
+        foreach ($audit as [$action, $entityType, $occurredAt, $entityId, $before, $after, $metadata]) {
+            $this->query->insert(
+                'INSERT INTO audit_events (organization_id, action, actor_id, occurred_at, entity_type, entity_id, before_json, after_json, metadata_json)'
+                . ' VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [$orgId, $action, $adminId, $occurredAt, $entityType, $entityId, $before, $after, $metadata],
+            );
+        }
+    }
+
+    /** The org's provisioned admin (created just before seed by the provisioner). */
+    private function adminId(int $orgId): int
+    {
+        $row = $this->query->fetchOne(
+            "SELECT id FROM users WHERE organization_id = ? AND role = 'admin' ORDER BY id LIMIT 1",
+            [$orgId],
+        );
+
+        return is_array($row) ? (int) $row['id'] : 0;
+    }
+}

--- a/src/Demo/DemoOrgProvisioner.php
+++ b/src/Demo/DemoOrgProvisioner.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Demo\DisposableOrgProvisionerInterface;
+use Nene2\Demo\ProvisionedDemoOrg;
+use Nene2\Demo\SlugConflictException;
+use NeneClear\Auth\Role;
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\Organization\OrganizationAlreadyExistsException;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCaseInterface;
+
+/**
+ * Creates one disposable demo organization + its seated admin (`Nene2\Demo`
+ * consumer, #275) through the same audited use cases the HTTP app uses — no
+ * auth code, no raw user INSERTs, bcrypt/uniqueness/audit identical to a real
+ * tenant. The admin's password is random and never disclosed: the demo
+ * session is seated by minting an access token directly
+ * ({@see DemoSessionSeater}), so nobody can (or needs to) log in as a demo
+ * admin from the login form.
+ */
+final readonly class DemoOrgProvisioner implements DisposableOrgProvisionerInterface
+{
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $createOrganization,
+        private CreateUserUseCaseInterface $createUser,
+    ) {
+    }
+
+    public function provision(string $slug, string $template): ProvisionedDemoOrg
+    {
+        try {
+            $org = $this->createOrganization->execute(new CreateOrganizationInput(
+                slug: $slug,
+                name: 'デモ商事株式会社（お試し）',
+                actorUserId: 0,
+            ));
+        } catch (OrganizationAlreadyExistsException $exception) {
+            throw new SlugConflictException($exception->getMessage(), previous: $exception);
+        }
+
+        $admin = $this->createUser->execute(new CreateUserInput(
+            organizationId: $org->id,
+            email: 'demo-admin@' . $slug . '.example',
+            role: Role::Admin,
+            password: bin2hex(random_bytes(16)),
+            actorUserId: 0,
+        ));
+
+        return new ProvisionedDemoOrg(
+            orgId: $org->id,
+            slug: $slug,
+            adminUserId: (int) ($admin->id ?? 0),
+        );
+    }
+}

--- a/src/Demo/DemoOrgReaper.php
+++ b/src/Demo/DemoOrgReaper.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Demo\DisposableOrgReaperInterface;
+
+/**
+ * Destroys one disposable demo organization and everything it owns
+ * (`Nene2\Demo` consumer, #275 — the teardown half of `tools/sweep-demo.php`
+ * and the sweeper's overflow/TTL path).
+ *
+ * Child rows are disposable demo data, so they are bulk-DELETEd here first
+ * (children → parents; the framework deliberately does not cascade — design
+ * doc risk 1), including the per-user TOTP tables that key on `user_id`
+ * rather than `organization_id`. The audit trail of a disposable org is part
+ * of its demo data and dies with it. `login_attempts` is identifier-hashed
+ * (no org column) and stays untouched.
+ *
+ * The org row itself is deleted directly (hard delete): the audited
+ * DeleteOrganization use case soft-deletes and records an audit event, but a
+ * reaped org's audit rows are removed in the same pass, so routing through it
+ * would only leave an orphaned tombstone. Idempotent by contract — reaping an
+ * org that a concurrent sweep already removed is success.
+ */
+final readonly class DemoOrgReaper implements DisposableOrgReaperInterface
+{
+    /** Child tables carrying `organization_id` directly, children first. */
+    private const array CHILD_TABLES = [
+        'dunning_pauses',
+        'dunning_notices',
+        'reconciliation_allocations',
+        'payment_reconciliations',
+        'client_credits',
+        'bank_transactions',
+        'bank_import_batches',
+        'bank_accounts',
+        'manual_receivables',
+        'clear_settings',
+        'user_invitations',
+        'audit_events',
+    ];
+
+    /** Per-user tables keyed on `user_id` (TOTP enrollment state). */
+    private const array USER_CHILD_TABLES = ['used_totp_steps', 'recovery_codes', 'totp_secrets'];
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function reap(int $orgId): void
+    {
+        foreach (self::CHILD_TABLES as $table) {
+            $this->query->execute("DELETE FROM {$table} WHERE organization_id = ?", [$orgId]);
+        }
+
+        foreach (self::USER_CHILD_TABLES as $table) {
+            $this->query->execute(
+                "DELETE FROM {$table} WHERE user_id IN (SELECT id FROM users WHERE organization_id = ?)",
+                [$orgId],
+            );
+        }
+
+        $this->query->execute('DELETE FROM users WHERE organization_id = ?', [$orgId]);
+        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$orgId]);
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Demo\CountingDemoCapacityGuard;
+use Nene2\Demo\DemoConfig;
+use Nene2\Demo\DemoRouteRegistrar;
+use Nene2\Demo\StartDisposableDemoHandler;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
+use NeneClear\Auth\TokenIssuerInterface;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\User\CreateUserUseCaseInterface;
+use NeneClear\User\UserRepositoryInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the disposable-demo domain as a `Nene2\Demo` consumer (#275): the
+ * product concretes (provisioner / seeder / seater / reaper), the
+ * creation-time capacity guard (per-IP file-backed throttle + instance-wide
+ * org ceiling), and the framework handler + route registrar. Everything is
+ * reused from existing providers — no auth code is added; the seater mints a
+ * token through the same {@see TokenIssuerInterface} a login uses.
+ *
+ * The registrar is registered unconditionally: {@see StartDisposableDemoHandler}
+ * answers 404 while {@see DemoConfig::$demoMode} is off (fail-close).
+ */
+final readonly class DemoServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * Demo starts allowed per client network per window. Deliberately generous
+     * (invoice's field-tested value, its #612): a "client" is really one
+     * office/carrier NAT, and runaway abuse stays bounded by the instance-wide
+     * org ceiling plus the sweep cron.
+     */
+    public const int THROTTLE_LIMIT = 30;
+    public const int THROTTLE_WINDOW_SECONDS = 3600;
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                DemoOrgProvisioner::class,
+                static fn (ContainerInterface $c): DemoOrgProvisioner => new DemoOrgProvisioner(
+                    ServiceResolver::get($c, CreateOrganizationUseCaseInterface::class),
+                    ServiceResolver::get($c, CreateUserUseCaseInterface::class),
+                ),
+            )
+            ->set(
+                DemoDataSeeder::class,
+                static fn (ContainerInterface $c): DemoDataSeeder => new DemoDataSeeder(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    ServiceResolver::get($c, ClockInterface::class),
+                ),
+            )
+            ->set(
+                DemoSessionSeater::class,
+                static fn (ContainerInterface $c): DemoSessionSeater => new DemoSessionSeater(
+                    ServiceResolver::get($c, UserRepositoryInterface::class),
+                    ServiceResolver::get($c, TokenIssuerInterface::class),
+                    ServiceResolver::get($c, Psr17Factory::class),
+                ),
+            )
+            ->set(
+                DemoOrgReaper::class,
+                static fn (ContainerInterface $c): DemoOrgReaper => new DemoOrgReaper(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                ),
+            )
+            ->set(
+                CountingDemoCapacityGuard::class,
+                static function (ContainerInterface $c): CountingDemoCapacityGuard {
+                    $config = ServiceResolver::get($c, DemoConfig::class);
+                    $query = ServiceResolver::get($c, DatabaseQueryExecutorInterface::class);
+
+                    return new CountingDemoCapacityGuard(
+                        demoOrgCount: static function () use ($query, $config): int {
+                            $row = $query->fetchOne(
+                                "SELECT COUNT(*) AS n FROM organizations WHERE slug LIKE ? ESCAPE '\\'",
+                                [str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $config->slugPrefix) . '%'],
+                            );
+
+                            return is_array($row) ? (int) $row['n'] : 0;
+                        },
+                        config: $config,
+                        throttleStorage: new FileRateLimitStorage(dirname(__DIR__, 2) . '/var', ServiceResolver::get($c, ClockInterface::class)),
+                        throttleLimit: self::THROTTLE_LIMIT,
+                        throttleWindowSeconds: self::THROTTLE_WINDOW_SECONDS,
+                        clock: ServiceResolver::get($c, ClockInterface::class),
+                    );
+                },
+            )
+            ->set(
+                StartDisposableDemoHandler::class,
+                static fn (ContainerInterface $c): StartDisposableDemoHandler => new StartDisposableDemoHandler(
+                    config: ServiceResolver::get($c, DemoConfig::class),
+                    capacityGuard: ServiceResolver::get($c, CountingDemoCapacityGuard::class),
+                    provisioner: ServiceResolver::get($c, DemoOrgProvisioner::class),
+                    seeder: ServiceResolver::get($c, DemoDataSeeder::class),
+                    seater: ServiceResolver::get($c, DemoSessionSeater::class),
+                    problemDetails: ServiceResolver::get($c, ProblemDetailsResponseFactory::class),
+                    templateKeyClass: DemoTemplate::class,
+                ),
+            )
+            ->set(
+                DemoRouteRegistrar::class,
+                static fn (ContainerInterface $c): DemoRouteRegistrar => new DemoRouteRegistrar(
+                    ServiceResolver::get($c, StartDisposableDemoHandler::class),
+                ),
+            );
+    }
+}

--- a/src/Demo/DemoSessionSeater.php
+++ b/src/Demo/DemoSessionSeater.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Demo\DemoSessionSeaterInterface;
+use Nene2\Demo\ProvisionedDemoOrg;
+use NeneClear\Auth\TokenIssuerInterface;
+use NeneClear\User\UserRepositoryInterface;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+
+/**
+ * Seats the visitor into a freshly provisioned demo org (`Nene2\Demo`
+ * consumer, #275) — the Clear-specific JWT design the framework module left
+ * to the product (design doc §3: "JWT bearer での SPA 着地").
+ *
+ * Clear's SPA keeps its bearer token in `sessionStorage` (`nene_clear_token`)
+ * and sends it on every API call — there is no cookie session to set, so the
+ * invoice cookie seater does not transplant. Instead the seater mints a
+ * normal access token for the demo admin via the app's own
+ * {@see TokenIssuerInterface} (same claims, TTL and secret as a login) and
+ * serves a one-shot **seat page**: a nonce'd inline script stores the token
+ * and `location.replace('/')` into the SPA. Auth code is untouched.
+ *
+ * The page carries its own per-response CSP — `script-src 'nonce-…'` with
+ * everything else locked — because the app-wide `default-src 'self'` would
+ * block the inline script (the exact trap invoice hit in its #612; the NENE2
+ * security-headers middleware only fills headers that are absent, so this
+ * page-specific policy wins). The script embeds only server-generated values
+ * (JSON-encoded JWT); no request input is echoed.
+ *
+ * Product-honest constraint carried into the session: the access token
+ * expires after the normal TTL (1 h) with no refresh — the demo simply asks
+ * for a fresh `/demo/{template}` visit. `sessionStorage` also means the
+ * session is per-tab, like any Clear login.
+ */
+final readonly class DemoSessionSeater implements DemoSessionSeaterInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $users,
+        private TokenIssuerInterface $tokenIssuer,
+        private Psr17Factory $psr17,
+    ) {
+    }
+
+    public function seatAndRedirect(ServerRequestInterface $request, ProvisionedDemoOrg $org): ResponseInterface
+    {
+        $admin = $this->users->findById($org->adminUserId);
+
+        if ($admin === null) {
+            throw new RuntimeException(sprintf('Provisioned demo admin #%d is missing.', $org->adminUserId));
+        }
+
+        $token = $this->tokenIssuer->issueForUser($admin);
+        $nonce = base64_encode(random_bytes(18));
+
+        $tokenJs = json_encode($token, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+        $html = <<<HTML
+        <!DOCTYPE html>
+        <html lang="ja">
+        <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="robots" content="noindex">
+        <title>NeNe Clear — デモを準備しています…</title>
+        </head>
+        <body>
+        <noscript><p>デモの開始には JavaScript が必要です。ブラウザの JavaScript を有効にして、もう一度お試しください。</p></noscript>
+        <p>デモを準備しています…</p>
+        <script nonce="{$nonce}">
+        sessionStorage.setItem('nene_clear_token', {$tokenJs});
+        location.replace('/');
+        </script>
+        </body>
+        </html>
+        HTML;
+
+        $response = $this->psr17->createResponse(200)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            // Page-specific CSP: allow exactly this one nonce'd script; lock the rest.
+            ->withHeader('Content-Security-Policy', "default-src 'none'; script-src 'nonce-{$nonce}'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'")
+            ->withHeader('Cache-Control', 'no-store')
+            ->withHeader('Referrer-Policy', 'no-referrer');
+        $response->getBody()->write($html);
+
+        return $response;
+    }
+}

--- a/src/Demo/DemoTemplate.php
+++ b/src/Demo/DemoTemplate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Demo\DemoTemplateKeyInterface;
+
+/**
+ * The disposable-demo seed templates Clear offers (`Nene2\Demo` consumer,
+ * #275). One well-built reconciliation dataset beats several thin ones for
+ * this product — Clear's showcase is a single flow (bank deposits →
+ * name-mismatch matching → dunning), not per-industry document sets like
+ * invoice's. Adding a template means adding a case here, seeding it in
+ * {@see DemoDataSeeder}, and listing the exact path in
+ * {@see \NeneClear\Auth\AuthServiceProvider} public paths (exact-match
+ * blocklist) — the route itself (`/demo/{template}`) already matches.
+ */
+enum DemoTemplate: string implements DemoTemplateKeyInterface
+{
+    case Standard = 'standard';
+
+    public static function tryFromValue(string $value): ?static
+    {
+        return self::tryFrom($value);
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Demo/FileRateLimitStorage.php
+++ b/src/Demo/FileRateLimitStorage.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Http\ClockInterface;
+use Nene2\Middleware\RateLimitStorageInterface;
+
+/**
+ * File-backed {@see RateLimitStorageInterface}: one JSON state file per key
+ * (hashed) under `<baseDir>/rate-limits/`, mutated under an exclusive `flock`
+ * (`Nene2\Demo` consumer, #275 — ported from the proven invoice concrete).
+ *
+ * Exists because the bundled {@see \Nene2\Middleware\InMemoryRateLimitStorage}
+ * does not share state across PHP processes — on the Tier A shared-hosting
+ * target (one process per request, no Redis/Memcached) an in-memory window
+ * would simply never trigger. `var/` is the only writable runtime directory
+ * there.
+ *
+ * Best-effort: when the file cannot be opened or locked the hit is counted as
+ * the first of a fresh window (fail-open) and logged — the instance-wide org
+ * ceiling still bounds total growth. Stale files are pruned by
+ * `tools/sweep-demo.php`.
+ */
+final readonly class FileRateLimitStorage implements RateLimitStorageInterface
+{
+    public function __construct(
+        private string $baseDir,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @return array{count: int, reset_at: int}
+     */
+    public function hit(string $key, int $windowSeconds): array
+    {
+        $now = $this->clock->now()->getTimestamp();
+
+        $dir = $this->baseDir . '/rate-limits';
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0o775, true);
+        }
+
+        $file = $dir . '/' . hash('sha256', $key) . '.json';
+        $handle = @fopen($file, 'c+');
+
+        if ($handle === false) {
+            error_log(sprintf('NeNe Clear: could not persist rate-limit state at %s; this hit is not counted against the window.', $file));
+
+            return ['count' => 1, 'reset_at' => $now + $windowSeconds];
+        }
+
+        try {
+            flock($handle, LOCK_EX);
+
+            $raw = stream_get_contents($handle);
+            $state = is_string($raw) && $raw !== '' ? json_decode($raw, true) : null;
+
+            $count = 1;
+            $resetAt = $now + $windowSeconds;
+
+            if (is_array($state) && isset($state['count'], $state['reset_at']) && (int) $state['reset_at'] > $now) {
+                $count = (int) $state['count'] + 1;
+                $resetAt = (int) $state['reset_at'];
+            }
+
+            ftruncate($handle, 0);
+            rewind($handle);
+            fwrite($handle, (string) json_encode(['count' => $count, 'reset_at' => $resetAt]));
+            fflush($handle);
+
+            return ['count' => $count, 'reset_at' => $resetAt];
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+}

--- a/src/Http/ApplicationFactory.php
+++ b/src/Http/ApplicationFactory.php
@@ -10,6 +10,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\Database\Preflight\CandidateProfile;
 use Nene2\Database\Preflight\DatabaseCandidateInspector;
+use Nene2\Demo\DemoConfig;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\Error\DomainExceptionHandlerInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
@@ -104,6 +105,7 @@ final class ApplicationFactory
         ?string $appVersion = null,
         ?DatabaseCandidateInspector $databaseCandidateInspector = null,
         array $databaseCandidateProfiles = [],
+        ?DemoConfig $demoConfig = null,
     ): RequestHandlerInterface {
         $psr17 = new Psr17Factory();
         $requestIdHolder = new RequestIdHolder();
@@ -145,6 +147,7 @@ final class ApplicationFactory
             $encryptionKey,
             $logger,
             $requestIdHolder,
+            $demoConfig,
         );
 
         $routeRegistrars = $container->get(ApplicationServiceProvider::ROUTE_REGISTRARS);
@@ -202,6 +205,7 @@ final class ApplicationFactory
         ?InvitationMailerInterface $invitationMailer = null,
         string $encryptionKey = '',
         bool $debug = false,
+        ?DemoConfig $demoConfig = null,
     ): ContainerInterface {
         $requestIdHolder = new RequestIdHolder();
         $logger = (new MonologLoggerFactory())->create('nene-clear', $debug, $requestIdHolder);
@@ -218,6 +222,7 @@ final class ApplicationFactory
             $encryptionKey,
             $logger,
             $requestIdHolder,
+            $demoConfig,
         );
     }
 
@@ -236,11 +241,14 @@ final class ApplicationFactory
         string $encryptionKey,
         LoggerInterface $logger,
         RequestIdHolder $requestIdHolder,
+        ?DemoConfig $demoConfig = null,
     ): ContainerInterface {
         $langDir = dirname(__DIR__, 2) . '/lang';
 
         return (new ContainerBuilder())
             ->set(Psr17Factory::class, static fn (ContainerInterface $c): Psr17Factory => $psr17)
+            // Disposable-demo config (#275): defaults keep DEMO_MODE off (fail-close).
+            ->set(DemoConfig::class, static fn (ContainerInterface $c): DemoConfig => $demoConfig ?? new DemoConfig())
             ->set(LoggerInterface::class, static fn (ContainerInterface $c): LoggerInterface => $logger)
             ->set(RequestIdHolder::class, static fn (ContainerInterface $c): RequestIdHolder => $requestIdHolder)
             ->set(ResponseFactoryInterface::class, static fn (ContainerInterface $c): ResponseFactoryInterface => $psr17)

--- a/src/Http/ApplicationServiceProvider.php
+++ b/src/Http/ApplicationServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneClear\Http;
 
+use Nene2\Demo\DemoRouteRegistrar;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use NeneClear\Audit\AuditRouteRegistrar;
@@ -24,6 +25,7 @@ use NeneClear\BankImport\DuplicateBankImportExceptionHandler;
 use NeneClear\BankImport\InvalidBankCsvExceptionHandler;
 use NeneClear\ClearSettings\ClearSettingsRouteRegistrar;
 use NeneClear\ClearSettings\ClearSettingsServiceProvider;
+use NeneClear\Demo\DemoServiceProvider;
 use NeneClear\Dunning\DunningNoticeNotFoundExceptionHandler;
 use NeneClear\Dunning\DunningPausedExceptionHandler;
 use NeneClear\Dunning\DunningRouteRegistrar;
@@ -97,7 +99,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new InvoiceUpstreamServiceProvider())
             ->addProvider(new ExportServiceProvider())
             ->addProvider(new DunningServiceProvider())
-            ->addProvider(new MfaServiceProvider());
+            ->addProvider(new MfaServiceProvider())
+            ->addProvider(new DemoServiceProvider());
 
         $builder
             ->set(self::ROUTE_REGISTRARS, static function (ContainerInterface $c): array {
@@ -116,6 +119,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, ExportRouteRegistrar::class),
                     ServiceResolver::get($c, DunningRouteRegistrar::class),
                     ServiceResolver::get($c, MfaRouteRegistrar::class),
+                    // Disposable demo (#275): registered unconditionally — the framework
+                    // handler answers 404 while DEMO_MODE is off (fail-close).
+                    ServiceResolver::get($c, DemoRouteRegistrar::class),
                 ];
 
                 return $registrars;

--- a/tests/Demo/DemoDataSeederTest.php
+++ b/tests/Demo/DemoDataSeederTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Demo\DemoDataSeeder;
+use NeneClear\Demo\DemoTemplate;
+use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class DemoDataSeederTest extends TestCase
+{
+    private const int ORG = 42;
+
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-demo-seed-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createOrganizations($this->query);
+        SchemaFixture::createUsers($this->query);
+        SchemaFixture::createBankAccounts($this->query);
+        SchemaFixture::createBankImportBatches($this->query);
+        SchemaFixture::createBankTransactions($this->query);
+        SchemaFixture::createPaymentReconciliations($this->query);
+        SchemaFixture::createReconciliationAllocations($this->query);
+        SchemaFixture::createClientCredits($this->query);
+        SchemaFixture::createClearSettings($this->query);
+        SchemaFixture::createDunningNotices($this->query);
+        SchemaFixture::createDunningPauses($this->query);
+        SchemaFixture::createManualReceivables($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+
+        $this->query->execute(
+            "INSERT INTO organizations (id, slug, name, created_at, is_deleted) VALUES (?, 'demo-test', 'Demo', '2026-07-10 00:00:00', 0)",
+            [self::ORG],
+        );
+        $this->query->execute(
+            "INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (?, 'demo-admin@demo-test.example', 'admin', 'active', 'x', 0)",
+            [self::ORG],
+        );
+
+        (new DemoDataSeeder($this->query, new FixedClock('2026-07-10T09:00:00+00:00')))
+            ->seed(self::ORG, DemoTemplate::Standard);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dbPath);
+    }
+
+    /** @param list<string|int> $params */
+    private function countRows(string $sql, array $params = []): int
+    {
+        $row = $this->query->fetchOne($sql, array_merge([self::ORG], $params));
+
+        return is_array($row) ? (int) array_values($row)[0] : -1;
+    }
+
+    public function test_seeds_a_compact_but_complete_dataset(): void
+    {
+        self::assertGreaterThan(50, $this->countRows('SELECT COUNT(*) FROM bank_transactions WHERE organization_id = ?'));
+        self::assertSame(7, $this->countRows('SELECT COUNT(*) FROM manual_receivables WHERE organization_id = ?'));
+        self::assertGreaterThan(20, $this->countRows('SELECT COUNT(*) FROM payment_reconciliations WHERE organization_id = ?'));
+        self::assertSame(6, $this->countRows('SELECT COUNT(*) FROM dunning_notices WHERE organization_id = ?'));
+        self::assertSame(1, $this->countRows('SELECT COUNT(*) FROM dunning_pauses WHERE organization_id = ?'));
+        self::assertGreaterThan(30, $this->countRows('SELECT COUNT(*) FROM audit_events WHERE organization_id = ?'));
+    }
+
+    public function test_every_confirmed_reconciliation_has_exactly_one_allocation(): void
+    {
+        $orphans = $this->countRows(
+            'SELECT COUNT(*) FROM payment_reconciliations pr WHERE pr.organization_id = ? AND'
+            . ' (SELECT COUNT(*) FROM reconciliation_allocations ra WHERE ra.payment_reconciliation_id = pr.id) != 1',
+        );
+        self::assertSame(0, $orphans);
+    }
+
+    public function test_settled_manual_receivables_balance_with_their_allocations(): void
+    {
+        $inconsistent = $this->countRows(
+            'SELECT COUNT(*) FROM manual_receivables mr WHERE mr.organization_id = ? AND mr.total_cents - '
+            . ' COALESCE((SELECT SUM(ra.amount_cents) FROM reconciliation_allocations ra WHERE ra.manual_receivable_id = mr.id), 0)'
+            . ' != mr.outstanding_cents',
+        );
+        self::assertSame(0, $inconsistent);
+    }
+
+    public function test_the_name_mismatch_showcase_is_pre_staged(): void
+    {
+        // The open receivable (kanji client name)…
+        $mr = $this->query->fetchOne(
+            "SELECT total_cents, due_at FROM manual_receivables WHERE organization_id = ? AND client_name = '株式会社山田工務店' AND status = 'open'",
+            [self::ORG],
+        );
+        self::assertIsArray($mr);
+        self::assertSame(42350000, (int) $mr['total_cents']);
+        self::assertSame('2026-07-20', (string) $mr['due_at']); // T+10, due soon
+
+        // …and its exact-amount unmatched deposit under the katakana transfer name.
+        $tx = $this->query->fetchOne(
+            "SELECT amount_cents FROM bank_transactions WHERE organization_id = ? AND counterparty_text = 'ヤマダコウムテン（カ' AND status = 'unmatched'",
+            [self::ORG],
+        );
+        self::assertIsArray($tx);
+        self::assertSame(42350000, (int) $tx['amount_cents']);
+    }
+
+    public function test_dunning_history_aligns_with_the_live_upstream_fixture(): void
+    {
+        // INV-2026-057 was noticed 2 days ago — the min-interval throttle showcase.
+        $row = $this->query->fetchOne(
+            "SELECT sent_at FROM dunning_notices WHERE organization_id = ? AND invoice_number = 'INV-2026-057'",
+            [self::ORG],
+        );
+        self::assertIsArray($row);
+        self::assertStringStartsWith('2026-07-08', (string) $row['sent_at']);
+    }
+
+    public function test_seed_is_deterministic_for_the_same_org_and_day(): void
+    {
+        $before = $this->countRows('SELECT COUNT(*) FROM bank_transactions WHERE organization_id = ?');
+
+        // A different org id on a second database yields the same structure.
+        $dbPath = sys_get_temp_dir() . '/' . uniqid('clear-demo-seed2-', true) . '.sqlite';
+        $query = DatabaseTestKit::sqlite($dbPath)->queryExecutor;
+        SchemaFixture::createOrganizations($query);
+        SchemaFixture::createUsers($query);
+        SchemaFixture::createBankAccounts($query);
+        SchemaFixture::createBankImportBatches($query);
+        SchemaFixture::createBankTransactions($query);
+        SchemaFixture::createPaymentReconciliations($query);
+        SchemaFixture::createReconciliationAllocations($query);
+        SchemaFixture::createClientCredits($query);
+        SchemaFixture::createClearSettings($query);
+        SchemaFixture::createDunningNotices($query);
+        SchemaFixture::createDunningPauses($query);
+        SchemaFixture::createManualReceivables($query);
+        SchemaFixture::createAuditEvents($query);
+        $query->execute("INSERT INTO organizations (id, slug, name, created_at, is_deleted) VALUES (42, 'demo-x', 'Demo', '2026-07-10', 0)");
+        $query->execute("INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (42, 'a@demo-x.example', 'admin', 'active', 'x', 0)");
+        (new DemoDataSeeder($query, new FixedClock('2026-07-10T09:00:00+00:00')))->seed(42, DemoTemplate::Standard);
+
+        $row = $query->fetchOne('SELECT COUNT(*) AS n FROM bank_transactions WHERE organization_id = 42');
+        self::assertSame($before, is_array($row) ? (int) $row['n'] : -1);
+        @unlink($dbPath);
+    }
+}

--- a/tests/Demo/DemoOrgProvisionerTest.php
+++ b/tests/Demo/DemoOrgProvisionerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Demo\SlugConflictException;
+use NeneClear\Demo\DemoOrgProvisioner;
+use NeneClear\Organization\CreateOrganizationInput;
+use NeneClear\Organization\CreateOrganizationOutput;
+use NeneClear\Organization\CreateOrganizationUseCaseInterface;
+use NeneClear\Organization\OrganizationAlreadyExistsException;
+use NeneClear\User\CreateUserInput;
+use NeneClear\User\CreateUserUseCaseInterface;
+use NeneClear\User\User;
+use NeneClear\User\UserStatus;
+use PHPUnit\Framework\TestCase;
+
+final class DemoOrgProvisionerTest extends TestCase
+{
+    /** @param \ArrayObject<int, CreateUserInput> $capturedUsers */
+    private function provisioner(bool $slugTaken, \ArrayObject $capturedUsers): DemoOrgProvisioner
+    {
+        $createOrg = new class ($slugTaken) implements CreateOrganizationUseCaseInterface {
+            public function __construct(private readonly bool $slugTaken)
+            {
+            }
+
+            public function execute(CreateOrganizationInput $input): CreateOrganizationOutput
+            {
+                if ($this->slugTaken) {
+                    throw new OrganizationAlreadyExistsException($input->slug);
+                }
+
+                return new CreateOrganizationOutput(id: 55, slug: $input->slug, name: $input->name);
+            }
+        };
+
+        $createUser = new class ($capturedUsers) implements CreateUserUseCaseInterface {
+            /** @param \ArrayObject<int, CreateUserInput> $captured */
+            public function __construct(private readonly \ArrayObject $captured)
+            {
+            }
+
+            public function execute(CreateUserInput $input): User
+            {
+                $this->captured->append($input);
+
+                return new User(
+                    email: $input->email,
+                    role: $input->role,
+                    status: UserStatus::Active,
+                    passwordHash: 'x',
+                    organizationId: $input->organizationId,
+                    id: 77,
+                );
+            }
+        };
+
+        return new DemoOrgProvisioner($createOrg, $createUser);
+    }
+
+    public function test_provisions_org_and_admin_and_reports_their_ids(): void
+    {
+        $captured = new \ArrayObject();
+        $org = $this->provisioner(false, $captured)->provision('demo-ab12cd34', 'standard');
+
+        self::assertSame(55, $org->orgId);
+        self::assertSame('demo-ab12cd34', $org->slug);
+        self::assertSame(77, $org->adminUserId);
+
+        self::assertCount(1, $captured);
+        $input = $captured[0];
+        self::assertInstanceOf(CreateUserInput::class, $input);
+        self::assertSame('demo-admin@demo-ab12cd34.example', $input->email);
+        self::assertSame(55, $input->organizationId);
+        // The password is random and long — nobody logs in as a demo admin.
+        self::assertGreaterThanOrEqual(32, strlen((string) $input->password));
+    }
+
+    public function test_slug_conflicts_map_to_the_framework_exception_for_retry(): void
+    {
+        $captured = new \ArrayObject();
+
+        $this->expectException(SlugConflictException::class);
+        $this->provisioner(true, $captured)->provision('demo-ab12cd34', 'standard');
+    }
+}

--- a/tests/Demo/DemoOrgReaperTest.php
+++ b/tests/Demo/DemoOrgReaperTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Demo\DemoOrgReaper;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class DemoOrgReaperTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-reaper-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createOrganizations($this->query);
+        SchemaFixture::createUsers($this->query);
+        SchemaFixture::createUserInvitations($this->query);
+        SchemaFixture::createBankAccounts($this->query);
+        SchemaFixture::createBankImportBatches($this->query);
+        SchemaFixture::createBankTransactions($this->query);
+        SchemaFixture::createPaymentReconciliations($this->query);
+        SchemaFixture::createReconciliationAllocations($this->query);
+        SchemaFixture::createClientCredits($this->query);
+        SchemaFixture::createClearSettings($this->query);
+        SchemaFixture::createDunningNotices($this->query);
+        SchemaFixture::createDunningPauses($this->query);
+        SchemaFixture::createManualReceivables($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+        SchemaFixture::createTotpTables($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dbPath);
+    }
+
+    /** Seed a minimal org with one row in every reaped table. */
+    private function seedOrg(int $orgId, string $slug): int
+    {
+        $q = $this->query;
+        $q->execute("INSERT INTO organizations (id, slug, name, created_at, is_deleted) VALUES (?, ?, 'Demo', '2026-07-01 00:00:00', 0)", [$orgId, $slug]);
+        $userId = $q->insert(
+            "INSERT INTO users (organization_id, email, role, status, password_hash, is_deleted) VALUES (?, ?, 'admin', 'active', 'x', 0)",
+            [$orgId, 'demo-admin@' . $slug . '.example'],
+        );
+        $q->execute('INSERT INTO totp_secrets (user_id, secret, is_enabled, failed_attempts, created_at) VALUES (?, ?, 0, 0, ?)', [$userId, 's', '2026-07-01 00:00:00']);
+        $q->execute("INSERT INTO clear_settings (organization_id, dunning_min_interval_days, created_at, updated_at) VALUES (?, 7, '2026-07-01', '2026-07-01')", [$orgId]);
+        $accountId = $q->insert(
+            "INSERT INTO bank_accounts (organization_id, bank_name, bank_branch, account_type, account_number, csv_encoding, csv_date_format, csv_date_column, csv_amount_column, csv_counterparty_column, csv_header_rows, is_deleted) VALUES (?, 'B', 'H', 'ordinary', '1', 'utf8', 'Y/m/d', 0, 1, 3, 1, 0)",
+            [$orgId],
+        );
+        $batchId = $q->insert(
+            "INSERT INTO bank_import_batches (organization_id, bank_account_id, file_hash, source_filename, row_count, status, imported_by, imported_at) VALUES (?, ?, ?, 'x.csv', 1, 'imported', ?, '2026-07-01')",
+            [$orgId, $accountId, 'h' . $orgId, $userId],
+        );
+        $txId = $q->insert(
+            "INSERT INTO bank_transactions (organization_id, bank_import_batch_id, bank_account_id, value_date, amount_cents, counterparty_text, line_key, status, created_at) VALUES (?, ?, ?, '2026-07-01', 100, 'X', ?, 'matched', '2026-07-01')",
+            [$orgId, $batchId, $accountId, 'k' . $orgId],
+        );
+        $reconId = $q->insert(
+            "INSERT INTO payment_reconciliations (organization_id, bank_transaction_id, status, confirmed_by, confirmed_at, created_at, idempotency_key) VALUES (?, ?, 'confirmed', ?, '2026-07-01', '2026-07-01', ?)",
+            [$orgId, $txId, $userId, 'idem-' . $orgId],
+        );
+        $q->execute(
+            "INSERT INTO reconciliation_allocations (organization_id, payment_reconciliation_id, invoice_id, amount_cents, created_at, source) VALUES (?, ?, 1, 100, '2026-07-01', 'invoice_upstream')",
+            [$orgId, $reconId],
+        );
+        $q->execute(
+            "INSERT INTO client_credits (organization_id, client_id, amount_cents, remaining_cents, status, source_bank_transaction_id, reconciliation_id, created_by, created_at) VALUES (?, 1, 10, 10, 'open', ?, ?, ?, '2026-07-01')",
+            [$orgId, $txId, $reconId, $userId],
+        );
+        $q->execute(
+            "INSERT INTO manual_receivables (organization_id, reference_number, client_name, recipient_email, total_cents, outstanding_cents, currency, issued_at, due_at, status, created_by, created_at, updated_at, is_deleted) VALUES (?, ?, 'C', 'a@b.example', 100, 100, 'JPY', '2026-07-01', '2026-07-10', 'open', ?, '2026-07-01', '2026-07-01', 0)",
+            [$orgId, 'MR-' . $orgId, $userId],
+        );
+        $q->execute(
+            "INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, recipient_email, outstanding_cents, due_at, channel, sent_by, sent_at, created_at, template_version) VALUES (?, 1, 'INV-1', 1, 'a@b.example', 100, '2026-07-01', 'log', ?, '2026-07-01', '2026-07-01', '1.0')",
+            [$orgId, $userId],
+        );
+        $q->execute(
+            "INSERT INTO dunning_pauses (organization_id, invoice_id, paused_by, paused_at, paused_reason) VALUES (?, 1, ?, '2026-07-01', 'r')",
+            [$orgId, $userId],
+        );
+        $q->execute(
+            "INSERT INTO audit_events (organization_id, action, actor_id, occurred_at, entity_type, entity_id) VALUES (?, 'organization_created', ?, '2026-07-01 00:00:00', 'organization', ?)",
+            [$orgId, $userId, $orgId],
+        );
+
+        return $userId;
+    }
+
+    private function countFor(string $table, int $orgId): int
+    {
+        $row = $this->query->fetchOne("SELECT COUNT(*) AS n FROM {$table} WHERE organization_id = ?", [$orgId]);
+
+        return is_array($row) ? (int) $row['n'] : -1;
+    }
+
+    public function test_reap_removes_the_org_and_every_child_but_leaves_others_untouched(): void
+    {
+        $this->seedOrg(10, 'demo-aaaa');
+        $keptUser = $this->seedOrg(20, 'real-org');
+
+        (new DemoOrgReaper($this->query))->reap(10);
+
+        foreach ([
+            'organizations' => 'id', 'users' => 'organization_id', 'clear_settings' => 'organization_id',
+            'bank_accounts' => 'organization_id', 'bank_import_batches' => 'organization_id',
+            'bank_transactions' => 'organization_id', 'payment_reconciliations' => 'organization_id',
+            'reconciliation_allocations' => 'organization_id', 'client_credits' => 'organization_id',
+            'manual_receivables' => 'organization_id', 'dunning_notices' => 'organization_id',
+            'dunning_pauses' => 'organization_id', 'audit_events' => 'organization_id',
+        ] as $table => $column) {
+            $row = $this->query->fetchOne("SELECT COUNT(*) AS n FROM {$table} WHERE {$column} = ?", [10]);
+            self::assertSame(0, is_array($row) ? (int) $row['n'] : -1, "{$table} not fully reaped");
+        }
+
+        // Per-user TOTP rows of the reaped org are gone; the other org's remain.
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS n FROM totp_secrets');
+        self::assertSame(1, is_array($row) ? (int) $row['n'] : -1);
+        $row = $this->query->fetchOne('SELECT COUNT(*) AS n FROM totp_secrets WHERE user_id = ?', [$keptUser]);
+        self::assertSame(1, is_array($row) ? (int) $row['n'] : -1);
+
+        self::assertSame(1, $this->countFor('users', 20));
+        self::assertSame(1, $this->countFor('dunning_notices', 20));
+    }
+
+    public function test_reap_is_idempotent(): void
+    {
+        $this->seedOrg(10, 'demo-aaaa');
+        $reaper = new DemoOrgReaper($this->query);
+
+        $reaper->reap(10);
+        $reaper->reap(10); // already gone — success, no throw
+
+        self::assertSame(0, $this->countFor('users', 10));
+    }
+}

--- a/tests/Demo/DemoSessionSeaterTest.php
+++ b/tests/Demo/DemoSessionSeaterTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Demo\ProvisionedDemoOrg;
+use NeneClear\Auth\Role;
+use NeneClear\Auth\TokenIssuerInterface;
+use NeneClear\Demo\DemoSessionSeater;
+use NeneClear\User\User;
+use NeneClear\User\UserRepositoryInterface;
+use NeneClear\User\UserStatus;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class DemoSessionSeaterTest extends TestCase
+{
+    private function seater(?User $admin): DemoSessionSeater
+    {
+        $users = new class ($admin) implements UserRepositoryInterface {
+            public function __construct(private readonly ?User $admin)
+            {
+            }
+
+            public function findById(int $id): ?User
+            {
+                return $this->admin;
+            }
+
+            public function findByEmail(string $email): ?User
+            {
+                return null;
+            }
+
+            public function existsByEmail(string $email): bool
+            {
+                return false;
+            }
+
+            public function findAllByOrganization(?int $organizationId, int $limit, int $offset): array
+            {
+                return [];
+            }
+
+            public function countByOrganization(?int $organizationId): int
+            {
+                return 0;
+            }
+
+            public function save(User $user): int
+            {
+                return 1;
+            }
+
+            public function delete(?int $organizationId, int $id, string $deletedAt): void
+            {
+            }
+        };
+
+        $issuer = new class () implements TokenIssuerInterface {
+            public function issueForUser(User $user): string
+            {
+                return 'demo-jwt-for-' . ($user->id ?? 0);
+            }
+        };
+
+        return new DemoSessionSeater($users, $issuer, new Psr17Factory());
+    }
+
+    private function request(): \Psr\Http\Message\ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', '/demo/standard');
+    }
+
+    private function admin(): User
+    {
+        return new User(
+            email: 'demo-admin@demo-abc.example',
+            role: Role::Admin,
+            status: UserStatus::Active,
+            passwordHash: 'x',
+            organizationId: 42,
+            id: 7,
+        );
+    }
+
+    public function test_seat_page_stores_the_token_and_redirects_into_the_spa(): void
+    {
+        $response = $this->seater($this->admin())->seatAndRedirect(
+            $this->request(),
+            new ProvisionedDemoOrg(orgId: 42, slug: 'demo-abc', adminUserId: 7),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+
+        $html = (string) $response->getBody();
+        self::assertStringContainsString("sessionStorage.setItem('nene_clear_token', \"demo-jwt-for-7\")", $html);
+        self::assertStringContainsString("location.replace('/')", $html);
+    }
+
+    public function test_page_specific_csp_allows_exactly_the_embedded_nonce(): void
+    {
+        $response = $this->seater($this->admin())->seatAndRedirect(
+            $this->request(),
+            new ProvisionedDemoOrg(orgId: 42, slug: 'demo-abc', adminUserId: 7),
+        );
+
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+        self::assertStringContainsString("default-src 'none'", $csp);
+        self::assertSame(1, preg_match("/script-src 'nonce-([^']+)'/", $csp, $m));
+        $nonce = $m[1] ?? '';
+        self::assertNotSame('', $nonce);
+
+        // The nonce in the policy is the nonce on the script tag.
+        self::assertStringContainsString('<script nonce="' . $nonce . '">', (string) $response->getBody());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+    }
+
+    public function test_nonces_are_unique_per_response(): void
+    {
+        $seater = $this->seater($this->admin());
+        $org = new ProvisionedDemoOrg(orgId: 42, slug: 'demo-abc', adminUserId: 7);
+
+        $first = $seater->seatAndRedirect($this->request(), $org)->getHeaderLine('Content-Security-Policy');
+        $second = $seater->seatAndRedirect($this->request(), $org)->getHeaderLine('Content-Security-Policy');
+
+        self::assertNotSame($first, $second);
+    }
+
+    public function test_missing_admin_fails_loudly(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->seater(null)->seatAndRedirect(
+            $this->request(),
+            new ProvisionedDemoOrg(orgId: 42, slug: 'demo-abc', adminUserId: 7),
+        );
+    }
+}

--- a/tests/Demo/FileRateLimitStorageTest.php
+++ b/tests/Demo/FileRateLimitStorageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use NeneClear\Demo\FileRateLimitStorage;
+use NeneClear\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class FileRateLimitStorageTest extends TestCase
+{
+    private string $baseDir;
+
+    protected function setUp(): void
+    {
+        $this->baseDir = sys_get_temp_dir() . '/' . uniqid('clear-throttle-', true);
+        mkdir($this->baseDir, 0775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->baseDir . '/rate-limits/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->baseDir . '/rate-limits');
+        @rmdir($this->baseDir);
+    }
+
+    public function test_counts_hits_within_the_window_across_instances(): void
+    {
+        $clock = new FixedClock('2026-07-10T09:00:00+00:00');
+
+        // A fresh instance per hit — the shared-hosting reality (one process per request).
+        $first = (new FileRateLimitStorage($this->baseDir, $clock))->hit('ip:1.2.3.4', 3600);
+        $second = (new FileRateLimitStorage($this->baseDir, $clock))->hit('ip:1.2.3.4', 3600);
+        $third = (new FileRateLimitStorage($this->baseDir, $clock))->hit('ip:1.2.3.4', 3600);
+
+        self::assertSame(1, $first['count']);
+        self::assertSame(2, $second['count']);
+        self::assertSame(3, $third['count']);
+        self::assertSame($first['reset_at'], $third['reset_at']);
+    }
+
+    public function test_keys_are_isolated(): void
+    {
+        $clock = new FixedClock('2026-07-10T09:00:00+00:00');
+        $storage = new FileRateLimitStorage($this->baseDir, $clock);
+
+        $storage->hit('ip:1.2.3.4', 3600);
+        $other = $storage->hit('ip:5.6.7.8', 3600);
+
+        self::assertSame(1, $other['count']);
+    }
+
+    public function test_expired_window_starts_fresh(): void
+    {
+        $storage = new FileRateLimitStorage($this->baseDir, new FixedClock('2026-07-10T09:00:00+00:00'));
+        $storage->hit('ip:1.2.3.4', 3600);
+        $storage->hit('ip:1.2.3.4', 3600);
+
+        $later = new FileRateLimitStorage($this->baseDir, new FixedClock('2026-07-10T10:00:01+00:00'));
+        $fresh = $later->hit('ip:1.2.3.4', 3600);
+
+        self::assertSame(1, $fresh['count']);
+    }
+}

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Disposable-demo sweep (`Nene2\Demo` consumer, #275): expires demo orgs past
+ * their TTL and reaps overflow beyond DEMO_MAX_ORGS. Thin by design — org
+ * selection here (the product owns its schema), TTL/overflow policy in the
+ * framework {@see \Nene2\Demo\DisposableDemoSweeper}, teardown in
+ * {@see \NeneClear\Demo\DemoOrgReaper}. Also prunes stale per-IP rate-limit
+ * state files. Run hourly from cron.
+ *
+ * Only orgs whose slug carries the demo prefix (`demo-…`) are ever selected;
+ * the fixed showcase org (slug `demo`, no hyphen) and real tenants are
+ * untouched.
+ *
+ * Usage: php tools/sweep-demo.php
+ * Config-boundary entry point: DB wiring mirrors public_html/index.php.
+ */
+
+use Dotenv\Dotenv;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Demo\DemoConfig;
+use Nene2\Demo\DemoOrgRecord;
+use Nene2\Demo\DisposableDemoSweeper;
+use Nene2\Http\UtcClock;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Demo\DemoOrgReaper;
+use NeneClear\Demo\DemoServiceProvider;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, 'This script must be run from the command line.' . PHP_EOL);
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+if (is_file($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
+
+$adapter = $env('DB_ADAPTER', 'sqlite');
+$connectionFactory = (static function () use ($env, $adapter, $root): ?DatabaseConnectionFactoryInterface {
+    try {
+        $config = match ($adapter) {
+            'mysql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'mysql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '3306'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8mb4'),
+            ),
+            'pgsql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'pgsql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '5432'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8'),
+            ),
+            default => DatabaseConfig::sqlite($env('DB_NAME') ?: $root . '/database/nene_clear.sqlite3'),
+        };
+
+        return new PdoConnectionFactory($config);
+    } catch (\Throwable) {
+        return null;
+    }
+})();
+
+if ($connectionFactory === null) {
+    fwrite(STDERR, 'Database is not configured or unreachable. Check .env (DB_ADAPTER, DB_*).' . PHP_EOL);
+    exit(1);
+}
+
+$query = new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter);
+
+$config = new DemoConfig(
+    demoMode: true, // irrelevant to sweeping; the constructor validates the knobs below
+    ttlHours: (int) ($env('DEMO_TTL_HOURS') ?: '3'),
+    maxOrgs: (int) ($env('DEMO_MAX_ORGS') ?: '200'),
+);
+
+$likePrefix = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $config->slugPrefix) . '%';
+$rows = $query->fetchAll(
+    "SELECT id, created_at FROM organizations WHERE slug LIKE ? ESCAPE '\\'",
+    [$likePrefix],
+);
+
+$records = [];
+foreach ($rows as $row) {
+    $records[] = new DemoOrgRecord(
+        orgId: (int) $row['id'],
+        createdAt: new DateTimeImmutable((string) $row['created_at']),
+    );
+}
+
+$report = (new DisposableDemoSweeper($config, new DemoOrgReaper($query), new UtcClock()))->sweep($records);
+
+// Prune stale per-IP throttle state (fully expired windows only).
+$pruned = 0;
+$cutoff = time() - DemoServiceProvider::THROTTLE_WINDOW_SECONDS * 2;
+foreach (glob($root . '/var/rate-limits/*.json') ?: [] as $file) {
+    $mtime = @filemtime($file);
+    if ($mtime !== false && $mtime < $cutoff && @unlink($file)) {
+        $pruned++;
+    }
+}
+
+fwrite(STDOUT, sprintf(
+    "demo sweep: %d org(s) total, %d expired, %d overflow, %d reaped, %d throttle file(s) pruned\n",
+    count($records),
+    count($report->expiredOrgIds),
+    count($report->overflowOrgIds),
+    count($report->reapedOrgIds),
+    $pruned,
+));
+
+exit(0);


### PR DESCRIPTION
Clear's turn in the consumer rollout (design doc §5: NENE2 module → invoice → **clear** → vault; invoice PR #611 is the reference). Full scope in #275.

## The Clear-specific piece: JWT seating

Clear has no cookie session — the SPA keeps its bearer in `sessionStorage`. The seater mints a normal access token via the existing `TokenIssuerInterface` (same claims/TTL/secret as a login; the demo admin's real password is random and never disclosed) and serves a one-shot **seat page**: a nonce'd inline script stores the token and `location.replace('/')`. The page carries its own per-response CSP (`script-src 'nonce-…'`, everything else `'none'`) — the NENE2 security-headers middleware only fills absent headers, so the invoice #612 inline-CSP trap is dodged by construction. Session honesty: 1-hour token, no refresh; re-visit the demo URL for a fresh org.

## Everything else mirrors invoice

Provisioner (audited use cases, `SlugConflictException` mapping for retry), reaper (children→parents incl. TOTP tables, idempotent, hard-delete — a disposable org's audit trail dies with it), compact T-relative seeder with the 名義ズレ showcase **pre-staged** (open receivables + exact-amount deposits already present; propose→confirm works with zero setup), `FileRateLimitStorage` port (InMemory never fires per-request-process), fail-close `DEMO_*` at the config boundary, `tools/sweep-demo.php` (TTL + overflow, `demo-` prefix only — the fixed `demo` org is untouchable), terminology registry additions, `/demo/standard` in the auth public paths (exact match — unknown templates 401, tighter than invoice) and exempted from the SPA fallback.

## Verification (local, real outputs)

- `composer check` green — 391 backend tests (17 new across seater/provisioner/reaper/seeder/throttle).
- `GET /demo/standard` → seat page (`CSP: default-src 'none'; script-src 'nonce-…'`, `no-store`) → seated `GET /admin/auth/me` → `demo-admin@demo-03c901a1.example admin org 7`.
- Staged showcase: propose on the ヤマダコウムテン（カ deposit → `MR-2026-005 0.7 | exact amount match; due soon`; dunning history 6; upstream fixture 6 invoices.
- **Throttle fired at hit 31**: `429 Too Many Requests` + `Retry-After: 3560`.
- Sweep with a lowered ceiling: `30 org(s) total, 27 overflow, 27 reaped` — **zero orphan rows**, fixed `demo` org intact.
- `DEMO_MODE=0` → 404 (fail-close).

Browser-facing HTML for 429/503 is deferred to the pending upstream negotiation proposal (`handoff-nene2-demo-html-negotiation-2026-07-10-proposal.md`).

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)