### PR TITLE
fix(i18n): interpolate manual-receivable import result banner (#322)

### DIFF
--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -362,7 +362,7 @@ export const en: Record<MessageKey, string> = {
   'manualReceivables.import': 'Import CSV',
   'manualReceivables.importSub': 'Bulk-register receivables from a CSV.',
   'manualReceivables.importColumns': 'CSV header columns: reference_number, client_name, total_cents (optional: recipient_email, due_at, issued_at, currency). Common Japanese export headers from freee / MoneyForward / Yayoi / Misoca (請求書番号 / 取引先名 / 金額 / 期日, etc.) are auto-recognized, and Shift-JIS files and ¥/comma-formatted amounts are handled. Duplicate reference numbers are skipped.',
-  'manualReceivables.importResult': 'Created {created} / skipped {skipped} / errors {errors}',
+  'manualReceivables.importResult': 'Created {{created}} / skipped {{skipped}} / errors {{errors}}',
   'manualReceivables.csvRow': 'CSV row',
   'manualReceivables.referenceNumber': 'Reference number',
   'manualReceivables.referenceHint': 'The document number from the tool that issued the invoice (the reconciliation key).',

--- a/frontend/src/locales/index.test.ts
+++ b/frontend/src/locales/index.test.ts
@@ -16,6 +16,15 @@ describe('translate (pure)', () => {
     )
   })
 
+  it('interpolates the manual-receivable import result banner (regression #322)', () => {
+    expect(translate('ja', 'manualReceivables.importResult', { created: 2, skipped: 1, errors: 0 })).toBe(
+      '作成 2 件 / スキップ 1 件 / エラー 0 件',
+    )
+    expect(translate('en', 'manualReceivables.importResult', { created: 2, skipped: 1, errors: 0 })).toBe(
+      'Created 2 / skipped 1 / errors 0',
+    )
+  })
+
   it('falls back to the authoritative ja catalog and never returns the raw key', () => {
     expect(translate('en', 'nav.dashboard')).not.toBe('nav.dashboard')
   })

--- a/frontend/src/locales/ja.ts
+++ b/frontend/src/locales/ja.ts
@@ -358,7 +358,7 @@ export const ja = {
   'manualReceivables.import': 'CSV取込',
   'manualReceivables.importSub': '売掛をCSVで一括登録します。',
   'manualReceivables.importColumns': 'CSVのヘッダー列: reference_number, client_name, total_cents（任意: recipient_email, due_at, issued_at, currency）。freee・マネーフォワード・弥生・Misoca 等のよくある日本語ヘッダー（請求書番号・取引先名・金額・期日 など）も自動認識し、Shift-JIS や ¥・カンマ付きの金額にも対応します。重複する請求書番号はスキップされます。',
-  'manualReceivables.importResult': '作成 {created} 件 / スキップ {skipped} 件 / エラー {errors} 件',
+  'manualReceivables.importResult': '作成 {{created}} 件 / スキップ {{skipped}} 件 / エラー {{errors}} 件',
   'manualReceivables.csvRow': 'CSV行',
   'manualReceivables.referenceNumber': '請求書番号',
   'manualReceivables.referenceHint': '他ツールで発行した請求書の番号（消込の参照キー）。',


### PR DESCRIPTION
Fixes the demo-visible wording bug where the manual-receivable CSV import success banner showed literal `{created}/{skipped}/{errors}`.

**Root cause:** catalog strings used single braces; `t()` only interpolates `{{...}}` (locales/index.ts:30).
**Fix:** ja/en `manualReceivables.importResult` → double braces + regression test in `locales/index.test.ts`.

i18n-only, no behavior change. `npm run check` green (tsc / eslint / 54 tests / knip).

Closes #322