### PR TITLE
test(format): shared/lib/format の金額・日付整形に単体テスト (T1-lite)

### DIFF
--- a/frontend/src/shared/lib/format.test.ts
+++ b/frontend/src/shared/lib/format.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { yen, formatDate, formatDateTime, daysOverdue } from './format'
+
+describe('yen', () => {
+  it('renders integer cents as a JPY string (cents ÷ 100, ja-JP separators)', () => {
+    expect(yen(0)).toBe('¥0')
+    expect(yen(100)).toBe('¥1')
+    expect(yen(150000)).toBe('¥1,500')
+    expect(yen(250000)).toBe('¥2,500')
+    expect(yen(11000000)).toBe('¥110,000')
+    expect(yen(1234567800)).toBe('¥12,345,678')
+  })
+
+  it('floors sub-yen cents rather than rounding', () => {
+    // 250 cents = ¥2.50 → floored to ¥2 (documents Math.floor, not round).
+    expect(yen(250)).toBe('¥2')
+    expect(yen(199)).toBe('¥1')
+  })
+})
+
+describe('formatDate', () => {
+  it('keeps only the YYYY-MM-DD date, for space- and T-separated timestamps', () => {
+    expect(formatDate('2026-04-01 09:00:00')).toBe('2026-04-01')
+    expect(formatDate('2026-04-01T09:00:00Z')).toBe('2026-04-01')
+  })
+})
+
+describe('formatDateTime', () => {
+  it('renders YYYY-MM-DD HH:mm, normalizing a T separator to a space', () => {
+    expect(formatDateTime('2026-04-01T09:30:00')).toBe('2026-04-01 09:30')
+    expect(formatDateTime('2026-04-01 09:30:45')).toBe('2026-04-01 09:30')
+  })
+})
+
+describe('daysOverdue', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns the em dash when there is no due date', () => {
+    expect(daysOverdue(null)).toBe('—')
+    expect(daysOverdue('')).toBe('—')
+  })
+
+  it('counts whole days past a due date, and shows the em dash before/at due', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-10T00:00:00Z'))
+    expect(daysOverdue('2026-04-05')).toBe('5日') // 5 days elapsed
+    expect(daysOverdue('2026-04-10')).toBe('—')   // due today → not yet overdue
+    expect(daysOverdue('2026-04-15')).toBe('—')   // future due date
+  })
+})


### PR DESCRIPTION
## 概要
T1-lite（承認雛形・self-merge）。TOP5 ③ = `shared/lib/format.ts`（純関数・完全 stable・0 test）。テスト追加のみ・config/依存変更なし。**vitest 66→72 全緑**。

## ケース
- `yen`: cents÷100・ja-JP 桁区切り・**sub-yen は floor**（round でない）を明記
- `formatDate`: T/空白区切りとも YYYY-MM-DD
- `formatDateTime`: T→空白正規化で YYYY-MM-DD HH:mm
- `daysOverdue`: null/'' →「—」・超過→「N日」・当日/未来→「—」（`vi.useFakeTimers` で Date.now 固定）

※ format.ts は #358 で将来 nene2-i18n/format へ移設予定（外部 subpath 出荷待ち）だが現時点 in-repo stable。挙動を固定する本テストは移設先へも転用可。

Refs #376