### PR TITLE
chore(frontend): self-host fonts only, drop the Google Fonts CDN (#307)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>NeNe Clear</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Fonts are self-hosted via @fontsource (see src/main.tsx); no CDN link
+         so a future `font-src 'self'` CSP holds (#307, invoice shape). -->
   </head>
   <body data-theme="a">
     <!-- SVG Icon Sprite -->

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,6 @@
 import '@fontsource/noto-sans-jp/400.css'
+import '@fontsource/noto-sans-jp/500.css'
+import '@fontsource/noto-sans-jp/600.css'
 import '@fontsource/noto-sans-jp/700.css'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/600.css'


### PR DESCRIPTION
Refs #307 （umbrella #287 finding 10 / (i) — the small independent item）

## 変更内容

- `frontend/index.html` — Google Fonts CDN の 3 リンク（preconnect ×2 ＋ Noto Sans JP stylesheet）を削除。フォントは `src/main.tsx` の @fontsource 自己ホストに一本化（invoice 形）。将来の `font-src 'self'` CSP と両立。
- `frontend/src/main.tsx` — CDN が供給していた Noto Sans JP の 500 / 600 ウェイトを @fontsource 側に追加（design.css が 500/600 を使用しているため、自己ホストで再現するのに必要）。

## 検収

- `npm run build` OK（noto-sans-jp 400/500/600/700 が自己ホストで同梱されることを確認）。
- `npm run check`（type-check + lint + 46 tests）全緑。

Bundle 影響: 自己ホスト woff は subset 済み・ネットワークは同一オリジンのみに。

🤖 Generated with [Claude Code](https://claude.com/claude-code)