### PR TITLE
fix(installer): self-delete install.php after a successful install (#306)

### DIFF
--- a/public_html/install.php
+++ b/public_html/install.php
@@ -33,7 +33,13 @@ declare(strict_types=1);
  * WARNING: NeNe Clear handles bank deposits and PII. Shared hosting is NOT
  * recommended for production data (roadmap Phase 3 / #193) — VPS + Docker is
  * the recommended target. This installer surfaces that warning but does not
- * block. DELETE this file immediately after a successful install.
+ * block.
+ *
+ * On a successful install this file self-deletes via @unlink(__FILE__)
+ * (#306 / audit finding (j) — deal/vault/invoice shape). If the unlink fails
+ * (FS permissions), the completion screen falls back to the manual-delete
+ * notice. Either way the re-install guard (var/.installed marker +
+ * adapter-aware database probe) refuses any re-run as defense in depth.
  */
 
 use Nene2\Config\DatabaseConfig;
@@ -299,6 +305,7 @@ function database_already_provisioned(string $envFile): bool
  *   fieldErrors?: array<string, string>,
  *   old?: array<string, string>,
  *   summary?: string,
+ *   selfDeleted?: bool,
  *   blockedMessage?: string
  * } $state
  */
@@ -311,6 +318,7 @@ function render_installer_page(array $state): string
     $fieldErrors = $state['fieldErrors'] ?? [];
     $oldValues = $state['old'] ?? [];
     $summary = $state['summary'] ?? '';
+    $selfDeleted = (bool) ($state['selfDeleted'] ?? false);
     $blockedMessage = $state['blockedMessage'] ?? '';
 
     $old = static fn (string $k, string $default = ''): string => h($oldValues[$k] ?? $default);
@@ -544,19 +552,31 @@ function render_installer_page(array $state): string
             . '<button type="submit" class="btn btn-primary">インストールを実行' . ico('arrow') . '</button></div>'
             . '</form>';
     } else { // complete
+        // Success self-deletes install.php (#306); the completion screen
+        // reflects whether the unlink actually landed. On failure we keep the
+        // original manual-delete instruction and the "delete first" step.
+        if ($selfDeleted) {
+            $secWarn = '<div class="sec-warn"><span class="sw-ico">' . ico('trash') . '</span><div>'
+                . '<div class="sw-t">install.php は自動的に削除されました</div>'
+                . '<div class="sw-d">このページを離れると再表示できません。もしファイルが残っている場合は、FTP またはファイルマネージャから <code>install.php</code> を<b>手動で削除</b>してください。</div>'
+                . '</div></div>';
+            $nextList = '<li><span class="nl-n">1</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>'
+                . '<li><span class="nl-n">2</span><div><b>銀行口座（CSV 取込プロファイル）を設定</b><div class="nl-d">設定画面で口座と CSV 列の対応を登録すると、入金 CSV の取込と消込を始められます。</div></div></li>';
+        } else {
+            $secWarn = '<div class="sec-warn"><span class="sw-ico">' . ico('trash') . '</span><div>'
+                . '<div class="sw-t">セキュリティ: 必ず install.php を削除してください</div>'
+                . '<div class="sw-d">自動削除に失敗しました（ファイル権限をご確認ください）。放置すると第三者に再セットアップされる恐れがあります。FTP またはファイルマネージャから <code>install.php</code> を<b>削除（またはリネーム）</b>してください。</div>'
+                . '</div></div>';
+            $nextList = '<li><span class="nl-n">1</span><div><b><code>install.php</code> を削除する</b><div class="nl-d">最優先。サーバーからこのファイルを消します。</div></div></li>'
+                . '<li><span class="nl-n">2</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>'
+                . '<li><span class="nl-n">3</span><div><b>銀行口座（CSV 取込プロファイル）を設定</b><div class="nl-d">設定画面で口座と CSV 列の対応を登録すると、入金 CSV の取込と消込を始められます。</div></div></li>';
+        }
         $body = '<div class="done-mark">' . ico('check') . '</div>'
             . '<div class="done-title">インストール完了</div>'
             . '<div class="done-sub">' . h($summary) . '</div>'
-            . '<div class="sec-warn"><span class="sw-ico">' . ico('trash') . '</span><div>'
-            . '<div class="sw-t">セキュリティ: 必ず install.php を削除してください</div>'
-            . '<div class="sw-d">放置すると第三者に再セットアップされる恐れがあります。FTP またはファイルマネージャから <code>install.php</code> を<b>削除（またはリネーム）</b>してください。</div>'
-            . '</div></div>'
+            . $secWarn
             . '<div class="next-h">次のステップ</div>'
-            . '<ol class="next-list">'
-            . '<li><span class="nl-n">1</span><div><b><code>install.php</code> を削除する</b><div class="nl-d">最優先。サーバーからこのファイルを消します。</div></div></li>'
-            . '<li><span class="nl-n">2</span><div><b>管理画面にログイン</b><div class="nl-d">先ほど設定した管理者メール・パスワードで。</div></div></li>'
-            . '<li><span class="nl-n">3</span><div><b>銀行口座（CSV 取込プロファイル）を設定</b><div class="nl-d">設定画面で口座と CSV 列の対応を登録すると、入金 CSV の取込と消込を始められます。</div></div></li>'
-            . '</ol>'
+            . '<ol class="next-list">' . $nextList . '</ol>'
             . '<a class="btn btn-primary btn-block btn-lg" href="./">' . ico('login') . '管理画面にログイン</a>';
     }
 
@@ -976,7 +996,8 @@ if (PHP_SAPI === 'cli') {
         '06-admin-single' => ['view' => 'admin'],
         '07-admin-multi' => ['view' => 'admin', 'old' => ['tenant_mode' => 'multi']],
         '08-admin-errors' => ['view' => 'admin', 'errors' => ['入力内容に誤りがあります。'], 'fieldErrors' => ['org_name' => '組織名を入力してください。', 'admin_email' => '有効なメールアドレスを入力してください。', 'admin_password' => 'パスワードは 12 文字以上にしてください。'], 'old' => ['org_name' => '', 'org_slug' => 'nene-shoji', 'admin_email' => 'admin@example', 'tenant_mode' => 'single']],
-        '09-complete' => ['view' => 'complete', 'summary' => '組織「株式会社ねね商事」（#1）と管理者 admin@nene-shoji.co.jp を作成しました。'],
+        '09-complete' => ['view' => 'complete', 'selfDeleted' => true, 'summary' => '組織「株式会社ねね商事」（#1）と管理者 admin@nene-shoji.co.jp を作成しました。'],
+        '09-complete-manual' => ['view' => 'complete', 'selfDeleted' => false, 'summary' => '組織「株式会社ねね商事」（#1）と管理者 admin@nene-shoji.co.jp を作成しました。'],
         '10-acquire' => ['view' => 'acquire', 'checks' => $acquireChecks, 'reqErrors' => []],
         '11-acquire-error' => ['view' => 'acquire', 'checks' => $acquireChecks, 'reqErrors' => [], 'errors' => ['SHA-256 が一致しません。公式配布元からダウンロードした ZIP と、そのページに記載のハッシュを確認してください。'], 'old' => ['expected_sha256' => '87ad144743f185bf19cbd15f678a54b65f8343e8dfc97ad93b5840972756bfd4']],
         '12-blocked' => ['view' => 'blocked', 'blockedMessage' => 'インストール済みです。install.php を削除してください。'],
@@ -1006,6 +1027,7 @@ $errors = [];
 /** @var array<string, string> $fieldErrors */
 $fieldErrors = [];
 $success = false;
+$selfDeleted = false;
 $summary = '';
 
 // Entry guards (both phases): completed-marker + provisioned-database probe.
@@ -1263,6 +1285,13 @@ if ($method === 'POST' && $reqErrors === []) {
 
                     $reinstallGuard->markInstalled(gmdate('c'));
                     $success = true;
+
+                    // Self-delete (#306 — deal/vault/invoice shape): a completed
+                    // install must not leave the installer behind. On failure
+                    // (FS permissions) the completion screen falls back to the
+                    // manual-delete notice; the marker (var/.installed) + DB
+                    // probe re-install guard still refuses any re-run.
+                    $selfDeleted = @unlink(__FILE__);
                 } catch (PDOException $e) {
                     $errors[] = 'データベースエラー: ' . $e->getMessage();
                 } catch (\Throwable $e) {
@@ -1303,4 +1332,5 @@ echo render_installer_page([
     'fieldErrors' => $fieldErrors,
     'old' => $oldValues,
     'summary' => $summary,
+    'selfDeleted' => $selfDeleted,
 ]);

--- a/tests/Install/InstallerSelfDeleteTest.php
+++ b/tests/Install/InstallerSelfDeleteTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Install;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the installer self-delete behaviour (#306 / audit finding (j) —
+ * deal/vault/invoice shape): a completed install must remove `install.php`
+ * on success, fall back to the manual-delete notice when the unlink fails,
+ * and — as defense in depth — the re-install guard must refuse any re-run
+ * with HTTP 403 even if the file is put back.
+ *
+ * Two layers:
+ *  1. Rendering (always runs): the CLI pattern export proves the completion
+ *     screen branches on the self-delete result — no live DB or server needed.
+ *  2. End-to-end (skips unless the installer's own requirement extensions are
+ *     present, like the Invoice contract tests): drives the real wizard over
+ *     the PHP built-in server against a throwaway SQLite database, asserts the
+ *     installer copy deletes itself, then re-uploads it and asserts the guard
+ *     answers 403.
+ */
+final class InstallerSelfDeleteTest extends TestCase
+{
+    private const REQUIRED_EXTENSIONS = ['pdo', 'pdo_mysql', 'pdo_sqlite', 'mbstring', 'openssl', 'json', 'curl'];
+
+    private string $work = '';
+
+    /** @var array<int, resource> */
+    private array $procs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->procs as $proc) {
+            @proc_terminate($proc);
+            @proc_close($proc);
+        }
+        $this->procs = [];
+
+        if ($this->work !== '' && is_dir($this->work)) {
+            self::removeTree($this->work);
+        }
+        $this->work = '';
+    }
+
+    /** The exported completion pattern reflects a successful self-delete. */
+    public function testCompletionScreenReportsSelfDeleteOnSuccess(): void
+    {
+        $patterns = $this->exportPatterns();
+
+        $html = $patterns['09-complete'];
+        self::assertStringContainsString('install.php は自動的に削除されました', $html);
+        // The "delete install.php first" step is dropped once it is gone.
+        self::assertStringNotContainsString('を削除する</b>', $html);
+        self::assertStringContainsString('管理画面にログイン', $html);
+    }
+
+    /** When the unlink fails the screen keeps the manual-delete instruction. */
+    public function testCompletionScreenFallsBackToManualDeleteWhenUnlinkFails(): void
+    {
+        $patterns = $this->exportPatterns();
+
+        $html = $patterns['09-complete-manual'];
+        self::assertStringContainsString('自動削除に失敗しました', $html);
+        self::assertStringContainsString('を削除する</b>', $html);
+    }
+
+    public function testWizardSelfDeletesOnSuccessAndGuardRefusesReRun(): void
+    {
+        foreach (self::REQUIRED_EXTENSIONS as $ext) {
+            if (!extension_loaded($ext)) {
+                self::markTestSkipped("installer requirement extension '{$ext}' is not loaded");
+            }
+        }
+
+        [$root, $installer] = $this->stageInstaller();
+        [$proc, $base] = $this->startServer($root);
+        $this->procs[] = $proc;
+
+        // Step 1 — database: SQLite, applies the schema and writes .env (PRG).
+        $step1 = $this->post($base . '/install.php?step=1', ['db_adapter' => 'sqlite']);
+        self::assertContains($step1['status'], [302, 303], 'DB step should PRG-redirect to the admin step: ' . $step1['body']);
+        self::assertFileExists($root . '/.env', 'the database step must write .env');
+
+        // Step 2 — admin: creates the org + admin, marks installed, self-deletes.
+        $step2 = $this->post($base . '/install.php?step=2', [
+            'tenant_mode' => 'single',
+            'org_name' => '株式会社ねね商事',
+            'org_slug' => 'nene-shoji',
+            'admin_email' => 'admin@nene-shoji.co.jp',
+            'admin_password' => 'correct horse battery',
+        ]);
+
+        self::assertSame(200, $step2['status'], $step2['body']);
+        self::assertStringContainsString('インストール完了', $step2['body']);
+        self::assertStringContainsString('install.php は自動的に削除されました', $step2['body']);
+        self::assertFileDoesNotExist($installer, 'install.php must remove itself after a successful install');
+        self::assertFileExists($root . '/var/.installed', 'the completed marker must remain as the re-install guard');
+
+        // Belt and suspenders: an operator re-uploads install.php — the marker
+        // (+ provisioned DB) guard must still refuse with 403.
+        copy($this->sourceInstaller(), $installer);
+        $reRun = $this->get($base . '/install.php');
+        self::assertSame(403, $reRun['status'], $reRun['body']);
+        self::assertStringContainsString('インストール済みです', $reRun['body']);
+    }
+
+    // -- helpers -----------------------------------------------------------
+
+    private function sourceInstaller(): string
+    {
+        return dirname(__DIR__, 2) . '/public_html/install.php';
+    }
+
+    /**
+     * Runs `install.php --export-patterns` and returns each pattern's HTML.
+     *
+     * @return array<string, string>
+     */
+    private function exportPatterns(): array
+    {
+        $out = sys_get_temp_dir() . '/' . uniqid('clear-installer-patterns-', true);
+        mkdir($out, 0775, true);
+
+        $proc = proc_open(
+            [PHP_BINARY, $this->sourceInstaller(), '--export-patterns', $out],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+        self::assertIsResource($proc);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        self::assertSame(0, proc_close($proc), 'pattern export failed: ' . $stderr);
+
+        $patterns = [];
+        foreach (glob($out . '/*.html') ?: [] as $file) {
+            $patterns[basename($file, '.html')] = (string) file_get_contents($file);
+        }
+        self::removeTree($out);
+
+        self::assertArrayHasKey('09-complete', $patterns);
+        self::assertArrayHasKey('09-complete-manual', $patterns);
+
+        return $patterns;
+    }
+
+    /**
+     * Builds a throwaway repo root: a real copy of install.php, a symlinked
+     * vendor/ + migrations (so the app classes and schema resolve) and writable
+     * var/ + database/ for the marker, .env and SQLite file.
+     *
+     * @return array{0: string, 1: string} [root, installerPath]
+     */
+    private function stageInstaller(): array
+    {
+        $this->work = sys_get_temp_dir() . '/' . uniqid('clear-installer-', true);
+        $realRoot = dirname(__DIR__, 2);
+
+        mkdir($this->work . '/public_html', 0775, true);
+        mkdir($this->work . '/var', 0775, true);
+        mkdir($this->work . '/database', 0775, true);
+
+        $installer = $this->work . '/public_html/install.php';
+        copy($this->sourceInstaller(), $installer);
+        symlink($realRoot . '/vendor', $this->work . '/vendor');
+        symlink($realRoot . '/database/migrations', $this->work . '/database/migrations');
+
+        return [$this->work, $installer];
+    }
+
+    /**
+     * Starts the PHP built-in server on a free port and waits for it to answer.
+     *
+     * @return array{0: resource, 1: string} [process, baseUrl]
+     */
+    private function startServer(string $root): array
+    {
+        $port = $this->freePort();
+        $base = 'http://127.0.0.1:' . $port;
+
+        $proc = proc_open(
+            [PHP_BINARY, '-S', '127.0.0.1:' . $port, '-t', $root . '/public_html'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $root,
+        );
+        self::assertIsResource($proc);
+        // Non-blocking pipes so a chatty server never deadlocks the test.
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+
+        for ($i = 0; $i < 100; $i++) {
+            $probe = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.2);
+            if (is_resource($probe)) {
+                fclose($probe);
+
+                return [$proc, $base];
+            }
+            usleep(50_000);
+        }
+
+        self::fail('PHP built-in server did not start on port ' . $port);
+    }
+
+    private function freePort(): int
+    {
+        $sock = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        self::assertIsResource($sock);
+        $name = (string) stream_socket_get_name($sock, false);
+        fclose($sock);
+
+        return (int) substr($name, (int) strrpos($name, ':') + 1);
+    }
+
+    /** @return array{status: int, body: string} */
+    private function get(string $url): array
+    {
+        return $this->request('GET', $url, null);
+    }
+
+    /**
+     * @param array<string, string> $fields
+     * @return array{status: int, body: string}
+     */
+    private function post(string $url, array $fields): array
+    {
+        return $this->request('POST', $url, http_build_query($fields));
+    }
+
+    /** @return array{status: int, body: string} */
+    private function request(string $method, string $url, ?string $body): array
+    {
+        $ch = curl_init($url);
+        self::assertNotFalse($ch);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false); // assert redirects explicitly
+        curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+        if ($method === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, (string) $body);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/x-www-form-urlencoded']);
+        }
+        $response = curl_exec($ch);
+        self::assertNotFalse($response, 'HTTP request failed: ' . curl_error($ch));
+        $status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return ['status' => $status, 'body' => (string) $response];
+    }
+
+    private static function removeTree(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+
+            return;
+        }
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            self::removeTree($path . '/' . $entry);
+        }
+        @rmdir($path);
+    }
+}


