### PR TITLE
docs: P3 ③ — 生き導線を private mirror へ repoint（sweep）

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ NeNe Clear is built through small, Issue-driven changes. This document is the sh
 | AI tools | `docs/integrations/ai-tools.md` |
 | Agent entry point | `AGENTS.md` |
 | Roadmap | `docs/roadmap.md` |
-| Current work | `docs/todo/current.md` |
+| Current work | `nene-origin/internal-docs/clear/todo/current.md` |
 
 ## Collaboration Policy
 
@@ -29,7 +29,7 @@ Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://gith
 4. Push, open PR with `Closes #number`, merge after checks — **do not push directly to `main`**.
 
 - Use one branch and one PR per focused work unit.
-- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and `nene-origin/internal-docs/clear/todo/current.md` updated when direction changes.
 - Explain intent, impact, verification, and remaining risk in PRs.
 - Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
 

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -14,7 +14,7 @@ Write an ADR when a decision affects:
 - release, versioning, or compatibility policy
 - long-term maintenance cost
 
-Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/current.md`.
+Do **not** use ADRs for routine task detail — use Issues, PRs, and `nene-origin/internal-docs/clear/todo/current.md`.
 
 ## Directory and naming
 

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -9,13 +9,13 @@ Source policies:
 - `docs/inheritance-from-nene2.md`
 - `docs/explanation/glossary.md`
 - `docs/development/naming-conventions.md`
-- `docs/todo/current.md`
+- `nene-origin/internal-docs/clear/todo/current.md`
 - `docs/roadmap.md`
 
 ## Checklist
 
 - [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
-- [ ] `docs/roadmap.md` or `docs/todo/current.md` updated when project state changed.
+- [ ] `docs/roadmap.md` or `nene-origin/internal-docs/clear/todo/current.md` updated when project state changed.
 - [ ] Major architecture decisions considered whether an ADR is needed.
 - [ ] NENE2 inheritance changes reflected in `docs/inheritance-from-nene2.md`.
 - [ ] Public source-of-truth docs and OpenAPI text remain English unless policy allows otherwise.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,7 +7,7 @@ See also: `docs/inheritance-from-nene2.md`.
 ## Standard Flow
 
 1. Create or reuse a focused GitHub Issue.
-2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `nene-origin/internal-docs/clear/todo/current.md`.
 3. Create a branch from `main` named like `type/issue-number-summary`.
 4. Implement the smallest useful change.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
@@ -63,7 +63,7 @@ To prevent it:
 
 - `docs/roadmap.md`: long-lived direction and phases
 - `docs/milestones/`: medium-sized goals and acceptance criteria
-- `docs/todo/current.md`: current task board and handoff notes
+- `nene-origin/internal-docs/clear/todo/current.md`: current task board and handoff notes
 - `docs/adr/`: major architecture decisions
 - `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
 
@@ -90,4 +90,4 @@ If a user explicitly says investigation only, no commit, no PR, or another narro
 
 ## Initial Issues Backlog
 
-Phase 0 bootstrap Issues are tracked in `docs/todo/current.md`. After governance lands, use GitHub Issues for all work — no direct `main` commits.
+Phase 0 bootstrap Issues are tracked in `nene-origin/internal-docs/clear/todo/current.md`. After governance lands, use GitHub Issues for all work — no direct `main` commits.


### PR DESCRIPTION
## 概要
P3 Phase 3 の **③ sweep**（最終弾）。②（運用ログ private 移設・2e02b85）を受け、公開 governance/dev docs の**生きた `docs/todo/current.md` 参照**を private `nene-origin/internal-docs/clear/todo/current.md` へ path-for-path 差替。読者向けリンク切れを解消。

## 変更（8参照・4ファイル）
- `docs/CONTRIBUTING.md`（Current work 表・direction 更新項）
- `docs/development/adr.md`（routine task 参照）
- `docs/workflow.md`（context 確認・task board・Phase0）
- `docs/review/docs-policy.md`（更新対象リスト）

## 放置（意図的）
歴史（`docs/milestones/`・`docs/journal/`）= 裁定1A。`docs/roadmap.md` 等の公開 docs 参照は不変。

これで **P3 完結**（①搬入 nene-origin #340 → ②削除 #393 → ③本 PR）。docs のみ・self-merge（hub 承認）。

Refs #376