### PR TITLE
feat(frontend): adopt @hideyukimori/nene2-client transport in shared apiClient

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -17,15 +17,16 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      // All network calls must go through the shared API client, which applies
-      // the Authorization + X-Authorization mirror (#265). A raw fetch() drops
+      // All network calls must go through the shared API client (fleet
+      // transport, `@hideyukimori/nene2-client`), which applies the
+      // Authorization + X-Authorization mirror (#265). A raw fetch() drops
       // the mirror and 401s behind the shared-hosting proxy (#312).
       'no-restricted-syntax': [
         'error',
         {
           selector: "CallExpression[callee.name='fetch']",
           message:
-            'Do not call fetch() directly — use `api` or `apiFetch` from src/api/client.ts so the Authorization/X-Authorization mirror is sent (#265, #312).',
+            'Do not call fetch() directly — use `api` from src/api/client.ts so the Authorization/X-Authorization mirror is sent (#265, #312).',
         },
       ],
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
+        "@hideyukimori/nene2-client": "^1.1.0",
         "@tanstack/react-query": "^5.90.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -698,6 +699,16 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@hideyukimori/nene2-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-client/-/nene2-client-1.1.0.tgz",
+      "integrity": "sha512-s625luvNkeUZnunF2o3HInpExd6sORR929PFH1kCHtGnNwvlqC6CXK4RHoWCtrcDaHe94z464Eqnd75htSWlyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22 <25",
+        "npm": ">=10 <12"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "check": "npm run type-check && npm run lint && npm run test:run && npm run knip"
   },
   "dependencies": {
+    "@hideyukimori/nene2-client": "^1.1.0",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@tanstack/react-query": "^5.90.11",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,23 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { api, ApiError, storeToken, clearToken, isAuthenticated } from './client'
 
-function mockResponse(opts: {
-  ok: boolean
-  status: number
-  json?: unknown
-  jsonThrows?: boolean
-}): Response {
-  return {
-    ok: opts.ok,
-    status: opts.status,
-    json: opts.jsonThrows
-      ? () => Promise.reject(new Error('not json'))
-      : () => Promise.resolve(opts.json),
-  } as unknown as Response
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { status })
+}
+
+/** A non-JSON error body (e.g. an upstream 5xx served by a proxy, not PHP). */
+function nonJsonResponse(status: number): Response {
+  return new Response('Internal Server Error', {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  })
 }
 
 describe('token storage', () => {
   it('stores, reads, and clears the token', () => {
+    clearToken()
     expect(isAuthenticated()).toBe(false)
     storeToken('jwt-abc')
     expect(isAuthenticated()).toBe(true)
@@ -26,10 +31,11 @@ describe('token storage', () => {
   })
 })
 
-describe('api request', () => {
+describe('api request (nene2-client transport adapter)', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    clearToken()
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -39,7 +45,7 @@ describe('api request', () => {
   })
 
   it('GET sends Accept header and parses JSON', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, json: { hello: 'world' } }))
+    fetchMock.mockResolvedValue(jsonResponse({ hello: 'world' }))
 
     const result = await api.get<{ hello: string }>('/admin/x')
 
@@ -47,44 +53,32 @@ describe('api request', () => {
     const [path, init] = fetchMock.mock.calls[0]
     expect(path).toBe('/admin/x')
     expect(init.method).toBe('GET')
-    expect(init.headers.Accept).toBe('application/json')
+    expect(init.headers.get('Accept')).toBe('application/json')
     expect(init.body).toBeUndefined()
   })
 
-  it('injects the bearer token on both headers (Authorization + X-Authorization mirror, #265)', async () => {
-    storeToken('jwt-xyz')
-    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, json: {} }))
-
-    await api.get('/admin/x')
-
-    const init = fetchMock.mock.calls[0][1]
-    expect(init.headers.Authorization).toBe('Bearer jwt-xyz')
-    // The proxy strips Authorization in production; the mirror must ride along.
-    expect(init.headers['X-Authorization']).toBe('Bearer jwt-xyz')
-  })
-
   it('omits Authorization when no token', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, json: {} }))
+    fetchMock.mockResolvedValue(jsonResponse({}))
 
     await api.get('/admin/x')
 
     const init = fetchMock.mock.calls[0][1]
