### PR TITLE
ci: job名 'check' の衝突を解消（backend-check / frontend-check へ rename）

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  check:
+  backend-check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  check:
+  frontend-check:
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## ⚠️ このPRは required contexts の PATCH まで merge しない（正順）

## 概要

`backend-ci.yml` と `frontend-ci.yml` の両方が job id `check` を持ち、check run の context 名 `check` が衝突していた。branch protection の required status check を一意にするため:

- `backend-ci.yml`: job `check` → **`backend-check`**
- `frontend-ci.yml`: job `check` → **`frontend-check`**

（`postgres-migrate` は変更なし）

## merge 手順（正順・②実測に基づく）

1. **このPR**でジョブを rename → CI 緑を確認するが **merge しない**。rename により旧 required context `check` が emit されなくなり、このPR自身が blocked になる（意図的）。
2. hub が branch protection の required contexts を **`[backend-check, frontend-check, postgres-migrate]`** に PATCH。
   - `postgres-migrate`: PR で走る決定的ゲート（全 migration を PostgreSQL に適用）→ required 昇格。
   - `close-referenced-issues`: **push 限定**（PR では走らない）ので required 候補外＝実測どおり。
   - `e2e` / `release-zip`: flakiness 観測後の締め増し枠に保留。
3. unblock 確認 → self-merge → SHA 一報。

## 検証

- `needs:` による job id 参照なし・docs 側の context 名参照なし（rename の副作用なし）を確認済み。

Refs #366