### PR TITLE
ci(check): add openapi and mcp validation gates to composer check (#298)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,11 +43,15 @@
         "migrations:migrate": "phinx migrate -c phinx.php",
         "migrations:rollback": "phinx rollback -c phinx.php",
         "release:zip": "bash tools/build-release.sh",
+        "openapi": "php tools/validate-openapi.php",
+        "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
         "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=.",
         "check": [
             "@test",
             "@analyse",
             "@cs",
+            "@openapi",
+            "@mcp",
             "@conformance"
         ]
     }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -207,7 +207,7 @@ paths:
         '410':
           description: Invitation token expired (`invitation-expired`).
         '422':
-          $ref: '#/components/responses/ValidationError'
+          $ref: '#/components/responses/ValidationFailed'
 
   /admin/organizations:
     get:

--- a/tools/validate-openapi.php
+++ b/tools/validate-openapi.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+// Validate every OpenAPI document under docs/openapi/ (operator + service surfaces).
+$paths = glob(dirname(__DIR__) . '/docs/openapi/*.yaml');
+
+if ($paths === false || $paths === []) {
+    fwrite(STDERR, "No OpenAPI documents found under docs/openapi/.\n");
+    exit(1);
+}
+
+$errors = [];
+
+foreach ($paths as $path) {
+    $name = basename($path);
+
+    try {
+        $document = Yaml::parseFile($path);
+    } catch (ParseException $exception) {
+        $errors[] = sprintf('%s: YAML parse error: %s', $name, $exception->getMessage());
+        continue;
+    }
+
+    if (!is_array($document)) {
+        $errors[] = sprintf('%s: document must parse to a mapping.', $name);
+        continue;
+    }
+
+    foreach (['openapi', 'info', 'paths', 'components'] as $requiredKey) {
+        if (!array_key_exists($requiredKey, $document)) {
+            $errors[] = sprintf('%s: missing required top-level key: %s', $name, $requiredKey);
+        }
+    }
+
+    if (($document['openapi'] ?? null) !== '3.1.0') {
+        $errors[] = sprintf('%s: OpenAPI version must be 3.1.0.', $name);
+    }
+
+    validateInternalReferences($document, $document, '#', $errors);
+}
+
+if ($errors !== []) {
+    foreach ($errors as $error) {
+        fwrite(STDERR, sprintf("OpenAPI validation error: %s\n", $error));
+    }
+
+    exit(1);
+}
+
+echo sprintf("OpenAPI contracts are valid (%d document(s)).\n", count($paths));
+
+/**
+ * @param array<mixed> $node
+ * @param array<mixed> $document
+ * @param list<string> $errors
+ */
+function validateInternalReferences(array $node, array $document, string $path, array &$errors): void
+{
+    foreach ($node as $key => $value) {
+        $childPath = $path . '/' . (string) $key;
+
+        if ($key === '$ref' && is_string($value) && str_starts_with($value, '#/')) {
+            if (!hasJsonPointer($document, $value)) {
+                $errors[] = sprintf('Unresolved internal reference at %s: %s', $path, $value);
+            }
+
+            continue;
+        }
+
+        if (is_array($value)) {
+            validateInternalReferences($value, $document, $childPath, $errors);
+        }
+    }
+}
+
+/**
+ * @param array<mixed> $document
+ */
+function hasJsonPointer(array $document, string $reference): bool
+{
+    $current = $document;
+
+    foreach (explode('/', substr($reference, 2)) as $segment) {
+        $segment = str_replace(['~1', '~0'], ['/', '~'], $segment);
+
+        if (!is_array($current) || !array_key_exists($segment, $current)) {
+            return false;
+        }
+
+        $current = $current[$segment];
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary

Audit #287 item (4): `composer check` had no openapi/mcp gate although `docs/openapi/openapi.yaml` and `docs/mcp/tools.json` exist. Now (invoice scripts shape):

- `composer openapi` → product-local `tools/validate-openapi.php` (all `docs/openapi/*.yaml`, 3.1.0 required, all internal `$ref`s resolved).
- `composer mcp` → vendored `validate-mcp-tools.php --root=.`.
- Both added to the `check` chain; backend CI runs `composer check` so no workflow change needed.

The gate immediately caught (and this PR fixes) a real drift: `POST /admin/auth/invitation/accept` 422 referenced `#/components/responses/ValidationError`, which doesn't exist (`ValidationError` is a schema; the response component is `ValidationFailed`) — exactly the class of drift (#120/#264) this gate is for.

Work-order stop-gate check: the OpenAPI contract already exists (plus `tests/OpenApi/OpenApiContractTest.php`), so no contract-first planning issue was needed.

## Verification

`composer check` green end-to-end: 411 tests + phpstan + cs + **openapi valid** + **mcp valid** + conformance.

Closes #298
Refs #287 (checklist item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)