### PR TITLE
Portable LIKE escape for demo-slug queries (MySQL 1064)

### DIFF
--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -82,9 +82,11 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
 
                     return new CountingDemoCapacityGuard(
                         demoOrgCount: static function () use ($query, $config): int {
+                            // ESCAPE '|' — a backslash escape char is itself escaped
+                            // differently by MySQL string literals vs SQLite (#277).
                             $row = $query->fetchOne(
-                                "SELECT COUNT(*) AS n FROM organizations WHERE slug LIKE ? ESCAPE '\\'",
-                                [str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $config->slugPrefix) . '%'],
+                                "SELECT COUNT(*) AS n FROM organizations WHERE slug LIKE ? ESCAPE '|'",
+                                [str_replace(['|', '%', '_'], ['||', '|%', '|_'], $config->slugPrefix) . '%'],
                             );
 
                             return is_array($row) ? (int) $row['n'] : 0;

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -94,9 +94,11 @@ $config = new DemoConfig(
     maxOrgs: (int) ($env('DEMO_MAX_ORGS') ?: '200'),
 );
 
-$likePrefix = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $config->slugPrefix) . '%';
+// ESCAPE '|' — a backslash escape char is parsed differently by MySQL string
+// literals vs SQLite (#277); '|' needs no literal-level escaping anywhere.
+$likePrefix = str_replace(['|', '%', '_'], ['||', '|%', '|_'], $config->slugPrefix) . '%';
 $rows = $query->fetchAll(
-    "SELECT id, created_at FROM organizations WHERE slug LIKE ? ESCAPE '\\'",
+    "SELECT id, created_at FROM organizations WHERE slug LIKE ? ESCAPE '|'",
     [$likePrefix],
 );
 


### PR DESCRIPTION
Found on the production target while deploying #275: `ESCAPE '\'` inside a double-quoted SQL string is valid SQLite but a MySQL 1064 syntax error (the backslash consumes the closing quote of the literal). Both demo-slug queries — the capacity guard's count and the sweep SELECT — hit it.

Fix: `ESCAPE '|'` with `|`-escaping of the prefix; no literal-level escaping on any adapter. Proven against MySQL 8.4: backslash variant → 1064, pipe variant → OK. Demo tests + composer check green.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)