### PR TITLE
fix(ci): phpunit に APP_ENV=test を明示（NENE2 M-2 #1600 予防）

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,14 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <!-- NENE2 M-2 (#1600): an unset APP_ENV resolves to "production", where NENE2
+         fail-closes (the dev-secret opt-in is ignored), which reddens backend CI
+         once that NENE2 release resolves. Declare the test environment explicitly
+         (fleet directive; ref suite #404). This is an environment declaration, not
+         a bypass of the production fail-closed path. -->
+    <env name="APP_ENV" value="test"/>
+  </php>
   <source>
     <include>
       <directory>src</directory>


### PR DESCRIPTION
## 概要
フリート技術通達（NENE2 M-2 / #1600）の予防措置。**同型 PR は通達で事前承認済み**（CI 緑 self-merge・事後報告）。

## 機序
APP_ENV 未設定 → "production" 解決 → NENE2 が fail-closed（dev-secret opt-in 無視）。clear は NENE2 を `^1.11`（Packagist）で解決するため、M-2 を含む NENE2 リリースが範囲内で解決されると **backend CI が赤化しうる**。

## 変更
`phpunit.xml` の `<php>` に `<env name="APP_ENV" value="test"/>` を1行追加（機序コメント付き）。参照実装 = suite #404。

## 非該当
production の fail-closed 経路を弱めるものではない（test 環境の明示宣言）。現時点 backend CI は緑だが、次の NENE2 解決に備える予防措置。