### PR TITLE
docs(daily): 2026-07-17 日報＋日報規約を docs/daily 正本へ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,14 @@ Do **not** change these back to defaults (8080, 1025, 8025, 3306).
 | Terminology registry (binding) | `docs/explanation/terminology.md` |
 | Operator guide / system overview | `docs/explanation/operator-guide.md` |
 | TODO | `docs/todo/current.md` |
-| Daily work journal | `docs/journal/<session-start-date>.md` |
+| Daily report | `docs/daily/<YYYY-MM-DD>.md` (fleet convention) |
 
-Daily journals live in `docs/journal/`, one file per **session start date**
-(`YYYY-MM-DD.md`); append to the existing file if one already exists for that
-date rather than creating a second. English per ADR 0008 (a Japanese summary may
-follow in the reply, not the file).
+Daily reports follow the **fleet-wide convention**
+(`_work/daily-report-convention.md`, confirmed 2026-07-17): one file per calendar
+day under `docs/daily/`, **Japanese** (technical terms may stay English), no
+frontmatter, `# YYYY-MM-DD` + lead paragraph + `## topic` bullets with PR/Issue
+numbers; measured vs. hearsay numbers must be marked. Same-day extra sessions
+append under `## セッション2`. Index in `docs/daily/README.md`. This supersedes
+the earlier `docs/journal/` + English rule (that was set before the fleet
+convention was ratified). Daily reports are per-repo work; cross-repo/strategy
+notes go to `_work/` per the container CLAUDE.md.

--- a/docs/daily/2026-07-17.md
+++ b/docs/daily/2026-07-17.md
@@ -1,0 +1,42 @@
+# 2026-07-17
+
+施主「Phase3 今やろう」から始まり、統合リナのフロント大改修バーストと合流して **A2（FSD 5層再建）** に発展した一日。A2 設計書を hub 承認まで通し、shared foundation の Tier1（lib/i18n/api）を3本 self-merge。途中で **main が昨夜（#355）から CI 赤だった**のを発見し hotfix で緑に戻した。指揮は統合リナ（hub）、連絡は chat-relay。
+
+---
+
+## A2 設計書（FSD 5層再建）
+
+- **#356 / #357**: 現行 frontend → FSD 5層のマッピング設計書 `docs/development/fsd-migration-plan.md`。hub APPROVE・実行 GO。
+- 実測〔実測〕: clear は app/pages の名前だけで中身は非FSD。**9 off-layer ディレクトリ**・集約バレル `components/ui/index.ts` 21 export・default export 15。direct fetch は 0。
+- 再編先〔実測〕: **entity 11 / feature 19 / page 13**（endpoints.ts の 40 関数と response スキーマから境界導出）。
+- 設計中に潰した食い違い3件: ①指示書の「widgets」記述 vs 正本5層（widgets MUST NOT）→ hub 訂正 ②型生成が fleet で2路線（invoice=schema.gen import / payout=手書き DTO）・tiebreaker の generator は未実装 → hub 裁定 **A（schema.gen import）** ③payout は**構造の範のみ**（feature hooks/・`-form` 命名が違反）→ 優先順位 規約doc > invoice(型) > vault(命名)。
+
+## shared foundation（Tier1・機械的移設・self-merge）
+
+- **#359** shared/lib（utils の format/fiscal）・**#360** shared/i18n（locales/I18nContext/useTranslation）・**#362** shared/api（client/schema.gen）。
+- 全て挙動保存（move + import 書換のみ・ロジック diff ゼロ）・**frontend 62 tests 緑**〔実測〕。
+- formatter は逸脱注記＋追跡 **#358**（規約は shared/lib 禁止で nene2-i18n/format 正準だが、その sub-path が W0b 未実装＝移設先が存在しない経過措置・hub 裁定）。
+
+## 🔴 main 赤インシデント（本日最重要）
+
+- **#361 hotfix**: main の Frontend CI が **#355 以来ずっと codegen:check で赤**だった〔実測: Frontend CI run failure〕。原因は #341(#353・09:25:20 マージ)が openapi を変更したが schema.gen 未再生成、#355(Phase2・09:25:31 マージ)の schema.gen が #341 変更前の main から生成されていたこと。**11秒差マージ**で統合後 main が stale に。`npm run codegen` 再生成（client_name 等12行）で解消・緑復帰確認〔実測〕。
+- 🔴 **構造穴**: codegen:check / spec-parity 等の PR 単位ゲートは**マージ後の統合 main を検証しない**。2本の PR が各自緑でもマージ順で **PR緑→main赤**。fleet 台帳 **#60** に spec-parity gate 含め起票済み（invoice も同型）。
+- 🔴 **自分の見落とし**: #359/#360 を self-merge する際、Tier1 条件の「check 緑」を `npm run check` **全体**でなく個別コマンド（type-check/test/knip）で確認し **codegen:check をスキップ**していた。既に赤い main を継いだことに気づけず。→ Tier1 条件を「`npm run check` 全体で緑・個別代用禁止」に強化（hub 承認）。#362 で即実践。
+
+## ★教訓
+
+- **openapi.yaml を変えたら必ず `npm run codegen` で schema.gen を再生成してコミット**。PR 単位ゲートは統合後 main を守らない。
+- **self-merge 前の check は `npm run check` 全体で**。個別コマンドは gate を取りこぼす。
+- 昨日「Clear だけ先に日報軸を確定すると横断決定と食い違うリスク」と指摘した懸念が的中（#351 の docs/journal が本日の正本 docs/daily と食い違い）。**横断が割れている案件は、単リポ先行より横断確定を待つ**。
+
+## 📊 本日の数字
+
+- マージ: #357(A2設計) / #358(Issue) / #359(lib) / #360(i18n) / #361(hotfix) / #362(api)〔実測: 全て self-merge or squash 済み〕
+- frontend テスト **62 緑**〔実測〕・main Frontend CI **success 復帰**〔実測〕
+- open: #181(判断待ち・棚上げ)
+
+## 残タスク・申し送り
+
+- **shared/ui バレル解体**（Tier2 の最初の1本・hub レビュー）: 16コンポを 1コンポ=1dir=1index に・集約バレル撤去・keyboard(UI/フック)振り分け・ThemeContext→shared/ui/theme。hub のレビュー重点=「各 index の公開面」「keyboard 振り分け」。
+- **entities**（型再ポイント本体・#317 Phase3・escape hatch あり）・**pages/app**・**cleanup**（types/index.ts 解体）。
+- 日報の置き場を docs/journal → **docs/daily**（本日確定のフリート正本）に移行。既存 docs/journal/ の過去分の扱いは別途。

