### PR TITLE
build(deps): consume NENE2 from Packagist ^1.10 and harden the release build (#286)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,9 +34,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Clone NENE2 (local path dependency)
-        run: git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
-
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
@@ -80,9 +77,6 @@ jobs:
           php-version: '8.4'
           extensions: pdo, pdo_pgsql, mbstring
           coverage: none
-
-      - name: Clone NENE2 (local path dependency)
-        run: git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -30,13 +30,6 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Clone NENE2 (sibling path for Composer)
-        run: |
-          if [ ! -f ../NENE2/composer.json ]; then
-            git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
-          fi
-          test -f ../NENE2/composer.json
-
       - name: Build release ZIP
         run: composer release:zip
 
@@ -47,6 +40,10 @@ jobs:
           unzip -l "$ZIP" | grep -E 'nene-clear/vendor/autoload.php'
           unzip -l "$ZIP" | grep -E 'nene-clear/vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php'
           unzip -l "$ZIP" | grep -E 'nene-clear/vendor/hideyukimori/nene2/src/'
+          # v1.10.0 demo error-page renderer must be vendored (#286)
+          unzip -l "$ZIP" | grep -E 'nene-clear/vendor/hideyukimori/nene2/src/Demo/MinimalDemoErrorPageRenderer.php'
+          # SHA-256 sidecar must accompany the artifact (#286)
+          test -f "$ZIP.sha256"
           unzip -l "$ZIP" | grep -E 'nene-clear/public_html/install.php'
           unzip -l "$ZIP" | grep -E 'nene-clear/public_html/index.php'
           unzip -l "$ZIP" | grep -E 'nene-clear/public_html/assets/index.html'
@@ -59,5 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nene-clear-release
-          path: build/release/nene-clear-*.zip
+          path: |
+            build/release/nene-clear-*.zip
+            build/release/nene-clear-*.zip.sha256
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /frontend/apps/*/dist/
 /frontend/dist-e2e/
 /sec-router.php
+/composer.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Entry point for AI agents working on **NeNe Clear** (public repo `nene-clear`).
 
 ## Framework
 
-[NENE2](https://github.com/hideyukiMORI/NENE2) — wired via Composer as a local
-path dependency (`../NENE2`, `hideyukimori/nene2: @dev`). Runtime is live: PSR-15
-HTTP stack, DI via per-domain `ServiceProvider` + `ServiceResolver`, PHP 8.4.
+[NENE2](https://github.com/hideyukiMORI/NENE2) — consumed from Packagist as a
+tagged dist (`hideyukimori/nene2: ^1.10`), same as nene-invoice / nene-deal.
+Runtime: PSR-15 HTTP stack, DI via per-domain `ServiceProvider` +
+`ServiceResolver`, PHP 8.4. To develop against a local NENE2 checkout, use a
+git-ignored override (see `docs/development/nene2-compliance.md` §Local
+framework development) — never commit a path repository back into
+`composer.json` (#286).

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.4.1 <9.0",
         "ext-curl": "*",
         "firebase/php-jwt": "^7",
-        "hideyukimori/nene2": "@dev",
+        "hideyukimori/nene2": "^1.10",
         "robmorgan/phinx": "^0.16.11",
         "symfony/console": "^8.0",
         "symfony/mailer": "^8.1"
@@ -28,16 +28,6 @@
             "NeneClear\\Tests\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../NENE2",
-            "options": {
-                "symlink": true
-            }
-        }
-    ],
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34e281fa2cf1852838cd1a46759b17e7",
+    "content-hash": "10dd2c831f1d6c3ef6bfb2d9576063d6",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -602,11 +602,17 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "dev-main",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hideyukiMORI/NENE2.git",
+                "reference": "c5c1bb67819145099155bd969f3319294bca49d4"
+            },
             "dist": {
-                "type": "path",
-                "url": "../NENE2",
-                "reference": "b1a81244a21a69b924fa4fd522de1502c4733de0"
+                "type": "zip",
+                "url": "https://api.github.com/repos/hideyukiMORI/NENE2/zipball/c5c1bb67819145099155bd969f3319294bca49d4",
+                "reference": "c5c1bb67819145099155bd969f3319294bca49d4",
+                "shasum": ""
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -627,6 +633,7 @@
                 "symfony/yaml": "^8.0"
             },
             "suggest": {
+                "robmorgan/phinx": "Required by Nene2\\Install\\DatabaseSchemaApplier. A consumer that uses it MUST add phinx to its require (NOT require-dev) — it is here only as a dev dependency, so a --no-dev production build would omit it and installs would fatally fail when applying migrations.",
                 "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)"
             },
             "type": "library",
@@ -635,77 +642,16 @@
                     "Nene2\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Nene2\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit --testsuite NENE2,Database"
-                ],
-                "test:database": [
-                    "phpunit --testsuite Database"
-                ],
-                "test:database:mysql": [
-                    "phpunit --testsuite DatabaseMySQL"
-                ],
-                "analyse": [
-                    "phpstan analyse --memory-limit 512M"
-                ],
-                "cs": [
-                    "php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php"
-                ],
-                "cs:fix": [
-                    "php-cs-fixer fix --config=.php-cs-fixer.php"
-                ],
-                "openapi": [
-                    "php tools/validate-openapi.php"
-                ],
-                "openapi:docs": [
-                    "php tools/openapi-to-md.php"
-                ],
-                "howto:index": [
-                    "php tools/build-howto-index.php"
-                ],
-                "howto:frontmatter": [
-                    "php tools/validate-howto-frontmatter.php"
-                ],
-                "mcp": [
-                    "php tools/validate-mcp-tools.php"
-                ],
-                "version:check": [
-                    "php tools/validate-version.php"
-                ],
-                "migrations:status": [
-                    "phinx status -c phinx.php"
-                ],
-                "migrations:migrate": [
-                    "phinx migrate -c phinx.php"
-                ],
-                "migrations:rollback": [
-                    "phinx rollback -c phinx.php"
-                ],
-                "migrations:seed": [
-                    "phinx seed:run -c phinx.php"
-                ],
-                "check": [
-                    "@test",
-                    "@analyse",
-                    "@cs",
-                    "@openapi",
-                    "@mcp",
-                    "@version:check"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHP micro-framework: JSON APIs first, minimal server HTML, easy React/SPA integration, structure friendly to AI tooling.",
-            "transport-options": {
-                "symlink": true,
-                "relative": true
-            }
+            "support": {
+                "issues": "https://github.com/hideyukiMORI/NENE2/issues",
+                "source": "https://github.com/hideyukiMORI/NENE2/tree/v1.10.0"
+            },
+            "time": "2026-07-10T07:35:29+00:00"
         },
         {
             "name": "league/container",
@@ -6690,10 +6636,8 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
-    "stability-flags": {
-        "hideyukimori/nene2": 20
-    },
+    "minimum-stability": "stable",
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/docs/development/nene2-compliance.md
+++ b/docs/development/nene2-compliance.md
@@ -354,4 +354,33 @@ and `src/` first** and reuse it (§7).
 `quality-tools.md`. `docs/integrations/`: `openapi.md`, `mcp-tools.md`.
 ADRs: `0007-put-vs-patch-policy`, `0008-jwt-authentication`, `0010-rate-limiting`.
 
-Last updated: 2026-05-30
+---
+
+## Local framework development (NENE2 checkout)
+
+`hideyukimori/nene2` is consumed from **Packagist as a tagged dist** (`^1.10`).
+Do **not** commit a path repository or `@dev` constraint back into
+`composer.json` — that made releases non-reproducible and shipped whatever the
+local NENE2 checkout happened to contain (#286).
+
+To hack on NENE2 and Clear together, switch your working tree to the sibling
+checkout locally and revert before committing:
+
+```bash
+# switch to the local NENE2 checkout (working tree only — do not commit)
+composer config repositories.nene2-local path ../NENE2
+composer config repositories.nene2-local.options.symlink true
+composer require hideyukimori/nene2:@dev
+
+# ...develop against ../NENE2 HEAD...
+
+# revert to the tagged Packagist dist before committing
+git checkout composer.json composer.lock
+composer install
+```
+
+Release builds resolve their vendor from `composer.json` + `composer.lock` in
+a clean staging tree and fail on any symlink, so a forgotten override cannot
+ship.
+
+Last updated: 2026-07-11

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,32 +1,34 @@
 #!/usr/bin/env bash
-# Build a Tier A release ZIP for NeNe Clear — vendor bundled (--no-dev), the
-# React admin UI built into public_html/assets/, and the web installer included.
-# The artifact is what a human places on nene-origin.dev (see the origin `targets`
-# manifest); GitHub is not the source (docs/roadmap Phase 3, NENE_ORIGIN_URL).
+# NeNe Clear — Tier A release ZIP build (#286: allowlist + Packagist vendor + SHA-256 sidecar).
 #
-# NOTE: this runs `composer install --no-dev` in the repo, so the working tree's
-# vendor/ loses dev tools afterwards. Run `composer install` to restore them.
+# Usage:  bash tools/build-release.sh
+# Output: build/release/nene-clear-<version>.zip + .sha256 sidecar
+#
+# Design (follows nene-invoice tools/build-release.sh):
+# - The working tree's vendor/ is never touched. The distributed vendor is
+#   resolved fresh in a staging directory from composer.json + composer.lock
+#   (hideyukimori/nene2 comes from Packagist as a tagged dist — no path repo,
+#   no symlinks). A single leftover symlink fails the build.
+# - Files ship via an allowlist (structurally prevents dev-only files,
+#   secrets, and caches from leaking into the artifact).
+# - The archive keeps the `nene-clear/` top-level directory expected by the
+#   origin `targets` manifest and the release CI verify step.
+
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-NENE2_DIR="${NENE2_DIR:-$(dirname "$ROOT")/NENE2}"
 BUILD_DIR="${RELEASE_BUILD_DIR:-$ROOT/build/release}"
-STAGING_DIR="$BUILD_DIR/staging/nene-clear"
+STAGE="$BUILD_DIR/staging/nene-clear"
 VERSION="$(tr -d ' \n\r' < "$ROOT/VERSION" 2>/dev/null || echo 0.0.0-dev)"
 ZIP_PATH="${RELEASE_ZIP:-$BUILD_DIR/nene-clear-${VERSION}.zip}"
 
 echo "==> NeNe Clear release build (${VERSION})"
 
-if [[ ! -f "$NENE2_DIR/composer.json" ]]; then
-  echo "error: NENE2 not found at ${NENE2_DIR}. Clone it as a sibling or set NENE2_DIR." >&2
-  exit 1
-fi
-
-echo "==> Install PHP dependencies (production, no-dev)"
-composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader
-
+# ----------------------------------------
+# 1. Frontend build (Vite → public_html/assets/)
+# ----------------------------------------
 echo "==> Build the admin UI into public_html/assets/"
 (
   cd frontend
@@ -34,6 +36,50 @@ echo "==> Build the admin UI into public_html/assets/"
   npm run build
 )
 
+# ----------------------------------------
+# 2. Stage application files (allowlist)
+# ----------------------------------------
+echo "==> Stage release tree (allowlist)"
+rm -rf "$BUILD_DIR/staging"
+mkdir -p "$STAGE" "$STAGE/var" "$STAGE/tools"
+
+cp -r "$ROOT/src" "$STAGE/src"
+cp -r "$ROOT/lang" "$STAGE/lang"
+mkdir -p "$STAGE/database"
+cp -r "$ROOT/database/migrations" "$STAGE/database/migrations"
+if [[ -d "$ROOT/database/schema" ]]; then
+  cp -r "$ROOT/database/schema" "$STAGE/database/schema"
+fi
+# public_html contains the built SPA (assets/), install.php, index.php,
+# .htaccess — copy after the frontend build.
+cp -r "$ROOT/public_html" "$STAGE/public_html"
+cp "$ROOT/phinx.php" "$STAGE/phinx.php"
+cp "$ROOT/composer.json" "$STAGE/composer.json"
+cp "$ROOT/composer.lock" "$STAGE/composer.lock"
+cp "$ROOT/VERSION" "$STAGE/VERSION"
+cp "$ROOT/README.md" "$STAGE/README.md"
+cp "$ROOT/LICENSE" "$STAGE/LICENSE"
+cp "$ROOT/.env.example" "$STAGE/.env.example"
+# Production ops tools only (no build/dev tooling ships).
+cp "$ROOT/tools/create-admin.php" "$STAGE/tools/create-admin.php"
+cp "$ROOT/tools/sweep-demo.php" "$STAGE/tools/sweep-demo.php"
+cp "$ROOT/tools/seed-demo.php" "$STAGE/tools/seed-demo.php"
+touch "$STAGE/var/.gitkeep"
+
+# ----------------------------------------
+# 3. Production vendor resolved in staging (Packagist dist, no symlinks)
+# ----------------------------------------
+echo "==> composer install (production, staging, from lock)"
+(
+  cd "$STAGE"
+  composer install --no-dev --no-interaction --prefer-dist --no-scripts --optimize-autoloader --quiet
+)
+NENE2_RESOLVED="$(cd "$STAGE" && composer show hideyukimori/nene2 2>/dev/null | awk '/^versions/ {print $NF}')"
+echo "    nene2 resolved: ${NENE2_RESOLVED}"
+
+# ----------------------------------------
+# 4. Pre-ship inspection — required artifacts, zero symlinks, real nene2 dist
+# ----------------------------------------
 required_paths=(
   public_html/index.php
   public_html/install.php
@@ -41,60 +87,29 @@ required_paths=(
   public_html/assets/index.html
   vendor/autoload.php
   vendor/robmorgan/phinx/src/Phinx/Migration/Manager.php
+  vendor/hideyukimori/nene2/src/Demo/MinimalDemoErrorPageRenderer.php
 )
 for path in "${required_paths[@]}"; do
-  if [[ ! -e "$ROOT/$path" ]]; then
+  if [[ ! -e "$STAGE/$path" ]]; then
     echo "error: missing required release artifact: $path" >&2
     exit 1
   fi
 done
 
-echo "==> Stage release tree"
-rm -rf "$BUILD_DIR/staging"
-mkdir -p "$STAGING_DIR" "$STAGING_DIR/var"
-
-rsync -a \
-  --exclude='.git/' \
-  --exclude='.github/' \
-  --exclude='.cursor/' \
-  --exclude='.claude/' \
-  --exclude='.env' \
-  --exclude='.env.*' \
-  --exclude='.phpunit.cache/' \
-  --exclude='.phpunit.result.cache' \
-  --exclude='.phpstan.cache/' \
-  --exclude='.php-cs-fixer.cache' \
-  --exclude='build/' \
-  --exclude='docs/' \
-  --exclude='frontend/' \
-  --exclude='node_modules/' \
-  --exclude='tests/' \
-  --exclude='var/*' \
-  --exclude='database/*.sqlite3' \
-  --exclude='docker-compose.yml' \
-  --exclude='phpstan.neon' \
-  --exclude='phpunit.xml' \
-  --exclude='.php-cs-fixer.php' \
-  "$ROOT/" "$STAGING_DIR/"
-
-echo "==> Dereference path-dependency symlinks in staging vendor"
-# vendor/vendor is a self-referential symlink that zip would follow infinitely.
-rm -f "$STAGING_DIR/vendor/vendor"
-# vendor/hideyukimori/nene2 is a Composer path-repo symlink → copy real content
-# (src/ + composer.json are the only runtime-required pieces).
-NENE2_VENDOR_LINK="$STAGING_DIR/vendor/hideyukimori/nene2"
-if [[ -L "$NENE2_VENDOR_LINK" ]]; then
-  rm "$NENE2_VENDOR_LINK"
-  mkdir -p "$NENE2_VENDOR_LINK"
-  rsync -a "$NENE2_DIR/src/" "$NENE2_VENDOR_LINK/src/"
-  cp "$NENE2_DIR/composer.json" "$NENE2_VENDOR_LINK/composer.json"
+if [[ "$(find "$STAGE" -type l | wc -l)" -ne 0 ]]; then
+  echo "error: symlinks found in the release staging tree:" >&2
+  find "$STAGE" -type l >&2
+  exit 1
 fi
 
+# ----------------------------------------
+# 5. ZIP (nene-clear/ top-level) + SHA-256 sidecar
+# ----------------------------------------
 echo "==> Create ZIP: ${ZIP_PATH}"
 mkdir -p "$(dirname "$ZIP_PATH")"
-rm -f "$ZIP_PATH"
+rm -f "$ZIP_PATH" "$ZIP_PATH.sha256"
 if command -v zip >/dev/null 2>&1; then
-  ( cd "$BUILD_DIR/staging" && zip -rq "$ZIP_PATH" nene-clear )
+  ( cd "$BUILD_DIR/staging" && zip -rq "$ZIP_PATH" nene-clear -x "*.DS_Store" -x "__MACOSX/*" )
 else
   php -r '
     $zip = new ZipArchive();
@@ -119,11 +134,15 @@ else
   ' ZIP_PATH="$ZIP_PATH" STAGING_PARENT="$BUILD_DIR/staging"
 fi
 
-SHA256="$(sha256sum "$ZIP_PATH" | cut -d' ' -f1)"
+( cd "$(dirname "$ZIP_PATH")" && sha256sum "$(basename "$ZIP_PATH")" > "$(basename "$ZIP_PATH").sha256" )
+SHA256="$(cut -d' ' -f1 "$ZIP_PATH.sha256")"
+
 echo "==> Done"
 echo "    file:    ${ZIP_PATH} ($(du -h "$ZIP_PATH" | cut -f1))"
 echo "    version: ${VERSION}"
+echo "    nene2:   ${NENE2_RESOLVED}"
 echo "    sha256:  ${SHA256}"
+echo "    sidecar: ${ZIP_PATH}.sha256"
 echo ""
 echo "Next: upload the ZIP to nene-origin.dev and author a targets manifest"
 echo "(latest.json) with this artifact_url + artifact_sha256 (see Slice 3)."


### PR DESCRIPTION
## Summary

Fixes the audit's highest-impact build finding: the NENE2 dependency was a path repo (`../NENE2`, `symlink: true`, `@dev`), so releases silently vendored whatever the local checkout contained — the shipped 0.1.0 zip predated v1.10.0 and served raw Problem Details JSON on demo 429/503.

- **composer**: `hideyukimori/nene2` `@dev`+path repo → **Packagist `^1.10`** (invoice/deal shape); dropped `repositories` and `minimum-stability: dev`; lock now records the **v1.10.0 tagged dist**. `firebase/php-jwt` stays until #285.
- **tools/build-release.sh**: rebuilt in the nene-invoice shape — allowlist staging, production vendor resolved from `composer.json`+`composer.lock` in a clean stage, zero-symlink + required-artifact inspection (incl. `MinimalDemoErrorPageRenderer`), SHA-256 sidecar. Keeps the `nene-clear/` top-level zip layout the origin targets manifest expects.
- **CI**: sibling-NENE2 clone steps removed; release verify asserts the v1.10.0 demo error-page renderer is vendored and uploads the sidecar.
- **docs**: AGENTS.md framework note updated; `nene2-compliance.md` documents the working-tree-only local-NENE2 override (never committed).

## Acceptance evidence (local)

- `composer check` green on v1.10.0 (393 tests / phpstan / cs / conformance).
- `release:zip` rebuilt: nene2 resolved **v1.10.0**; zip contains `vendor/hideyukimori/nene2/src/Demo/MinimalDemoErrorPageRenderer.php` + `DemoErrorPageRendererInterface.php`; `.sha256` sidecar emitted; zero symlinks; stale 2026-07-10 zip deleted.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)