### PR TITLE
chore(demo): 入場ログ(層1)を var/ file sink 化（error_log→SSH可視）

### DIFF
--- a/src/Demo/DemoEntryLoggerFactory.php
+++ b/src/Demo/DemoEntryLoggerFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Demo;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\FallbackGroupHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds the dedicated {@see LoggerInterface} for the demo-entry attribution
+ * log ({@see DemoEntryLoggingHandler}, #324/#330): a `var/demo-entry.log`
+ * JSON-lines file instead of the app's shared logger (`php://stderr`), which
+ * on the Tier A shared-hosting target (HETEML) lands in the control-panel
+ * error_log — not directly readable over SSH and unsuited to precise UTM
+ * analysis.
+ *
+ * `var/` path resolution mirrors {@see FileRateLimitStorage}: the caller
+ * passes the same base dir (`dirname(__DIR__, 2) . '/var'`) so the entry log
+ * lives alongside the throttle state, the only writable runtime directory
+ * there.
+ *
+ * Fail-open, matching {@see FileRateLimitStorage}'s convention: when the file
+ * cannot be opened (missing/unwritable `var/`), the line falls back to PHP's
+ * `error_log()` — the line still surfaces, just back where it lived before
+ * this change, via a {@see FallbackGroupHandler} (Monolog forwards to the
+ * next handler only if the previous one throws). The line format (JSON,
+ * `message`/`context` shape) is unchanged either way — only the destination
+ * moves.
+ */
+final readonly class DemoEntryLoggerFactory
+{
+    public function create(string $varDir): LoggerInterface
+    {
+        $formatter = new JsonFormatter();
+
+        $file = new StreamHandler($varDir . '/demo-entry.log', Level::Info);
+        $file->setFormatter($formatter);
+
+        $fallback = new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, Level::Info);
+        $fallback->setFormatter($formatter);
+
+        return new Logger('nene-clear.demo-entry', [new FallbackGroupHandler([$file, $fallback])]);
+    }
+}

--- a/src/Demo/DemoServiceProvider.php
+++ b/src/Demo/DemoServiceProvider.php
@@ -20,7 +20,6 @@ use NeneClear\User\CreateUserUseCaseInterface;
 use NeneClear\User\UserRepositoryInterface;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * Wires the disposable-demo domain as a `Nene2\Demo` consumer (#275): the
@@ -129,10 +128,16 @@ final readonly class DemoServiceProvider implements ServiceProviderInterface
                 // Referer + UTM are captured server-side before the seat-page
                 // landing drops them. The registrar accepts any PSR-15 handler
                 // (ADR 0018), so no auth/orchestration code is touched.
+                //
+                // The entry log uses its own file-backed logger (#330), not the
+                // app's shared LoggerInterface: on Tier A hosting the shared
+                // logger's php://stderr lands in the HETEML control-panel
+                // error_log, which isn't SSH-readable — unsuited to precise UTM
+                // analysis. See DemoEntryLoggerFactory.
                 static fn (ContainerInterface $c): DemoRouteRegistrar => new DemoRouteRegistrar(
                     new DemoEntryLoggingHandler(
                         ServiceResolver::get($c, StartDisposableDemoHandler::class),
-                        ServiceResolver::get($c, LoggerInterface::class),
+                        (new DemoEntryLoggerFactory())->create(dirname(__DIR__, 2) . '/var'),
                     ),
                 ),
             );

