### PR TITLE
docs(journal): record the 2026-07-11 remediation-final-leg session

### DIFF
--- a/docs/journal/2026-07-11.md
+++ b/docs/journal/2026-07-11.md
@@ -30,3 +30,93 @@ Recorded in [`docs/audit/2026-07-11-structural-uniformity.md`](../audit/2026-07-
   installer guard-only cleanup.
 
 No code changed today — issues + docs only (#288 is this recording task).
+
+---
+
+## Evening — audit remediation final leg + two production sales-blockers
+
+Picked up the remediation campaign after the prior session stopped mid-run
+(OS crash). Merged the two CI-green PRs that were waiting (#308 installer
+self-delete → closed #306; #309 font dedup), then worked the remaining #287
+frontend items (#307) and two production bugs found in the browser
+walkthrough. All work was issue-driven, small PRs, squash-merged on green.
+
+### #307 frontend convergence (finding 9/10)
+
+- **knip + `--max-warnings 0`** (#310): dead-code / unused-dependency gate wired
+  into `npm run check`; removed 4 genuinely-unused deps
+  (`@hookform/resolvers`, `react-hook-form`, `zod`,
+  `@testing-library/user-event`).
+- **The type-check was a no-op** (#311) — the sharpest finding. `npm run
+  type-check` ran `tsc --noEmit` against the solution-style `tsconfig.json`
+  (`files: []`, project references only), which type-checks **nothing**. The
+  frontend had never actually been type-checked in CI. A real check (`tsc -b`)
+  surfaced **13 latent errors**, several shipped UI defects: a filter label
+  bound to a non-existent i18n key (rendered the raw key), a dead
+  `status === 'overdue'` comparison on the dunning page (always showed the
+  "partial" badge), `style` props silently dropped by `Icon`/`KpiGrid`, and 7
+  untyped CSS side-effect imports. Fixed the gate (`tsc -b`, dropped the
+  TS7-deprecated `baseUrl`) and all 13 errors. This was a prerequisite for the
+  codegen work — re-pointing types to generated schema is meaningless if `tsc`
+  never runs.
+- **React-connected i18n** (#316): moved the module-global `t()` in
+  `locales/index.ts` to a fleet-standard `I18nProvider` / `useTranslation`
+  context. `locales/index.ts` is now a pure `translate(locale, key, vars)`;
+  the provider owns locale state, `localStorage['locale']`, and `<html lang>`.
+  Behavior and every message key preserved. Added a `test/render.tsx` helper so
+  component tests get the provider.
+
+### Two stop-gates (plans only, awaiting go/no-go)
+
+- **OpenAPI codegen → #317.** Attempting the type re-point under the now-real
+  type-check surfaced **23 spec↔implementation divergences**, in three buckets:
+  spec missing fields the API returns (`User.fiscal_year_end_month`,
+  `BankAccount.csv_*`, `ClientCredit.created_at/…`), a vocabulary conflict
+  (`ClientCredit.status`), and nullability/union representation gaps. Done
+  properly this is a spec + terminology reconciliation that edits binding docs,
+  so it was planned rather than executed.
+- **FSD directory migration → #318.** ~65 files / ~124 imports plus config
+  (tsconfig paths, the ESLint raw-`fetch` ban exception path, knip globs);
+  lowest functional payoff, so deferred with a staged plan.
+
+### ClientCredit status drift (#264 → #319)
+
+Ruling recorded (code is canonical): the registry + OpenAPI spec said
+`open|partially_applied|applied` but the enum and frontend ship `open|voided`.
+Corrected `terminology.md`, `openapi.yaml`, and the phase-1 design doc to
+`open|voided` (docs/spec only). The richer applied-status lifecycle is left as
+a possible future enhancement tracked in #264.
+
+### Production sales-blockers (from the browser walkthrough)
+
+- **X-Authorization mirror missing on file I/O** (#312 → #313). The proxy in
+  front of the production demo strips `Authorization`; the shared API client
+  sends an `X-Authorization` mirror, but the three functions that call `fetch()`
+  directly (`downloadCsv`, `importBankCsv`, `importManualReceivables`) only
+  sent `Authorization`, so bank/manual CSV import and all four CSV exports 401'd
+  in production (curl/local set both headers, so it was invisible there).
+  Centralized the mirror in a `client.ts` `apiFetch()` helper, routed the three
+  through it, and added an ESLint `no-restricted-syntax` ban on raw `fetch()`
+  outside `client.ts` (ports the vault #177 guard) so it cannot regress.
+- **Settings-save 500** (#314 → #315). The walkthrough report hypothesized an
+  encrypted-column overflow; a **read-only** inspection of the live demo DB
+  **refuted** it (encryption is off, schema fully migrated,
+  `account_number` is `varchar(255)`). The real cause: `PdoClearSettingsRepository::save()`
+  chose insert-vs-update from the `UPDATE`'s affected-row count. MySQL (without
+  `MYSQL_ATTR_FOUND_ROWS`) reports rows *changed*, not matched, so a no-op save
+  (re-saving the dunning interval as `7` when it is already `7`) returned 0
+  affected rows → the code ran the INSERT → duplicate `organization_id` primary
+  key → 500. SQLite counts the matched row as changed, which is why the
+  SQLite-backed tests never caught it. Fixed with an explicit existence check;
+  the regression test reproduces MySQL's affected-row semantics on top of
+  SQLite (a wrapping executor that reports 0 for every UPDATE) and fails on the
+  old code with the exact production error.
+
+### Notes
+
+- Both production fixes reflect to the live demo only via a separate operator
+  step (owner GO). #312 is a production-only presentation and needs a browser
+  re-verify after deploy.
+- Lessons worth keeping: a solution-style `tsconfig.json` makes `tsc --noEmit`
+  a silent no-op — CI must run `tsc -b`; and MySQL's affected-row count is
+  *changed* not *matched*, so never use it as a row-existence proxy.


### PR DESCRIPTION
Appends the evening remediation session to `docs/journal/2026-07-11.md` (the morning entry recorded the audit findings; this records the execution).

Covers: #307 frontend items (knip #310, the type-check no-op fix #311, i18n #316), the two stop-gate plans (#317 codegen, #318 FSD), the #264 → #319 status-drift fix, and the two production sales-blockers (#312/#313 X-Authorization mirror, #314/#315 settings-save 500 with the corrected affected-rows diagnosis).

Docs-only. Refs #307, #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)