### PR TITLE
docs: 日報の規範（docs/journal・セッション開始日・既存追記）を CLAUDE.md に明記 (#350)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,9 @@ Do **not** change these back to defaults (8080, 1025, 8025, 3306).
 | Terminology registry (binding) | `docs/explanation/terminology.md` |
 | Operator guide / system overview | `docs/explanation/operator-guide.md` |
 | TODO | `docs/todo/current.md` |
+| Daily work journal | `docs/journal/<session-start-date>.md` |
+
+Daily journals live in `docs/journal/`, one file per **session start date**
+(`YYYY-MM-DD.md`); append to the existing file if one already exists for that
+date rather than creating a second. English per ADR 0008 (a Japanese summary may
+follow in the reply, not the file).


### PR DESCRIPTION
## 目的

施主裁定（2026-07-16）で確定した日報の規範を、Clear の CLAUDE.md に成文化する。これまでどの CLAUDE.md にも記述が 0 件＝完全な口伝だった状態を解消する。Closes #350。

**ADR 0015（#349）発効後の最初の日本語 PR・commit** です。CLAUDE.md の中身自体は英語のまま（ADR 0008 の対象＝docs/READMEs は英語維持）で、変わったのは PR/commit/Issue の記述言語だけです。

## 変更

`CLAUDE.md` の Canonical paths に1行＋規範を1段落（英語）:

| Purpose | Path |
| --- | --- |
| Daily work journal | `docs/journal/<session-start-date>.md` |

- **置き場**: `docs/journal/`（Clear は決定済み・現物5本）
- **日付軸**: セッション**開始日**（`YYYY-MM-DD.md`）
- **既存追記**: 同日付のファイルがあれば新規作成せず追記
- 言語: 本文は英語（ADR 0008）、日本語要約は返信で（ファイルには入れない）

## なぜ Clear だけ先行してよいか

横断（14リポ）では日報の置き場が6通りに割れているが、**Clear 単体では両軸とも既に確定済み**（置き場=`docs/journal`・日付軸=セッション開始日）。統合リナ確認済みで、横断決定と食い違うリスクはゼロ。他リポの置き場統一は別レイヤーの横断案件。

## スコープ外

- 他リポの置き場統一（横断）。
- 既存 journal ファイルのリネーム（規範は今後分に適用・遡及しない）。

## 検証

`composer conformance` 緑。docs のみ・コード変更なし。
