### PR TITLE
refactor(tenancy): inject CurrentOrganization scope, remove hand-propagated `?? 0` (#300, #301)

### DIFF
--- a/lang/en.php
+++ b/lang/en.php
@@ -34,6 +34,8 @@ return [
     'problem.insufficient-capability.title'  => 'Insufficient Capability',
     'problem.insufficient-capability.detail' => 'Your role lacks the capability required for this action.',
 
+    'problem.organization-not-resolved.title'  => 'Forbidden',
+    'problem.organization-not-resolved.detail' => 'This operation requires an organization-scoped session.',
     'problem.organization-not-found.title'  => 'Organization Not Found',
     'problem.organization-not-found.detail' => 'The requested organization was not found.',
 

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -34,6 +34,8 @@ return [
     'problem.insufficient-capability.title'  => '権限不足',
     'problem.insufficient-capability.detail' => 'このアクションに必要な権限がありません。',
 
+    'problem.organization-not-resolved.title'  => 'アクセスできません',
+    'problem.organization-not-resolved.detail' => 'この操作には組織に所属するセッションが必要です。',
     'problem.organization-not-found.title'  => '組織が見つかりません',
     'problem.organization-not-found.detail' => '指定された組織は存在しません。',
 

--- a/src/Audit/AuditServiceProvider.php
+++ b/src/Audit/AuditServiceProvider.php
@@ -16,6 +16,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Http\ServiceResolver;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -78,6 +79,7 @@ final readonly class AuditServiceProvider implements ServiceProviderInterface
                     new ListAuditEventsHandler(
                         ServiceResolver::get($c, AuditReadRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             );

--- a/src/Audit/ListAuditEventsHandler.php
+++ b/src/Audit/ListAuditEventsHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Audit;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListAuditEventsHandler
     public function __construct(
         private AuditReadRepositoryInterface $auditEvents,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
 
         $q = $request->getQueryParams();

--- a/src/Auth/AuthServiceProvider.php
+++ b/src/Auth/AuthServiceProvider.php
@@ -26,6 +26,7 @@ use NeneClear\Mfa\PdoRecoveryCodeRepository;
 use NeneClear\Mfa\RecoveryCodeRepositoryInterface;
 use NeneClear\Mfa\RecoveryCodeService;
 use NeneClear\Mfa\TotpAuthenticator;
+use NeneClear\Tenancy\OrgScopeMiddleware;
 use NeneClear\User\UserRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -210,8 +211,12 @@ final readonly class AuthServiceProvider implements ServiceProviderInterface
                         ],
                     );
 
+                    // Organization scope resolves from the verified claim between
+                    // bearer auth and capability checks (#300).
+                    $orgScope = ServiceResolver::get($c, OrgScopeMiddleware::class);
+
                     /** @var list<MiddlewareInterface> $stack */
-                    $stack = [$bearer, $capabilities];
+                    $stack = [$bearer, $orgScope, $capabilities];
 
                     return $stack;
                 },

--- a/src/BankImport/BankImportServiceProvider.php
+++ b/src/BankImport/BankImportServiceProvider.php
@@ -14,6 +14,7 @@ use Nene2\Http\JsonResponseFactory;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\Security\Encryptor;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -72,26 +73,32 @@ final readonly class BankImportServiceProvider implements ServiceProviderInterfa
                     new ImportBankCsvHandler(
                         ServiceResolver::get($c, ImportBankCsvUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListBankImportBatchesHandler(
                         ServiceResolver::get($c, BankImportBatchRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ReverseBankImportBatchHandler(
                         ServiceResolver::get($c, ReverseBankImportBatchUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListBankTransactionsHandler(
                         ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListUnmatchedTransactionsHandler(
                         ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new GetBankTransactionByIdHandler(
                         ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/BankImport/GetBankTransactionByIdHandler.php
+++ b/src/BankImport/GetBankTransactionByIdHandler.php
@@ -6,7 +6,7 @@ namespace NeneClear\BankImport;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +15,7 @@ final readonly class GetBankTransactionByIdHandler
     public function __construct(
         private BankTransactionRepositoryInterface $transactions,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -22,7 +23,7 @@ final readonly class GetBankTransactionByIdHandler
     {
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $transaction = $this->transactions->findById($organizationId, $id);
 

--- a/src/BankImport/ImportBankCsvHandler.php
+++ b/src/BankImport/ImportBankCsvHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -17,6 +18,7 @@ final readonly class ImportBankCsvHandler
     public function __construct(
         private ImportBankCsvUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -41,7 +43,7 @@ final readonly class ImportBankCsvHandler
         }
 
         $output = $this->useCase->execute(new ImportBankCsvInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             bankAccountId: $bankAccountId,
             sourceFilename: $file->getClientFilename() ?? 'upload.csv',
             contents: (string) $file->getStream(),

--- a/src/BankImport/ListBankImportBatchesHandler.php
+++ b/src/BankImport/ListBankImportBatchesHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\BankImport;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListBankImportBatchesHandler
     public function __construct(
         private BankImportBatchRepositoryInterface $batches,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
         $q = $request->getQueryParams();
         $str = static fn (string $k): ?string => isset($q[$k]) && is_string($q[$k]) && $q[$k] !== '' ? $q[$k] : null;

--- a/src/BankImport/ListBankTransactionsHandler.php
+++ b/src/BankImport/ListBankTransactionsHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\BankImport;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListBankTransactionsHandler
     public function __construct(
         private BankTransactionRepositoryInterface $transactions,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
         $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams());
 

--- a/src/BankImport/ListUnmatchedTransactionsHandler.php
+++ b/src/BankImport/ListUnmatchedTransactionsHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\BankImport;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListUnmatchedTransactionsHandler
     public function __construct(
         private BankTransactionRepositoryInterface $transactions,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
         $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams(), openForMatchingOnly: true);
 

--- a/src/BankImport/ReverseBankImportBatchHandler.php
+++ b/src/BankImport/ReverseBankImportBatchHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -17,6 +18,7 @@ final readonly class ReverseBankImportBatchHandler
     public function __construct(
         private ReverseBankImportBatchUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -33,7 +35,7 @@ final readonly class ReverseBankImportBatchHandler
         }
 
         $output = $this->useCase->execute(new ReverseBankImportBatchInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             batchId: $batchId,
             actorUserId: AuthContext::userId($request),
             reversalReason: $reversalReason,

--- a/src/ClearSettings/ClearSettingsServiceProvider.php
+++ b/src/ClearSettings/ClearSettingsServiceProvider.php
@@ -16,6 +16,7 @@ use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\Security\Encryptor;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -50,14 +51,17 @@ final readonly class ClearSettingsServiceProvider implements ServiceProviderInte
                     new GetClearSettingsHandler(
                         ServiceResolver::get($c, ClearSettingsRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new UpdateClearSettingsHandler(
                         ServiceResolver::get($c, UpdateClearSettingsUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new TestUpstreamConnectionHandler(
                         ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             );

--- a/src/ClearSettings/GetClearSettingsHandler.php
+++ b/src/ClearSettings/GetClearSettingsHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\ClearSettings;
 
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,12 +14,13 @@ final readonly class GetClearSettingsHandler
     public function __construct(
         private ClearSettingsRepositoryInterface $settings,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $settings = $this->settings->findByOrganization($organizationId)
             ?? new ClearSettings($organizationId, '', '', 7);
 

--- a/src/ClearSettings/TestUpstreamConnectionHandler.php
+++ b/src/ClearSettings/TestUpstreamConnectionHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NeneClear\ClearSettings;
 
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Auth\AuthContext;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\InvoiceUpstream\UpstreamInvoiceUnavailableException;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class TestUpstreamConnectionHandler
     public function __construct(
         private InvoiceUpstreamClientInterface $invoiceClient,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         try {
             $this->invoiceClient->listInvoices($organizationId, ['issued']);

--- a/src/ClearSettings/UpdateClearSettingsHandler.php
+++ b/src/ClearSettings/UpdateClearSettingsHandler.php
@@ -10,6 +10,7 @@ use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\AccountType;
 use NeneClear\BankImport\BankAccount;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,12 +19,13 @@ final readonly class UpdateClearSettingsHandler
     public function __construct(
         private UpdateClearSettingsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $body = (array) $request->getParsedBody();
         $errors = [];
 

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -19,6 +19,7 @@ use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\Security\Encryptor;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -83,31 +84,38 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                         ServiceResolver::get($c, SendDunningUseCaseInterface::class),
                         ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new PreviewDunningNoticeHandler(
                         ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                         new DunningMessageRenderer(ServiceResolver::get($c, MessageCatalog::class)),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListDunningNoticesHandler(
                         ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new GetDunningNoticeByIdHandler(
                         ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new PauseDunningHandler(
                         ServiceResolver::get($c, PauseDunningUseCase::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ResumeDunningHandler(
                         ServiceResolver::get($c, ResumeDunningUseCase::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListDunningPausesHandler(
                         ServiceResolver::get($c, DunningPauseRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new TestSendDunningHandler(
                         new SendTestDunningUseCase(
@@ -116,6 +124,7 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                             ServiceResolver::get($c, DunningMailerInterface::class),
                         ),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/Dunning/GetDunningNoticeByIdHandler.php
+++ b/src/Dunning/GetDunningNoticeByIdHandler.php
@@ -6,7 +6,7 @@ namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +15,7 @@ final readonly class GetDunningNoticeByIdHandler
     public function __construct(
         private DunningNoticeRepositoryInterface $notices,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -22,7 +23,7 @@ final readonly class GetDunningNoticeByIdHandler
     {
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $notice = $this->notices->findById($organizationId, $id);
 

--- a/src/Dunning/ListDunningNoticesHandler.php
+++ b/src/Dunning/ListDunningNoticesHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Dunning;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListDunningNoticesHandler
     public function __construct(
         private DunningNoticeRepositoryInterface $notices,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
         $filter = DunningNoticeFilter::fromQueryParams($request->getQueryParams());
 

--- a/src/Dunning/ListDunningPausesHandler.php
+++ b/src/Dunning/ListDunningPausesHandler.php
@@ -6,7 +6,7 @@ namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,12 +15,13 @@ final readonly class ListDunningPausesHandler
     public function __construct(
         private DunningPauseRepositoryInterface $pauses,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $q = (array) $request->getQueryParams();
         $activeOnly = ($q['active_only'] ?? null) === 'true';
         $limit = is_numeric($q['limit'] ?? null) ? (int) $q['limit'] : 50;

--- a/src/Dunning/PauseDunningHandler.php
+++ b/src/Dunning/PauseDunningHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +17,13 @@ final readonly class PauseDunningHandler
     public function __construct(
         private PauseDunningUseCase $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $actorUserId = AuthContext::userId($request);
         $body = (array) $request->getParsedBody();
 

--- a/src/Dunning/PreviewDunningNoticeHandler.php
+++ b/src/Dunning/PreviewDunningNoticeHandler.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Auth\AuthContext;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -21,12 +21,13 @@ final readonly class PreviewDunningNoticeHandler
         private InvoiceUpstreamClientInterface $invoiceClient,
         private DunningMessageRenderer $renderer,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $query = $request->getQueryParams();
         $invoiceId = (int) ($query['invoice_id'] ?? 0);
         $stage = DunningStage::fromString(is_string($query['stage'] ?? null) ? $query['stage'] : null);

--- a/src/Dunning/ResumeDunningHandler.php
+++ b/src/Dunning/ResumeDunningHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -17,12 +18,13 @@ final readonly class ResumeDunningHandler
     public function __construct(
         private ResumeDunningUseCase $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $actorUserId = AuthContext::userId($request);
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $invoiceId = (int) ($params['invoiceId'] ?? 0);

--- a/src/Dunning/SendDunningHandler.php
+++ b/src/Dunning/SendDunningHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -17,6 +18,7 @@ final readonly class SendDunningHandler
         private SendDunningUseCaseInterface $useCase,
         private DunningNoticeRepositoryInterface $notices,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -29,7 +31,7 @@ final readonly class SendDunningHandler
             throw new ValidationException([new ValidationError('invoice_id', 'A valid invoice id is required.', 'required')]);
         }
 
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $output = $this->useCase->execute(new SendDunningInput(
             organizationId: $organizationId,
             invoiceId: $invoiceId,

--- a/src/Dunning/TestSendDunningHandler.php
+++ b/src/Dunning/TestSendDunningHandler.php
@@ -6,6 +6,7 @@ namespace NeneClear\Dunning;
 
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,6 +15,7 @@ final readonly class TestSendDunningHandler
     public function __construct(
         private SendTestDunningUseCase $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -22,7 +24,7 @@ final readonly class TestSendDunningHandler
         $body = (array) ($request->getParsedBody() ?? []);
 
         $sentTo = $this->useCase->execute(new SendTestDunningInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             invoiceId: (int) ($body['invoice_id'] ?? 0),
             to: is_string($body['to'] ?? null) ? $body['to'] : '',
             actorUserId: AuthContext::userId($request),

--- a/src/Export/ExportBankTransactionsCsvHandler.php
+++ b/src/Export/ExportBankTransactionsCsvHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NeneClear\Export;
 
 use Nene2\Export\CsvWriter;
-use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\BankTransactionFilter;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,12 +21,13 @@ final readonly class ExportBankTransactionsCsvHandler
         private BankTransactionRepositoryInterface $transactions,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $filter = BankTransactionFilter::fromQueryParams($request->getQueryParams());
 
         $rows = [];

--- a/src/Export/ExportClientCreditsCsvHandler.php
+++ b/src/Export/ExportClientCreditsCsvHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NeneClear\Export;
 
 use Nene2\Export\CsvWriter;
-use NeneClear\Auth\AuthContext;
 use NeneClear\Reconciliation\ClientCreditFilter;
 use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,12 +21,13 @@ final readonly class ExportClientCreditsCsvHandler
         private ClientCreditRepositoryInterface $credits,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $filter = ClientCreditFilter::fromQueryParams($request->getQueryParams());
         $rows = [];

--- a/src/Export/ExportDunningNoticesCsvHandler.php
+++ b/src/Export/ExportDunningNoticesCsvHandler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace NeneClear\Export;
 
 use Nene2\Export\CsvWriter;
-use NeneClear\Auth\AuthContext;
 use NeneClear\Dunning\DunningNoticeFilter;
 use NeneClear\Dunning\DunningNoticeRepositoryInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,12 +21,13 @@ final readonly class ExportDunningNoticesCsvHandler
         private DunningNoticeRepositoryInterface $notices,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $filter = DunningNoticeFilter::fromQueryParams($request->getQueryParams());
         $rows = [];

--- a/src/Export/ExportReconciliationsCsvHandler.php
+++ b/src/Export/ExportReconciliationsCsvHandler.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace NeneClear\Export;
 
 use Nene2\Export\CsvWriter;
-use NeneClear\Auth\AuthContext;
 use NeneClear\BankImport\BankTransactionRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationFilter;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,12 +23,13 @@ final readonly class ExportReconciliationsCsvHandler
         private BankTransactionRepositoryInterface $transactions,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $filter = ReconciliationFilter::fromQueryParams($request->getQueryParams());
 
         $rows = [];

--- a/src/Export/ExportServiceProvider.php
+++ b/src/Export/ExportServiceProvider.php
@@ -11,6 +11,7 @@ use NeneClear\Dunning\DunningNoticeRepositoryInterface;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\Reconciliation\ClientCreditRepositoryInterface;
 use NeneClear\Reconciliation\ReconciliationRepositoryInterface;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -32,21 +33,25 @@ final readonly class ExportServiceProvider implements ServiceProviderInterface
                     ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
+                    ServiceResolver::get($c, CurrentOrganization::class),
                 ),
                 new ExportClientCreditsCsvHandler(
                     ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
+                    ServiceResolver::get($c, CurrentOrganization::class),
                 ),
                 new ExportBankTransactionsCsvHandler(
                     ServiceResolver::get($c, BankTransactionRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
+                    ServiceResolver::get($c, CurrentOrganization::class),
                 ),
                 new ExportDunningNoticesCsvHandler(
                     ServiceResolver::get($c, DunningNoticeRepositoryInterface::class),
                     ServiceResolver::get($c, ResponseFactoryInterface::class),
                     ServiceResolver::get($c, StreamFactoryInterface::class),
+                    ServiceResolver::get($c, CurrentOrganization::class),
                 ),
             ),
         );

--- a/src/Http/ApplicationServiceProvider.php
+++ b/src/Http/ApplicationServiceProvider.php
@@ -62,6 +62,8 @@ use NeneClear\Reconciliation\ReconciliationAlreadyReversedExceptionHandler;
 use NeneClear\Reconciliation\ReconciliationNotFoundExceptionHandler;
 use NeneClear\Reconciliation\ReconciliationRouteRegistrar;
 use NeneClear\Reconciliation\ReconciliationServiceProvider;
+use NeneClear\Tenancy\MissingOrganizationScopeExceptionHandler;
+use NeneClear\Tenancy\TenancyServiceProvider;
 use NeneClear\User\InvitationExpiredExceptionHandler;
 use NeneClear\User\InvitationInvalidExceptionHandler;
 use NeneClear\User\InvitationRouteRegistrar;
@@ -100,6 +102,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new ExportServiceProvider())
             ->addProvider(new DunningServiceProvider())
             ->addProvider(new MfaServiceProvider())
+            ->addProvider(new TenancyServiceProvider())
             ->addProvider(new DemoServiceProvider());
 
         $builder
@@ -166,6 +169,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     ServiceResolver::get($c, TotpLockedExceptionHandler::class),
                     ServiceResolver::get($c, TotpNotEnabledExceptionHandler::class),
                     ServiceResolver::get($c, TotpAlreadyEnabledExceptionHandler::class),
+                    ServiceResolver::get($c, MissingOrganizationScopeExceptionHandler::class),
                 ];
 
                 return $handlers;

--- a/src/InvoiceUpstream/InvoiceUpstreamServiceProvider.php
+++ b/src/InvoiceUpstream/InvoiceUpstreamServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -27,6 +28,7 @@ final readonly class InvoiceUpstreamServiceProvider implements ServiceProviderIn
                     new ListUpstreamInvoicesHandler(
                         ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/InvoiceUpstream/ListUpstreamInvoicesHandler.php
+++ b/src/InvoiceUpstream/ListUpstreamInvoicesHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace NeneClear\InvoiceUpstream;
 
 use Nene2\Http\JsonResponseFactory;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -14,12 +14,13 @@ final readonly class ListUpstreamInvoicesHandler
     public function __construct(
         private InvoiceUpstreamClientInterface $invoiceClient,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $q = (array) $request->getQueryParams();
 
         $statusParam = $q['status'] ?? null;

--- a/src/Mfa/DisableTotpHandler.php
+++ b/src/Mfa/DisableTotpHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,6 +17,7 @@ final readonly class DisableTotpHandler
     public function __construct(
         private DisableTotpUseCase $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -29,7 +31,7 @@ final readonly class DisableTotpHandler
 
         $this->useCase->execute(
             AuthContext::userId($request),
-            AuthContext::organizationId($request) ?? 0,
+            $this->organization->id(),
             $code,
         );
 

--- a/src/Mfa/EnableTotpHandler.php
+++ b/src/Mfa/EnableTotpHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,6 +17,7 @@ final readonly class EnableTotpHandler
     public function __construct(
         private EnableTotpUseCase $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -24,7 +26,7 @@ final readonly class EnableTotpHandler
         $code = self::code($request);
         $recoveryCodes = $this->useCase->execute(
             AuthContext::userId($request),
-            AuthContext::organizationId($request) ?? 0,
+            $this->organization->id(),
             $code,
         );
 

--- a/src/Mfa/MfaServiceProvider.php
+++ b/src/Mfa/MfaServiceProvider.php
@@ -15,6 +15,7 @@ use Nene2\Http\JsonResponseFactory;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\Security\Encryptor;
+use NeneClear\Tenancy\CurrentOrganization;
 use NeneClear\User\UserRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
@@ -96,6 +97,7 @@ final readonly class MfaServiceProvider implements ServiceProviderInterface
                     new EnableTotpHandler(
                         ServiceResolver::get($c, EnableTotpUseCase::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new GetTotpStatusHandler(
                         ServiceResolver::get($c, TotpAuthenticator::class),
@@ -105,6 +107,7 @@ final readonly class MfaServiceProvider implements ServiceProviderInterface
                     new DisableTotpHandler(
                         ServiceResolver::get($c, DisableTotpUseCase::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/Receivable/CancelManualReceivableHandler.php
+++ b/src/Receivable/CancelManualReceivableHandler.php
@@ -7,6 +7,7 @@ namespace NeneClear\Receivable;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +16,7 @@ final readonly class CancelManualReceivableHandler
     public function __construct(
         private CancelManualReceivableUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -25,7 +27,7 @@ final readonly class CancelManualReceivableHandler
 
         $receivable = $this->useCase->execute(
             $id,
-            AuthContext::organizationId($request) ?? 0,
+            $this->organization->id(),
             AuthContext::userId($request),
         );
 

--- a/src/Receivable/CreateManualReceivableHandler.php
+++ b/src/Receivable/CreateManualReceivableHandler.php
@@ -7,6 +7,7 @@ namespace NeneClear\Receivable;
 use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +16,7 @@ final readonly class CreateManualReceivableHandler
     public function __construct(
         private CreateManualReceivableUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -23,7 +25,7 @@ final readonly class CreateManualReceivableHandler
         $fields = ManualReceivableValidator::validate(JsonRequestBodyParser::parse($request));
 
         $receivable = $this->useCase->execute(new CreateManualReceivableInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             referenceNumber: $fields['reference_number'],
             clientName: $fields['client_name'],
             recipientEmail: $fields['recipient_email'],

--- a/src/Receivable/GetManualReceivableHandler.php
+++ b/src/Receivable/GetManualReceivableHandler.php
@@ -6,7 +6,7 @@ namespace NeneClear\Receivable;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +15,7 @@ final readonly class GetManualReceivableHandler
     public function __construct(
         private GetManualReceivableByIdUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -23,7 +24,7 @@ final readonly class GetManualReceivableHandler
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
 
-        $receivable = $this->useCase->execute($id, AuthContext::organizationId($request) ?? 0);
+        $receivable = $this->useCase->execute($id, $this->organization->id());
 
         return $this->response->create(ManualReceivableResponse::toArray($receivable));
     }

--- a/src/Receivable/ImportManualReceivablesHandler.php
+++ b/src/Receivable/ImportManualReceivablesHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
@@ -17,6 +18,7 @@ final readonly class ImportManualReceivablesHandler
     public function __construct(
         private ImportManualReceivablesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -28,7 +30,7 @@ final readonly class ImportManualReceivablesHandler
         }
 
         $output = $this->useCase->execute(new ImportManualReceivablesInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             contents: (string) $file->getStream(),
             actorUserId: AuthContext::userId($request),
         ));

--- a/src/Receivable/ListManualReceivablesHandler.php
+++ b/src/Receivable/ListManualReceivablesHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Receivable;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,6 +16,7 @@ final readonly class ListManualReceivablesHandler
     public function __construct(
         private ListManualReceivablesUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -23,7 +24,7 @@ final readonly class ListManualReceivablesHandler
     {
         $page = PaginationQueryParser::parse($request, 50, 200);
         $filter = ManualReceivableFilter::fromQueryParams((array) $request->getQueryParams());
-        $output = $this->useCase->execute(AuthContext::organizationId($request) ?? 0, $filter, $page->limit, $page->offset);
+        $output = $this->useCase->execute($this->organization->id(), $filter, $page->limit, $page->offset);
 
         return $this->response->create((new PaginationResponse(
             items: array_map(ManualReceivableResponse::toArray(...), $output->items),

--- a/src/Receivable/ManualReceivableServiceProvider.php
+++ b/src/Receivable/ManualReceivableServiceProvider.php
@@ -13,6 +13,7 @@ use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -83,26 +84,32 @@ final readonly class ManualReceivableServiceProvider implements ServiceProviderI
                     new ListManualReceivablesHandler(
                         ServiceResolver::get($c, ListManualReceivablesUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new CreateManualReceivableHandler(
                         ServiceResolver::get($c, CreateManualReceivableUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new GetManualReceivableHandler(
                         ServiceResolver::get($c, GetManualReceivableByIdUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new UpdateManualReceivableHandler(
                         ServiceResolver::get($c, UpdateManualReceivableUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new CancelManualReceivableHandler(
                         ServiceResolver::get($c, CancelManualReceivableUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ImportManualReceivablesHandler(
                         ServiceResolver::get($c, ImportManualReceivablesUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/Receivable/UpdateManualReceivableHandler.php
+++ b/src/Receivable/UpdateManualReceivableHandler.php
@@ -8,6 +8,7 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,6 +17,7 @@ final readonly class UpdateManualReceivableHandler
     public function __construct(
         private UpdateManualReceivableUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -27,7 +29,7 @@ final readonly class UpdateManualReceivableHandler
 
         $receivable = $this->useCase->execute(new UpdateManualReceivableInput(
             id: $id,
-            callerOrganizationId: AuthContext::organizationId($request) ?? 0,
+            callerOrganizationId: $this->organization->id(),
             referenceNumber: $fields['reference_number'],
             clientName: $fields['client_name'],
             recipientEmail: $fields['recipient_email'],

--- a/src/Reconciliation/ApplyCreditHandler.php
+++ b/src/Reconciliation/ApplyCreditHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -17,6 +18,7 @@ final readonly class ApplyCreditHandler
     public function __construct(
         private ApplyCreditUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -43,7 +45,7 @@ final readonly class ApplyCreditHandler
         }
 
         $output = $this->useCase->execute(new ApplyCreditInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             creditId: $creditId,
             invoiceId: $invoiceId,
             amountCents: $amountCents,

--- a/src/Reconciliation/ConfirmMatchHandler.php
+++ b/src/Reconciliation/ConfirmMatchHandler.php
@@ -9,6 +9,7 @@ use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
 use NeneClear\Receivable\ReceivableSource;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,6 +19,7 @@ final readonly class ConfirmMatchHandler
         private ConfirmMatchUseCaseInterface $useCase,
         private ReconciliationRepositoryInterface $reconciliations,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -72,7 +74,7 @@ final readonly class ConfirmMatchHandler
         }
 
         $reasonCode = isset($body['reason_code']) && is_string($body['reason_code']) ? $body['reason_code'] : null;
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $idempotencyKey = $request->getHeaderLine('Idempotency-Key');
         $idempotencyKey = $idempotencyKey !== '' ? $idempotencyKey : null;

--- a/src/Reconciliation/GetReconciliationByIdHandler.php
+++ b/src/Reconciliation/GetReconciliationByIdHandler.php
@@ -6,7 +6,7 @@ namespace NeneClear\Reconciliation;
 
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Routing\Router;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -15,6 +15,7 @@ final readonly class GetReconciliationByIdHandler
     public function __construct(
         private ReconciliationRepositoryInterface $reconciliations,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -22,7 +23,7 @@ final readonly class GetReconciliationByIdHandler
     {
         $params = (array) $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $id = (int) ($params['id'] ?? 0);
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $reconciliation = $this->reconciliations->findById($organizationId, $id);
 

--- a/src/Reconciliation/ListClientCreditsHandler.php
+++ b/src/Reconciliation/ListClientCreditsHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Reconciliation;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListClientCreditsHandler
     public function __construct(
         private ClientCreditRepositoryInterface $clientCredits,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
         $filter = ClientCreditFilter::fromQueryParams($request->getQueryParams());
 

--- a/src/Reconciliation/ListReconciliationsHandler.php
+++ b/src/Reconciliation/ListReconciliationsHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Reconciliation;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\PaginationQueryParser;
 use Nene2\Http\PaginationResponse;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,12 +16,13 @@ final readonly class ListReconciliationsHandler
     public function __construct(
         private ReconciliationRepositoryInterface $reconciliations,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
         $page = PaginationQueryParser::parse($request, 50, 200);
 
         $filter = ReconciliationFilter::fromQueryParams($request->getQueryParams());

--- a/src/Reconciliation/ProposeMatchHandler.php
+++ b/src/Reconciliation/ProposeMatchHandler.php
@@ -7,7 +7,7 @@ namespace NeneClear\Reconciliation;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
-use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -16,6 +16,7 @@ final readonly class ProposeMatchHandler
     public function __construct(
         private ProposeMatchUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -31,7 +32,7 @@ final readonly class ProposeMatchHandler
         }
 
         $output = $this->useCase->execute(new ProposeMatchInput(
-            organizationId: AuthContext::organizationId($request) ?? 0,
+            organizationId: $this->organization->id(),
             bankTransactionId: $bankTransactionId,
         ));
 

--- a/src/Reconciliation/ReconciliationServiceProvider.php
+++ b/src/Reconciliation/ReconciliationServiceProvider.php
@@ -18,6 +18,7 @@ use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
 use NeneClear\Receivable\ManualReceivableRepositoryInterface;
 use NeneClear\Receivable\PdoManualReceivableRepository;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -94,32 +95,39 @@ final readonly class ReconciliationServiceProvider implements ServiceProviderInt
                     new ProposeMatchHandler(
                         ServiceResolver::get($c, ProposeMatchUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ConfirmMatchHandler(
                         ServiceResolver::get($c, ConfirmMatchUseCaseInterface::class),
                         ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListReconciliationsHandler(
                         ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new GetReconciliationByIdHandler(
                         ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ReverseReconciliationHandler(
                         ServiceResolver::get($c, ReverseReconciliationUseCaseInterface::class),
                         ServiceResolver::get($c, ReconciliationRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ListClientCreditsHandler(
                         ServiceResolver::get($c, ClientCreditRepositoryInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                     new ApplyCreditHandler(
                         ServiceResolver::get($c, ApplyCreditUseCaseInterface::class),
                         ServiceResolver::get($c, JsonResponseFactory::class),
+                        ServiceResolver::get($c, CurrentOrganization::class),
                     ),
                 ),
             )

--- a/src/Reconciliation/ReverseReconciliationHandler.php
+++ b/src/Reconciliation/ReverseReconciliationHandler.php
@@ -9,6 +9,7 @@ use Nene2\Routing\Router;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
 use NeneClear\Auth\AuthContext;
+use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,6 +19,7 @@ final readonly class ReverseReconciliationHandler
         private ReverseReconciliationUseCaseInterface $useCase,
         private ReconciliationRepositoryInterface $reconciliations,
         private JsonResponseFactory $response,
+        private CurrentOrganization $organization,
     ) {
     }
 
@@ -33,7 +35,7 @@ final readonly class ReverseReconciliationHandler
             throw new ValidationException([new ValidationError('reversal_reason', 'A reversal reason is required.', 'required')]);
         }
 
-        $organizationId = AuthContext::organizationId($request) ?? 0;
+        $organizationId = $this->organization->id();
 
         $this->useCase->execute(new ReverseReconciliationInput(
             organizationId: $organizationId,

--- a/src/Tenancy/CurrentOrganization.php
+++ b/src/Tenancy/CurrentOrganization.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+/**
+ * The organization id that scopes the current request (#300, deal `Tenancy/`
+ * shape adapted to Clear's claim-only tenancy).
+ *
+ * Handlers on the org-scoped data plane receive this via constructor
+ * injection instead of hand-reading the JWT claim — the scope value can only
+ * come from the verified token, and forgetting it is a wiring error, not a
+ * silent `?? 0` empty scope.
+ */
+interface CurrentOrganization
+{
+    /**
+     * @throws MissingOrganizationScopeException when the request carries no
+     *         organization scope (e.g. a cross-tenant superadmin token on an
+     *         org-scoped surface) — fail-close, surfaced as 403.
+     */
+    public function id(): int;
+}

--- a/src/Tenancy/FixedOrganization.php
+++ b/src/Tenancy/FixedOrganization.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+/**
+ * {@see CurrentOrganization} pinned to a known organization id — for tests
+ * and non-HTTP entry points that operate on an explicitly chosen tenant.
+ */
+final readonly class FixedOrganization implements CurrentOrganization
+{
+    public function __construct(private int $organizationId)
+    {
+    }
+
+    public function id(): int
+    {
+        return $this->organizationId;
+    }
+}

--- a/src/Tenancy/HolderCurrentOrganization.php
+++ b/src/Tenancy/HolderCurrentOrganization.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+use Nene2\Http\RequestScopedHolder;
+
+/**
+ * {@see CurrentOrganization} backed by the request-scoped holder populated by
+ * {@see OrgScopeMiddleware}. Reading before the middleware ran — or when the
+ * verified token carries no `org` claim — throws, so org-scoped code fails
+ * closed (403) rather than silently crossing tenants or scoping to org 0.
+ */
+final readonly class HolderCurrentOrganization implements CurrentOrganization
+{
+    /**
+     * @param RequestScopedHolder<int> $orgIdHolder
+     */
+    public function __construct(
+        private RequestScopedHolder $orgIdHolder,
+    ) {
+    }
+
+    public function id(): int
+    {
+        if (!$this->orgIdHolder->isSet()) {
+            throw new MissingOrganizationScopeException();
+        }
+
+        return $this->orgIdHolder->get();
+    }
+}

--- a/src/Tenancy/MissingOrganizationScopeException.php
+++ b/src/Tenancy/MissingOrganizationScopeException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+use RuntimeException;
+
+/**
+ * The current request carries no organization scope but reached org-scoped
+ * code. Thrown by {@see HolderCurrentOrganization} (fail-close) and rendered
+ * as **403 `organization-not-resolved`** — the invoice OrgGuard "inconsistent
+ * token" semantics: a cross-tenant superadmin (`org = null`) token must be an
+ * explicit deny on the data plane, never an implicit empty org-0 view.
+ */
+final class MissingOrganizationScopeException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('The request carries no organization scope.');
+    }
+}

--- a/src/Tenancy/MissingOrganizationScopeExceptionHandler.php
+++ b/src/Tenancy/MissingOrganizationScopeExceptionHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class MissingOrganizationScopeExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private LocalizedProblemDetailsFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof MissingOrganizationScopeException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create($request, 'organization-not-resolved', 403);
+    }
+}

--- a/src/Tenancy/OrgScopeMiddleware.php
+++ b/src/Tenancy/OrgScopeMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneClear\Auth\AuthContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Populates the request-scoped organization holder from the verified bearer
+ * token's `org` claim (#300). Runs after {@see \Nene2\Auth\BearerTokenMiddleware}
+ * (claims must be verified) and before the capability middleware.
+ *
+ * Users belong to exactly one organization, so the signed claim is
+ * authoritative — it cannot be spoofed by a header, which also keeps a
+ * disposable-demo session locked to its own throwaway org. When the token
+ * carries no `org` claim (cross-tenant superadmin) or the route is public,
+ * the holder stays unset and org-scoped code fails closed downstream
+ * ({@see HolderCurrentOrganization} → 403).
+ */
+final readonly class OrgScopeMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param RequestScopedHolder<int> $orgIdHolder
+     */
+    public function __construct(
+        private RequestScopedHolder $orgIdHolder,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $organizationId = AuthContext::organizationId($request);
+
+        if ($organizationId !== null) {
+            $this->orgIdHolder->set($organizationId);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Tenancy/TenancyServiceProvider.php
+++ b/src/Tenancy/TenancyServiceProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tenancy;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\RequestScopedHolder;
+use NeneClear\Http\ServiceResolver;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wires the request organization scope (#300): the request-scoped holder, the
+ * {@see CurrentOrganization} read side injected into org-scoped handlers, the
+ * middleware that populates the holder from the verified `org` claim, and the
+ * 403 mapping for org-less tokens on the data plane.
+ */
+final readonly class TenancyServiceProvider implements ServiceProviderInterface
+{
+    /** Container key for the request-scoped organization-id holder. */
+    public const string ORG_ID_HOLDER = 'nene_clear.org_id_holder';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(self::ORG_ID_HOLDER, static fn (ContainerInterface $c): RequestScopedHolder => new RequestScopedHolder())
+            ->set(
+                CurrentOrganization::class,
+                static function (ContainerInterface $c): CurrentOrganization {
+                    $holder = $c->get(self::ORG_ID_HOLDER);
+                    \assert($holder instanceof RequestScopedHolder);
+
+                    /** @var RequestScopedHolder<int> $holder */
+                    return new HolderCurrentOrganization($holder);
+                },
+            )
+            ->set(
+                OrgScopeMiddleware::class,
+                static function (ContainerInterface $c): OrgScopeMiddleware {
+                    $holder = $c->get(self::ORG_ID_HOLDER);
+                    \assert($holder instanceof RequestScopedHolder);
+
+                    /** @var RequestScopedHolder<int> $holder */
+                    return new OrgScopeMiddleware($holder);
+                },
+            )
+            ->set(
+                MissingOrganizationScopeExceptionHandler::class,
+                static fn (ContainerInterface $c): MissingOrganizationScopeExceptionHandler => new MissingOrganizationScopeExceptionHandler(
+                    ServiceResolver::get($c, LocalizedProblemDetailsFactory::class),
+                ),
+            );
+    }
+}

--- a/tests/Tenancy/HolderCurrentOrganizationTest.php
+++ b/tests/Tenancy/HolderCurrentOrganizationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Tenancy;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneClear\Tenancy\FixedOrganization;
+use NeneClear\Tenancy\HolderCurrentOrganization;
+use NeneClear\Tenancy\MissingOrganizationScopeException;
+use NeneClear\Tenancy\OrgScopeMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the read side of tenant resolution (#300/#301): a handler that receives
+ * {@see \NeneClear\Tenancy\CurrentOrganization} gets the scoped id when the
+ * middleware ran with an `org` claim, and fails closed
+ * ({@see MissingOrganizationScopeException}) when it did not — never a silent
+ * org 0.
+ */
+final class HolderCurrentOrganizationTest extends TestCase
+{
+    public function test_returns_the_populated_organization_id(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $holder->set(42);
+
+        self::assertSame(42, (new HolderCurrentOrganization($holder))->id());
+    }
+
+    public function test_fails_closed_when_the_holder_was_never_populated(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+
+        $this->expectException(MissingOrganizationScopeException::class);
+
+        (new HolderCurrentOrganization($holder))->id();
+    }
+
+    public function test_end_to_end_org_claim_resolves_to_the_scoped_id(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $request = (new Psr17Factory())->createServerRequest('GET', '/admin/reconciliations')
+            ->withAttribute('nene2.auth.claims', ['org' => 7]);
+
+        (new OrgScopeMiddleware($holder))->process($request, new SpyRequestHandler());
+
+        self::assertSame(7, (new HolderCurrentOrganization($holder))->id());
+    }
+
+    public function test_end_to_end_superadmin_org_null_fails_closed(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $request = (new Psr17Factory())->createServerRequest('GET', '/admin/reconciliations')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin']);
+
+        (new OrgScopeMiddleware($holder))->process($request, new SpyRequestHandler());
+
+        $this->expectException(MissingOrganizationScopeException::class);
+
+        (new HolderCurrentOrganization($holder))->id();
+    }
+
+    public function test_fixed_organization_returns_its_pinned_id(): void
+    {
+        self::assertSame(99, (new FixedOrganization(99))->id());
+    }
+}

--- a/tests/Tenancy/MissingOrganizationScopeExceptionHandlerTest.php
+++ b/tests/Tenancy/MissingOrganizationScopeExceptionHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Tenancy;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneClear\I18n\LocalizedProblemDetailsFactory;
+use NeneClear\I18n\MessageCatalog;
+use NeneClear\Tenancy\MissingOrganizationScopeException;
+use NeneClear\Tenancy\MissingOrganizationScopeExceptionHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Pins the org-less-token mapping (#300/#301): a
+ * {@see MissingOrganizationScopeException} renders as a 403
+ * `organization-not-resolved` problem (invoice OrgGuard "inconsistent token"
+ * semantics), and the handler does not swallow unrelated exceptions.
+ */
+final class MissingOrganizationScopeExceptionHandlerTest extends TestCase
+{
+    private MissingOrganizationScopeExceptionHandler $handler;
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+        $problemDetails = new LocalizedProblemDetailsFactory(
+            new MessageCatalog(dirname(__DIR__, 2) . '/lang'),
+            new ProblemDetailsResponseFactory($this->psr17, $this->psr17, 'https://nene-clear.dev/problems/'),
+        );
+
+        $this->handler = new MissingOrganizationScopeExceptionHandler($problemDetails);
+    }
+
+    public function test_supports_only_the_missing_scope_exception(): void
+    {
+        self::assertTrue($this->handler->supports(new MissingOrganizationScopeException()));
+        self::assertFalse($this->handler->supports(new RuntimeException('unrelated')));
+    }
+
+    public function test_renders_403_organization_not_resolved(): void
+    {
+        $request = $this->psr17->createServerRequest('GET', '/admin/reconciliations');
+
+        $response = $this->handler->handle(new MissingOrganizationScopeException(), $request);
+
+        self::assertSame(403, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertStringContainsString('organization-not-resolved', (string) ($body['type'] ?? ''));
+        self::assertSame(403, $body['status'] ?? null);
+    }
+}

--- a/tests/Tenancy/OrgScopeMiddlewareTest.php
+++ b/tests/Tenancy/OrgScopeMiddlewareTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Tenancy;
+
+use Nene2\Http\RequestScopedHolder;
+use NeneClear\Tenancy\OrgScopeMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Records whether the downstream handler was reached.
+ */
+final class SpyRequestHandler implements RequestHandlerInterface
+{
+    public bool $called = false;
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->called = true;
+
+        return (new Psr17Factory())->createResponse(200);
+    }
+}
+
+/**
+ * Pins the tenant-resolution middleware (#300/#301): the organization scope is
+ * populated from the verified `org` claim, a header cannot forge it, and a
+ * cross-tenant superadmin (`org` absent) leaves the holder unset so downstream
+ * org-scoped code fails closed rather than scoping to org 0.
+ */
+final class OrgScopeMiddlewareTest extends TestCase
+{
+    private Psr17Factory $psr17;
+
+    protected function setUp(): void
+    {
+        $this->psr17 = new Psr17Factory();
+    }
+
+    /**
+     * @param RequestScopedHolder<int> $holder
+     */
+    private function process(RequestScopedHolder $holder, ServerRequestInterface $request): SpyRequestHandler
+    {
+        $next = new SpyRequestHandler();
+        (new OrgScopeMiddleware($holder))->process($request, $next);
+
+        return $next;
+    }
+
+    public function test_org_claim_populates_the_holder(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $request = $this->psr17->createServerRequest('GET', '/admin/reconciliations')
+            ->withAttribute('nene2.auth.claims', ['org' => 42]);
+
+        $next = $this->process($holder, $request);
+
+        self::assertTrue($holder->isSet());
+        self::assertSame(42, $holder->get());
+        self::assertTrue($next->called);
+    }
+
+    public function test_superadmin_without_org_claim_leaves_the_holder_unset(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $request = $this->psr17->createServerRequest('GET', '/admin/reconciliations')
+            ->withAttribute('nene2.auth.claims', ['role' => 'admin']);
+
+        $next = $this->process($holder, $request);
+
+        // Fail-close is deferred to the read side (HolderCurrentOrganization):
+        // the middleware itself never blocks, it simply does not scope.
+        self::assertFalse($holder->isSet());
+        self::assertTrue($next->called);
+    }
+
+    public function test_missing_claims_attribute_leaves_the_holder_unset(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        $request = $this->psr17->createServerRequest('GET', '/health');
+
+        $this->process($holder, $request);
+
+        self::assertFalse($holder->isSet());
+    }
+
+    public function test_a_header_cannot_forge_the_organization_scope(): void
+    {
+        /** @var RequestScopedHolder<int> $holder */
+        $holder = new RequestScopedHolder();
+        // A spoofed header must be ignored; only the verified claim counts.
+        $request = $this->psr17->createServerRequest('GET', '/admin/reconciliations')
+            ->withHeader('X-Organization-Id', '999')
+            ->withAttribute('nene2.auth.claims', ['org' => 7]);
+
+        $this->process($holder, $request);
+
+        self::assertSame(7, $holder->get());
+    }
+}


### PR DESCRIPTION
## What & why

Audit finding 7 (#287 item 5, #300): org scoping was hand-propagated as `AuthContext::organizationId($request) ?? 0` across **38 handler sites**, so a cross-tenant superadmin token (`org` absent) silently coerced to org 0 instead of an explicit decision. invoice/deal inject the scope into constructors so it cannot be forgotten. This adopts that shape for Clear.

Audit finding 8 (#287 item 6, #301): zero tenant-resolution tests — added.

## Changes

- **`src/Tenancy/`** (deal `Tenancy/` shape, adapted to Clear's claim-only tenancy):
  - `CurrentOrganization` (read side, injected into handlers) + `HolderCurrentOrganization` (request-scoped, fail-close) + `FixedOrganization` (tests/CLI).
  - `OrgScopeMiddleware` — populates the scope **only** from the verified `org` claim (a header cannot forge it, keeping disposable-demo sessions locked to their throwaway org); runs between bearer auth and capability checks.
  - `MissingOrganizationScopeException` + handler → **403 `organization-not-resolved`** (invoice OrgGuard "inconsistent token" semantics), wired into `ApplicationServiceProvider`.
  - `TenancyServiceProvider`.
- **38 handlers** across BankImport / Reconciliation / Receivable / Dunning / Export / ClearSettings / InvoiceUpstream / Mfa / Audit now receive `CurrentOrganization` via constructor; their 9 providers pass it through DI.
- **`tests/Tenancy/`** (11 tests): org-claim resolves to the scoped id; superadmin `org=null` fails closed; holder read-before-set throws; header cannot forge; 403 mapping.
- `lang/en|ja` for the new slug (already registered in the binding terminology registry on `main`).

## Semantics / no regression

- The `?? 0` → 0 coercion is gone: org-less tokens on the data plane are an explicit **403**, never an empty org-0 view.
- Real users belong to exactly one org, so the happy path is unchanged — 53 HTTP tests through the full container (Reconciliation/Audit/TOTP/BankImport/Export/Dunning) stay green, and the public demo seat (JWT carries the disposable org) is unaffected.
- MFA (a Clear strength) not regressed: TOTP enroll/disable are post-login flows where the `org` claim is always present.

## Quality gate

`composer check` fully green: **436 tests** (6 DB-adapter skips), phpstan OK, php-cs-fixer OK, OpenAPI valid, MCP valid, conformance OK.

Closes #300, Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)