-    expect(init.headers.Authorization).toBeUndefined()
+    expect(init.headers.get('Authorization')).toBeNull()
   })
 
   it('POST serializes body and sets Content-Type', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 201, json: { id: 1 } }))
+    fetchMock.mockResolvedValue(jsonResponse({ id: 1 }, 201))
 
     await api.post('/admin/x', { email: 'a@b.c' })
 
     const init = fetchMock.mock.calls[0][1]
     expect(init.method).toBe('POST')
-    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(init.headers.get('Content-Type')).toBe('application/json')
     expect(init.body).toBe(JSON.stringify({ email: 'a@b.c' }))
   })
 
   it('returns undefined for 204 No Content', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 204 }))
+    fetchMock.mockResolvedValue(emptyResponse(204))
 
     const result = await api.delete('/admin/x/1')
 
@@ -93,11 +87,7 @@ describe('api request', () => {
 
   it('throws ApiError with parsed problem details on 4xx', async () => {
     fetchMock.mockResolvedValue(
-      mockResponse({
-        ok: false,
-        status: 422,
-        json: { type: 'validation-failed', title: 'Validation Failed', status: 422, detail: 'bad input' },
-      }),
+      jsonResponse({ type: 'validation-failed', title: 'Validation Failed', status: 422, detail: 'bad input' }, 422),
     )
 
     await expect(api.post('/admin/x', {})).rejects.toMatchObject({
@@ -106,8 +96,8 @@ describe('api request', () => {
     })
   })
 
-  it('falls back to a generic problem when body is not JSON', async () => {
-    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 500, jsonThrows: true }))
+  it('falls back to a generic problem when the body is not JSON', async () => {
+    fetchMock.mockResolvedValue(nonJsonResponse(500))
 
     try {
       await api.get('/admin/x')
@@ -121,11 +111,86 @@ describe('api request', () => {
   })
 })
 
+/**
+ * The bearer token must ride on both `Authorization` and its `X-Authorization`
+ * mirror on every verb (#265): some shared-hosting front proxies strip the
+ * standard header before it reaches PHP. Mirrors the fleet transport-adopt
+ * wave-1 exemplar (nene-payout #155) — the mirror is now structural
+ * (`@hideyukimori/nene2-client`), not a hand-maintained helper a call site
+ * could forget.
+ */
+describe('auth header mirror on every verb (#265, #312)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  const TOKEN = 'jwt-xyz'
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    storeToken(TOKEN)
+  })
+
+  afterEach(() => {
+    clearToken()
+    vi.unstubAllGlobals()
+  })
+
+  function sentHeaders(callIndex = 0): Headers {
+    return fetchMock.mock.calls[callIndex][1].headers as Headers
+  }
+
+  it('mirrors both headers on GET', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}))
+    await api.get('/admin/x')
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it('mirrors both headers on POST', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}))
+    await api.post('/admin/x', { a: 1 })
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it('mirrors both headers on PUT', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}))
+    await api.put('/admin/x', { a: 1 })
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it('mirrors both headers on DELETE', async () => {
+    fetchMock.mockResolvedValue(emptyResponse(204))
+    await api.delete('/admin/x/1')
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+  })
+
+  it('mirrors both headers on upload (multipart)', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ row_count: 3 }))
+    await api.upload('/admin/bank-import-batches', new FormData())
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+    // Content-Type is left to the browser so it can add the multipart boundary.
+    expect(sentHeaders().has('Content-Type')).toBe(false)
+  })
+
+  it('mirrors both headers on getBlob (CSV export)', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(new Blob(['a,b\n1,2']), { status: 200, headers: { 'Content-Type': 'text/csv' } }),
+    )
+    await api.getBlob('/admin/export/bank-transactions')
+    expect(sentHeaders().get('Authorization')).toBe(`Bearer ${TOKEN}`)
+    expect(sentHeaders().get('X-Authorization')).toBe(`Bearer ${TOKEN}`)
+  })
+})
+
 describe('401 handling', () => {
   let fetchMock: ReturnType<typeof vi.fn>
   const realLocation = window.location
 
   beforeEach(() => {
+    clearToken()
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     Object.defineProperty(window, 'location', {
@@ -146,27 +211,25 @@ describe('401 handling', () => {
 
   it('clears the token on 401 (auth shell shows login in place — no hard redirect)', async () => {
     storeToken('expired-jwt')
-    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 401 }))
+    fetchMock.mockResolvedValue(emptyResponse(401))
 
     await expect(api.get('/admin/x')).rejects.toBeInstanceOf(ApiError)
 
     expect(isAuthenticated()).toBe(false)
     // The token is cleared but the URL is left intact, so re-login returns the
-    // user to the same screen.
+    // user to the same screen. No `onUnauthorized`/`onForbidden` redirect is
+    // configured — the auth shell is purely reactive (RequireAuth/router.tsx).
     expect(window.location.href).toBe('')
   })
 
-  it('does NOT clear or redirect on 401 from the login endpoint', async () => {
+  it('does NOT clear or redirect on 401 from the login endpoint (no token attached)', async () => {
     fetchMock.mockResolvedValue(
-      mockResponse({
-        ok: false,
-        status: 401,
-        json: { type: 'invalid-credentials', title: '認証失敗', status: 401, detail: 'wrong' },
-      }),
+      jsonResponse({ type: 'invalid-credentials', title: '認証失敗', status: 401, detail: 'wrong' }, 401),
     )
 
-    // The login 401 must surface as a normal ApiError (so the form can show it),
-    // not trigger the global redirect.
+    // The login 401 never carries a token (the user has no session yet), so
+    // the transport's default clearTokenOnStatuses/onUnauthorized never fire;
+    // it surfaces as a normal ApiError so the form can show it.
     await expect(api.post('/admin/auth/login', {})).rejects.toMatchObject({
       status: 401,
       problem: { type: 'invalid-credentials' },

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,11 @@
+import {
+  createNene2Transport,
+  createSessionTokenStore,
+  isNene2ClientError,
+  isValidationProblemDetails,
+  type Nene2ClientError,
+} from '@hideyukimori/nene2-client'
 import type { ProblemDetails } from '@/types'
-
-const STORAGE_KEY = 'nene_clear_token'
 
 export class ApiError extends Error {
   constructor(
@@ -27,37 +32,24 @@ export function describeApiError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function getToken(): string | null {
-  return sessionStorage.getItem(STORAGE_KEY)
-}
-
-// Reactive auth store: the token lives in sessionStorage (so it survives a
-// reload), but mutations also notify subscribers. The auth shell (RequireAuth)
-// subscribes via useSyncExternalStore, so storing a token reveals the app and
-// clearing it (logout or an expired 401) shows the login screen in place —
-// without a hard navigation that would blank the page and lose the route.
-const authListeners = new Set<() => void>()
-
-function notifyAuthChange(): void {
-  for (const listener of authListeners) listener()
-}
+/**
+ * Fleet-standard bearer token store (`@hideyukimori/nene2-client`,
+ * `createSessionTokenStore`): sessionStorage, same key as before this
+ * migration (`nene_clear_token`) so an in-flight session survives a deploy.
+ * The transport below is handed this same instance, so there is exactly one
+ * store — one source of truth for get/set/clear.
+ */
+export const tokenStore = createSessionTokenStore({ key: 'nene_clear_token' })
 
 /** Subscribe to token changes (for useSyncExternalStore in the auth shell). */
-export function subscribeAuthChange(listener: () => void): () => void {
-  authListeners.add(listener)
-  return () => {
-    authListeners.delete(listener)
-  }
-}
+export const subscribeAuthChange = tokenStore.subscribe
 
 export function storeToken(token: string): void {
-  sessionStorage.setItem(STORAGE_KEY, token)
-  notifyAuthChange()
+  tokenStore.setToken(token)
 }
 
 export function clearToken(): void {
-  sessionStorage.removeItem(STORAGE_KEY)
-  notifyAuthChange()
+  tokenStore.clearToken()
 }
 
 /**
@@ -83,7 +75,7 @@ function decodeJwtPayload(token: string): Record<string, unknown> | null {
  * useSyncExternalStore snapshot (it never mutates state).
  */
 export function isAuthenticated(): boolean {
-  const token = getToken()
+  const token = tokenStore.getToken()
   if (token === null) return false
 
   const claims = decodeJwtPayload(token)
@@ -99,7 +91,7 @@ export function isAuthenticated(): boolean {
  * stub token).
  */
 export function getUserRole(): string | null {
-  const token = getToken()
+  const token = tokenStore.getToken()
   if (token === null) return null
 
   const claims = decodeJwtPayload(token)
@@ -112,86 +104,90 @@ export function isAdmin(): boolean {
   return role === 'admin' || role === 'superadmin'
 }
 
-// The token goes to both headers: some shared-hosting front proxies (Tier A;
-// observed on HETEML) strip the standard `Authorization` header before it
-// reaches PHP, so the backend falls back to the `X-Authorization` mirror when
-// the standard header is missing (#265). Every request MUST carry the mirror —
-// this helper is the single place that applies it, so no call site can drop it.
-function withAuthHeaders(headers: Record<string, string> = {}): Record<string, string> {
-  const token = getToken()
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`
-    headers['X-Authorization'] = `Bearer ${token}`
-  }
-  return headers
-}
-
 /**
- * `fetch()` with the auth-header mirror applied, for the few calls that can't go
- * through `request()` — multipart uploads and binary downloads. Callers own the
- * response (blob / multipart error parsing); the mirror is guaranteed here so it
- * can't be forgotten (see #265, #312). Content-Type is intentionally left unset
- * so the browser can add the multipart boundary for FormData bodies.
+ * Fleet-standard transport (`@hideyukimori/nene2-client`, issue #102): every
+ * request mirrors the bearer token onto `Authorization` *and*
+ * `X-Authorization` so shared-hosting proxies that strip the standard header
+ * still authenticate (#265, #312) — structurally, not via a hand-maintained
+ * helper that a new call site could forget. `api` below is a thin adapter
+ * that keeps this product's existing surface (`get/post/put/delete`) verbatim
+ * so call sites did not need to change; `upload`/`getBlob` replace the old
+ * `apiFetch` multipart/binary escape hatch — the mirror is structural now, so
+ * a separate escape hatch is no longer needed (see
+ * nene2-js/docs-site/howto/migrate-product-client.md).
+ *
+ * A 401 on a request that carried a token clears the token store
+ * automatically (default `clearTokenOnStatuses: [401]`); the auth shell
+ * (`RequireAuth`) reacts via `subscribeAuthChange`/`isAuthenticated` and shows
+ * the login screen in place — no hard redirect. The login endpoint's own 401
+ * (wrong credentials) never carries a token, so it is left alone and surfaces
+ * as a normal `ApiError` to the login form, same as before.
  */
-export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  const headers = withAuthHeaders({ ...(init.headers as Record<string, string> | undefined) })
-  return fetch(path, { ...init, headers })
+const transport = createNene2Transport({
+  baseUrl: '',
+  tokenStore,
+  // Look up `fetch` at call time (not bind it once at module load): tests
+  // patch `globalThis.fetch` via `vi.stubGlobal`, which can run after this
+  // module has already been imported (nene2-js #105).
+  fetch: (input, init) => globalThis.fetch(input, init),
+})
+
+/** Maps the package's `Nene2ClientError` to this product's `ApiError` (unchanged shape for callers). */
+function toApiError(error: Nene2ClientError): ApiError {
+  const problem = error.problem
+  if (problem === undefined) {
+    return new ApiError(error.status, {
+      type: 'unknown',
+      title: 'Unknown error',
+      status: error.status,
+    })
+  }
+
+  const mapped: ProblemDetails = {
+    type: problem.type,
+    title: problem.title,
+    status: problem.status,
+  }
+  if (problem.detail !== undefined) {
+    mapped.detail = problem.detail
+  }
+  if (isValidationProblemDetails(problem)) {
+    mapped.errors = problem.errors
+  }
+  return new ApiError(error.status, mapped)
 }
 
-async function request<T>(
-  method: string,
-  path: string,
-  body?: unknown,
-  signal?: AbortSignal,
-): Promise<T> {
-  const headers = withAuthHeaders({ Accept: 'application/json' })
-
-  if (body !== undefined) {
-    headers['Content-Type'] = 'application/json'
-  }
-
-  const res = await fetch(path, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-    signal,
-  })
-
-  // A 401 on a normal call means the session expired → clear the token. The auth
-  // shell reacts to that and shows the login screen in place, at the current URL,
-  // so re-logging in returns the user to the same screen. The login endpoint is
-  // excluded: its 401 is "wrong credentials" and must surface to the form.
-  if (res.status === 401 && !path.includes('/auth/login')) {
-    clearToken()
-    throw new ApiError(401, { type: 'unauthorized', title: 'Unauthorized', status: 401 })
-  }
-
-  if (!res.ok) {
-    let problem: ProblemDetails
-    try {
-      problem = (await res.json()) as ProblemDetails
-    } catch {
-      problem = { type: 'unknown', title: 'Unknown error', status: res.status }
+async function unwrap<T>(promise: Promise<T>): Promise<T> {
+  try {
+    return await promise
+  } catch (error) {
+    if (isNene2ClientError(error)) {
+      throw toApiError(error)
     }
-    throw new ApiError(res.status, problem)
+    throw error
   }
-
-  if (res.status === 204) return undefined as T
-
-  return res.json() as Promise<T>
 }
 
 export const api = {
   get<T>(path: string, signal?: AbortSignal): Promise<T> {
-    return request<T>('GET', path, undefined, signal)
+    return unwrap(transport.get<T>(path, signal !== undefined ? { signal } : {}))
   },
   post<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>('POST', path, body)
+    return unwrap(transport.post<T>(path, body))
   },
   put<T>(path: string, body?: unknown): Promise<T> {
-    return request<T>('PUT', path, body)
+    return unwrap(transport.put<T>(path, body))
   },
   delete(path: string): Promise<void> {
-    return request<void>('DELETE', path)
+    return unwrap(transport.delete<void>(path))
+  },
+  /** multipart/form-data upload; `Content-Type` (with boundary) is left to the browser. */
+  upload<T>(path: string, formData: FormData): Promise<T> {
+    return unwrap(transport.upload<T>(path, formData))
+  },
+  /** Authenticated binary download (CSV export). */
+  async getBlob(path: string): Promise<Blob> {
+    const { blob } = await unwrap(transport.getBlob(path))
+    return blob
   },
 }

--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -13,8 +13,16 @@ import {
 } from './endpoints'
 import { storeToken } from './client'
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
 /**
- * These tests drive the endpoint functions through the real api client and a
+ * These tests drive the endpoint functions through the real api client (the
+ * `@hideyukimori/nene2-client` transport adapter, src/api/client.ts) and a
  * mocked global fetch, asserting the request URL, query string, method, and
  * body shape. Field names must stay snake_case (terminology.md).
  */
@@ -22,11 +30,7 @@ describe('endpoint request construction', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({}),
-    } as unknown as Response)
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({}))
     vi.stubGlobal('fetch', fetchMock)
   })
 
@@ -38,7 +42,7 @@ describe('endpoint request construction', () => {
     return String(fetchMock.mock.calls[0][0])
   }
 
-  function calledInit(): { method: string; body?: string; headers: Record<string, string> } {
+  function calledInit(): { method: string; body?: string; headers: Headers } {
     return fetchMock.mock.calls[0][1]
   }
 
@@ -135,21 +139,18 @@ describe('endpoint request construction', () => {
 })
 
 /**
- * The multipart upload and CSV export helpers call fetch through apiFetch rather
- * than the JSON request(). They must still carry the Authorization +
- * X-Authorization mirror, or they 401 behind the production proxy (#265, #312).
+ * The multipart upload and CSV export helpers (`api.upload` / `api.getBlob`,
+ * src/api/client.ts) go through the transport's dedicated paths rather than
+ * the JSON verbs. They must still carry the Authorization + X-Authorization
+ * mirror, or they 401 behind the production proxy (#265, #312) — the mirror
+ * is structural in the transport now, not a hand-maintained helper.
  */
 describe('file-I/O endpoints carry the auth mirror (#312)', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     storeToken('jwt-file')
-    fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ created: 0, skipped: 0, errors: [] }),
-      blob: () => Promise.resolve(new Blob(['csv'])),
-    } as unknown as Response)
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ created: 0, skipped: 0, errors: [] }))
     vi.stubGlobal('fetch', fetchMock)
     URL.createObjectURL = vi.fn(() => 'blob:mock')
     URL.revokeObjectURL = vi.fn()
@@ -159,25 +160,28 @@ describe('file-I/O endpoints carry the auth mirror (#312)', () => {
     vi.unstubAllGlobals()
   })
 
-  function sentHeaders(): Record<string, string> {
+  function sentHeaders(): Headers {
     return fetchMock.mock.calls[0][1].headers
   }
 
   it('importBankCsv sends both auth headers', async () => {
     await importBankCsv(1, new File(['a,b'], 'bank.csv', { type: 'text/csv' }))
-    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
-    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('Authorization')).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('X-Authorization')).toBe('Bearer jwt-file')
   })
 
   it('importManualReceivables sends both auth headers', async () => {
     await importManualReceivables(new File(['a,b'], 'mr.csv', { type: 'text/csv' }))
-    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
-    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('Authorization')).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('X-Authorization')).toBe('Bearer jwt-file')
   })
 
   it('downloadCsv (CSV export) sends both auth headers', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(new Blob(['csv']), { status: 200, headers: { 'Content-Type': 'text/csv' } }),
+    )
     await downloadCsv('/admin/export/bank-transactions', 'bank.csv')
-    expect(sentHeaders()['Authorization']).toBe('Bearer jwt-file')
-    expect(sentHeaders()['X-Authorization']).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('Authorization')).toBe('Bearer jwt-file')
+    expect(sentHeaders().get('X-Authorization')).toBe('Bearer jwt-file')
   })
 })

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,9 +1,7 @@
-import { api, apiFetch } from './client'
+import { api } from './client'
 
 export async function downloadCsv(path: string, filename: string): Promise<void> {
-  const res = await apiFetch(path)
-  if (!res.ok) throw new Error(`Export failed: ${res.status}`)
-  const blob = await res.blob()
+  const blob = await api.getBlob(path)
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -70,32 +68,13 @@ export function listBankImportBatches(params: BankImportBatchQuery, signal?: Abo
   return api.get<ListEnvelope<BankImportBatch>>(`${BASE}/bank-import-batches?${q}`, signal)
 }
 
-export async function importBankCsv(bankAccountId: number, file: File) {
+export function importBankCsv(bankAccountId: number, file: File) {
   const form = new FormData()
   form.append('bank_account_id', String(bankAccountId))
   form.append('file', file)
-  const res = await apiFetch(`${BASE}/bank-import-batches`, {
-    method: 'POST',
-    body: form,
-  })
-
-  const data = await res.json().catch(() => null)
-
-  // Multipart upload bypasses the JSON api client, so status handling lives here:
-  // a non-2xx response must surface as an error, not be treated as a successful import.
-  if (!res.ok) {
-    const detail =
-      data && typeof data === 'object' && 'detail' in data
-        ? String((data as { detail?: unknown }).detail ?? '')
-        : ''
-    const title =
-      data && typeof data === 'object' && 'title' in data
-        ? String((data as { title?: unknown }).title ?? '')
-        : `Import failed (${res.status})`
-    throw new Error(detail || title)
-  }
-
-  return data
+  // Non-2xx responses throw ApiError (transport-mapped, see src/api/client.ts);
+  // callers should read the message via describeApiError, not err.message.
+  return api.upload<{ row_count?: number }>(`${BASE}/bank-import-batches`, form)
 }
 
 export function reverseBankImportBatch(batchId: number, reversalReason: string) {
@@ -343,20 +322,12 @@ export function cancelManualReceivable(id: number) {
   return api.post<ManualReceivable>(`${BASE}/manual-receivables/${id}/cancel`)
 }
 
-export async function importManualReceivables(file: File): Promise<ManualReceivableImportResult> {
+export function importManualReceivables(file: File): Promise<ManualReceivableImportResult> {
   const form = new FormData()
   form.append('file', file)
-  const res = await apiFetch(`${BASE}/manual-receivable-imports`, {
-    method: 'POST',
-    body: form,
-  })
-  const data = await res.json().catch(() => null)
-  if (!res.ok) {
-    const detail = data && typeof data === 'object' && 'detail' in data ? String((data as { detail?: unknown }).detail ?? '') : ''
-    const title = data && typeof data === 'object' && 'title' in data ? String((data as { title?: unknown }).title ?? '') : `Import failed (${res.status})`
-    throw new Error(detail || title)
-  }
-  return data as ManualReceivableImportResult
+  // Non-2xx responses throw ApiError (transport-mapped, see src/api/client.ts);
+  // callers should read the message via describeApiError, not err.message.
+  return api.upload<ManualReceivableImportResult>(`${BASE}/manual-receivable-imports`, form)
 }
 
 // --- Upstream invoices ---

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listBankImportBatches, importBankCsv, reverseBankImportBatch, getClearSettings } from '@/api/endpoints'
+import { describeApiError } from '@/api/client'
 import type { BankImportBatch } from '@/types'
 import { Icon, StatusBadge, Button, Card, CardHead, CardBody, DataTable, TableStateRow, Notice, Modal, PageHead, FilterBar, FilterField, DatePicker, SortableTh, nextSort, Pager } from '@/components/ui'
 import type { StatusMeta, SortState } from '@/components/ui'
@@ -100,7 +101,7 @@ export default function BankImportPage() {
       void qc.invalidateQueries({ queryKey: ['bank-import-batches'] })
       void qc.invalidateQueries({ queryKey: ['bank-transactions'] })
     },
-    onError: (err: Error) => setUploadMsg({ ok: false, text: err.message }),
+    onError: (err: Error) => setUploadMsg({ ok: false, text: describeApiError(err) }),
   })
 
   function handleUpload(e: React.FormEvent) {

--- a/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
+++ b/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   listManualReceivables, createManualReceivable, cancelManualReceivable, importManualReceivables,
 } from '@/api/endpoints'
+import { describeApiError } from '@/api/client'
 import type { ManualReceivable, ManualReceivableImportResult } from '@/types'
 import { Icon, StatusBadge, Button, Card, DataTable, TableStateRow, Modal, Notice, PageHead } from '@/components/ui'
 import type { StatusMeta } from '@/components/ui'
@@ -91,7 +92,7 @@ function ImportModal({ onClose }: { onClose: () => void }) {
   const mut = useMutation({
     mutationFn: () => importManualReceivables(file as File),
     onSuccess: (r) => { setResult(r); void qc.invalidateQueries({ queryKey: ['manual-receivables'] }) },
-    onError: (e: Error) => setError(e.message),
+    onError: (e: Error) => setError(describeApiError(e)),
   })
 
   return (


### PR DESCRIPTION
## Purpose

Fleet frontend-standards convergence, transport adoption **wave 2** (wave 1 exemplar: nene-payout PR [#155](https://github.com/hideyukiMORI/nene-payout/pull/155), merged 2026-07-14). Replaces `frontend/src/api/client.ts`'s hand-rolled `fetch()` request plumbing with `createNene2Transport` + `createSessionTokenStore` from `@hideyukimori/nene2-client` (^1.1.0), kept as a thin adapter.

Closes #332.

## Standards basis

- `_work/reports/2026-07-14-frontend-standards/02-data-flow.md` §2:
  - **A-1** (MUST): HTTP boundary is `createNene2Transport` only — no raw `fetch()` outside the adapter.
  - **A-2** (MUST): adapter is a single file (`frontend/src/api/client.ts`, unchanged location — clear is not FSD yet), existing public surface preserved.
- §3 **AU-1** (MUST): token store key is `nene_<product>_token` — clear already used `nene_clear_token`; unchanged by this PR (same sessionStorage key, so an in-flight session survives the deploy).
- Migration reference: `nene2-js/docs-site/howto/migrate-product-client.md` has a clear-specific mapping table (`frontend/src/api/client.ts` row) that this PR follows directly.

**No FSD/layout migration in this PR** — file stays at `frontend/src/api/client.ts` (not moved to `shared/api/`). That track is the separate stop-gated #307/#318; out of scope here per the work order.

## Changes

- `frontend/src/api/client.ts`: `api.get/post/put/delete` are now thin wrappers over `transport.get/post/put/delete`, catching `Nene2ClientError` and mapping it back to this product's `ApiError` (unchanged public shape: `status` + `problem: ProblemDetails`). `storeToken/clearToken/subscribeAuthChange` now delegate to `createSessionTokenStore`'s `tokenStore` (same `sessionStorage` key). JWT decode helpers (`isAuthenticated`, `getUserRole`, `isAdmin`) stay app-side (out of transport scope), reading via `tokenStore.getToken()`.
- The old `apiFetch` multipart/binary escape hatch is **removed** — the Authorization/X-Authorization mirror is now structural (built into the transport for every path), so a separate hand-maintained escape hatch is no longer needed. Replaced by two new `api` methods backed directly by the transport: `api.upload` (multipart) and `api.getBlob` (binary download).
- `frontend/src/api/endpoints.ts`: `importBankCsv`, `importManualReceivables` now call `api.upload`; `downloadCsv` now calls `api.getBlob`. Both upload endpoints no longer hand-roll their own non-2xx status/JSON parsing — they throw `ApiError` via the shared `unwrap()` path like every other endpoint.
- `frontend/src/pages/bank-import/BankImportPage.tsx`, `frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx`: the two upload mutations' `onError` now read the message via `describeApiError(err)` instead of `err.message`, to keep showing the backend's `detail` field preferentially (see "Behavior notes" below).
- `frontend/eslint.config.js`: updated the `no-restricted-syntax` fetch-ban message (`apiFetch` no longer exists; it now points at `api`).
- `package.json` / `package-lock.json`: add `@hideyukimori/nene2-client@^1.1.0`.

## Behavior notes (honesty section — read this)

- **Upload error messages (`importBankCsv`, `importManualReceivables`)**: before this PR, these two functions parsed the failure body by hand and threw a plain `Error(detail || title || 'Import failed (<status>)')`, and their pages read `err.message` directly. After this PR they throw the standard `ApiError` (message = `problem.title` only), so I updated both `onError` handlers to call `describeApiError(err)` instead, which applies the same detail-preferred logic (`errors[]` → `detail` → `title`) already used everywhere else in the app (e.g. `ReconciliationPage`). Net effect on what the user sees should be unchanged or better (validation `errors[]` are now surfaced too, which the old hand-rolled path didn't check for at all).
- **Non-login 401 error body**: before this PR, a 401 on any authenticated (non-`/auth/login`) call *always* threw a synthetic `{type:'unauthorized', title:'Unauthorized', status:401}`, discarding whatever the backend actually sent. After this PR, the transport parses and surfaces the real Problem Details body when the backend sends one (falling back to the same synthetic shape only when the body is absent/unparseable). Since the backend is NENE2/RFC-9457-based throughout, this is very likely closer to (or identical to) the old synthetic text in practice, but I have not verified the real backend 401 body content directly — flagging it as the one behavior surface I could not fully pin down to "provably byte-identical."
- **Login 401 (wrong credentials)**: unchanged — still surfaces as `ApiError` with the real body to the login form. This now relies on the transport's built-in `tokenAttached`-gated clearing (the login call carries no token, so the transport never clears/never fires `onUnauthorized`) rather than the old explicit `path.includes('/auth/login')` check; verified via the "does NOT clear or redirect on 401 from the login endpoint" test.
- No `onUnauthorized`/`onForbidden` callbacks are wired — clear's auth shell (`RequireAuth` in `router.tsx`) is purely reactive via `subscribeAuthChange`/`isAuthenticated`, same as before this PR; there's no hard redirect and no `/forbidden` route in this app.

## Tests (measured)

- `npm run check` (`type-check && lint && test:run && knip`) — **all green**, measured locally in an isolated worktree.
  - `type-check`: clean.
  - `lint` (`eslint src --max-warnings 0`): clean.
  - `test:run`: **62/62 tests passing across 9 files**.
  - `knip`: clean (no unused deps/exports flagged for the new package).
- Added a dedicated "auth header mirror on every verb (#265, #312)" describe block in `client.test.ts` asserting both `Authorization` and `X-Authorization` on GET/POST/PUT/DELETE/upload/getBlob — mirrors the wave-1 (payout #155) pattern.
- Sabotage check: intentionally broke the 5 new mirror assertions (`Authorization` → `'WRONG'`) and re-ran — **6 tests failed** as expected (confirming the suite actually exercises the mirror), then reverted and re-ran — back to 62/62 green.
- `client.test.ts` / `endpoints.test.ts` mocks were switched from hand-rolled `{ok, status, json}` objects to real `Response` instances (`new Response(...)`) — the transport's `parseJsonBody` reads via `response.text()` and `getBlob`/`postBlob` read `response.headers`, which the old plain-object mocks didn't implement. jsdom/Node's native `Response`/`Headers`/`Blob`/`FormData` were confirmed available in this test environment, so no new test dependency (e.g. msw) was needed to fix this.

## Not done / out of scope

- FSD directory migration (separate stop-gated #307/#318).
- OpenAPI codegen (separate stop-gated #317).
- Did not independently verify the real backend's non-login 401 Problem Details body content against the old synthetic fallback (see behavior note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)