--- a/tests/Demo/DemoEntryLoggerFactoryTest.php
+++ b/tests/Demo/DemoEntryLoggerFactoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Demo;
+
+use NeneClear\Demo\DemoEntryLoggerFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DemoEntryLoggerFactoryTest extends TestCase
+{
+    private string $varDir;
+
+    protected function setUp(): void
+    {
+        $this->varDir = sys_get_temp_dir() . '/' . uniqid('clear-entry-log-', true);
+        mkdir($this->varDir, 0775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->varDir . '/demo-entry.log');
+        @rmdir($this->varDir);
+    }
+
+    public function test_writes_a_json_line_to_the_var_file(): void
+    {
+        $logger = (new DemoEntryLoggerFactory())->create($this->varDir);
+
+        $logger->info('Demo entry recorded.', [
+            'template' => 'standard',
+            'referer' => 'https://www.facebook.com/',
+            'utm_source' => 'facebook',
+            'utm_medium' => 'social',
+            'utm_campaign' => 'launch',
+        ]);
+
+        $path = $this->varDir . '/demo-entry.log';
+        self::assertFileExists($path);
+
+        $lines = array_values(array_filter(explode("\n", (string) file_get_contents($path))));
+        self::assertCount(1, $lines);
+
+        $record = json_decode($lines[0], true);
+        self::assertIsArray($record);
+        self::assertSame('Demo entry recorded.', $record['message']);
+        self::assertSame('INFO', $record['level_name']);
+        self::assertSame([
+            'template' => 'standard',
+            'referer' => 'https://www.facebook.com/',
+            'utm_source' => 'facebook',
+            'utm_medium' => 'social',
+            'utm_campaign' => 'launch',
+        ], $record['context']);
+    }
+
+    public function test_falls_back_to_error_log_when_the_file_cannot_be_opened(): void
+    {
+        // A regular file in place of the var dir: fopen()'ing a path *through*
+        // it fails with ENOTDIR regardless of filesystem permissions/uid, so
+        // this failure mode is deterministic even when tests run as root
+        // (where a chmod-based unwritable-directory test would not fail).
+        $blocker = $this->varDir . '/blocker-not-a-directory';
+        file_put_contents($blocker, '');
+
+        $errorLogFile = $this->varDir . '/fallback-error.log';
+        $previous = ini_set('error_log', $errorLogFile);
+
+        try {
+            $logger = (new DemoEntryLoggerFactory())->create($blocker);
+            $logger->info('Demo entry recorded.', ['template' => 'standard']);
+        } finally {
+            ini_set('error_log', $previous === false ? '' : $previous);
+        }
+
+        self::assertFileDoesNotExist($blocker . '/demo-entry.log');
+        self::assertFileExists($errorLogFile);
+
+        $fallbackContents = (string) file_get_contents($errorLogFile);
+        self::assertStringContainsString('Demo entry recorded.', $fallbackContents);
+
+        @unlink($blocker);
+        @unlink($errorLogFile);
+    }
+}


### PR DESCRIPTION
## 目的

Closes #330

デモ入場ログ（attribution 層1、`DemoEntryLoggingHandler` #324）の出力先を、アプリ共有の `LoggerInterface`（Monolog、`php://stderr`）から `var/demo-entry.log` の file sink に切り替える。現状 HETEML（Tier A 共有ホスティング）では `stderr` がコントロールパネルの error_log に流れ込み、SSH からは直接読めず、精密な UTM 分析に使えないため。

## 変更点

- `src/Demo/DemoEntryLoggerFactory.php`（新規）: `var/demo-entry.log` への Monolog `StreamHandler`（JsonFormatter）と `ErrorLogHandler` を `FallbackGroupHandler` で束ねた専用ロガーを構築。`var/` パス解決は `FileRateLimitStorage` と同一方式（`dirname(__DIR__, 2) . '/var'` を呼び出し側=`DemoServiceProvider` から渡す）。
- `src/Demo/DemoServiceProvider.php`: `DemoEntryLoggingHandler` に渡すロガーを、アプリ共有 `LoggerInterface` から `DemoEntryLoggerFactory` 製の専用ロガーに差し替え。未使用になった `LoggerInterface` import を削除。
- `tests/Demo/DemoEntryLoggerFactoryTest.php`（新規）: file sink への JSON 行書き込み、および書込失敗時の error_log フォールバック（`ini_set('error_log', ...)` でリダイレクトして検証。ディレクトリの代わりに通常ファイルを置くことで ENOTDIR を発生させ、root 実行下でも決定的に失敗させる手法）をテスト。

`DemoEntryLoggingHandler` 自体（PSR-3 `LoggerInterface->info($message, $context)` の呼び出し）は無変更 — 行フォーマット（JSON の `message`/`context` 構造）は変わらず、宛先だけが変わる。`var/` は既に `.gitignore` の `/var/` で無視済み（追加変更不要）。

## 検証結果

- `vendor/bin/phpunit`: 461 tests, 7365 assertions, OK（既存6件 skip は無関係）
- `vendor/bin/phpstan analyse`: 505 files, No errors
- `vendor/bin/php-cs-fixer check`: 変更ファイルに指摘なし

Self-review: backend-api

## 残リスク

- 本番 HETEML 環境での実際の書込確認（パーミッション等）は未実施 — ローカルテストで file sink 書込とフォールバックの両経路を確認済み。