### PR TITLE
fix(frontend): make the type-check gate real and fix the errors it was hiding (#307)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc -b",
     "lint": "eslint src --max-warnings 0",
     "format": "prettier --write src",
     "test": "vitest",

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -108,11 +108,11 @@ describe('endpoint request construction', () => {
   })
 
   it('confirmMatch posts snake_case allocation payload', async () => {
-    await confirmMatch(99, [{ invoice_id: 1, amount_cents: 110000 }], 'fee_absorption')
+    await confirmMatch(99, [{ source: 'invoice_upstream', invoice_id: 1, amount_cents: 110000 }], 'fee_absorption')
     expect(calledUrl()).toBe('/admin/reconciliations')
     expect(JSON.parse(calledInit().body!)).toEqual({
       bank_transaction_id: 99,
-      allocations: [{ invoice_id: 1, amount_cents: 110000 }],
+      allocations: [{ source: 'invoice_upstream', invoice_id: 1, amount_cents: 110000 }],
       reason_code: 'fee_absorption',
     })
   })

--- a/frontend/src/components/ui/Icon.tsx
+++ b/frontend/src/components/ui/Icon.tsx
@@ -1,9 +1,12 @@
+import type { CSSProperties } from 'react'
+
 type IconSize = 'sm' | 'md' | 'lg'
 
 interface IconProps {
   name: string
   size?: IconSize
   className?: string
+  style?: CSSProperties
 }
 
 const sizeClass: Record<IconSize, string> = {
@@ -12,9 +15,9 @@ const sizeClass: Record<IconSize, string> = {
   lg: 'ic ic-lg',
 }
 
-export function Icon({ name, size = 'md', className }: IconProps) {
+export function Icon({ name, size = 'md', className, style }: IconProps) {
   return (
-    <svg className={[sizeClass[size], className].filter(Boolean).join(' ')}>
+    <svg className={[sizeClass[size], className].filter(Boolean).join(' ')} style={style}>
       <use href={`#i-${name}`} />
     </svg>
   )

--- a/frontend/src/components/ui/Kpi.tsx
+++ b/frontend/src/components/ui/Kpi.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 
 type KpiAccent = 'default' | 'accent' | 'warn' | 'bad'
 
@@ -32,6 +32,6 @@ export function Kpi({ icon, label, value, sub, accent = 'default', testId }: Kpi
   )
 }
 
-export function KpiGrid({ children }: { children: ReactNode }) {
-  return <div className="kpi-grid">{children}</div>
+export function KpiGrid({ children, style }: { children: ReactNode; style?: CSSProperties }) {
+  return <div className="kpi-grid" style={style}>{children}</div>
 }

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -205,7 +205,7 @@ export default function DunningPage() {
                 <tr key={inv.invoice_id} data-kbd-row={index} className={[paused ? 'dim' : '', cursor === index ? 'is-cursor' : ''].filter(Boolean).join(' ') || undefined}>
                   <td className="strong mono">{inv.invoice_number}</td>
                   <td>
-                    {inv.status === 'overdue' ? <Badge variant="bad" dot>{t('dunning.status.overdue')}</Badge> : <Badge variant="warn" dot>{t('dunning.status.partial')}</Badge>}
+                    {daysNum > 0 ? <Badge variant="bad" dot>{t('dunning.status.overdue')}</Badge> : <Badge variant="warn" dot>{t('dunning.status.partial')}</Badge>}
                   </td>
                   <td className="num">{yen(inv.outstanding_cents)}</td>
                   <td className="muted">{inv.due_at ?? '—'}</td>

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -350,7 +350,7 @@ export default function ReconciliationPage() {
               <option value="reversed">{t('reconciliation.status.reversed')}</option>
             </select>
           </FilterField>
-          <FilterField label={t('table.invoiceId')}>
+          <FilterField label={t('reconciliation.invoiceId')}>
             <input className="inp tnum" data-kbd="search" type="number" placeholder="#" style={{ width: 110 }} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
           </FilterField>
           <FilterField label={t('table.confirmedAt')}>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,9 +17,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
Part of the frontend fleet-alignment remediation (#287 finding 9, tracked in #307).

## The problem

`npm run type-check` ran `tsc --noEmit` against the **solution-style** `tsconfig.json` (`files: []`, only project references). In that mode `tsc --noEmit` type-checks **nothing** — so the frontend has never actually been type-checked, in CI or locally. `npm run build` had the same no-op `tsc --noEmit` before `vite build` (esbuild doesn't type-check either).

A real check (`tsc -b`) surfaced **13 latent errors**, several of them real UI defects that shipped:

| Site | Defect |
| --- | --- |
| `ReconciliationPage.tsx` | invoice-id filter used `t('table.invoiceId')` — a **non-existent key**; the label rendered the raw string `"table.invoiceId"`. Now `reconciliation.invoiceId` (already registered). |
| `DunningPage.tsx` | `inv.status === 'overdue'` — `UpstreamInvoice.status` can never be `'overdue'`, so the branch was **dead code** and every eligible invoice showed the "partial" badge. Now derived from the due date (`daysOverdue(due_at) > 0`), consistent with the elapsed-days column. |
| `DashboardPage.tsx` | `style`/`icon` inline styles passed to `Icon`/`KpiGrid`, which didn't accept them → **silently dropped**. `style` now forwarded on both. |
| `endpoints.test.ts` | confirmMatch allocation omitted the required `source` field (ADR 0014). |
| `main.tsx` ×7 | CSS / `@fontsource` side-effect imports had no module declarations under `noUncheckedSideEffectImports`. Added `src/vite-env.d.ts`. |

## Gate changes

- `type-check` and `build` now run `tsc -b`, so the referenced projects are actually checked.
- Removed the deprecated `baseUrl` from `tsconfig.app.json` (goes away in TS 7.0; the installed `typescript@~6` already errors on it under a real check) and made `@/*` resolve relative to the config.

## Why now / why separate

This is a prerequisite for the OpenAPI codegen item: re-pointing types to generated schema is meaningless if `tsc` never checks. Split out so the codegen PR stays about codegen.

## Verify

- `npm run check` green — type-check (`tsc -b`), lint, **46** unit tests, knip.
- `npm run build` green from a clean `tsbuildinfo`.
- E2E specs assert on none of the changed labels/badges (`daysOverdue` derivation matches the existing elapsed-days display; dunning E2E asserts on recipient email + interval message only).

Refs #307 finding 9. Does not close #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)