### PR TITLE
feat(demo): env-gated cookieless analytics beacon + server-side entry logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,3 +100,11 @@ NENE_CLEAR_DEMO_VIEWER_PASSWORD=
 DEMO_MODE=
 DEMO_TTL_HOURS=3
 DEMO_MAX_ORGS=200
+
+# Cookieless demo analytics (#324). Set ONLY on the hosted demo deployment to a
+# bare https origin of a self-hosted GoatCounter (e.g. https://stats.example.com);
+# the SPA shell then injects the beacon and emits a demo-only CSP allowing that
+# origin. MUST stay empty in this template and in any OSS/self-hosted install:
+# an empty value means the served shell is byte-identical to the built artifact
+# and carries zero telemetry. Never bake this into the frontend build.
+DEMO_ANALYTICS_ENDPOINT=

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -211,6 +211,18 @@ pure calendar dates use `_date` (documented exception: `value_date`); booleans
 use `is_` / `has_`; foreign keys are `{singular_entity}_id`. See
 `naming-conventions.md` for the full pattern set.
 
+### Demo analytics (#324)
+
+Env-gated, demo-only cookieless analytics. Not a domain entity — an env key
+plus the fixed context keys of the server-side demo-entry log line. UTM keys use
+the standard Google Analytics spelling (external contract; do not rename).
+
+| Term | Canonical | Never |
+| --- | --- | --- |
+| Analytics endpoint env var (bare https origin) | `DEMO_ANALYTICS_ENDPOINT` | `ANALYTICS_URL`, `GOATCOUNTER_URL`, `DEMO_ANALYTICS_SITE` |
+| Demo-entry log message | `Demo entry recorded.` | `demo_entry`, `demo hit` |
+| Entry log context keys | `template`, `referer`, `utm_source`, `utm_medium`, `utm_campaign` | `referrer`, `utm_src`, `campaign`, `source` |
+
 ---
 
 ## 4. Problem Details type slugs (kebab-case)

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Nene2\Http\ResponseEmitter;
 use NeneClear\Http\AuthorizationHeaderFallback;
+use NeneClear\Http\DemoAnalyticsInjection;
 use NeneClear\Http\JsonRequestBody;
 use NeneClear\Http\RuntimeBootstrap;
 use NeneClear\Http\SpaFallback;
@@ -40,8 +41,20 @@ $request = JsonRequestBody::normalize($request);
 // SPA fallback: browser navigation requests receive the built shell.
 $spaShell = SpaFallback::shellPath($request, __DIR__);
 if ($spaShell !== null) {
+    // Demo-only, env-gated cookieless analytics (#324). Injection happens here,
+    // server-side, so the beacon is never baked into the committed frontend
+    // build or the release ZIP: when DEMO_ANALYTICS_ENDPOINT is unset (the OSS
+    // default) the shell is served byte-identically with no analytics CSP.
+    $analytics = DemoAnalyticsInjection::fromEnv($_ENV);
+    $html = (string) file_get_contents($spaShell);
+
     header('Content-Type: text/html; charset=utf-8');
-    readfile($spaShell);
+    $csp = $analytics->contentSecurityPolicy();
+    if ($csp !== null) {
+        header('Content-Security-Policy: ' . $csp);
+    }
+
+    echo $analytics->injectHead($html);
     exit;
 }
 

