### PR TITLE
docs: record the disposable-demo live rollout

### DIFF
--- a/docs/journal/2026-07-10.md
+++ b/docs/journal/2026-07-10.md
@@ -74,3 +74,21 @@ staged 名義ズレ propose 0.7 → dunning history 6 → upstream fixture 6;
 ceiling reaped 27/30 orgs with zero orphan rows and the fixed org intact;
 DEMO_MODE=0 → 404. Browser-facing HTML for 429/503 deliberately deferred to
 the upstream negotiation proposal.
+
+## Live rollout of the disposable demo (clear.ayane.co.jp)
+
+Deployed after merge (clean artifact via build-release.sh staging; rsync -c of
+vendor/ src/ tools/ + index.php — the live vendor predated NENE2 v1.9.0 and
+lacked Nene2\Demo). One production-only bug surfaced and was fixed the same
+hour (#277 / PR #278): `LIKE ? ESCAPE '\'` is valid SQLite but a MySQL 1064
+syntax error (the backslash eats the literal's closing quote) — both the
+capacity-guard count and the sweep SELECT hit it; switched to `ESCAPE '|'`
+(proven against MySQL 8.4 both ways).
+
+Live verification on production MySQL: `/demo/standard` → seat page (nonce
+CSP) → seated `demo-admin@demo-c66a497a.example` → staged 名義ズレ propose
+(`MR-2026-005 0.7`) → confirm (`recon 650 confirmed`) → dunning notice on
+fixture INV-2026-056 recorded (`channel log`, SMTP unset). A second visit
+provisioned a second org; the fixed `demo` org is untouched. Sweep wrapper
+installed at `~/bin/sweep-clear-demo.sh` (exit 0 on live MySQL) — hourly cron
+registration in the HETEML panel is the owner's step.

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-07-09
+Last updated: 2026-07-10
 
 > **Latest: demo enablement shipped (#260–#262, 2026-07-09)** — one-command
 > T-relative demo seeder (`tools/seed-demo.php`), env-gated demo upstream
@@ -13,11 +13,16 @@ Last updated: 2026-07-09
 > reverted. **The demo is live at `https://clear.ayane.co.jp` (deployed
 > 2026-07-09 evening, owner GO)** — HETEML, MySQL `_nene_clear`, invoice-shaped
 > docroot; the deployment surfaced and fixed two more Tier A bugs (#265
-> Authorization stripped by the front proxy, #268 SPA asset base). Remaining
-> owner step: register the nightly reset cron (`~/bin/reseed-clear-demo.sh`)
-> in the HETEML panel. SMTP is unset (dunning channel `log`), and the
+> Authorization stripped by the front proxy, #268 SPA asset base).
+> **2026-07-10: the disposable-org demo is live too** (`/demo/standard`,
+> `Nene2\Demo` v1.9.0 consumer, #275; MySQL LIKE-escape fix #277) — hand out
+> `https://clear.ayane.co.jp/demo/standard` and every visitor gets a fresh
+> throttled, TTL-swept org. Remaining owner steps (HETEML panel, cron):
+> nightly fixed-org reset `~/bin/reseed-clear-demo.sh` and hourly demo sweep
+> `~/bin/sweep-clear-demo.sh`. SMTP is unset (dunning channel `log`), and the
 > `client_credit.status` registry/enum drift is #264. Details:
-> [`docs/journal/2026-07-09.md`](../journal/2026-07-09.md).
+> [`docs/journal/2026-07-09.md`](../journal/2026-07-09.md) and
+> [`docs/journal/2026-07-10.md`](../journal/2026-07-10.md).
 > Qiita shots 3, 4, 5, 7 are still open
 > ([handoff-2026-07-03](handoff-2026-07-03.md)); dev work otherwise resumes at
 > **installer Slice 3** ([handoff-2026-07-02 §3](handoff-2026-07-02.md)).


### PR DESCRIPTION
Journal + current.md for the #275 consumer adoption going live on clear.ayane.co.jp (incl. the #277 MySQL LIKE-escape production fix and the remaining owner cron steps). Docs only. Refs #275, #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)