### PR TITLE
docs(journal): record the 2026-07-10 live-demo happy-path keying walkthrough

### DIFF
--- a/docs/journal/2026-07-10.md
+++ b/docs/journal/2026-07-10.md
@@ -92,3 +92,50 @@ fixture INV-2026-056 recorded (`channel log`, SMTP unset). A second visit
 provisioned a second org; the fixed `demo` org is untouched. Sweep wrapper
 installed at `~/bin/sweep-clear-demo.sh` (exit 0 on live MySQL) — hourly cron
 registration in the HETEML panel is the owner's step.
+
+## Full happy-path keying of the live demo (all demo-reachable features)
+
+Exercised every feature a `/demo/standard` visitor can reach on
+clear.ayane.co.jp, end to end over the real API (curl with the seat-page JWT;
+one disposable org, 21 staged deposits). **Every endpoint passed on the happy
+path**: health; seat flow (org provisioned in ~0.9 s, JWT org/admin/1 h);
+dashboard reads; bank CSV import against the seeded みずほ account (deposit
+row imported, withdrawal row filtered) and batch reverse (1 row voided);
+transaction list/filter/unmatched/detail; the staged 名義ズレ showcase —
+propose on `ヤマダコウムテン（カ` ¥423,500 suggests MR-2026-005 (0.7, "exact
+amount match; due soon") → confirm #987; a second confirm #988 then reversed,
+with the transaction verified back to `unmatched` and the receivable to
+`open`; an upstream allocation confirm #989 → INV-2026-060 recording
+`payment_id` + `external_reference clear:recon:989:2060`; upstream list +
+test-upstream (`reachable: true`); credit apply (103 → INV-2026-060,
+remaining 20 000 → 15 000); manual receivable create/get/update/cancel and
+CSV bulk import (2 created, 0 errors); dunning send on overdue INV-2026-056
+(#207), notice get, pause + resume on INV-2026-061 (204; only the seeded
+pause stays active); all four CSV exports (UTF-8 BOM); audit log carrying
+every action above (87 events); settings get/update/restore; user
+invite/create (status `invited`), role update, get. `GET /admin/organizations`
+is 403 for the demo admin — correct scope, superadmin only.
+
+Three observations worth carrying forward (none is a happy-path failure):
+
+1. **`PUT /admin/clear-settings` is a full replace.** A body containing only
+   `dunning_min_interval_days` silently cleared the bank accounts, upstream
+   URL/token ref and fiscal year end (restored immediately from the prior
+   GET). The SPA always sends the whole object so users never hit this, but
+   unlike `UpdateManualReceivableRequest` the OpenAPI spec does not say "full
+   replace" here — an API-first caller will lose data. Issue candidate:
+   document it (or make the PUT merge-patch).
+2. **Direct API keying must use `X-Authorization`.** HETEML strips the
+   standard `Authorization` header (known, #265); every call 401s
+   ("No Bearer token was provided") until switched to the mirror header. Any
+   demo/API walkthrough doc should say so explicitly.
+3. **Dunning mail channel on the live host is `log`** (SMTP unset): the send
+   is recorded and audited but no mail leaves the box — for prospect demos,
+   present the *send record*, not an inbox.
+
+Also confirmed: `GET /` content-negotiates (browsers get the SPA shell,
+API clients the NENE2 JSON banner), and the login form is intentionally
+unreachable for demo orgs (random undisclosed admin password; seating is
+token-mint only). All writes stayed inside the throwaway org, which the
+hourly sweep will reap. Evidence (every response JSON/CSV) kept in the
+session scratchpad (`demo-keying/`).


### PR DESCRIPTION
Commits the demo happy-path keying write-up left uncommitted by a prior session. Docs-only (2026-07-10 journal); no code change.

Full end-to-end keying of every `/demo/standard`-reachable feature over the real API on clear.ayane.co.jp (one disposable org, 21 staged deposits) — all endpoints passed on the happy path. Records three follow-up observations: clear-settings PUT is full-replace (#284), direct-API keying needs `X-Authorization` (#265), live dunning channel is `log`.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)