### PR TITLE
refactor(http): adopt ConfigLoader/AppConfig and thin the front controller to 48 lines (#294)

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -2,26 +2,11 @@
 
 declare(strict_types=1);
 
-use Dotenv\Dotenv;
-use Nene2\Config\AppEnvironment;
-use Nene2\Config\DatabaseConfig;
-use Nene2\Database\DatabaseConnectionFactoryInterface;
-use Nene2\Database\PdoConnectionFactory;
-use Nene2\Database\PdoDatabaseQueryExecutor;
-use Nene2\Database\PdoDatabaseTransactionManager;
-use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
-use Nene2\Demo\DemoConfig;
 use Nene2\Http\ResponseEmitter;
-use NeneClear\Auth\AuthServiceProvider;
-use NeneClear\Database\AdapterAwareQueryExecutor;
-use NeneClear\Database\AdapterAwareTransactionManager;
-use NeneClear\Database\ApplicationDatabaseIdentity;
-use NeneClear\Database\CandidateProfiles;
-use NeneClear\Database\MigrationVersions;
-use NeneClear\Http\ApplicationFactory;
 use NeneClear\Http\AuthorizationHeaderFallback;
-use NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture;
-use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\Http\JsonRequestBody;
+use NeneClear\Http\RuntimeBootstrap;
+use NeneClear\Http\SpaFallback;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7Server\ServerRequestCreator;
 
@@ -38,154 +23,9 @@ if (PHP_SAPI === 'cli-server') {
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$root = dirname(__DIR__);
-
-// Config boundary: raw env access stays here, not in application code.
-if (is_file($root . '/.env')) {
-    Dotenv::createImmutable($root)->safeLoad();
-}
-
-$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
-
-$debug = $env('APP_DEBUG', 'false') === 'true';
-
-// JWT secret — fleet-standard resolution (#285): the canonical env is
-// NENE2_LOCAL_JWT_SECRET; NENE_CLEAR_JWT_SECRET remains a transitional
-// fallback for one release (deployed demo migration, see docs/demo.md).
-// GuardedJwtSecretResolver fails closed: without a configured secret the dev
-// path needs an explicit NENE2_ALLOW_DEV_SECRET opt-in (never honoured in
-// production). An unresolvable secret keeps the admin surface unmounted
-// (health-only branch in ApplicationFactory) — same semantics as before.
-$jwtSecret = AuthServiceProvider::resolveJwtSecret(
-    configuredSecret: $env('NENE2_LOCAL_JWT_SECRET') ?: $env('NENE_CLEAR_JWT_SECRET'),
-    environment: AppEnvironment::fromConfigValue($env('APP_ENV', 'local')),
-    allowDevSecret: in_array(strtolower(trim($env('NENE2_ALLOW_DEV_SECRET'))), ['1', 'true', 'yes'], true),
-);
-
-// Resilient DB wiring: if the database is unconfigured or unreachable, the app
-// still boots and serves /health. Authenticated routes activate only when the
-// executor, the transaction manager, and a JWT secret are all available (see
-// ApplicationFactory). The executor and the transaction manager share one
-// connection factory so transactional() can open its own connection (Issue #122).
-$adapter = $env('DB_ADAPTER', 'sqlite');
-
-$connectionFactory = (static function () use ($env, $adapter): ?DatabaseConnectionFactoryInterface {
-    try {
-        // `charset` is intentionally omitted for pgsql — the DSN ignores it and
-        // PostgreSQL derives the client encoding from server_encoding (UTF-8 by
-        // default). See NENE2 docs/howto/use-postgresql.md.
-        $config = match ($adapter) {
-            'mysql' => new DatabaseConfig(
-                url: $env('DATABASE_URL') ?: null,
-                environment: $env('DB_ENV', 'production'),
-                adapter: 'mysql',
-                host: $env('DB_HOST', '127.0.0.1'),
-                port: (int) $env('DB_PORT', '3306'),
-                name: $env('DB_NAME', 'nene_clear'),
-                user: $env('DB_USER', 'nene_clear'),
-                password: $env('DB_PASSWORD'),
-                charset: $env('DB_CHARSET', 'utf8mb4'),
-            ),
-            'pgsql' => new DatabaseConfig(
-                url: $env('DATABASE_URL') ?: null,
-                environment: $env('DB_ENV', 'production'),
-                adapter: 'pgsql',
-                host: $env('DB_HOST', '127.0.0.1'),
-                port: (int) $env('DB_PORT', '5432'),
-                name: $env('DB_NAME', 'nene_clear'),
-                user: $env('DB_USER', 'nene_clear'),
-                password: $env('DB_PASSWORD'),
-                // Non-empty to satisfy DatabaseConfig validation; the pgsql DSN
-                // ignores it (encoding comes from server_encoding, UTF-8).
-                charset: $env('DB_CHARSET', 'utf8'),
-            ),
-            default => DatabaseConfig::sqlite($env('DB_NAME') ?: dirname(__DIR__) . '/database/nene_clear.sqlite3'),
-        };
-
-        return new PdoConnectionFactory($config);
-    } catch (\Throwable) {
-        return null;
-    }
-})();
-
-// Decorate so INSERT … RETURNING id is used on PostgreSQL (PDO::lastInsertId()
-// returns 0 there). No-op for mysql/sqlite. See NeneClear\Database decorators.
-$query = $connectionFactory !== null
-    ? new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter)
-    : null;
-$transactionManager = $connectionFactory !== null
-    ? new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter)
-    : null;
-
-$smtpHost = $env('SMTP_HOST') ?: null;
-$invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
-
-// Demo upstream fixture (#260): when NENE_CLEAR_DEMO_UPSTREAM=1 and no real
-// upstream is configured, pre-populate the standalone fake client with
-// T-relative demo invoices/clients so upstream match suggestions and live
-// dunning sends work in a standalone demo. Off by default; a configured real
-// upstream always wins. See NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture.
-$invoiceClient = null;
-if ($env('NENE_CLEAR_DEMO_UPSTREAM') === '1' && $invoiceApiBaseUrl === null) {
-    $invoiceClient = new FakeInvoiceUpstreamClient();
-    DemoInvoiceUpstreamFixture::populate($invoiceClient, new DateTimeImmutable('today'));
-}
-
-// Disposable-demo config (#275). DEMO_MODE parses strictly (only 1/true/yes
-// enable it) and defaults OFF — the demo route creates organizations without
-// authentication, so a typo must fail closed. Numeric knobs fall back to the
-// framework defaults (3h TTL / 200 orgs / 5 slug attempts) when unset.
-$demoConfig = new DemoConfig(
-    demoMode: in_array(strtolower($env('DEMO_MODE')), ['1', 'true', 'yes'], true),
-    ttlHours: (int) ($env('DEMO_TTL_HOURS') ?: '3'),
-    maxOrgs: (int) ($env('DEMO_MAX_ORGS') ?: '200'),
-);
-
-// Machine surface (issue #182): the repo VERSION file is this app's release
-// version, surfaced on the auth-gated GET /machine/health so deployment tooling
-// (e.g. NeNe Suite update tracking) can read the installed version.
-$machineApiKey = $env('NENE2_MACHINE_API_KEY') ?: null;
-$appVersion = is_file($root . '/VERSION') ? trim((string) file_get_contents($root . '/VERSION')) : '';
-
-// Candidate-database preflight (issue #183): the inspector knows this app's
-// migration versions + identity; candidates come only from the env allowlist
-// (NENE_CLEAR_DB_CANDIDATE_*), never from the request body (SSRF prevention).
-$candidateInspector = new DefaultDatabaseCandidateInspector(
-    applicationMigrationVersions: MigrationVersions::fromDirectory($root . '/database/migrations'),
-    // This app's Phinx ledger is `phinxlog` (phinx.php default_migration_table),
-    // not the inspector's `phinx_log` default — required for schema recognition.
-    ledgerTable: 'phinxlog',
-    applicationIdentity: ApplicationDatabaseIdentity::identity(),
-);
-$candidateProfiles = CandidateProfiles::fromEnv($_ENV);
-
-$application = ApplicationFactory::create(
-    debug: $debug,
-    allowedOrigins: [],
-    query: $query,
-    transactionManager: $transactionManager,
-    jwtSecret: $jwtSecret,
-    invoiceClient: $invoiceClient,
-    smtpHost: $smtpHost,
-    smtpPort: (int) $env('SMTP_PORT', '1025'),
-    smtpUsername: $env('SMTP_USERNAME'),
-    smtpPassword: $env('SMTP_PASSWORD'),
-    smtpFromAddress: $env('SMTP_FROM_ADDRESS', 'noreply@nene-clear.dev'),
-    smtpFromName: $env('SMTP_FROM_NAME', 'NeNe Clear'),
-    invoiceApiBaseUrl: $invoiceApiBaseUrl,
-    invoiceBearerToken: $env('NENE_INVOICE_BEARER_TOKEN'),
-    // Absolute base for invitation e-mail links. Same-origin in production; the
-    // dev frontend (Vite) runs on a separate port, so default to it locally.
-    appBaseUrl: $env('NENE_CLEAR_APP_URL', 'http://localhost:5383'),
-    // Optional encryption-at-rest key (base64 of 32 bytes). When unset, sensitive
-    // fields are stored as-is; when set, they are encrypted on write (#192/#195).
-    encryptionKey: $env('NENE_CLEAR_ENCRYPTION_KEY'),
-    machineApiKey: $machineApiKey,
-    appVersion: $appVersion !== '' ? $appVersion : null,
-    databaseCandidateInspector: $candidateInspector,
-    databaseCandidateProfiles: $candidateProfiles,
-    demoConfig: $demoConfig,
-);
+// Composition root (#294): configuration via Nene2 ConfigLoader/AppConfig and
+// all service wiring live in NeneClear\Http\RuntimeBootstrap.
+$application = RuntimeBootstrap::application(dirname(__DIR__));
 
 $psr17 = new Psr17Factory();
 $request = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGlobals();