### PR DESCRIPTION
Closes #306 （umbrella #287 item 11 / (j)）

## 変更内容

- `public_html/install.php` — インストール成功時（`markInstalled` 直後）に `@unlink(__FILE__)` で自己削除（deal/vault/invoice 形）。完了画面は `$selfDeleted` で分岐: 成功→「install.php は自動的に削除されました（残っていたら手動削除）」＋「削除する」ステップを省略／失敗→従来の手動削除案内＋権限確認。再設置ガード（`var/.installed` marker ＋ adapter-aware DB probe）は不変（belt-and-suspenders）。ヘッダ docblock 更新。CLI パターン出力に成功／失敗の両状態（`09-complete` / `09-complete-manual`）。
- `tests/Install/InstallerSelfDeleteTest.php`（新規・3 tests / 30 assertions）
  - 完了画面の分岐をパターン出力で pin（常時実行・DB/サーバ不要）。
  - **実ウィザードを PHP ビルトインサーバ＋使い捨て SQLite で実走**し、成功時に install.php が自己削除されること・再アップロード時に再設置ガードが **403** を返すことを pin。要件拡張（pdo_mysql/curl）が無い環境では skip（Invoice 契約テストと同じ形）。

## 検収

- `composer check` 全緑: backend 439 tests（6 skipped・+3 新規）・PHPStan level 8・CS・OpenAPI/MCP・conformance。
- `php -l public_html/install.php` OK。
- 実ウィザード E2E（自己削除＋403 ガード）ローカル実走で緑。

## セルフレビュー

- インストーラ後始末のみ・アプリ本体/API 無変更・用語レジストリ影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)