### PR TITLE
fix(demo): sweep の created_at を UTC として明示パース（JST ホストで即時 reap されるバグ）

### DIFF
--- a/tests/Demo/SweepDemoScriptTest.php
+++ b/tests/Demo/SweepDemoScriptTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the real `tools/sweep-demo.php` as a subprocess with the host timezone
+ * pinned to Asia/Tokyo — the production (HETEML) configuration where #280 was
+ * caught live. `created_at` is written in UTC, so a bare `DateTimeImmutable`
+ * parse reads every org as 9 hours older than it is and the hourly cron reaps
+ * freshly provisioned demo orgs on the spot. The script must parse UTC
+ * explicitly: fresh orgs survive, genuinely expired ones are still reaped.
+ */
+final class SweepDemoScriptTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-sweep-script-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createOrganizations($this->query);
+        SchemaFixture::createUsers($this->query);
+        SchemaFixture::createUserInvitations($this->query);
+        SchemaFixture::createBankAccounts($this->query);
+        SchemaFixture::createBankImportBatches($this->query);
+        SchemaFixture::createBankTransactions($this->query);
+        SchemaFixture::createPaymentReconciliations($this->query);
+        SchemaFixture::createReconciliationAllocations($this->query);
+        SchemaFixture::createClientCredits($this->query);
+        SchemaFixture::createClearSettings($this->query);
+        SchemaFixture::createDunningNotices($this->query);
+        SchemaFixture::createDunningPauses($this->query);
+        SchemaFixture::createManualReceivables($this->query);
+        SchemaFixture::createAuditEvents($this->query);
+        SchemaFixture::createTotpTables($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->dbPath);
+    }
+
+    public function testFreshOrgSurvivesAndExpiredOrgIsReapedOnAJstHost(): void
+    {
+        $nowUtc = time();
+        $this->insertOrg(1, 'demo-fresh', gmdate('Y-m-d H:i:s', $nowUtc - 60));            // 1 minute old
+        $this->insertOrg(2, 'demo-expired', gmdate('Y-m-d H:i:s', $nowUtc - 4 * 3600));    // past the 3h TTL
+        $this->insertOrg(3, 'demo', gmdate('Y-m-d H:i:s', $nowUtc - 30 * 24 * 3600));      // fixed showcase org (no hyphen)
+
+        $output = $this->runSweep('Asia/Tokyo');
+
+        self::assertStringContainsString('2 org(s) total, 1 expired, 0 overflow, 1 reaped', $output);
+        self::assertSame(['demo', 'demo-fresh'], $this->remainingSlugs());
+    }
+
+    public function testBehavesIdenticallyOnAUtcHost(): void
+    {
+        $nowUtc = time();
+        $this->insertOrg(1, 'demo-fresh', gmdate('Y-m-d H:i:s', $nowUtc - 60));
+        $this->insertOrg(2, 'demo-expired', gmdate('Y-m-d H:i:s', $nowUtc - 4 * 3600));
+
+        $output = $this->runSweep('UTC');
+
+        self::assertStringContainsString('2 org(s) total, 1 expired, 0 overflow, 1 reaped', $output);
+        self::assertSame(['demo-fresh'], $this->remainingSlugs());
+    }
+
+    private function insertOrg(int $id, string $slug, string $createdAtUtc): void
+    {
+        $this->query->execute(
+            "INSERT INTO organizations (id, slug, name, created_at, is_deleted) VALUES (?, ?, 'Demo', ?, 0)",
+            [$id, $slug, $createdAtUtc],
+        );
+    }
+
+    /** @return list<string> remaining org slugs, sorted */
+    private function remainingSlugs(): array
+    {
+        return array_map(
+            static fn (array $row): string => (string) $row['slug'],
+            $this->query->fetchAll('SELECT slug FROM organizations ORDER BY slug', []),
+        );
+    }
+
+    private function runSweep(string $timezone): string
+    {
+        $root = dirname(__DIR__, 2);
+        $command = [
+            PHP_BINARY,
+            '-d', 'date.timezone=' . $timezone,
+            $root . '/tools/sweep-demo.php',
+        ];
+
+        // Explicit env wins over the repo's .env: Dotenv::safeLoad() is immutable.
+        $env = [
+            'DB_ADAPTER' => 'sqlite',
+            'DB_NAME' => $this->dbPath,
+            'DEMO_TTL_HOURS' => '3',
+            'DEMO_MAX_ORGS' => '200',
+            'PATH' => (string) getenv('PATH'),
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $root, $env);
+        self::assertIsResource($process);
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        self::assertSame(0, $exitCode, 'sweep-demo.php failed: ' . $stderr);
+
+        return $stdout;
+    }
+}

--- a/tools/sweep-demo.php
+++ b/tools/sweep-demo.php
@@ -106,7 +106,12 @@ $records = [];
 foreach ($rows as $row) {
     $records[] = new DemoOrgRecord(
         orgId: (int) $row['id'],
-        createdAt: new DateTimeImmutable((string) $row['created_at']),
+        // created_at is written in UTC (MySQL CURRENT_TIMESTAMP on a UTC
+        // server; SQLite CURRENT_TIMESTAMP is always UTC). Parse it as UTC
+        // explicitly: on a host whose default timezone is ahead of UTC
+        // (production runs Asia/Tokyo) a bare parse would read every fresh
+        // org as hours old and expire it on the spot (#280, deal #72).
+        createdAt: new DateTimeImmutable((string) $row['created_at'], new DateTimeZone('UTC')),
     );
 }
 


### PR DESCRIPTION
## 目的

`tools/sweep-demo.php` が UTC 書き込みの `organizations.created_at` をホスト既定 TZ で素パースしており、JST 本番（clear.ayane.co.jp）では作成直後の demo org まで TTL 超過と誤判定して毎時 cron が全 reap する。deal #72 で捕捉された同型バグの clear 横展開。

## 変更点

- `tools/sweep-demo.php`: `DemoOrgRecord::$createdAt` を `new DateTimeImmutable(..., new DateTimeZone('UTC'))` で組み立て（NENE2 の UTC 契約どおり・deal #72 と同型）
- `tests/Demo/SweepDemoScriptTest.php`（新規）: 実スクリプトを `date.timezone=Asia/Tokyo` / `UTC` の両方で子プロセス実行する回帰テスト。fresh org 生存・TTL 超過 org の reap・固定 `demo` org（ハイフンなし）不可触を固定

## 検証結果

- 本番実打で再現済み: `/demo/standard` で org 作成（age 1 秒）→ sweep 手動実行 → `1 expired, 1 reaped`（本番 MySQL は `NOW() == UTC_TIMESTAMP()` を実測確認）
- 新テストは修正なしで赤（`2 expired, 2 reaped` — fresh org 全滅）・修正ありで緑
- `composer check` 全緑（phpunit / phpstan level 8 / php-cs-fixer / conformance）

## 残リスク

- なし（1 行の TZ 明示化。SQLite・UTC ホストでは挙動不変であることをテストで固定済み）

Self-review: backend-api

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)