### PR TITLE
fix(mcp): client_credit.status の旧 enum を tools.json と設計文書から一掃 (#264)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 /frontend/dist-e2e/
 /sec-router.php
 /composer.local.json
+/.claude/settings.local.json
+/.claude/worktrees/

--- a/docs/development/phase-1-reconciliation-design.md
+++ b/docs/development/phase-1-reconciliation-design.md
@@ -160,7 +160,7 @@ Overpayment balance (前受金/預り金 相当) — never discarded (compliance
 | `client_id` | BIGINT | upstream client id |
 | `amount_cents` | BIGINT | original excess |
 | `remaining_cents` | BIGINT | unused balance |
-| `status` | VARCHAR | `open` / `partially_applied` / `applied` |
+| `status` | VARCHAR | `open` / `voided`; application progress lives in `remaining_cents` (#264) |
 | `source_bank_transaction_id` | BIGINT | provenance |
 | `created_by`, `created_at` | | |
 
@@ -294,10 +294,11 @@ optional `reason_code` (fee absorption).
 
 ### 5.5 `applyClientCredit`
 
-- Apply `remaining_cents` (or a portion) of an `open`/`partially_applied` credit
+- Apply `remaining_cents` (or a portion) of an `open` credit
   to a chosen invoice via upstream `createPayment` (idempotent,
-  `external_reference = clear:credit:{id}`); decrement `remaining_cents`; set
-  status; audit. **Explicit operator action only** — never automatic (compliance §2.5).
+  `external_reference = clear:credit:{id}`); decrement `remaining_cents` — the
+  credit stays `open` while a balance remains and flips to `voided` once it
+  reaches 0; audit. **Explicit operator action only** — never automatic (compliance §2.5).
 
 ---
 

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -150,7 +150,7 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "status": { "type": "string", "enum": ["open", "partially_applied", "applied"] },
+          "status": { "type": "string", "enum": ["open", "voided"] },
           "client_id": { "type": "integer", "format": "int64" },
           "limit": { "type": "integer", "minimum": 1, "maximum": 200 },
           "offset": { "type": "integer", "minimum": 0 }


### PR DESCRIPTION
## 目的

#264 のレジストリ/コード・ドリフトのうち、**#319 が取りこぼした残りの成果物**を実装準拠に揃える。

`Refs #264`（**あえて `Closes` にしていません** — 理由は末尾「#264 の扱い」）。

## 背景: #319 は既知の対象を1つ取りこぼしていた

#264 の 2026-07-10 のコメントは、レジストリ側の値集合が残る箇所を**明示的に列挙**していました:

> - `docs/openapi/openapi.yaml:2353` — `ClientCreditStatus` schema
> - **`docs/mcp/tools.json:153` — same enum in the MCP tool schema**

#319（`c590df2`）は terminology.md と openapi.yaml を直しましたが、**`tools.json` は最初から touch されていません**（`git show --stat c590df2` = 3ファイル）。その結果、07-11 の「Registry/spec drift resolved by #319」というコメントは、実際には未完のまま記録されていました。

## 🔴 これは docs の瑕疵ではなく、MCP 経由で到達可能な実バグ

#264 自身が Behavioral consequence として指摘済みの挙動です。`ClientCreditFilter::fromQueryParams` は `tryFrom` で status を解決するため:

```php
status: is_string($statusParam) ? ClientCreditStatus::tryFrom($statusParam) : null,
```

`applied` は enum に無い → `tryFrom` が `null` → **フィルタ無し扱いで全件返却**（エラーにならない）。修正前の `tools.json` はその `applied` / `partially_applied` を **MCP クライアントに広告し続けていた**ため、「applied の与信だけ一覧したい」という正当な呼び出しが**無音で全件を返す**状態でした。

## 変更点

- **`docs/mcp/tools.json`** — `listClientCredits.status` の enum を `[open, partially_applied, applied]` → `[open, voided]`。実装 `ClientCreditStatus` および `openapi.yaml` の `ClientCreditStatus` と一致。
- **`docs/development/phase-1-reconciliation-design.md`**
  - §2.7 DB スキーマ表: `status` 行を `open` / `voided` に。進捗が `remaining_cents` にあることを明記。
  - §5.5 `applyClientCredit`: `open`/`partially_applied` → `open`。**部分適用では `open` のままで、`remaining_cents` が 0 になった時点で `voided` へ遷移する**という実装の挙動を明記。

実装の裏取り（`PdoClientCreditRepository::applyAmount`）:

```sql
UPDATE client_credits SET status = 'voided'
 WHERE id = ? AND organization_id = ? AND remaining_cents <= 0 AND status = 'open'
```

`docs/journal/` にも旧値が残っていますが、**当時の事実の記録＝歴史文書につき不可触**としました（対象外）。

## 🔴 なぜ CI で捕まらなかったか（#317 への入力）

`tools.json` が `[open,partially_applied,applied]`、`openapi.yaml` が `[open,voided]` と**真っ向から矛盾している状態で、両バリデータとも緑**でした:

```
$ composer mcp      → MCP tool catalog is valid.
$ composer openapi  → OpenAPI contracts are valid (1 document(s)).
```

`validate-mcp-tools.php` は operationId の対応や構造は検証しますが、**enum 値の一致は突合していません**。CLAUDE.md が binding と定める用語レジストリの一致を、CI は機械的に保証できていない（人間の目視のみが頼り）状態です。**#317（spec↔実装ドリフトゲート）の射程に enum 突合を含めるべき実例**として、GO 材料に含めます。横断分（他リポの `tools.json` 同型調査）は統合リナが `_work/issues.md` #52 で引き取り済み。

## 検証（すべて変更後の実測）

| ゲート | 結果 |
| --- | --- |
| `composer test` | ✅ **Tests: 461, Assertions: 7375, Skipped: 6** |
| `composer analyse`（PHPStan lv8） | ✅ No errors |
| `composer cs` | ✅ clean |
| `composer openapi` | ✅ valid |
| `composer mcp` | ✅ valid |
| `composer conformance` | ✅ No findings |

生きた成果物からの旧値一掃も実測:

```
$ grep -rn 'partially_applied' docs/ src/ frontend/src/ | grep -v '/journal/'
（出力なし）
```

## #264 の扱い（判断を仰ぎます）

`Closes #264` を**付けていません**。#264 の最終コメント（2026-07-11 14:20）が明示しているためです:

> Leaving this issue open to track only the **optional future enhancement**: a richer `partially_applied` / `applied` credit-application lifecycle.

つまり #264 は「閉じ忘れ」ではなく、**将来拡張の追跡用に意図して open** にされています。本 PR がドリフトを完全に解消しても、追跡対象（将来拡張）は残るため、機械的に閉じると記録が失われます。

一方で、#264 のタイトルは今も `Registry/code drift: …` であり、実際に追跡している内容（将来拡張）と一致していません。**要判断**:

- **(a)** #264 は open のまま（本 PR は `Refs` のみ）＋ タイトル/本文を将来拡張トラッカーとして書き直す
- **(b)** ドリフトは本 PR で完全解消したとして #264 を close し、将来拡張は新規 Issue に切り出す（タイトルが実態と一致する）

どちらでも本 PR の内容は変わりません。
