### PR TITLE
fix(api): send the X-Authorization mirror on file upload/download fetches (#312)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -17,7 +17,23 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      // All network calls must go through the shared API client, which applies
+      // the Authorization + X-Authorization mirror (#265). A raw fetch() drops
+      // the mirror and 401s behind the shared-hosting proxy (#312).
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.name='fetch']",
+          message:
+            'Do not call fetch() directly — use `api` or `apiFetch` from src/api/client.ts so the Authorization/X-Authorization mirror is sent (#265, #312).',
+        },
+      ],
     },
+  },
+  {
+    // The shared API client is the single sanctioned place that calls fetch().
+    files: ['src/api/client.ts'],
+    rules: { 'no-restricted-syntax': 'off' },
   },
   eslintConfigPrettier,
 )

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -51,7 +51,7 @@ describe('api request', () => {
     expect(init.body).toBeUndefined()
   })
 
-  it('injects the bearer token when present', async () => {
+  it('injects the bearer token on both headers (Authorization + X-Authorization mirror, #265)', async () => {
     storeToken('jwt-xyz')
     fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, json: {} }))
 
@@ -59,6 +59,8 @@ describe('api request', () => {
 
     const init = fetchMock.mock.calls[0][1]
     expect(init.headers.Authorization).toBe('Bearer jwt-xyz')
+    // The proxy strips Authorization in production; the mirror must ride along.
+    expect(init.headers['X-Authorization']).toBe('Bearer jwt-xyz')
   })
 
   it('omits Authorization when no token', async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -112,25 +112,39 @@ export function isAdmin(): boolean {
   return role === 'admin' || role === 'superadmin'
 }
 
+// The token goes to both headers: some shared-hosting front proxies (Tier A;
+// observed on HETEML) strip the standard `Authorization` header before it
+// reaches PHP, so the backend falls back to the `X-Authorization` mirror when
+// the standard header is missing (#265). Every request MUST carry the mirror —
+// this helper is the single place that applies it, so no call site can drop it.
+function withAuthHeaders(headers: Record<string, string> = {}): Record<string, string> {
+  const token = getToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+    headers['X-Authorization'] = `Bearer ${token}`
+  }
+  return headers
+}
+
+/**
+ * `fetch()` with the auth-header mirror applied, for the few calls that can't go
+ * through `request()` — multipart uploads and binary downloads. Callers own the
+ * response (blob / multipart error parsing); the mirror is guaranteed here so it
+ * can't be forgotten (see #265, #312). Content-Type is intentionally left unset
+ * so the browser can add the multipart boundary for FormData bodies.
+ */
+export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = withAuthHeaders({ ...(init.headers as Record<string, string> | undefined) })
+  return fetch(path, { ...init, headers })
+}
+
 async function request<T>(
   method: string,
   path: string,
   body?: unknown,
   signal?: AbortSignal,
 ): Promise<T> {
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-  }
-
-  // The token goes to both headers: some shared-hosting front proxies (Tier A;
-  // observed on HETEML) strip the standard `Authorization` header before it
-  // reaches PHP, so the backend falls back to the `X-Authorization` mirror
-  // when the standard header is missing (#265).
-  const token = getToken()
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-    headers['X-Authorization'] = `Bearer ${token}`
-  }
+  const headers = withAuthHeaders({ Accept: 'application/json' })
 
   if (body !== undefined) {
     headers['Content-Type'] = 'application/json'

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -7,7 +7,11 @@ import {
   confirmMatch,
   reverseReconciliation,
   sendDunningNotice,
+  downloadCsv,
+  importBankCsv,
+  importManualReceivables,
 } from './endpoints'
+import { storeToken } from './client'
 
 /**
  * These tests drive the endpoint functions through the real api client and a
@@ -127,5 +131,53 @@ describe('endpoint request construction', () => {
     await sendDunningNotice(123)
     expect(calledUrl()).toBe('/admin/dunning-notices')
     expect(JSON.parse(calledInit().body!)).toEqual({ invoice_id: 123, stage: 'initial' })
+  })
+})
+
+/**
+ * The multipart upload and CSV export helpers call fetch through apiFetch rather
+ * than the JSON request(). They must still carry the Authorization +
+ * X-Authorization mirror, or they 401 behind the production proxy (#265, #312).
+ */
+describe('file-I/O endpoints carry the auth mirror (#312)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    storeToken('jwt-file')
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ created: 0, skipped: 0, errors: [] }),
+      blob: () => Promise.resolve(new Blob(['csv'])),
+    } as unknown as Response)
+    vi.stubGlobal('fetch', fetchMock)
+    URL.createObjectURL = vi.fn(() => 'blob:mock')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function sentHeaders(): Record<string, string> {
+    return fetchMock.mock.calls[0][1].headers
+  }
+
+  it('importBankCsv sends both auth headers', async () => {
+    await importBankCsv(1, new File(['a,b'], 'bank.csv', { type: 'text/csv' }))
+    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
+  })
+
+  it('importManualReceivables sends both auth headers', async () => {
+    await importManualReceivables(new File(['a,b'], 'mr.csv', { type: 'text/csv' }))
+    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
+  })
+
+  it('downloadCsv (CSV export) sends both auth headers', async () => {
+    await downloadCsv('/admin/export/bank-transactions', 'bank.csv')
+    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
   })
 })

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,10 +1,7 @@
-import { api } from './client'
+import { api, apiFetch } from './client'
 
 export async function downloadCsv(path: string, filename: string): Promise<void> {
-  const token = sessionStorage.getItem('nene_clear_token')
-  const res = await fetch(path, {
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
-  })
+  const res = await apiFetch(path)
   if (!res.ok) throw new Error(`Export failed: ${res.status}`)
   const blob = await res.blob()
   const url = URL.createObjectURL(blob)
@@ -77,10 +74,8 @@ export async function importBankCsv(bankAccountId: number, file: File) {
   const form = new FormData()
   form.append('bank_account_id', String(bankAccountId))
   form.append('file', file)
-  const token = sessionStorage.getItem('nene_clear_token')
-  const res = await fetch(`${BASE}/bank-import-batches`, {
+  const res = await apiFetch(`${BASE}/bank-import-batches`, {
     method: 'POST',
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: form,
   })
 
@@ -351,10 +346,8 @@ export function cancelManualReceivable(id: number) {
 export async function importManualReceivables(file: File): Promise<ManualReceivableImportResult> {
   const form = new FormData()
   form.append('file', file)
-  const token = sessionStorage.getItem('nene_clear_token')
-  const res = await fetch(`${BASE}/manual-receivable-imports`, {
+  const res = await apiFetch(`${BASE}/manual-receivable-imports`, {
     method: 'POST',
-    headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: form,
   })
   const data = await res.json().catch(() => null)


### PR DESCRIPTION
Closes #312. **Sales-blocking production bug** found in the 2026-07-11 browser walkthrough.

## Problem

Behind the production proxy (which strips the standard `Authorization` header), these 401'd with `No Bearer token was provided.`:

- Bank statement CSV import, Manual receivable CSV import (multipart uploads)
- CSV export ×4 (bank transactions, reconciliations, client credits, dunning notices)

The shared client already sends the token on **both** `Authorization` and `X-Authorization` (#265), but `downloadCsv`, `importBankCsv`, and `importManualReceivables` called `fetch()` directly with only `Authorization`. They bypass `request()` because they do binary downloads / multipart uploads. curl and local dev set both headers, so this only reproduced behind the proxy — the 2026-07-10 curl walkthrough missed it.

## Fix

- **Centralize the mirror**: `withAuthHeaders()` in `client.ts` is now the single place that applies both headers, used by `request()` and by a new exported **`apiFetch()`** (fetch + mirror; caller owns the response; no forced `Content-Type` so `FormData` keeps its multipart boundary).
- Route the three functions through `apiFetch()`.
- **Prevent regression**: ESLint `no-restricted-syntax` forbids raw `fetch()` everywhere except `src/api/client.ts` (ports the vault #177 guard; rides on the lint gate from #310).
- **Pin it in tests**: `request()` and all three file-I/O helpers now assert both `Authorization` and `X-Authorization` are sent.

## Verify

- `npm run check` green — type-check, lint (incl. the new fetch ban), **49** unit tests (+3), knip.
- `npm run build` green.
- Confirmed the ESLint rule errors on a raw `fetch()` in any other file and passes in `client.ts`.

Production reflection is a separate operator step (owner GO); re-verify with a browser walkthrough after deploy (this is a production-only presentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)