@@ -194,42 +34,15 @@ $request = (new ServerRequestCreator($psr17, $psr17, $psr17, $psr17))->fromGloba
 // the SPA's X-Authorization mirror when the standard header is absent (#265).
 $request = AuthorizationHeaderFallback::apply($request);
 
-// fromGlobals() fills parsedBody from $_POST (form/multipart) only. The SPA
-// posts application/json, so decode it once here; handlers keep reading
-// getParsedBody() and serve form and JSON clients alike (#262). Handlers that
-// parse the raw body themselves (JsonRequestBodyParser) are unaffected — the
-// body stream stays readable.
-if (str_contains($request->getHeaderLine('Content-Type'), 'application/json')) {
-    $decodedBody = json_decode((string) $request->getBody(), associative: true);
-    if (is_array($decodedBody)) {
-        $request = $request->withParsedBody($decodedBody);
-    }
+// Fill parsedBody for application/json requests (the SPA's default; #262).
+$request = JsonRequestBody::normalize($request);
+
+// SPA fallback: browser navigation requests receive the built shell.
+$spaShell = SpaFallback::shellPath($request, __DIR__);
+if ($spaShell !== null) {
+    header('Content-Type: text/html; charset=utf-8');
+    readfile($spaShell);
+    exit;
 }
 
-// SPA fallback: serve the built index.html for browser navigation requests.
-// Browsers send Accept: text/html,... — API clients send Accept: application/json
-// or Accept: */* only. We only intercept when text/html is explicit.
-$path = $request->getUri()->getPath() ?: '/';
-$acceptHeader = $request->getHeaderLine('Accept');
-$wantHtml = str_contains($acceptHeader, 'text/html')
-    && !str_contains($acceptHeader, 'application/json');
-$isSpaRoute = $wantHtml
-    && $request->getMethod() === 'GET'
-    && !str_starts_with($path, '/health')
-    && !str_starts_with($path, '/machine')
-    && !str_starts_with($path, '/assets/')
-    // The demo start route serves its own HTML (seat page) — never the SPA shell (#275).
-    && !str_starts_with($path, '/demo/');
-
-if ($isSpaRoute) {
-    $spaIndex = __DIR__ . '/assets/index.html';
-    if (is_file($spaIndex)) {
-        header('Content-Type: text/html; charset=utf-8');
-        readfile($spaIndex);
-        exit;
-    }
-}
-
-$response = $application->handle($request);
-
-(new ResponseEmitter())->emit($response);
+(new ResponseEmitter())->emit($application->handle($request));

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -10,6 +10,7 @@ use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Auth\GuardedJwtSecretResolver;
 use Nene2\Auth\JwtSecretException;
 use Nene2\Auth\TokenVerifierInterface;
+use Nene2\Config\AppConfig;
 use Nene2\Config\AppEnvironment;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\DatabaseTransactionManagerInterface;
@@ -57,6 +58,20 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
      * explicit NENE2_ALLOW_DEV_SECRET opt-in and is never honoured in
      * production ({@see GuardedJwtSecretResolver}).
      */
+    /**
+     * {@see resolveJwtSecret()} over typed config — the fleet-standard
+     * `GuardedJwtSecretResolver::fromConfig()` path used by the composition
+     * root ({@see \NeneClear\Http\RuntimeBootstrap}).
+     */
+    public static function resolveJwtSecretFromConfig(AppConfig $config): ?string
+    {
+        try {
+            return GuardedJwtSecretResolver::fromConfig($config, self::DEFAULT_DEV_SECRET);
+        } catch (JwtSecretException) {
+            return null;
+        }
+    }
+
     public static function resolveJwtSecret(
         string $configuredSecret,
         AppEnvironment $environment,

--- a/src/Http/JsonRequestBody.php
+++ b/src/Http/JsonRequestBody.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Fills the PSR-7 parsed body for `application/json` requests.
+ *
+ * `ServerRequestCreator::fromGlobals()` fills `parsedBody` from `$_POST`
+ * (form/multipart) only. The SPA posts `application/json`, so decode it once
+ * here; handlers keep reading `getParsedBody()` and serve form and JSON
+ * clients alike (#262). Handlers that parse the raw body themselves
+ * (`JsonRequestBodyParser`) are unaffected — the body stream stays readable.
+ */
+final class JsonRequestBody
+{
+    public static function normalize(ServerRequestInterface $request): ServerRequestInterface
+    {
+        if (!str_contains($request->getHeaderLine('Content-Type'), 'application/json')) {
+            return $request;
+        }
+
+        $decoded = json_decode((string) $request->getBody(), associative: true);
+
+        return is_array($decoded) ? $request->withParsedBody($decoded) : $request;
+    }
+}

--- a/src/Http/RuntimeBootstrap.php
+++ b/src/Http/RuntimeBootstrap.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use Dotenv\Dotenv;
+use Nene2\Config\AppConfig;
+use Nene2\Config\ConfigException;
+use Nene2\Config\ConfigLoader;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use Nene2\Database\Preflight\DefaultDatabaseCandidateInspector;
+use NeneClear\Auth\AuthServiceProvider;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
+use NeneClear\Database\ApplicationDatabaseIdentity;
+use NeneClear\Database\CandidateProfiles;
+use NeneClear\Database\MigrationVersions;
+use NeneClear\InvoiceUpstream\DemoInvoiceUpstreamFixture;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Composition root for the HTTP runtime (#294): loads configuration through
+ * the framework {@see ConfigLoader} → {@see AppConfig} (fleet standard —
+ * invoice/deal/vault shape), resolves the JWT secret via
+ * {@see AuthServiceProvider::resolveJwtSecretFromConfig()} (fail-close), and
+ * assembles {@see ApplicationFactory::create()}. The front controller only
+ * builds the PSR-7 request and emits the response.
+ *
+ * Resilience contract (unchanged from the previous inline wiring): when the
+ * database is unconfigured/unreachable or no JWT secret resolves, the app
+ * still boots and serves the public/health surface — admin routes are simply
+ * not mounted (see ApplicationFactory).
+ */
+final readonly class RuntimeBootstrap
+{
+    /**
+     * Product defaults layered under the environment (ConfigLoader semantics):
+     * Clear's dev default is a zero-config SQLite file, and its Problem
+     * Details live under the product domain. `DB_NAME` is completed per
+     * adapter in {@see configDefaults()}.
+     *
+     * @var array<string, string>
+     */
+    private const array CONFIG_DEFAULTS = [
+        'APP_NAME' => 'NeNe Clear',
+        'PROBLEM_DETAILS_BASE_URL' => 'https://nene-clear.dev/problems/',
+        'DB_ADAPTER' => 'sqlite',
+        'DB_USER' => 'nene_clear',
+    ];
+
+    /**
+     * Conservative values that make {@see ConfigLoader::load()} always succeed
+     * when the environment carries malformed values (bad DB_PORT, non-boolean
+     * APP_DEBUG, …). Only used for the degraded retry: the database is then
+     * treated as unavailable, so the app serves the public/health surface only
+     * — the same resilience the previous inline wiring provided.
+     *
+     * @var array<string, string>
+     */
+    private const array DEGRADED_CONFIG = [
+        'APP_ENV' => 'production',
+        'APP_DEBUG' => 'false',
+        'DATABASE_URL' => '',
+        'DB_ADAPTER' => 'sqlite',
+        'DB_NAME' => ':memory:',
+        'DB_PORT' => '1',
+        'DEMO_MODE' => '',
+        'DEMO_TTL_HOURS' => '3',
+        'DEMO_MAX_ORGS' => '200',
+        'DEMO_SLUG_ATTEMPTS' => '5',
+        'DEMO_SLUG_PREFIX' => 'demo-',
+        'NENE2_LOCAL_JWT_SECRET' => '',
+        'NENE2_ALLOW_DEV_SECRET' => '',
+    ];
+
+    /**
+     * Builds the fully-wired PSR-15 application for a project root.
+     *
+     * @param array<string, string> $envOverrides Test seam: values layered over
+     *        the environment exactly like {@see ConfigLoader::load()} overrides.
+     */
+    public static function application(string $projectRoot, array $envOverrides = []): RequestHandlerInterface
+    {
+        $env = static fn (string $key, string $default = ''): string => (string) ($envOverrides[$key] ?? $_ENV[$key] ?? (getenv($key) ?: $default));
+
+        // Load .env before anything reads the environment (idempotent — the
+        // ConfigLoader safeLoad below never overwrites what is already set).
+        if (is_file($projectRoot . '/.env')) {
+            Dotenv::createImmutable($projectRoot)->safeLoad();
+        }
+
+        $loader = new ConfigLoader($projectRoot, self::configDefaults($projectRoot, $env));
+
+        // Resilience contract: malformed configuration must not take /health
+        // down. On a ConfigException, retry with conservative values and treat
+        // the database as unavailable (→ public/health surface only), exactly
+        // like the previous inline wiring's guarded DB construction.
+        $degraded = false;
+        try {
+            $config = $loader->load($envOverrides);
+        } catch (ConfigException) {
+            $degraded = true;
+            $config = $loader->load(array_merge(self::DEGRADED_CONFIG, ['APP_NAME' => 'NeNe Clear']));
+        }
+
+        // Transitional fallback (#285, one release): the pre-fleet env name
+        // still resolves when the canonical NENE2_LOCAL_JWT_SECRET is unset.
+        // Probed only after the first load() so the value can come from .env.
+        if (!$degraded && ($config->localJwtSecret ?? '') === '') {
+            $legacySecret = $env('NENE_CLEAR_JWT_SECRET');
+            if ($legacySecret !== '') {
+                $config = $loader->load(array_merge($envOverrides, ['NENE2_LOCAL_JWT_SECRET' => $legacySecret]));
+            }
+        }
+
+        // Fleet-standard fail-close secret resolution (#285): null keeps the
+        // admin surface unmounted (health-only branch in ApplicationFactory).
+        $jwtSecret = AuthServiceProvider::resolveJwtSecretFromConfig($config);
+
+        // Resilient DB wiring: if the database is unconfigured or unreachable,
+        // the app still boots and serves /health. The executor and transaction
+        // manager share one connection factory so transactional() can open its
+        // own connection (#122).
+        $adapter = trim($config->database->adapter) !== '' ? trim($config->database->adapter) : 'sqlite';
+        $connectionFactory = $degraded ? null : self::connectionFactory($config);
+
+        // Decorate so INSERT … RETURNING id is used on PostgreSQL
+        // (PDO::lastInsertId() returns 0 there). No-op for mysql/sqlite.
+        $query = $connectionFactory !== null
+            ? new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter)
+            : null;
+        $transactionManager = $connectionFactory !== null
+            ? new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter)
+            : null;
+
+        $smtpHost = $env('SMTP_HOST') ?: null;
+        $invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
+
+        // Candidate-database preflight (#183): candidates come only from the
+        // env allowlist (NENE_CLEAR_DB_CANDIDATE_*), never the request body.
+        $candidateInspector = new DefaultDatabaseCandidateInspector(
+            applicationMigrationVersions: MigrationVersions::fromDirectory($projectRoot . '/database/migrations'),
+            // This app's Phinx ledger is `phinxlog` (phinx.php default_migration_table),
+            // not the inspector's `phinx_log` default — required for schema recognition.
+            ledgerTable: 'phinxlog',
+            applicationIdentity: ApplicationDatabaseIdentity::identity(),
+        );
+
+        $appVersion = is_file($projectRoot . '/VERSION') ? trim((string) file_get_contents($projectRoot . '/VERSION')) : '';
+
+        return ApplicationFactory::create(
+            debug: $config->debug,
+            allowedOrigins: [],
+            query: $query,
+            transactionManager: $transactionManager,
+            jwtSecret: $jwtSecret,
+            invoiceClient: self::demoUpstreamFixture($env, $invoiceApiBaseUrl),
+            smtpHost: $smtpHost,
+            smtpPort: (int) $env('SMTP_PORT', '1025'),
+            smtpUsername: $env('SMTP_USERNAME'),
+            smtpPassword: $env('SMTP_PASSWORD'),
+            smtpFromAddress: $env('SMTP_FROM_ADDRESS', 'noreply@nene-clear.dev'),
+            smtpFromName: $env('SMTP_FROM_NAME', 'NeNe Clear'),
+            invoiceApiBaseUrl: $invoiceApiBaseUrl,
+            invoiceBearerToken: $env('NENE_INVOICE_BEARER_TOKEN'),
+            // Absolute base for invitation e-mail links. Same-origin in production;
+            // the dev frontend (Vite) runs on a separate port, so default to it locally.
+            appBaseUrl: $env('NENE_CLEAR_APP_URL', 'http://localhost:5383'),
+            // Optional encryption-at-rest key (base64 of 32 bytes). When unset,
+            // sensitive fields are stored as-is (#192/#195).
+            encryptionKey: $env('NENE_CLEAR_ENCRYPTION_KEY'),
+            machineApiKey: $config->machineApiKey,
+            appVersion: $appVersion !== '' ? $appVersion : null,
+            databaseCandidateInspector: $candidateInspector,
+            databaseCandidateProfiles: CandidateProfiles::fromEnv(array_merge($_ENV, $envOverrides)),
+            // Strict opt-in parsing (a DEMO_MODE typo fails closed) is owned by
+            // ConfigLoader; the framework defaults (3 h / 200 orgs) apply when unset.
+            demoConfig: $config->demo,
+        );
+    }
+
+    /**
+     * Completes the product defaults with the adapter-dependent database name
+     * and port. `DB_ADAPTER` may itself come from `.env` (loaded above), so
+     * this runs after the dotenv load.
+     *
+     * @param callable(string, string=): string $env
+     *
+     * @return array<string, string>
+     */
+    private static function configDefaults(string $projectRoot, callable $env): array
+    {
+        $adapter = strtolower(trim($env('DB_ADAPTER', 'sqlite'))) ?: 'sqlite';
+
+        return array_merge(self::CONFIG_DEFAULTS, match ($adapter) {
+            'mysql' => ['DB_NAME' => 'nene_clear'],
+            'pgsql' => ['DB_NAME' => 'nene_clear', 'DB_PORT' => '5432'],
+            default => ['DB_NAME' => $projectRoot . '/database/nene_clear.sqlite3'],
+        });
+    }
+
+    private static function connectionFactory(AppConfig $config): ?DatabaseConnectionFactoryInterface
+    {
+        try {
+            // ConfigLoader already parsed and validated the database values
+            // (adapter-aware: sqlite skips host/user/charset validation).
+            return new PdoConnectionFactory($config->database);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Demo upstream fixture (#260): when NENE_CLEAR_DEMO_UPSTREAM=1 and no real
+     * upstream is configured, pre-populate the standalone fake client with
+     * T-relative demo invoices/clients so upstream match suggestions and live
+     * dunning sends work in a standalone demo. Off by default; a configured
+     * real upstream always wins.
+     *
+     * @param callable(string, string=): string $env
+     */
+    private static function demoUpstreamFixture(callable $env, ?string $invoiceApiBaseUrl): ?InvoiceUpstreamClientInterface
+    {
+        if ($env('NENE_CLEAR_DEMO_UPSTREAM') !== '1' || $invoiceApiBaseUrl !== null) {
+            return null;
+        }
+
+        $client = new FakeInvoiceUpstreamClient();
+        DemoInvoiceUpstreamFixture::populate($client, new \DateTimeImmutable('today'));
+
+        return $client;
+    }
+}

--- a/src/Http/SpaFallback.php
+++ b/src/Http/SpaFallback.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Decides whether a request is a browser navigation that should receive the
+ * built SPA shell (`public_html/assets/index.html`) instead of hitting the
+ * API router.
+ *
+ * Browsers send `Accept: text/html,...` — API clients send
+ * `Accept: application/json` or a bare wildcard only, so the shell is served
+ * only when `text/html` is explicit (and `application/json` is not). API
+ * surfaces (`/health`, `/machine`), static assets, and the demo start route
+ * (which serves its own seat page, #275) are never intercepted.
+ */
+final class SpaFallback
+{
+    /**
+     * Returns the shell path to serve, or null when the request must reach
+     * the application (including when the SPA has not been built).
+     */
+    public static function shellPath(ServerRequestInterface $request, string $publicHtmlDir): ?string
+    {
+        $acceptHeader = $request->getHeaderLine('Accept');
+        $wantsHtml = str_contains($acceptHeader, 'text/html')
+            && !str_contains($acceptHeader, 'application/json');
+
+        if (!$wantsHtml || $request->getMethod() !== 'GET') {
+            return null;
+        }
+
+        $path = $request->getUri()->getPath() ?: '/';
+        foreach (['/health', '/machine', '/assets/', '/demo/'] as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return null;
+            }
+        }
+
+        $shell = $publicHtmlDir . '/assets/index.html';
+
+        return is_file($shell) ? $shell : null;
+    }
+}

--- a/tests/Http/JsonRequestBodyTest.php
+++ b/tests/Http/JsonRequestBodyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\JsonRequestBody;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class JsonRequestBodyTest extends TestCase
+{
+    private function request(string $contentType, string $body): ServerRequestInterface
+    {
+        $psr17 = new Psr17Factory();
+
+        return $psr17->createServerRequest('POST', '/admin/auth/login')
+            ->withHeader('Content-Type', $contentType)
+            ->withBody($psr17->createStream($body));
+    }
+
+    public function test_json_body_is_decoded_into_the_parsed_body(): void
+    {
+        $request = JsonRequestBody::normalize($this->request('application/json', '{"email":"a@b.c","password":"x"}'));
+
+        self::assertSame(['email' => 'a@b.c', 'password' => 'x'], $request->getParsedBody());
+        // The raw body stream stays readable for handlers that parse it themselves.
+        self::assertSame('{"email":"a@b.c","password":"x"}', (string) $request->getBody());
+    }
+
+    public function test_charset_suffixed_content_type_is_still_decoded(): void
+    {
+        $request = JsonRequestBody::normalize($this->request('application/json; charset=utf-8', '{"a":1}'));
+
+        self::assertSame(['a' => 1], $request->getParsedBody());
+    }
+
+    public function test_non_json_and_malformed_bodies_are_left_untouched(): void
+    {
+        $form = JsonRequestBody::normalize($this->request('application/x-www-form-urlencoded', 'a=1'));
+        self::assertNull($form->getParsedBody());
+
+        $malformed = JsonRequestBody::normalize($this->request('application/json', '{not json'));
+        self::assertNull($malformed->getParsedBody());
+
+        $scalar = JsonRequestBody::normalize($this->request('application/json', '"just-a-string"'));
+        self::assertNull($scalar->getParsedBody());
+    }
+}

--- a/tests/Http/RuntimeBootstrapTest.php
+++ b/tests/Http/RuntimeBootstrapTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\RuntimeBootstrap;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Pins the composition-root behaviour (#294): ConfigLoader/AppConfig-driven
+ * wiring keeps the resilience contract — health always answers, the admin
+ * surface mounts only when a JWT secret resolves (fail-close, #285), and the
+ * transitional legacy env name still works for one release.
+ */
+final class RuntimeBootstrapTest extends TestCase
+{
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, string> $overrides
+     */
+    private function handle(array $overrides, string $method = 'GET', string $path = '/health'): ResponseInterface
+    {
+        $dbPath = sys_get_temp_dir() . '/' . uniqid('clear-bootstrap-', true) . '.sqlite';
+        $this->tempFiles[] = $dbPath;
+
+        $application = RuntimeBootstrap::application(dirname(__DIR__, 2), array_merge([
+            'APP_ENV' => 'local',
+            'APP_DEBUG' => 'false',
+            'DB_ADAPTER' => 'sqlite',
+            'DB_NAME' => $dbPath,
+            'NENE2_LOCAL_JWT_SECRET' => '',
+            'NENE_CLEAR_JWT_SECRET' => '',
+            'NENE2_ALLOW_DEV_SECRET' => '',
+            'DEMO_MODE' => '',
+        ], $overrides));
+
+        $request = (new Psr17Factory())->createServerRequest($method, $path)
+            ->withHeader('Accept', 'application/json');
+
+        return $application->handle($request);
+    }
+
+    public function test_health_answers_even_without_a_jwt_secret(): void
+    {
+        self::assertSame(200, $this->handle([])->getStatusCode());
+    }
+
+    public function test_admin_surface_is_unmounted_without_a_jwt_secret(): void
+    {
+        self::assertSame(404, $this->handle([], 'GET', '/admin/receivables')->getStatusCode());
+    }
+
+    public function test_admin_surface_mounts_with_the_canonical_env(): void
+    {
+        $response = $this->handle(
+            ['NENE2_LOCAL_JWT_SECRET' => str_repeat('a', 64)],
+            'GET',
+            '/admin/receivables',
+        );
+
+        // 401 (bearer required) — the route exists, unlike the 404 above.
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_legacy_env_name_still_mounts_the_admin_surface(): void
+    {
+        $response = $this->handle(
+            ['NENE_CLEAR_JWT_SECRET' => str_repeat('b', 64)],
+            'GET',
+            '/admin/receivables',
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_dev_secret_opt_in_mounts_the_admin_surface_in_local(): void
+    {
+        $response = $this->handle(
+            ['NENE2_ALLOW_DEV_SECRET' => '1'],
+            'GET',
+            '/admin/receivables',
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_malformed_configuration_degrades_to_the_health_surface(): void
+    {
+        // A garbage DB_PORT used to be caught by the guarded DB construction;
+        // with ConfigLoader it throws at load() time — the bootstrap must
+        // degrade to the public/health surface instead of crashing (#294).
+        $overrides = ['DB_PORT' => 'not-a-port', 'NENE2_LOCAL_JWT_SECRET' => str_repeat('c', 64)];
+
+        self::assertSame(200, $this->handle($overrides)->getStatusCode());
+        self::assertSame(404, $this->handle($overrides, 'GET', '/admin/receivables')->getStatusCode());
+    }
+
+    public function test_production_ignores_the_dev_secret_opt_in(): void
+    {
+        $response = $this->handle(
+            ['APP_ENV' => 'production', 'NENE2_ALLOW_DEV_SECRET' => '1'],
+            'GET',
+            '/admin/receivables',
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/tests/Http/SpaFallbackTest.php
+++ b/tests/Http/SpaFallbackTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\SpaFallback;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class SpaFallbackTest extends TestCase
+{
+    private string $publicDir;
+
+    protected function setUp(): void
+    {
+        $this->publicDir = sys_get_temp_dir() . '/' . uniqid('clear-spa-', true);
+        mkdir($this->publicDir . '/assets', recursive: true);
+        file_put_contents($this->publicDir . '/assets/index.html', '<html>shell</html>');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->publicDir . '/assets/index.html');
+        @rmdir($this->publicDir . '/assets');
+        @rmdir($this->publicDir);
+    }
+
+    private function request(string $method, string $path, string $accept): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest($method, $path)->withHeader('Accept', $accept);
+    }
+
+    public function test_browser_navigation_gets_the_shell(): void
+    {
+        $shell = SpaFallback::shellPath($this->request('GET', '/receivables', 'text/html,application/xhtml+xml'), $this->publicDir);
+
+        self::assertSame($this->publicDir . '/assets/index.html', $shell);
+    }
+
+    public function test_api_clients_never_get_the_shell(): void
+    {
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/receivables', 'application/json'), $this->publicDir));
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/receivables', '*/*'), $this->publicDir));
+        // Explicit JSON wins even when text/html is also present.
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/receivables', 'text/html,application/json'), $this->publicDir));
+    }
+
+    public function test_non_get_and_reserved_prefixes_are_never_intercepted(): void
+    {
+        $accept = 'text/html';
+        self::assertNull(SpaFallback::shellPath($this->request('POST', '/receivables', $accept), $this->publicDir));
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/health', $accept), $this->publicDir));
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/machine/health', $accept), $this->publicDir));
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/assets/app.js', $accept), $this->publicDir));
+        // The demo start route serves its own seat page (#275).
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/demo/standard', $accept), $this->publicDir));
+    }
+
+    public function test_missing_build_falls_through_to_the_application(): void
+    {
+        unlink($this->publicDir . '/assets/index.html');
+
+        self::assertNull(SpaFallback::shellPath($this->request('GET', '/receivables', 'text/html'), $this->publicDir));
+    }
+}


### PR DESCRIPTION
## Summary

Audit #287 item (2): the 221-line `public_html/index.php` composition root moves into `NeneClear\Http\RuntimeBootstrap`, with framework configuration loaded through `Nene2\Config\ConfigLoader` → `AppConfig` (invoice/deal/vault shape). The front controller is now 48 lines.

- JWT secret resolution is now literally `GuardedJwtSecretResolver::fromConfig()` (completes #285's fleet shape); the transitional `NENE_CLEAR_JWT_SECRET` fallback stays for one release.
- `DemoConfig` comes from `AppConfig->demo` (strict opt-in parsing owned by the framework — same fail-close semantics as the hand parsing it replaces).
- Clear's resilience contract is preserved **and newly pinned by tests**: ConfigLoader validates eagerly, so a degraded retry keeps `/health` alive on malformed config (garbage `DB_PORT` etc.) exactly like the old guarded DB construction; sqlite/mysql/pgsql defaults unchanged (pgsql keeps 5432).
- `JsonRequestBody` / `SpaFallback` extracted with unit tests (JSON parsed-body decode incl. charset suffix + malformed bodies; SPA shell rules incl. `/demo/` seat-page and `/health`/`/machine`/`/assets/` exclusions).

## Verification

- `composer check` green — **416 tests** (+14: RuntimeBootstrapTest ×7 incl. fail-close × canonical/legacy/dev-opt-in envs and the degraded-config path, SpaFallbackTest, JsonRequestBodyTest).
- Dev runtime smoke: `/health` 200, browser navigation gets the SPA shell, `POST /admin/auth/login` 401, `/demo/standard` renders the seat page (public-demo regression check).

Closes #294
Refs #287 (checklist item 2), #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)