### PR TITLE
fix(settings): stop the no-op settings save from 500ing on MySQL (#314)

### DIFF
--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -49,32 +49,44 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
 
     public function save(ClearSettings $settings): void
     {
-        // Upsert without a destructive DELETE: update the existing row, and
-        // insert only when no row was affected (first save for the org).
-        $affected = $this->query->execute(
-            'UPDATE clear_settings SET upstream_base_url = ?, upstream_token_ref = ?, dunning_min_interval_days = ?, fiscal_year_end_month = ? '
-            . 'WHERE organization_id = ?',
-            [
-                $settings->upstreamBaseUrl,
-                $settings->upstreamTokenRef,
-                $settings->dunningMinIntervalDays,
-                $settings->fiscalYearEndMonth,
-                $settings->organizationId,
-            ],
-        );
+        // Upsert without a destructive DELETE. Decide insert-vs-update by an
+        // explicit existence check — NOT by the UPDATE's affected-row count.
+        // MySQL (without MYSQL_ATTR_FOUND_ROWS) reports rows *changed*, not
+        // matched, so a no-op save (identical values) reports 0 affected rows;
+        // treating that as "row absent" fires the INSERT and collides with the
+        // organization_id primary key → 500. SQLite counts the matched row as
+        // changed, which is why this only surfaced on MySQL in production (#314).
+        $exists = $this->query->fetchOne(
+            'SELECT 1 AS present FROM clear_settings WHERE organization_id = ?',
+            [$settings->organizationId],
+        ) !== null;
 
-        if ($affected === 0) {
+        if ($exists) {
             $this->query->execute(
-                'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month) '
-                . 'VALUES (?, ?, ?, ?, ?)',
+                'UPDATE clear_settings SET upstream_base_url = ?, upstream_token_ref = ?, dunning_min_interval_days = ?, fiscal_year_end_month = ? '
+                . 'WHERE organization_id = ?',
                 [
-                    $settings->organizationId,
                     $settings->upstreamBaseUrl,
                     $settings->upstreamTokenRef,
                     $settings->dunningMinIntervalDays,
                     $settings->fiscalYearEndMonth,
+                    $settings->organizationId,
                 ],
             );
+
+            return;
         }
+
+        $this->query->execute(
+            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month) '
+            . 'VALUES (?, ?, ?, ?, ?)',
+            [
+                $settings->organizationId,
+                $settings->upstreamBaseUrl,
+                $settings->upstreamTokenRef,
+                $settings->dunningMinIntervalDays,
+                $settings->fiscalYearEndMonth,
+            ],
+        );
     }
 }

