### PR TITLE
feat(fsd): A2 E2 — receivables + dunning を entities へ (#376)

### DIFF
--- a/frontend/src/entities/dunning-notice/index.ts
+++ b/frontend/src/entities/dunning-notice/index.ts
@@ -1,0 +1,1 @@
+export type { DunningNotice } from './model'

--- a/frontend/src/entities/dunning-notice/model.ts
+++ b/frontend/src/entities/dunning-notice/model.ts
@@ -1,0 +1,18 @@
+// Domain model for a dunning notice. Mirrors the API JSON exactly (snake_case;
+// no renaming) — see docs/development/fsd-a2-entities.md §4.1 (transitional: the
+// A1 codemod later introduces the camelCase model + mapper).
+
+export interface DunningNotice {
+  dunning_notice_id: number
+  organization_id: number
+  invoice_id: number
+  invoice_number: string
+  client_id: number
+  recipient_email: string
+  outstanding_at_send_cents: number
+  due_at: string | null
+  channel: string
+  template_version: string
+  sent_by: number
+  sent_at: string
+}

--- a/frontend/src/entities/manual-receivable/index.ts
+++ b/frontend/src/entities/manual-receivable/index.ts
@@ -1,0 +1,1 @@
+export type { ManualReceivable, ManualReceivableImportResult } from './model'

--- a/frontend/src/entities/manual-receivable/model.ts
+++ b/frontend/src/entities/manual-receivable/model.ts
@@ -1,0 +1,31 @@
+// Domain models for manual receivables. Mirror the API JSON exactly (snake_case;
+// no renaming) — see docs/development/fsd-a2-entities.md §4.1 (transitional: the
+// A1 codemod later introduces the camelCase model + mapper).
+
+/**
+ * A receivable entered directly in Clear, not sourced from NeNe Invoice
+ * (ADR 0014). A reconciliation reference — NOT an issued invoice / 適格請求書 /
+ * tax original. `*_cents` are integer cents (yen × 100), like everywhere else.
+ */
+export interface ManualReceivable {
+  manual_receivable_id: number
+  organization_id: number
+  source: 'manual'
+  reference_number: string
+  client_name: string
+  recipient_email: string | null
+  total_cents: number
+  outstanding_cents: number
+  currency: string
+  issued_at: string | null
+  due_at: string | null
+  status: 'open' | 'partially_paid' | 'paid' | 'cancelled'
+  created_at: string
+  updated_at: string
+}
+
+export interface ManualReceivableImportResult {
+  created: number
+  skipped: number
+  errors: { row: number; errors: { field: string; message: string }[] }[]
+}

--- a/frontend/src/pages/manual-receivables/ManualReceivablesPage.test.tsx
+++ b/frontend/src/pages/manual-receivables/ManualReceivablesPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderWithProviders } from '@/test/render'
-import type { ManualReceivable } from '@/types'
+import type { ManualReceivable } from '@/entities/manual-receivable'
 
 const row: ManualReceivable = {
   manual_receivable_id: 1,

--- a/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
+++ b/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
@@ -4,7 +4,7 @@ import {
   listManualReceivables, createManualReceivable, cancelManualReceivable, importManualReceivables,
 } from '@/shared/api/endpoints'
 import { describeApiError } from '@/shared/api/client'
-import type { ManualReceivable, ManualReceivableImportResult } from '@/types'
+import type { ManualReceivable, ManualReceivableImportResult } from '@/entities/manual-receivable'
 import { Button } from '@/shared/ui/button'
 import { Card } from '@/shared/ui/card'
 import { DataTable, TableStateRow } from '@/shared/ui/data-table'

--- a/frontend/src/shared/api/endpoints.ts
+++ b/frontend/src/shared/api/endpoints.ts
@@ -1,8 +1,9 @@
 import { api } from './client'
 import type {
-  User, DunningNotice, ClearSettings, UpstreamInvoice,
-  AuditEvent, ManualReceivable, ManualReceivableImportResult,
+  User, ClearSettings, UpstreamInvoice, AuditEvent,
 } from '@/types'
+import type { ManualReceivable, ManualReceivableImportResult } from '@/entities/manual-receivable'
+import type { DunningNotice } from '@/entities/dunning-notice'
 import type { BankImportBatch } from '@/entities/bank-import-batch'
 import type { BankTransaction } from '@/entities/bank-transaction'
 import type { Reconciliation } from '@/entities/reconciliation'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,49 +10,6 @@ export interface User {
   fiscal_year_end_month?: number | null
 }
 
-/**
- * A receivable entered directly in Clear, not sourced from NeNe Invoice
- * (ADR 0014). A reconciliation reference — NOT an issued invoice / 適格請求書 /
- * tax original. `*_cents` are integer cents (yen × 100), like everywhere else.
- */
-export interface ManualReceivable {
-  manual_receivable_id: number
-  organization_id: number
-  source: 'manual'
-  reference_number: string
-  client_name: string
-  recipient_email: string | null
-  total_cents: number
-  outstanding_cents: number
-  currency: string
-  issued_at: string | null
-  due_at: string | null
-  status: 'open' | 'partially_paid' | 'paid' | 'cancelled'
-  created_at: string
-  updated_at: string
-}
-
-export interface ManualReceivableImportResult {
-  created: number
-  skipped: number
-  errors: { row: number; errors: { field: string; message: string }[] }[]
-}
-
-export interface DunningNotice {
-  dunning_notice_id: number
-  organization_id: number
-  invoice_id: number
-  invoice_number: string
-  client_id: number
-  recipient_email: string
-  outstanding_at_send_cents: number
-  due_at: string | null
-  channel: string
-  template_version: string
-  sent_by: number
-  sent_at: string
-}
-
 export interface ClearSettings {
   organization_id: number
   upstream_base_url: string


### PR DESCRIPTION
## 概要
A2 entities 再建（#376）の **E2** = receivables + dunning。型のみ移設（Strategy R・挙動保存）。

## 変更
- `entities/manual-receivable`（`ManualReceivable` + `ManualReceivableImportResult`・ADR 0014 コメント同梱）
- `entities/dunning-notice`（`DunningNotice`）
- consumer 再ポイント: `endpoints.ts` の型 block、`manual-receivables` page + test。

`DunningNotice` の外部 consumer は `endpoints.ts` のみ。`DunningPause`/`DunningPreview`/`DunningStage` 等の request/response 型は `endpoints.ts` に残置（設計 §6.3・A1 が `entities/*/api-types.ts` へ）。

## logic-diff-0 証明（設計 §8）
- `types/index.ts`: 3 interface の削除のみ（**+0 行**）。移設 body は **md5 一致**。新規行は header doc comment のみ。
- `npm run check` 緑（**vitest 62 不変**）。

Refs #376
