### PR TITLE
docs(todo): correct two wrong statements in current.md and catch up to main (#343)

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -1,6 +1,6 @@
 # Current Work
 
-Last updated: 2026-07-11
+Last updated: 2026-07-16
 
 > **2026-07-11: fleet structural-uniformity audit recorded** — Clear findings,
 > strengths, and tracking issues (#285 JWT stack, #286 NENE2 `@dev` dependency,
@@ -17,9 +17,17 @@ Last updated: 2026-07-11
 > dedup (#309), `knip` + `--max-warnings 0` (#310), a real `type-check`
 > (`tsc -b`) + the 13 latent errors it had hidden (#311), React-connected
 > i18n → `I18nProvider`/`useTranslation` (#316). **OpenAPI codegen** is a
-> **stop-gate — plan #317** (23 spec↔impl divergences need reconciling first);
-> the `client_credit.status` conflict was fixed (#264 → #319). **FSD migration**
-> is a **stop-gate — plan #318**. Also fixed 2 production sales-blockers from
+> **stop-gate — plan #317** (the spec must be reconciled first; the divergences
+> were re-verified against the code on 2026-07-16 —
+> [`../audit/2026-07-16-openapi-spec-drift.md`](../audit/2026-07-16-openapi-spec-drift.md),
+> which refutes several of #317's claims and finds 7 shipped endpoints the spec
+> omits). The `client_credit.status` drift is **now fully resolved**: #319
+> corrected the registry + spec, and **#340** corrected the artifact #319 missed
+> (`docs/mcp/tools.json`, which had kept advertising the retired values).
+> **#264 itself stays open on purpose** — it now tracks only an optional future
+> enhancement (a richer `partially_applied` / `applied` lifecycle); it is not a
+> leftover to close. **FSD migration** is a **stop-gate — plan #318**. Also
+> fixed 2 production sales-blockers from
 > the browser walkthrough: X-Authorization mirror on file I/O (#312 / #313) and
 > the no-op settings-save 500 (#314 / #315).
 
@@ -55,15 +63,17 @@ Last updated: 2026-07-11
 **Infrastructure — Complete** (docker-compose + Mailpit; SmtpDunningMailer; InvoiceUpstreamHttpClient; login throttle).
 **Security — Assessed** (2-round multi-tenant pentest; 4 findings fixed incl. one critical privilege escalation; `docs/security/assessment-2026-05.md`).
 **Post-Phase-2 hardening — Merged** (PR #99–#118): bug fixes, 6 frontend gap closures, CSV export, per-invoice dunning pause, `template_version`, OpenAPI Dunning/Export spec, NENE2-compliant DI + soft-delete + full audit trail, admin audit-log page, shared `StatusBadge`/`Pager`, ClaudeDesign design system, E2E realign + a11y.
-**nene-invoice upstream — Their side implemented (PR #141); Clear client + contract tests ready. Real connection (set env vars) still pending.**
+**nene-invoice upstream — Verified live once (2026-06-27, `28bb88b`): all 6 contract tests passed against a running Invoice and surfaced 2 real contract bugs (#214). No *deployed* environment is configured against a live Invoice yet, so the tests auto-skip in CI.**
 
 ### Tests / quality gates
 
+Counts measured 2026-07-16 by the runners themselves (not by `grep`).
+
 | Layer | Count | Tool |
 | --- | --- | --- |
-| Backend | 436 (6 skipped) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
-| Frontend unit | 27 | Vitest |
-| Browser E2E | 43 | Playwright (API mocked) |
+| Backend | 461 (6 skipped; 7375 assertions) | PHPUnit; PHPStan level 8; PHP-CS-Fixer |
+| Frontend unit | 62 (9 files) | Vitest |
+| Browser E2E | 54 (16 files) | Playwright (API mocked) |
 
 CI: GitHub Actions — `backend-ci`, `frontend-ci`, `e2e-ci` run on push/PR to main;
 `close-issues` auto-closes linked Issues on rebase-merge to main.
@@ -106,10 +116,15 @@ Fixed local ports (see `CLAUDE.md`; do **not** revert to framework defaults).
 
 ## Open risks
 
-1. **Real upstream connection not yet exercised** — `InvoiceUpstreamHttpClient` +
-   contract tests are ready; set `NENE_INVOICE_API_BASE_URL` /
-   `NENE_INVOICE_BEARER_TOKEN` against a live Invoice instance and run the
-   contract suite to confirm the integration end-to-end.
+1. **No standing connection to a live Invoice** — *narrower than it used to read.*
+   The integration **has** been exercised end-to-end: `28bb88b` (2026-06-27)
+   records all 6 InvoiceUpstream contract tests passing **against a live Invoice**
+   (63 assertions), and the two contract fixes in #214 were found *by* that run.
+   So "does this work at all" is answered. What remains is operational: no
+   deployed environment has `NENE_INVOICE_API_BASE_URL` /
+   `NENE_INVOICE_BEARER_TOKEN` set against a real Invoice instance, so the 6
+   contract tests auto-skip in CI and the pairing is unproven outside a
+   developer machine. Re-run them whenever the upstream contract changes.
 
 ## Next steps
 
@@ -144,7 +159,10 @@ term tooltips (#196); server-side account-number withholding (#192); column-mapp
 UI (#191); dunning stage persistence + ADR 0011 tone review (#194).
 
 **Then resume prior roadmap:**
-2. **Activate real Invoice upstream** — set env vars, run contract tests live.
+2. **Activate real Invoice upstream** — set the env vars in a *deployed*
+   environment and keep the contract suite green there. (The suite already
+   passed against a live Invoice on 2026-06-27; what is missing is a standing
+   pairing, not a first proof.)
 3. **CSV export — tax advisor sign-off** — review column set per compliance §9.
 4. **Phase 4 — Ecosystem** — MCP tools (`listUnmatchedTransactions`,
    `proposeMatch`, `sendDunningNotice`).
@@ -155,6 +173,24 @@ Business/owner levers (not code; see review doc): managed/SaaS supply, pricing
 
 ## Recently completed
 
+- **Since 2026-07-11** (these landed after this file's previous update):
+  - **#331** — demo entry logging moved from `error_log` to a `var/` file sink
+    (readable over SSH on shared hosting).
+  - **#333** — the shared `apiClient` adopts the `@hideyukimori/nene2-client`
+    transport.
+  - **#335** — `design.css` isolated into `@layer legacy` + a machine-generated
+    manifest (W1 pilot for the fleet style work).
+  - **#337** — the X-Authorization fallback receiver switched to NENE2's opt-in
+    flag (`enableAuthorizationHeaderFallback`), retiring Clear's own
+    implementation; `hideyukimori/nene2` → `^1.11`.
+  - **#339** — `.gitignore`: `.claude/worktrees/` + `.claude/settings.local.json`
+    (the latter had been protected only by a developer's *global* ignore, so the
+    public repo had no such protection for anyone else).
+  - **#340** — `client_credit.status`: removed the retired enum from
+    `docs/mcp/tools.json` and the phase-1 design doc. This closed the gap #319
+    left (see the header note); `?status=applied` had been silently returning
+    *all* credits through the MCP surface, because `ClientCreditFilter` resolves
+    status with `tryFrom`.
 - **Candidate-database preflight adopted** (#183): opt-in
   `POST /machine/database/preflight` is live — `DefaultDatabaseCandidateInspector`
   wired with this app's Phinx versions (`MigrationVersions`), the **`phinxlog`**


### PR DESCRIPTION
## Purpose

`docs/todo/current.md` is this repo's living handoff. Two of its statements were **wrong**, not merely stale — and both had already been acted on by someone else. Closes #343.

## The two corrections

### 1. "the `client_credit.status` conflict was fixed (#264 → #319)"

#319 corrected `terminology.md` and `openapi.yaml` but left `docs/mcp/tools.json:153` advertising the retired enum — a file #264's **own 2026-07-10 comment listed as a drift site**. The drift was live until #340 (merged today), and via the MCP surface `?status=applied` silently returned *all* credits (`ClientCreditFilter` resolves with `tryFrom`).

This line was read as "done" and produced a proposal to close #264 on a false premise. Now rewritten to credit #319 **and** #340, and to record that **#264 is deliberately open** as a future-enhancement tracker (per its 2026-07-11 comment) — so the next reader does not try to close it.

### 2. Open risk #1 — "Real upstream connection not yet exercised"

Already false when the file was last touched. `28bb88b` (2026-06-27, on main):

> All 6 InvoiceUpstream contract tests now pass against the live Invoice (63 assertions).

— and the two contract bugs fixed in #214 were *found by that run*. current.md was updated 2026-07-11, two weeks later, still saying "not yet exercised". This mattered beyond the repo: the cross-repo board treated the Invoice live connection as Clear's near-only remaining work.

Narrowed to what actually remains: **no deployed environment is paired with a live Invoice**, so the 6 contract tests auto-skip in CI. The Status line and roadmap item are narrowed to the same granularity.

## Test counts — from the runners, not grep

| Layer | Was | Now | Source |
| --- | --- | --- | --- |
| Backend | 436 (6 skipped) | **461** (6 skipped, 7375 assertions) | `composer test` |
| Frontend unit | 27 | **62** (9 files) | `npm run test -- --run` |
| Browser E2E | 43 | **54** (16 files) | `npx playwright test --list` |

## Also

- Records the six merges since 2026-07-11: #331, #333, #335, #337, #339, #340.
- #317's entry now points at `docs/audit/2026-07-16-openapi-spec-drift.md` (PR #342) instead of repeating its "23 divergences" figure, which that audit could not reproduce.

## Not included

`docs/todo/handoff-2026-07-11-remediation-final-leg.md` is still uncommitted. It is **written in Japanese**, and ADR 0008 makes everything under `docs/` English-only — so committing it as-is would violate a binding ADR. Raised separately rather than decided here.

## Verification

Documentation only; no code changes. `composer conformance` ✅. Every number above came from the tool named beside it.