### PR TITLE
docs(journal): 2026-07-16 のセッションを記録

### DIFF
--- a/docs/journal/2026-07-16.md
+++ b/docs/journal/2026-07-16.md
@@ -1,0 +1,67 @@
+# 2026-07-16 — spec/registry drift campaign, PR triage, and two governance ADRs
+
+Worked under 統合リナ (the cross-repo lead); the owner delegated day-to-day
+direction there. Received tasks over the ccbridge relay, pushed questions back
+with evidence, and reported completion/review requests the same way.
+
+## Shipped (merged)
+
+- **#339** — `.gitignore`: `.claude/worktrees/` + `.claude/settings.local.json`.
+  The latter had been protected only by a developer's *global* ignore, so the
+  public repo had no protection for anyone else.
+- **#340** — `client_credit.status`: removed the retired enum from
+  `docs/mcp/tools.json` and the phase-1 design doc. Not a doc typo — a live bug:
+  `?status=applied` was silently returning *all* credits through the MCP surface
+  (`ClientCreditFilter` resolves with `tryFrom`). #319 had missed this artifact.
+- **#342** — audit `docs/audit/2026-07-16-openapi-spec-drift.md`: re-verified
+  #317's claims against the code. Found 2 of its Bucket A claims wrong, 7 shipped
+  endpoints the spec omits, and that no `composer check` gate compares enum
+  members between artifacts.
+- **#344** — `current.md`: corrected two *wrong* (not just stale) statements —
+  the "#264 fixed" claim and Open risk #1 ("upstream never exercised", actually
+  verified live on 2026-06-27). Refreshed test counts from the runners
+  (436→461 / 27→62 / 43→54).
+- **#347** — #317 Phase 1: reconciled 13 schemas + the registry with the
+  implementation (required lists, null-safety, BankAccount request/response
+  split, two spec bugs, D1/D2/D4). Verified builder-by-builder; docs only.
+- **#349** — ADR 0015: split the language policy (docs English-only;
+  Issues/PRs/commits may be Japanese), superseding ADR 0008 *in part*.
+
+## In flight
+
+- **#351** — journal convention in CLAUDE.md (this file's own rule). First
+  Japanese-authored PR after ADR 0015.
+- **#181** — Docker one-command setup: not closed; both its premises
+  (sibling-clone of NENE2, bundled-MySQL default) have gone stale. Commented for
+  an owner decision.
+
+## Filed, not fixed
+
+- **#341** — a real bug: a manual-receivable overpayment credit renders `#null`
+  in the UI (`client_id` is null for manual source; `client_name` is not in the
+  response). Reachable on the live demo.
+- **#345** — the 7 undocumented endpoints (5 MFA/TOTP + 2 registered dunning
+  ops). Split out of #317 Phase 1 as its own P1.
+
+## Mistakes caught and corrected (recorded on purpose)
+
+1. **repo-status mis-called #264 a close-forget.** It is deliberately open
+   (future-enhancement tracker). Caught by reading the issue before acting on the
+   close instruction — which then surfaced the real #340 bug and #341.
+2. **"Docker ✅ so verify #181" was imprecise** — current.md's ✅ was the data
+   tier only; no contradiction with #180.
+3. **"Japanese commits started 2026-07-12" was wrong.** Measured across all of
+   `main`: Japanese present since commit #1 (2026-05-29), 20 of 212 commits. This
+   became ADR 0015's strongest argument (the rule never held where it had no
+   reader; docs English held throughout).
+4. **A drift probe was left in `frontend/src`** because a delete ran from inside
+   `frontend/` with a `frontend/src/...` path (→ `frontend/frontend/src`, a
+   no-op). Caught by a pre-commit file-existence check. Lesson: build throwaway
+   files in the scratchpad, never in the repo tree.
+
+## Method note
+
+The recurring win was measuring before acting on an instruction — twice the
+cross-repo lead's direction rested on hearsay (mine, in one case), and verifying
+first prevented burying a live drift as "resolved" and prevented a literal
+application of #317 that would have introduced a spec bug.


### PR DESCRIPTION
## 目的

2026-07-16 のセッション（spec/registry ドリフト是正・PR 棚卸し・ガバナンス ADR 2件）を日報として記録する。**#350 で今まさに成文化した規範に自ら従う最初の日報**（`docs/journal/`・セッション開始日・英語本文・日本語要約は返信で）。

## 内容

- マージ済み6本（#339/#340/#342/#344/#347/#349）と仕掛かり・起票の記録
- **今日見つけて訂正した自分の誤り4件を明記**（#264 の性質・#181 の Docker 状態・言語ドリフトの時期・探針の削除ミス）— 隠さず記録するのが日報の価値という判断

## 検証

`composer conformance` 緑。docs のみ。