--- a/tests/Database/PdoClearSettingsRepositoryTest.php
+++ b/tests/Database/PdoClearSettingsRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\BankImport\PdoBankAccountRepository;
+use NeneClear\ClearSettings\ClearSettings;
+use NeneClear\ClearSettings\PdoClearSettingsRepository;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoClearSettingsRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $real;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('clear-settings-repo-', true) . '.sqlite';
+        $this->real = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createBankAccounts($this->real);
+        SchemaFixture::createClearSettings($this->real);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    /**
+     * Re-saving unchanged settings must update in place, not duplicate-insert.
+     *
+     * On MySQL (without MYSQL_ATTR_FOUND_ROWS) a matched-but-unchanged UPDATE
+     * reports 0 affected rows. The executor below reproduces that semantic on
+     * top of SQLite so the regression is exercised in the normal test suite: a
+     * repository that keys insert-vs-update off the affected-row count would
+     * fall through to the INSERT and hit the organization_id primary key (#314).
+     */
+    public function testResavingUnchangedSettingsDoesNotDuplicateInsert(): void
+    {
+        $query = $this->mysqlAffectedRowsExecutor($this->real);
+        $repo = new PdoClearSettingsRepository($query, new PdoBankAccountRepository($this->real));
+
+        $settings = new ClearSettings(
+            organizationId: 21,
+            upstreamBaseUrl: 'https://invoice.example',
+            upstreamTokenRef: 'NENE_INVOICE_BEARER_TOKEN',
+            dunningMinIntervalDays: 7,
+            fiscalYearEndMonth: 3,
+        );
+
+        $repo->save($settings);            // first save → INSERT
+        $repo->save($settings);            // re-save identical → must UPDATE, not INSERT again
+
+        $rows = $this->real->fetchAll('SELECT organization_id, dunning_min_interval_days FROM clear_settings');
+        self::assertCount(1, $rows);
+        self::assertSame(7, (int) $rows[0]['dunning_min_interval_days']);
+    }
+
+    /**
+     * Wraps a real executor but reports 0 affected rows for every UPDATE, the
+     * way MySQL reports a no-op UPDATE. The wrapped statement still runs, so the
+     * existence check and the eventual INSERT observe real SQLite state.
+     */
+    private function mysqlAffectedRowsExecutor(DatabaseQueryExecutorInterface $inner): DatabaseQueryExecutorInterface
+    {
+        return new class ($inner) implements DatabaseQueryExecutorInterface {
+            public function __construct(private DatabaseQueryExecutorInterface $inner)
+            {
+            }
+
+            public function execute(string $sql, array $parameters = []): int
+            {
+                $affected = $this->inner->execute($sql, $parameters);
+
+                return stripos(ltrim($sql), 'UPDATE') === 0 ? 0 : $affected;
+            }
+
+            public function insert(string $sql, array $parameters = []): int
+            {
+                return $this->inner->insert($sql, $parameters);
+            }
+
+            public function lastInsertId(): int
+            {
+                return $this->inner->lastInsertId();
+            }
+
+            public function fetchOne(string $sql, array $parameters = []): ?array
+            {
+                return $this->inner->fetchOne($sql, $parameters);
+            }
+
+            public function fetchAll(string $sql, array $parameters = []): array
+            {
+                return $this->inner->fetchAll($sql, $parameters);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #314. **Sales-blocking production bug** #2 from the 2026-07-11 browser walkthrough.

## Symptom

Saving the settings form when the `clear_settings` row ends up unchanged — e.g. re-saving the dunning interval as `7` when it is already `7`, upstream/fiscal fields untouched — returned `500` on `PUT /admin/clear-settings`. Reading settings and changing a value both worked.

## Root cause

`PdoClearSettingsRepository::save()` picked insert-vs-update from the UPDATE's affected-row count:

```php
$affected = UPDATE clear_settings ... WHERE organization_id = ?
if ($affected === 0) { INSERT ... }   // ← wrong on MySQL
```

MySQL (without `MYSQL_ATTR_FOUND_ROWS`) reports rows **changed**, not matched. A matched-but-unchanged UPDATE returns `0`, so the code concluded "row absent" and ran the INSERT → duplicate `organization_id` primary key → `PDOException` → 500. SQLite counts the matched row as changed (returns `1`), so the fallback never fired — which is why the SQLite-backed suite never caught it.

## Diagnosis (confirmed against the live demo DB, read-only)

The report's original hypothesis (encrypted `account_number` overflowing `VARCHAR(64)`) **did not hold**:
- `NENE_CLEAR_ENCRYPTION_KEY` is unset in the demo → encryption off → `account_number` stored as plaintext.
- Schema is fully migrated: `account_number` is `varchar(255)`, all `csv_*` columns present, widen migration `20260627120000` applied.
- The `clear_settings` rows have `dunning_min_interval_days = 7` — so "saving 7" is a genuine no-op UPDATE. That is the trigger.

## Fix

- Choose insert-vs-update by an explicit `SELECT 1 ... WHERE organization_id = ?` existence check (DB-agnostic; correct on MySQL/SQLite/Postgres).
- Regression test reproduces MySQL's affected-row semantics on top of SQLite (a wrapping executor that reports `0` for every UPDATE) and asserts a re-save updates in place. **It fails on the old code with the exact production error** (`UNIQUE constraint failed: clear_settings.organization_id`) and passes on the fix.

## On "Problem Details"

The 500 was an unexpected duplicate-key crash from a logic defect, not a legitimate constraint the user should ever hit. Fixing it makes the save succeed, so there is no error state left to convert — no bespoke Problem Details mapping is warranted for this path.

## Verify

- `composer check` green: **440** tests (+1), phpstan, cs, openapi, mcp, conformance.

Production reflection is a separate operator step (owner GO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)