--- a/docs/daily/README.md
+++ b/docs/daily/README.md
@@ -1,6 +1,17 @@
-# Daily Reports
+# docs/daily — 日報
 
-Dated work logs for NeNe Clear, one file per day: `YYYY-MM-DD.md`.
+NeNe Clear リポの**日々の作業記録**。書式・規約はフリート共通の正本
+`_work/daily-report-convention.md`（2026-07-17 確定）に従う。
 
-English only (ADR 0008). Each entry records what was done, key decisions, and
-what remains, so the next session (human or AI) can pick up with full context.
+## 役割と線引き
+
+- **`docs/daily/`（ここ）** … このリポ内の作業の記録（触った PR/Issue・裏取り・残タスク）。
+- **`_work/daily/` / `_work/discussion-log/`** … 横断・戦略・複数リポにまたがる話・事業議論。ここには書かない（`/home/xi/docker/CLAUDE.md` の規約）。
+
+1日1ファイル `YYYY-MM-DD.md`。日本語（技術語は英語可）。frontmatter は付けない。数字は実測値か伝聞かを必ず書き分ける。同日に複数セッションがあれば1ファイル内に `## セッション2` で追記。
+
+> 2026-07-16 以前の日報は `docs/journal/` にある（フリート正本が確定する前の置き場）。過去分の移行は別途。
+
+## 索引
+
+- [2026-07-17](2026-07-17.md) — A2（FSD 5層再建）着手・設計書 hub 承認（#357）・shared foundation Tier1（#359/#360/#362）・main 赤を hotfix #361 で解消


### PR DESCRIPTION
## 目的

本日確定したフリート共通の日報正本（`_work/daily-report-convention.md`・hub APPROVE 2026-07-17）に Clear の日報を合わせる。

## 変更

- **`docs/daily/2026-07-17.md`**: 本日の日報（A2 FSD 再建の着手・shared foundation Tier1・main 赤 hotfix）。正本書式（`# 日付`・リード・`## トピック`＋PR/Issue 番号・数字の実測/伝聞書き分け・frontmatter なし・日本語）。
- **`docs/daily/README.md`**: 正本準拠に更新（役割・`_work/` との線引き・索引・日本語）。
- **`CLAUDE.md`**: 日報行を `docs/journal/`（英語）→ `docs/daily/`（日本語・正本参照）へ。

## 昨日の #351 との関係

昨日 #351 で「日報は `docs/journal/`・英語」と CLAUDE.md に明記したが、それはフリート正本の確定**前**だった。その際「Clear だけ先に日報軸を確定すると横断決定と食い違うリスク」と指摘したとおり、翌日の正本（`docs/daily`・日本語）と食い違った。**正本に合わせて上書き**する。既存 `docs/journal/` 過去分の移行は別途（大きいため）。

## 検証

`composer conformance` 緑。docs のみ。