### PR TITLE
docs(terminology): align client_credit.status with the shipped enum (#264)

### DIFF
--- a/docs/development/phase-1-reconciliation-design.md
+++ b/docs/development/phase-1-reconciliation-design.md
@@ -188,7 +188,8 @@ Per [`domain-model.md`](../explanation/domain-model.md). Enforced in UseCases:
   return `invalid-state-transition`.
 - `payment_reconciliation`: `confirmed → reversed` (reversing an already-reversed
   one is `invalid-state-transition`).
-- `client_credit`: `open → partially_applied → applied`.
+- `client_credit`: `open → voided`. Application progress is tracked by
+  `remaining_cents`, not by a status value (#264).
 
 ---
 

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -85,7 +85,7 @@ Stored and transmitted **exactly** as written (lowercase snake_case).
 | `bank_transaction.status` | `unmatched`, `partially_matched`, `matched`, `voided` |
 | `bank_import_batch.status` | `imported`, `reversed` |
 | `payment_reconciliation.status` | `confirmed`, `reversed` |
-| `client_credit.status` | `open`, `partially_applied`, `applied` |
+| `client_credit.status` | `open`, `voided` |
 | `manual_receivable.status` | `open`, `partially_paid`, `paid`, `cancelled` (ADR 0014; Clear-computed) |
 | Receivable `source` (allocations, dunning, credits, receivable reads) | `invoice_upstream`, `manual` (ADR 0014) |
 | `dunning_notice.status` | `sent`, `failed` |

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2350,7 +2350,9 @@ components:
 
     ClientCreditStatus:
       type: string
-      enum: [open, partially_applied, applied]
+      # Matches the ClientCreditStatus enum. Application progress is expressed by
+      # remaining_cents, not a status value (#264).
+      enum: [open, voided]
     ClientCredit:
       type: object
       required: [client_credit_id, organization_id, client_id, amount_cents, remaining_cents, status]


### PR DESCRIPTION
Resolves the registry/spec ↔ implementation drift tracked in #264, per the ruling recorded there (code is canonical).

## Change

The binding terminology registry and the OpenAPI spec listed `client_credit.status` as `open | partially_applied | applied`, but the `ClientCreditStatus` enum and the frontend both use `open | voided`. The registry now follows the implementation:

- `docs/explanation/terminology.md` §2 → `open`, `voided`
- `docs/openapi/openapi.yaml` `ClientCreditStatus` → `enum: [open, voided]`
- `docs/development/phase-1-reconciliation-design.md` → state line corrected to `open → voided`

Application progress is expressed by `remaining_cents`, not a status value.

## Scope

Docs/spec only — no code change (the enum and frontend already ship `open`/`voided`). This is a *registry-follows-implementation* correction, not a new-term introduction, so it complies with the terminology-registry rule.

The optional `partially_applied` / `applied` lifecycle is left as a possible **future enhancement** tracked in #264 (not closed by this PR).

## Verify

- `composer check` green: 440 tests, phpstan, cs, **openapi valid**, mcp valid, **conformance OK**.

Refs #264, #307 (unblocks the codegen plan #317 Bucket B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)