--- a/src/Demo/DemoEntryLoggingHandler.php
+++ b/src/Demo/DemoEntryLoggingHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Nene2\Demo\StartDisposableDemoHandler;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Records the acquisition context of a demo entry (`GET /demo/{template}`)
+ * before delegating to the wrapped framework handler — a `Nene2\Demo`
+ * decorator ({@see \Nene2\Demo\DemoRouteRegistrar} accepts any PSR-15 handler,
+ * ADR 0018).
+ *
+ * Why server-side: the seat-page landing replaces the URL as it drops the
+ * visitor into the SPA, so `utm_*` query parameters never survive to the
+ * cookieless client beacon (which only sees the post-landing回遊). Attribution
+ * must therefore be captured here, at entry. Only the `Referer` and the three
+ * standard UTM parameters are logged — no cookie, no user identity, no request
+ * body; nothing that identifies a person.
+ */
+final readonly class DemoEntryLoggingHandler implements RequestHandlerInterface
+{
+    /** Cap logged free-text so a crafted Referer/UTM cannot bloat a log line. */
+    private const int MAX_VALUE_LENGTH = 512;
+
+    public function __construct(
+        private RequestHandlerInterface $inner,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+
+        $this->logger->info('Demo entry recorded.', [
+            'template' => Router::param($request, StartDisposableDemoHandler::TEMPLATE_PARAMETER),
+            'referer' => $this->clean($request->getHeaderLine('Referer')),
+            'utm_source' => $this->cleanParam($query['utm_source'] ?? null),
+            'utm_medium' => $this->cleanParam($query['utm_medium'] ?? null),
+            'utm_campaign' => $this->cleanParam($query['utm_campaign'] ?? null),
+        ]);
+
+        return $this->inner->handle($request);
+    }
+
+    private function clean(string $value): ?string
+    {
+        $value = trim($value);
+
+        return $value === '' ? null : mb_substr($value, 0, self::MAX_VALUE_LENGTH);
+    }
+
+    private function cleanParam(mixed $value): ?string
+    {
+        return is_string($value) ? $this->clean($value) : null;
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -20,6 +20,7 @@ use NeneClear\User\CreateUserUseCaseInterface;
 use NeneClear\User\UserRepositoryInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Wires the disposable-demo domain as a `Nene2\Demo` consumer (#275): the
@@ -124,8 +125,15 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
             )
             ->set(
                 DemoRouteRegistrar::class,
+                // Wrap the framework handler in the entry-logging decorator (#324):
+                // Referer + UTM are captured server-side before the seat-page
+                // landing drops them. The registrar accepts any PSR-15 handler
+                // (ADR 0018), so no auth/orchestration code is touched.
                 static fn (ContainerInterface $c): DemoRouteRegistrar => new DemoRouteRegistrar(
-                    ServiceResolver::get($c, StartDisposableDemoHandler::class),
+                    new DemoEntryLoggingHandler(
+                        ServiceResolver::get($c, StartDisposableDemoHandler::class),
+                        ServiceResolver::get($c, LoggerInterface::class),
+                    ),
                 ),
             );
     }

--- a/src/Http/DemoAnalyticsInjection.php
+++ b/src/Http/DemoAnalyticsInjection.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Http;
+
+/**
+ * Env-gated, demo-only injection of a cookieless GoatCounter beacon into the
+ * SPA shell `<head>`, with a matching Content-Security-Policy.
+ *
+ * OSS-release integrity is the load-bearing constraint: the beacon is **never**
+ * baked into the committed frontend build or the release ZIP. It is emitted
+ * only by the server shell in {@see \NeneClear\Http\SpaFallback} path, and only
+ * when `DEMO_ANALYTICS_ENDPOINT` names a valid https origin — the demo HETEML
+ * deployment sets it in its own `.env`, while the shipped `.env.example` leaves
+ * it empty. A default (OSS) install therefore injects nothing and emits no
+ * analytics CSP: the served shell is byte-identical to the built artifact, so
+ * self-hosters ship zero telemetry.
+ *
+ * Self-hosted GoatCounter (`https://stats.ayane.co.jp`) is cookieless — no
+ * consent gate, no PII. The single endpoint origin drives both the beacon URLs
+ * (`/count.js`, `/count`) and the CSP allow-list; it is validated to a bare
+ * https origin so a misconfigured value can neither break the head markup nor
+ * silently widen the policy.
+ */
+final readonly class DemoAnalyticsInjection
+{
+    private function __construct(private ?string $endpoint)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $env Environment map (typically `$_ENV`).
+     */
+    public static function fromEnv(array $env): self
+    {
+        $raw = is_string($env['DEMO_ANALYTICS_ENDPOINT'] ?? null) ? trim($env['DEMO_ANALYTICS_ENDPOINT']) : '';
+
+        return new self(self::normaliseEndpoint($raw));
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->endpoint !== null;
+    }
+
+    /**
+     * Returns the shell HTML with the beacon inserted just before `</head>`.
+     * When disabled — or when the shell carries no `</head>` marker — the HTML
+     * is returned unchanged (OSS default: no injection).
+     */
+    public function injectHead(string $html): string
+    {
+        if ($this->endpoint === null) {
+            return $html;
+        }
+
+        $pos = stripos($html, '</head>');
+        if ($pos === false) {
+            return $html;
+        }
+
+        return substr($html, 0, $pos) . '    ' . $this->beaconTag() . "\n  " . substr($html, $pos);
+    }
+
+    /**
+     * The demo-only CSP for the shell: the framework-proven `default-src 'self'`
+     * baseline (the sibling SPA runs under it) plus the analytics origin on the
+     * directives GoatCounter needs — `count.js` (script), the hit beacon
+     * (`navigator.sendBeacon` → connect; `<img>` pixel fallback → img). Returns
+     * null when disabled so the OSS shell keeps its current header set unchanged.
+     */
+    public function contentSecurityPolicy(): ?string
+    {
+        if ($this->endpoint === null) {
+            return null;
+        }
+
+        $origin = $this->endpoint;
+
+        return "default-src 'self'; "
+            . "script-src 'self' {$origin}; "
+            . "connect-src 'self' {$origin}; "
+            . "img-src 'self' data: {$origin}; "
+            . "base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
+    }
+
+    /**
+     * The GoatCounter beacon tag. Empty string when disabled.
+     */
+    public function beaconTag(): string
+    {
+        if ($this->endpoint === null) {
+            return '';
+        }
+
+        $count = htmlspecialchars($this->endpoint . '/count', ENT_QUOTES);
+        $countJs = htmlspecialchars($this->endpoint . '/count.js', ENT_QUOTES);
+
+        return sprintf('<script data-goatcounter="%s" async src="%s"></script>', $count, $countJs);
+    }
+
+    /**
+     * Accept only a bare https origin (scheme + host [+ optional port]). Anything
+     * with a path, query, fragment, credentials, or unexpected characters is
+     * rejected (→ null → disabled) so the value is safe in both an HTML attribute
+     * and a response-header context.
+     */
+    private static function normaliseEndpoint(string $raw): ?string
+    {
+        if ($raw === '') {
+            return null;
+        }
+
+        // Defence-in-depth for HTML-attribute + HTTP-header contexts.
+        if (preg_match('/[\s"\'<>;]/', $raw) === 1) {
+            return null;
+        }
+
+        $parts = parse_url($raw);
+        if (!is_array($parts) || ($parts['scheme'] ?? '') !== 'https' || ($parts['host'] ?? '') === '') {
+            return null;
+        }
+
+        foreach (['path', 'query', 'fragment', 'user', 'pass'] as $unexpected) {
+            if (($parts[$unexpected] ?? '') !== '') {
+                return null;
+            }
+        }
+
+        $origin = 'https://' . $parts['host'];
+        if (isset($parts['port'])) {
+            $origin .= ':' . $parts['port'];
+        }
+
+        return $origin;
+    }
+}

--- a/src/Http/DemoAnalyticsInjection.php
+++ b/src/Http/DemoAnalyticsInjection.php
@@ -64,8 +64,11 @@ final readonly class DemoAnalyticsInjection
     }
 
     /**
-     * The demo-only CSP for the shell: the framework-proven `default-src 'self'`
-     * baseline (the sibling SPA runs under it) plus the analytics origin on the
+     * The demo-only CSP for the shell: **invoice's production-proven BASE_CSP**
+     * (nene-invoice `SpaShell::BASE_CSP`, its #659 — the identical React/Vite
+     * stack ships under it, so `style-src 'self' 'unsafe-inline'` and
+     * `font-src 'self' data:` keep inline styles and self-hosted @fontsource
+     * fonts working) with the analytics origin added to exactly the three
      * directives GoatCounter needs — `count.js` (script), the hit beacon
      * (`navigator.sendBeacon` → connect; `<img>` pixel fallback → img). Returns
      * null when disabled so the OSS shell keeps its current header set unchanged.
@@ -80,9 +83,11 @@ final readonly class DemoAnalyticsInjection
 
         return "default-src 'self'; "
             . "script-src 'self' {$origin}; "
-            . "connect-src 'self' {$origin}; "
+            . "style-src 'self' 'unsafe-inline'; "
             . "img-src 'self' data: {$origin}; "
-            . "base-uri 'self'; form-action 'self'; frame-ancestors 'none'";
+            . "font-src 'self' data:; "
+            . "connect-src 'self' {$origin}; "
+            . "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'";
     }
 
     /**

--- a/tests/Demo/DemoEntryLoggingHandlerTest.php
+++ b/tests/Demo/DemoEntryLoggingHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use Nene2\Demo\StartDisposableDemoHandler;
+use Nene2\Routing\Router;
+use NeneClear\Demo\DemoEntryLoggingHandler;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+final class DemoEntryLoggingHandlerTest extends TestCase
+{
+    public function test_records_referer_and_utm_before_delegating(): void
+    {
+        $logger = $this->recordingLogger();
+        $inner = $this->spyHandler();
+
+        $request = $this->demoRequest('standard', ['utm_source' => 'facebook', 'utm_medium' => 'social', 'utm_campaign' => 'launch'])
+            ->withHeader('Referer', 'https://www.facebook.com/');
+
+        $response = (new DemoEntryLoggingHandler($inner, $logger))->handle($request);
+
+        self::assertTrue($inner->called, 'inner handler must run');
+        self::assertSame(299, $response->getStatusCode());
+
+        self::assertCount(1, $logger->records);
+        [$level, $message, $context] = $logger->records[0];
+        self::assertSame('info', $level);
+        self::assertSame('Demo entry recorded.', $message);
+        self::assertSame([
+            'template' => 'standard',
+            'referer' => 'https://www.facebook.com/',
+            'utm_source' => 'facebook',
+            'utm_medium' => 'social',
+            'utm_campaign' => 'launch',
+        ], $context);
+    }
+
+    public function test_absent_referer_and_utm_are_recorded_as_null(): void
+    {
+        $logger = $this->recordingLogger();
+
+        (new DemoEntryLoggingHandler($this->spyHandler(), $logger))->handle($this->demoRequest('standard', []));
+
+        self::assertSame([
+            'template' => 'standard',
+            'referer' => null,
+            'utm_source' => null,
+            'utm_medium' => null,
+            'utm_campaign' => null,
+        ], $logger->records[0][2]);
+    }
+
+    public function test_non_string_utm_array_is_dropped(): void
+    {
+        $logger = $this->recordingLogger();
+
+        // ?utm_source[]=a — PSR-7 parses this into an array; it must not be logged.
+        (new DemoEntryLoggingHandler($this->spyHandler(), $logger))->handle($this->demoRequest('standard', ['utm_source' => ['a', 'b']]));
+
+        self::assertNull($logger->records[0][2]['utm_source']);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    private function demoRequest(string $template, array $query): ServerRequestInterface
+    {
+        return (new Psr17Factory())->createServerRequest('GET', '/demo/' . $template)
+            ->withQueryParams($query)
+            ->withAttribute(Router::PARAMETERS_ATTRIBUTE, [StartDisposableDemoHandler::TEMPLATE_PARAMETER => $template]);
+    }
+
+    /**
+     * @return RequestHandlerInterface&object{called: bool}
+     */
+    private function spyHandler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public bool $called = false;
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->called = true;
+
+                return (new Psr17Factory())->createResponse(299);
+            }
+        };
+    }
+
+    /**
+     * @return AbstractLogger&object{records: list<array{string, string, array<string, mixed>}>}
+     */
+    private function recordingLogger(): AbstractLogger
+    {
+        return new class () extends AbstractLogger {
+            /** @var list<array{string, string, array<string, mixed>}> */
+            public array $records = [];
+
+            /**
+             * @param array<string, mixed> $context
+             */
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = [(string) $level, (string) $message, $context];
+            }
+        };
+    }
+}

