### PR TITLE
chore(git): .claude/ の worktrees と settings.local.json を ignore (#338)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 /frontend/dist-e2e/
 /sec-router.php
 /composer.local.json
+/.claude/settings.local.json
+/.claude/worktrees/


### PR DESCRIPTION
## 目的

`.claude/worktrees/` を `.gitignore` に追加し、worktree 一式の誤コミットを防ぐ。併せて `.claude/settings.local.json` の ignore がリポ外（開発機のグローバル ignore）に依存している状態を解消する。

Closes #338

## 変更点

`.gitignore` に 2 行のみ追加（既存のルート先頭 `/` 記法に合わせた）:

```
/.claude/settings.local.json
/.claude/worktrees/
```

## なぜ settings.local.json も要るのか（一見不要に見えるが必要）

このリポの `.gitignore` には `.claude` 系の記述が 1 行も無かった。にもかかわらず `settings.local.json` が漏れていなかったのは、**開発機のグローバル ignore が効いていたから**である。

```
$ git check-ignore -v .claude/settings.local.json     # 変更前
/root/.config/git/ignore:1:**/.claude/settings.local.json	.claude/settings.local.json
```

`/root/.config/git/ignore` はコミットされていないため、他のコントリビュータや CI には存在しない。public リポでこれに依存しているのは「たまたま今の 1 台では漏れていない」状態。変更後はリポ側で解決される:

```
$ git check-ignore -v .claude/settings.local.json     # 変更後
.gitignore:23:/.claude/settings.local.json	.claude/settings.local.json
```

## `/.claude/` の一括 ignore にしなかった理由

`.claude/skills/run-local/` は意図的に追跡しており、一括 ignore はこれを追跡から外す。ignore 対象は上記 2 パスのみに限定した。

```
$ git ls-files .claude/     # 変更後も不変
.claude/skills/run-local/SKILL.md
.claude/skills/run-local/run-local.sh
```

## 受け入れ条件の実測（全て変更後の実行結果）

| 条件 | 結果 |
| --- | --- |
| `git status --porcelain .claude/` が空 | ✅ 出力なし（変更前は `?? .claude/worktrees/`） |
| `git ls-files .claude/` が skills の 2 ファイルを返す | ✅ 上記のとおり不変 |
| ignore の出所がリポ側 | ✅ `.gitignore:23` / `.gitignore:24` |

## 横断案件との関係

Clear 固有ではなくフリート共通の穴（統合リナ経由: payout も独立に同型を実測、**18 リポ中 17 リポが該当**。先例 payout#180）。横断側は統合リナが `_work/issues.md` #51 で引き取り済みで、本 PR はその方針と同一形（2 行のみ・skills は追跡維持）の Clear 単体先行分。統合リナの合意のうえで実施している。

## リスク

無し（追跡中のファイルは 1 つも動かない。`git ls-files` で実測確認済み）。
