### PR TITLE
docs(todo): §8 是正 — 運用ログから本番配備 infra を参照要約へ（P3 前段）

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -76,16 +76,16 @@ Last updated: 2026-07-18
 > (#261), and JSON POST bodies were never parsed at the entry point, so the
 > SPA's propose/confirm/dunning-send failed against the real backend (#262).
 > The 2026-07-03 screenshot session's `.env` (dead stub on 8390) has been
-> reverted. **The demo is live at `https://clear.ayane.co.jp` (deployed
-> 2026-07-09 evening, owner GO)** — HETEML, MySQL `_nene_clear`, invoice-shaped
-> docroot; the deployment surfaced and fixed two more Tier A bugs (#265
-> Authorization stripped by the front proxy, #268 SPA asset base).
+> reverted. **The public demo is live (deployed 2026-07-09 evening, owner GO)**;
+> the hosting / DB / docroot specifics live in the non-public deploy runbook.
+> The deployment surfaced and fixed two more Tier A bugs (#265 Authorization
+> stripped by the front proxy, #268 SPA asset base).
 > **2026-07-10: the disposable-org demo is live too** (`/demo/standard`,
-> `Nene2\Demo` v1.9.0 consumer, #275; MySQL LIKE-escape fix #277) — hand out
-> `https://clear.ayane.co.jp/demo/standard` and every visitor gets a fresh
-> throttled, TTL-swept org. Remaining owner steps (HETEML panel, cron):
-> nightly fixed-org reset `~/bin/reseed-clear-demo.sh` and hourly demo sweep
-> `~/bin/sweep-clear-demo.sh`. SMTP is unset (dunning channel `log`), and the
+> `Nene2\Demo` v1.9.0 consumer, #275; SQL LIKE-escape fix #277) — hand out the
+> demo URL (kept in the non-public deploy runbook) and every visitor gets a
+> fresh throttled, TTL-swept org. Remaining owner steps (hosting panel + the
+> nightly reset / hourly sweep cron) live in that runbook. SMTP is unset
+> (dunning channel `log`), and the
 > `client_credit.status` registry/enum drift is #264. Details:
 > [`docs/journal/2026-07-09.md`](../journal/2026-07-09.md) and
 > [`docs/journal/2026-07-10.md`](../journal/2026-07-10.md).

--- a/docs/todo/handoff-2026-07-02.md
+++ b/docs/todo/handoff-2026-07-02.md
@@ -32,8 +32,8 @@ Quality: `composer check` green throughout (now **338 tests**, PHPStan L8, PHP-C
 
 ## 2. The installer / distribution effort — state
 
-**Goal:** a browser `install.php` an operator drops on shared hosting (HETEML/
-sakura), which sets up the DB, picks single/multi tenancy, downloads the app, and
+**Goal:** a browser `install.php` an operator drops on typical Japanese shared
+hosting, which sets up the DB, picks single/multi tenancy, downloads the app, and
 creates the first admin.
 
 **Locked decisions (owner):**


### PR DESCRIPTION
## 概要
日報規約 §8（NG-1 インフラ固有情報）の**公開側是正**。hub 裁定 A2 に従い、P3 ①搬入の前に公開露出を閉じる（suite #403 の型）。

## 変更（本番配備 infra → 非公開 runbook 参照要約）
- `current.md` デモ配備ブロック: 本番 FQDN・ホスティング名・本番 DB 名・docroot・オペレータ script・cron を参照要約へ。実質情報（デモ稼働／使い捨て org デモ／TTL sweep／修正 Issue #265・#268・#275・#277／SMTP=log）は保持。
- `handoff-2026-07-02`: 導入先例示の `HETEML/sakura` を汎用表現へ。

## scope 判断（hub 確認用）
- **是正した** = 本番配備固有 infra（FQDN／ホスティング名／本番 DB 名／オペレータ script パス／cron）。
- **是正外** = ①ローカル dev ポート（公開 `CLAUDE.md` ポートレジストリと同一＝秘匿対象でない）②env 変数名（値でなく名前）③`_work/` 内部パス（**NG-4＝hub 裁定で private nav 温存**・②で公開docごと削除）。
- 実測: 本番 FQDN/HETEML/`_nene_clear`/オペレータ script の残存 **0**（`NENE_SUITE_APP_NENE_CLEAR_MACHINE_KEY` は env 変数名の別物）。

docs のみ・挙動不変。CI 緑後 hub レビュー依頼。