### PR TITLE
docs: current.md + 日報(セッション2) を A2 entities 完了に追随

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -47,3 +47,33 @@
 
 - entities 層（本丸）は明日以降、設計書ゲートから。
 - keyboard は fleet-tooling#89 の配置裁定待ちで凍結。
+
+---
+
+## セッション2（施主起動→hub 指揮・A2 entities 層 完走）
+
+施主から「指揮は hub に委任・疑問は理由つきで hub へ差し戻し・完了時に hub へ完了報告＋レビュー依頼」の運用指示を受けて起動。hub から entities 層 GO（2段階ゲート）を受領し、**設計→承認→E0〜E4 実行までを1セッションで完走**。#376 CLOSED。
+
+### 設計ゲート（マッピング設計書）
+- `docs/development/fsd-a2-entities.md` 作成 → hub レビュー **APPROVE**（PR #377）。
+- 中核の発見〔実測〕: exemplar payout の entities は model/mapper/queries/mutations の完全形。clear は snake_case 1 型/noun ＋ pages が生 promise を inline useQuery＝**真逆**。この差分こそ A1 codemod（hooks→model・A2 の後・手作業禁止）の担当分。かつ clear は **gen:entity 未配線・FSD 境界 lint 未導入**〔実測〕。
+- 規約（entity は gen 必須・mapper MUST・model=zod）と「挙動保存・A1 は後」の**両立不可**を §2 に明記し、**Strategy R（型のみ移設）**を提案 → hub 採用。過渡状態は §4.1 に conformance 註記（出口=A1）。
+
+### 実行（全 base=main・各 PR 緑＋logic-diff-0 証明・self-merge）
+- **E0 #378**: `endpoints.ts`→`shared/api`・`downloadCsv`→`shared/lib`・`ProblemDetails`/`ListEnvelope`→`shared/api/http-types`。`src/api/` 空化。証明: rename 97%＋移設 460 行 md5 一致。
+- **E1 #379**: `bank-transaction`/`bank-import-batch`/`reconciliation`(+allocation 同梱)/`client-credit`。
+- **E2 #380**: `manual-receivable`/`dunning-notice`。E2 完了で hub へ中間報告→継続 GO。
+- **E3 #381**: `user`/`clear-settings`(BankAccount 同梱・sibling import 回避)/`audit-event`/`upstream-invoice`。`@/types` 参照 0 化＋`src/types/index.ts` 削除。
+- **E4 #383**: `useFiscalYearDefault`→`entities/user/model/`（100% rename）・`src/hooks/` 撤去・doc §4 追随。**Closes #376**。
+
+### 逸脱1件（hub 裁定で処理）
+- `UpstreamClient` は**実測 consumer 皆無の dead export**。独立 slice にすると knip が dead file を赤検出 → hub 承認の **option A** で `upstream-invoice` に同梱（削除せず・可逆）。去就は **#382** で追跡。設計 §4 表も訂正。
+
+### 到達状態
+- entities **10 slice**・`src/` 直下から types/api/hooks 消滅。全 PR で **vitest 62 不変・knip clean・md5/rename 証明**。
+- 残置は `components/keyboard`（fleet#89 凍結・対象外）。A2 完了に伴い **A1 codemod 適用可**（着手は hub 指揮）。
+
+### ★教訓
+- **exemplar と現状の乖離を先に数値化すると、A2/A1 の責務境界が自然に決まる**〔実測〕。「型のみ移設」という読みは、payout 完全形との差分＝hooks→model が A1 の担当と確定した瞬間に唯一解になった。
+- **dead export は移設で初めて可視化される**。types/index.ts に埋もれていた UpstreamClient は、slice 化して knip に当てて初めて「誰も使っていない」と判明。逸脱は隠さず PR＋relay の両方で hub に上げ、台帳（#382）化。
+- **md5一致＋pure-removal のパターン固定でレビューコストが最小化**（hub 評）。各 PR が同じ証明形なので、hub は差分を機械確認できる。

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,6 +2,26 @@
 
 Last updated: 2026-07-18
 
+> **2026-07-18 (session 2): A2 — the `entities/` layer is COMPLETE (#376 closed).**
+> Design gate `docs/development/fsd-a2-entities.md` was hub-approved (#377), then
+> executed in five behavior-preserving PRs, each with a logic-diff-0 proof and CI
+> green: **E0** #378 (`endpoints.ts`→`shared/api`, `downloadCsv`→`shared/lib`,
+> `ProblemDetails`/`ListEnvelope`→`shared/api/http-types`; `src/api/` emptied),
+> **E1** #379 (bank-transaction / bank-import-batch / reconciliation / client-credit),
+> **E2** #380 (manual-receivable / dunning-notice), **E3** #381 (user /
+> clear-settings[+BankAccount] / audit-event / upstream-invoice; `@/types` → 0,
+> `src/types/index.ts` deleted), **E4** #383 (`useFiscalYearDefault` →
+> `entities/user/model/`, `src/hooks/` removed). Result: **10 entity slices**,
+> `types/`·`api/`·`hooks/` gone from `src/`; every PR kept **vitest 62** and knip
+> clean. Chosen strategy = **types-only relocation** (snake_case `model.ts`
+> verbatim, no mapper/zod yet): a hub-approved **transitional** state whose exit is
+> the **A1 codemod** (hooks→model), now unblocked. One deviation: `UpstreamClient`
+> (a dead export) is co-located in `entities/upstream-invoice` rather than its own
+> slice — tracked in **#382**. FSD boundary-lint zones remain deferred (a
+> follow-on under the front-test-hardening campaign). `components/keyboard` stays
+> frozen (**fleet-tooling#89**) — the only `src/components/` resident.
+> Details: [`../daily/2026-07-18.md`](../daily/2026-07-18.md) (session 2).
+
 > **2026-07-18: A2 (FSD 5-layer rebuild) — shared foundation essentially done.**
 > After Tier1 (`shared/lib` #359 / `shared/i18n` #360 / `shared/api` #362),
 > **Tier2 `shared/ui`** landed (design #369 / impl #370): the 15 `components/ui`


### PR DESCRIPTION
A2 entities 層完了（#376 CLOSED）に伴うトラッカー追随。docs のみ。

- `current.md`: entities 完了の lead block（E0〜E4 要約・transitional・#382・境界lint後置・keyboard凍結）。
- `daily/2026-07-18.md`: `## セッション2`（設計ゲート〜E4 完走・逸脱処理・教訓）。

Refs #376