### PR TITLE
chore(eslint): fetch() 例外 override を shared/api 移設に追随 (#362)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -26,14 +26,14 @@ export default tseslint.config(
         {
           selector: "CallExpression[callee.name='fetch']",
           message:
-            'Do not call fetch() directly — use `api` from src/api/client.ts so the Authorization/X-Authorization mirror is sent (#265, #312).',
+            'Do not call fetch() directly — use `api` from src/shared/api/client.ts so the Authorization/X-Authorization mirror is sent (#265, #312).',
         },
       ],
     },
   },
   {
     // The shared API client is the single sanctioned place that calls fetch().
-    files: ['src/api/client.ts'],
+    files: ['src/shared/api/client.ts'],
     rules: { 'no-restricted-syntax': 'off' },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
## 概要

`frontend/eslint.config.js` の `fetch()` 直呼び禁止ルール（`no-restricted-syntax`）の唯一の例外 override が、#362 の api client 移設（`src/api/client.ts` → `src/shared/api/client.ts`）に追随しておらず旧パスを指していた。override の `files` と lint メッセージ内の案内パスを新パスに更新する。

## 実害

なし（台帳腐敗のみ）。二重確認済み:
1. 旧パス `src/api/client.ts` は現状どのファイルにもマッチしない（exempt 対象ゼロ）。
2. 守る対象 `src/shared/api/client.ts` の唯一の `fetch` は `globalThis.fetch(...)`（MemberExpression）で、selector `CallExpression[callee.name='fetch']`（bare `fetch(...)` のみ）に非マッチ。∴ override 空振りでも lint は緑。

将来 `client.ts` に sanctioned な bare `fetch(...)` を足した際の false-positive を防ぐ意図した保護を復元する。

## 検証

- `npm run lint` 緑（ローカル実測）

Closes #364