### PR TITLE
docs(adr): 0015 — split language policy, Issues/PRs/commits may be Japanese (supersede 0008 in part) (#348)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Strategy: [publication-strategy `docs/products/nene-clear.md`](https://github.co
 - **Terminology registry is binding** — every identifier (Problem Details slug, field name, status value, operationId) MUST be registered in `docs/explanation/terminology.md` **before first use**. Check the registry before introducing any new term. Spelling MUST match exactly — same characters, same case, same separators. No synonyms, no abbreviations, no typos.
 - No direct commits to `main`; Issue required
 - Closing **multiple** issues from one PR: repeat the keyword for each — `Closes #a, Closes #b, Closes #c`. A single `Closes #a, #b, #c` only closes the first; the rest stay open
-- Repository docs: English only (ADR 0008)
+- Repository docs: English only (ADR 0008). **Issues, PRs, and commit messages may be Japanese** (ADR 0015) — the English rule covers `docs/`, READMEs, OpenAPI, and Problem Details, not coordination text.
 
 ## Local development ports
 

--- a/docs/adr/0008-english-only-repository-documentation.md
+++ b/docs/adr/0008-english-only-repository-documentation.md
@@ -25,8 +25,12 @@ All **repository documentation** is **English only**:
 - Everything under `docs/` (explanation, ADR, review, development, integrations)
 - `.cursor/rules/` summaries
 - OpenAPI descriptions and Problem Details metadata (when added)
-- GitHub Issue titles and bodies, PR titles and bodies, and commit message
-  descriptions for this repository
+
+> **Superseded in part by [ADR 0015](0015-language-policy-repository-external-authoring.md):**
+> GitHub Issue titles/bodies, PR titles/bodies, and commit message descriptions
+> were originally required to be English here. ADR 0015 (2026-07-16) permits
+> Japanese for that repository-external coordination text. Everything else in
+> this ADR stands — repository documentation remains English-only.
 
 **Exceptions (not repository docs):**
 
@@ -58,4 +62,4 @@ All **repository documentation** is **English only**:
 - `docs/inheritance-from-nene2.md` — language policy row updated
 - Issue: `#3`
 - Supersedes: informal "Japanese allowed in commits/rules" wording
-- Superseded by: none
+- Superseded by: [ADR 0015](0015-language-policy-repository-external-authoring.md) — in part (Issue/PR/commit language only; the documentation rules stand)

--- a/docs/adr/0015-language-policy-repository-external-authoring.md
+++ b/docs/adr/0015-language-policy-repository-external-authoring.md
@@ -1,0 +1,99 @@
+# ADR 0015: Language Policy — Repository-External Authoring May Be Japanese
+
+## Status
+
+accepted
+
+## Context
+
+[ADR 0008](0008-english-only-repository-documentation.md) made **all** repository
+documentation English-only. Its Decision list included one item that is not
+documentation in the sense ADR 0008's own rationale describes — **GitHub Issue
+titles and bodies, PR titles and bodies, and commit message descriptions**.
+
+ADR 0008's rationale is specifically about *published engineering documentation*:
+it is read by "contributors, AI agents, and international reviewers — including
+accounting advisors evaluating compliance design", and mixed-language **docs**
+"created drift: statutory labels duplicated in kanji inside English sections".
+That reasoning is strong for `docs/`, the READMEs, and the OpenAPI/Problem
+Details prose that ships in the contract. It does not extend to Issues, PRs, and
+commit messages, which are **maintainer-facing coordination**, not part of the
+product or its compliance-review surface.
+
+The evidence that the two cases differ is in this repository's own history
+(measured 2026-07-16 at `767931b`):
+
+- Of 212 commits on `main`, **20 contain Japanese**. The **earliest is the very
+  first commit**, `#1` "docs: ガバナンスとプロダクト基盤の初期化" (2026-05-29) —
+  authored *before* ADR 0008 (`#3`) existed — and Japanese commits continue
+  through the most recent work.
+- Meanwhile **`docs/` has stayed English** throughout. The English rule that
+  *was* about published docs held; the part that reached into commit/Issue/PR
+  text **never took effect in the ~14 months of the project** and was corrected
+  by hand only sporadically.
+
+So the split is not aspirational — it already describes reality. The maintainer
+and the day-to-day contributors are Japanese speakers; forcing English onto
+coordination text has a real cost (slower, less precise issue-writing) with no
+reader who benefits, because that text has no international or advisor audience.
+
+This ADR was requested by the owner (2026-07-16 ruling) after the discrepancy was
+found while auditing repository practice, and mirrors the same split adopted
+across sibling NeNe products.
+
+## Decision
+
+Language policy is **split by audience**.
+
+**English only** (unchanged from ADR 0008 — these are the product / review
+surface):
+
+- `README.md`, `AGENTS.md`, `CLAUDE.md`
+- Everything under `docs/` (explanation, ADR, review, development, integrations)
+- `.cursor/rules/` summaries
+- OpenAPI descriptions and Problem Details metadata
+
+**Japanese permitted** (English also fine — these are maintainer coordination,
+not published docs):
+
+- GitHub **Issue** titles and bodies
+- **Pull request** titles and bodies
+- **Commit message** subjects and bodies
+
+The exceptions ADR 0008 lists (qualified-invoice statutory text, admin-UI locale
+catalogs, operator install guides, Japanese law names in parentheses) are
+**unchanged** and continue to apply.
+
+This **supersedes ADR 0008 in part**: only the fourth bullet of ADR 0008's
+Decision (the one naming Issues, PRs, and commit messages). Every other clause of
+ADR 0008 remains in force — repository documentation is still English-only.
+
+## Consequences
+
+**Benefits**
+
+- The written rule now matches ~14 months of actual practice, so it is
+  enforceable rather than routinely-and-silently broken.
+- Maintainers write coordination text in their working language, precisely.
+- The compliance-review surface (docs, OpenAPI, Problem Details) stays
+  single-language English, preserving ADR 0008's actual benefit.
+
+**Costs**
+
+- Contributors and tools must know the boundary: English stops at the repository
+  contents; Issues/PRs/commits may be either language. A reviewer scanning commit
+  history sees mixed languages by design.
+- Automated checks that assumed English commit/Issue text (if any are added
+  later) must scope themselves to `docs/` and the READMEs, not to git metadata.
+- Existing English Issues/PRs/commits are **not** rewritten (history is not
+  edited); the mix is expected.
+
+## Related
+
+- [ADR 0008](0008-english-only-repository-documentation.md) — superseded in part
+  (Issue/PR/commit language only); its documentation rules stand.
+- [ADR 0005](0005-bilingual-ja-en-scope.md) — admin UI ja/en, source of the
+  standing exceptions.
+- `docs/inheritance-from-nene2.md` — language policy row.
+- Owner ruling: 2026-07-16.
+- Supersedes: ADR 0008, Decision bullet 4 (repository-external authoring) only.

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -54,7 +54,7 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + reconciliation/dunning additions |
 | Backend standards | `docs/development/backend-standards.md` — PHP/API strict policy |
 | Monetary values | Integer **cents** in DB and JSON; no floats |
-| Language policy | **English** for all repository docs, Issues, PRs, commits, OpenAPI, API errors (ADR 0008); admin UI **ja + en** only (ADR 0005) |
+| Language policy | **English** for repository docs, OpenAPI, API errors (ADR 0008); **Japanese permitted** for Issues, PRs, commit messages (ADR 0015); admin UI **ja + en** only (ADR 0005) |
 | Review checklists | `docs/review/` — task-specific lists for this product |
 
 ## NeNe Clear–specific (not inherited)


### PR DESCRIPTION
## Purpose

Owner ruling (2026-07-16): split the language policy so **repository docs stay English-only** but **Issues / PRs / commit messages may be Japanese**. Captured as ADR 0015, superseding ADR 0008 in part. Closes #348.

## Why the split (not a full supersede)

ADR 0008's rationale is about *published engineering documentation* — read by "contributors, AI agents, and international reviewers, including accounting advisors evaluating compliance design". That reasoning is strong for `docs/`, the READMEs, and the OpenAPI/Problem-Details prose that ships in the contract. It does **not** describe Issues, PRs, and commit messages, which are maintainer coordination with no international or advisor audience.

The repository's own history shows the two cases behave differently (measured at `767931b`):

| | Japanese present? | Since |
| --- | --- | --- |
| `docs/` contents | No — English throughout | — |
| Commit messages | Yes — 20 of 212 commits | **commit `#1`, 2026-05-29** (before ADR 0008 = `#3`) |

The English rule held exactly where it had a reader (docs) and never held where it did not (commit/Issue/PR text), for ~14 months. **ADR 0015 codifies what practice already is** — it does not loosen a working rule, it retires an unenforced one while keeping the one that works.

Because `docs/` English is still wanted, ADR 0008 is **not** fully superseded — only its Decision bullet naming Issues/PRs/commits. Everything else in 0008 stands. (A full `Status: superseded` would have dropped the docs-English rule too, contradicting the ruling.)

## Changes

- **New** `docs/adr/0015-language-policy-repository-external-authoring.md` — the split, with the measured history as evidence and ADR 0008's exceptions carried over unchanged.
- **ADR 0008** — annotated superseded-in-part (Decision bullet 4 only); `Superseded by` updated.
- **`docs/inheritance-from-nene2.md`** — language-policy row split.
- **`CLAUDE.md`** — the Hard-rules language line now states the boundary.

## Correcting my own earlier report

While auditing this I found an informal claim I made on 2026-07-16 — that Japanese commits "started 2026-07-12" and everything before 2026-07-11 was English — was **wrong**. The accurate distribution (Japanese since commit `#1`) is in the ADR and stated as superseding that claim. Flagging it here so the record is clean.

## Note on this PR's own language

This PR and its commit are in **English**, deliberately: ADR 0015 is not merged yet, so the English rule is still fully in force as I write. The switch to permitting Japanese takes effect once this lands.

## Out of scope

- Rewriting existing history (not done; a mixed log is expected).
- The day-report location/format convention (a separate `CLAUDE.md` change, coming next).

## Verification

`composer conformance` green. All cross-references resolve (0008 ↔ 0015, CLAUDE.md → 0015, inheritance → 0015; ADR 0005 link corrected to its real filename). Docs only.
