### PR TITLE
feat(fsd): A2 — AppShell を app/layout/AppLayout へ移設 (#318)

### DIFF
--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -45,7 +45,7 @@ function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; la
   )
 }
 
-export default function AppShell() {
+export default function AppLayout() {
   const { t, locale, setLocale } = useTranslation()
   const navigate = useNavigate()
   const admin = isAdmin()

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from 'react'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 import { isAuthenticated, isAdmin, subscribeAuthChange } from '@/shared/api/client'
-import AppShell from '@/components/AppShell'
+import AppLayout from '@/app/layout/AppLayout'
 import LoginPage from '@/pages/login/LoginPage'
 import AcceptInvitePage from '@/pages/accept-invite/AcceptInvitePage'
 import DashboardPage from '@/pages/dashboard/DashboardPage'
@@ -44,7 +44,7 @@ export const router = createBrowserRouter([
     path: '/admin',
     element: (
       <RequireAuth>
-        <AppShell />
+        <AppLayout />
       </RequireAuth>
     ),
     children: [


### PR DESCRIPTION
## 概要

layout composition は **app レイヤー**（plan §2）。`components/AppShell.tsx` → `app/layout/AppLayout.tsx`（識別子 `AppShell`→`AppLayout` に rename）。consumer は `router.tsx` の import + JSX のみ。

`components/keyboard` は今夜のスライスから**除外**（規約 01 §4 決定木で未決の配置＝shared/lib 仮置き禁止・hub が spec 欠陥として issue 化。toast の U-9 と同族）。

## 🔬 logic-diff-0 の機械証明（self-merge 条件・A2 同型）

```
rename: components/AppShell.tsx → app/layout/AppLayout.tsx (99%)
全 +/- 行:
  -export default function AppShell() {   +export default function AppLayout() {
  -import AppShell from '@/components/AppShell'   +import AppLayout from '@/app/layout/AppLayout'
  -<AppShell />   +<AppLayout />
非 (AppShell/AppLayout/import) 変更行: 0
```

pure symbol rename + import path のみ。`npm run check` 緑（type-check・lint・vitest **62**・knip）。`composer check` 不干渉。

Refs #318