### PR TITLE
docs(readme): remove static status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PHP 8.4](https://img.shields.io/badge/PHP-8.4-777BB4?logo=php)](https://www.php.net/)
-[![Public](https://img.shields.io/badge/status-public-brightgreen)]()
 
 **Payment reconciliation and dunning — self-hosted for Japan SMB.**
 


### PR DESCRIPTION
## Summary

- Removes the static `status-public` badge from the README header (line 5).
- Static status/phase badges are prohibited by the fleet template convention — maturity is already communicated in the `## Status` section further down in this README, so the badge was redundant and prone to going stale.
- Closes #176: that issue originally asked to swap `status-private` (red) for `status-public` (green), which happened in an earlier commit, but the underlying problem — a static, decorative status badge with a dead link (`]()`) — remained. This PR resolves it fully by removing the badge instead of maintaining another static variant.
- License and PHP version badges are untouched.

## Test plan

- [x] `git diff` shows a single-line removal, no other README content touched
- [x] Verified the badge row (License/PHP) still renders correctly with no doubled blank lines
- [x] Confirmed a `## Status` section already exists in the README to convey product maturity

🤖 Generated with [Claude Code](https://claude.com/claude-code)