--- a/tests/Http/DemoAnalyticsInjectionTest.php
+++ b/tests/Http/DemoAnalyticsInjectionTest.php
@@ -46,17 +46,23 @@ final class DemoAnalyticsInjectionTest extends TestCase
         self::assertStringContainsString('<body></body>', $out);
     }
 
-    public function test_enabled_csp_allows_only_self_and_the_endpoint_origin(): void
+    public function test_enabled_csp_is_invoice_base_csp_plus_the_endpoint_origin(): void
     {
         $csp = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => 'https://stats.ayane.co.jp'])
             ->contentSecurityPolicy();
 
-        self::assertNotNull($csp);
-        self::assertStringContainsString("default-src 'self'", $csp);
-        self::assertStringContainsString("script-src 'self' https://stats.ayane.co.jp", $csp);
-        self::assertStringContainsString("connect-src 'self' https://stats.ayane.co.jp", $csp);
-        self::assertStringContainsString("img-src 'self' data: https://stats.ayane.co.jp", $csp);
-        self::assertStringContainsString("frame-ancestors 'none'", $csp);
+        // Exactly invoice's production-proven BASE_CSP (nene-invoice
+        // SpaShell::BASE_CSP, #659) with the origin added to script/img/connect.
+        self::assertSame(
+            "default-src 'self'; "
+            . "script-src 'self' https://stats.ayane.co.jp; "
+            . "style-src 'self' 'unsafe-inline'; "
+            . "img-src 'self' data: https://stats.ayane.co.jp; "
+            . "font-src 'self' data:; "
+            . "connect-src 'self' https://stats.ayane.co.jp; "
+            . "object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'",
+            $csp,
+        );
     }
 
     /**

--- a/tests/Http/DemoAnalyticsInjectionTest.php
+++ b/tests/Http/DemoAnalyticsInjectionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Http;
+
+use NeneClear\Http\DemoAnalyticsInjection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DemoAnalyticsInjectionTest extends TestCase
+{
+    private const string SHELL = "<!doctype html>\n<html><head>\n    <title>NeNe Clear</title>\n  </head>\n<body></body></html>";
+
+    public function test_disabled_when_env_is_unset_or_empty(): void
+    {
+        self::assertFalse(DemoAnalyticsInjection::fromEnv([])->isEnabled());
+        self::assertFalse(DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => ''])->isEnabled());
+        self::assertFalse(DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => '   '])->isEnabled());
+    }
+
+    public function test_disabled_leaves_shell_byte_identical_and_emits_no_csp(): void
+    {
+        $analytics = DemoAnalyticsInjection::fromEnv([]);
+
+        self::assertSame(self::SHELL, $analytics->injectHead(self::SHELL));
+        self::assertNull($analytics->contentSecurityPolicy());
+        self::assertSame('', $analytics->beaconTag());
+    }
+
+    public function test_enabled_injects_the_beacon_before_head_close(): void
+    {
+        $analytics = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => 'https://stats.ayane.co.jp']);
+
+        self::assertTrue($analytics->isEnabled());
+
+        $out = $analytics->injectHead(self::SHELL);
+        self::assertStringContainsString(
+            '<script data-goatcounter="https://stats.ayane.co.jp/count" async src="https://stats.ayane.co.jp/count.js"></script>',
+            $out,
+        );
+        // Injected inside the head, before the closing tag.
+        self::assertStringContainsString('data-goatcounter', $out);
+        self::assertLessThan(strpos($out, '</head>'), strpos($out, 'data-goatcounter'));
+        // Body is untouched.
+        self::assertStringContainsString('<body></body>', $out);
+    }
+
+    public function test_enabled_csp_allows_only_self_and_the_endpoint_origin(): void
+    {
+        $csp = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => 'https://stats.ayane.co.jp'])
+            ->contentSecurityPolicy();
+
+        self::assertNotNull($csp);
+        self::assertStringContainsString("default-src 'self'", $csp);
+        self::assertStringContainsString("script-src 'self' https://stats.ayane.co.jp", $csp);
+        self::assertStringContainsString("connect-src 'self' https://stats.ayane.co.jp", $csp);
+        self::assertStringContainsString("img-src 'self' data: https://stats.ayane.co.jp", $csp);
+        self::assertStringContainsString("frame-ancestors 'none'", $csp);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function rejectedEndpoints(): iterable
+    {
+        yield 'http (not https)' => ['http://stats.ayane.co.jp'];
+        yield 'with path' => ['https://stats.ayane.co.jp/count'];
+        yield 'with trailing slash path' => ['https://stats.ayane.co.jp/'];
+        yield 'with query' => ['https://stats.ayane.co.jp?a=1'];
+        yield 'with fragment' => ['https://stats.ayane.co.jp#x'];
+        yield 'with credentials' => ['https://user:pass@stats.ayane.co.jp'];
+        yield 'no host' => ['https://'];
+        yield 'quote injection' => ['https://x"/onerror'];
+        yield 'space injection' => ['https://x y'];
+        yield 'header injection' => ['https://x;script-src'];
+    }
+
+    #[DataProvider('rejectedEndpoints')]
+    public function test_malformed_endpoints_disable_injection(string $endpoint): void
+    {
+        $analytics = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => $endpoint]);
+
+        self::assertFalse($analytics->isEnabled(), $endpoint);
+        self::assertSame(self::SHELL, $analytics->injectHead(self::SHELL));
+        self::assertNull($analytics->contentSecurityPolicy());
+    }
+
+    public function test_endpoint_with_explicit_port_is_accepted(): void
+    {
+        $analytics = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => 'https://stats.ayane.co.jp:8443']);
+
+        self::assertTrue($analytics->isEnabled());
+        self::assertStringContainsString('https://stats.ayane.co.jp:8443/count.js', $analytics->beaconTag());
+    }
+
+    public function test_shell_without_head_marker_is_returned_unchanged(): void
+    {
+        $analytics = DemoAnalyticsInjection::fromEnv(['DEMO_ANALYTICS_ENDPOINT' => 'https://stats.ayane.co.jp']);
+        $noHead = '<html><body>no head</body></html>';
+
+        self::assertSame($noHead, $analytics->injectHead($noHead));
+    }
+}


### PR DESCRIPTION
## 目的
デモ（`/demo/standard`）に cookieless 計測（GoatCounter・ConoHa 自己ホスト `https://stats.ayane.co.jp`）を **env駆動・デモ限定・OSSリリース無汚染** で配線する。invoice と同型の対応を clear にも入れる。

## 変更点
### ② SPAシェル env-gate 注入 ＋ CSP
- `src/Http/DemoAnalyticsInjection.php`（新規）: `DEMO_ANALYTICS_ENDPOINT` を bare https origin に検証し、有効時のみ `<head>` にビーコンを注入＋デモ限定 CSP を組む。無効時は無注入・CSP null。
- `public_html/index.php`: シェル配信経路（`readfile`→`file_get_contents`＋注入）で env-gate。env 未設定＝配信シェルはビルド成果物と **byte 一致**。
- CSP（env有効時のみ）: `default-src 'self'` ベース＋計測ホストを `script-src`/`connect-src`/`img-src` に許可。OSS 既定（env無し）は不変。

### ③ サーバ側 入場ログ（Referer＋UTM）
- `src/Demo/DemoEntryLoggingHandler.php`（新規）: `Nene2\Demo` の PSR-15 デコレータ（`DemoRouteRegistrar` は任意ハンドラ可・ADR 0018）。着地前に Referer＋`utm_source`/`utm_medium`/`utm_campaign` を PSR-3 ログへ。PII 非保存。
- `src/Demo/DemoServiceProvider.php`: framework ハンドラをデコレータで wrap。

### リリース無汚染
- `.env.example` の `DEMO_ANALYTICS_ENDPOINT` は空。
- grep 確認: `goatcounter`/`stats.ayane` はビルド成果物（`public_html/assets/`）・`frontend/dist*`・`build/` に不在。`frontend/src/` に不在。参照はサーバ側 PHP・テスト・docs のみ。

## clear と invoice の相違（実査）
- invoice はシェルを **PHP テンプレ `SpaShell.php`** でパイプライン経由配信し `script-src 'self'` の CSP を持つ。clear は **ビルド静的シェルを `index.php` で `readfile`**（#268）しパイプライン外＝**元々 CSP なし**。よって「既存 CSP の拡張」ではなく env 有効時のみ CSP を新規発行する形にした（env 無効時は現状どおり CSP なし＝不変）。
- デモ入場は両者 `Nene2\Demo` consumer（#275）。ただし clear は 302 ではなく **seat-page(200)** 着地。ログ取得点は同じ「入場ハンドラ」。

## 検証
- `composer check` 緑（test 459・analyse 503・cs・openapi・mcp・conformance）。
- `npm run check --prefix frontend` 緑（type-check・eslint・vitest 54・knip）。
- 実シェルでスモーク: 無効→byte一致・CSP null／有効→ビーコンが `<head>` 内・CSP 発行。

## 新規識別子
`docs/explanation/terminology.md` に `DEMO_ANALYTICS_ENDPOINT`・ログメッセージ・入場ログ context キーを登録。

## デモ機 `.env` に設定すべき値
```
DEMO_MODE=1
DEMO_ANALYTICS_ENDPOINT=https://stats.ayane.co.jp
```
（`DEMO_ANALYTICS_ENDPOINT` は ① ConoHa 設置＋TLS 稼働後に有効化。末尾スラッシュなし bare origin。）

## Self-review
backend-api, middleware-security, view-rendering

## 残リスク / 要判断（統合リナ確認）
- clear シェルは元々 CSP 皆無のため、env 有効時に **新規 CSP** を課す。sibling(invoice) の同スタック SPA が `default-src 'self'` 下で本番稼働している実績から安全と判断したが、本番デモで実ロードの目視確認を推奨。
- **マージしない**（レビュー／本番デプロイは別GO）。① ConoHa 設置は施主 GO 待ち。

Closes #324