### PR TITLE
fix(codegen): schema.gen を openapi に追随（main の codegen:check 赤を解消）

### DIFF
--- a/frontend/src/api/schema.gen.ts
+++ b/frontend/src/api/schema.gen.ts
@@ -1117,6 +1117,18 @@ export interface components {
             organization_id: number;
             /** Format: int64 */
             client_id: number | null;
+            /** @description Payer name for a manual-receivable credit; null for an upstream credit (client_id identifies the payer instead). ADR 0014, */
+            client_name: string | null;
+            /**
+             * @description Which receivable the overpayment came from (ADR 0014).
+             * @enum {string}
+             */
+            source: "invoice_upstream" | "manual";
+            /**
+             * Format: int64
+             * @description Set for a manual-source credit; null for upstream.
+             */
+            manual_receivable_id: number | null;
             /** Format: int64 */
             amount_cents: number;
             /** Format: int64 */


### PR DESCRIPTION
## 緊急度: main が #355 以来ずっと Frontend CI 赤

main の Frontend CI が `codegen:check` で fail し続けていた（`schema.gen.ts is stale`）。

## 原因

- **#341(#353・09:25:20 マージ)** が `openapi.yaml` の ClientCredit を変更（client_name / source / manual_receivable_id 追加）したが schema.gen を再生成しなかった（当時 Phase2 未マージで schema.gen が存在しなかった）。
- **#317 Phase2(#355・09:25:31 マージ)** が codegen:check gate と schema.gen を導入したが、そのブランチは #341 変更**前**の main から切られていたため schema.gen が #341 を含まず。
- **11秒差のマージ**で、統合後の main が「#341 の openapi + #341 を含まない schema.gen」= stale に。

## 🔴 なぜ gate をすり抜けたか（横断 #52 に関わる）

`codegen:check` は **PR ブランチ単位**で走り、マージ後の統合状態を検証しない。両 PR は各自のブランチでは緑（自分の openapi と schema.gen が一致）だが、マージ後の main だけが赤くなる。**PR 緑 → main 赤** が起こりうる構造的な穴。

## 修正

`npm run codegen` で再生成し openapi に追随（client_name/source/manual_receivable_id の12行）。**`npm run check` 全体緑**（codegen:check 込み）。

## 私の見落とし（記録）

#359/#360 の self-merge 検証で `npm run check` 全体ではなく個別コマンド（type-check/test/knip）で確認し、**codegen:check をスキップ**していたため、既に赤かった main を継いだことに気づけなかった。以後 Tier1 の check 緑は `npm run check` 全体で確認する。