### PR TITLE
feat(mobile): <=820px でサイドバー→ボトムタブ＋メニューシート化

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>NeNe Clear</title>
     <!-- Fonts are self-hosted via @fontsource (see src/main.tsx); no CDN link

--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Link, Outlet, useNavigate } from 'react-router-dom'
+import { useState } from 'react'
+import { NavLink, Link, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from '@/shared/i18n/use-translation'
 import { clearToken, isAdmin } from '@/shared/api/client'
@@ -31,6 +32,19 @@ const ADMIN_NAV: NavEntry[] = [
   { to: '/admin/audit-log', labelKey: 'nav.auditLog', icon: 'clock', adminOnly: true },
 ]
 
+// Mobile bottom-tab bar (<=820px): the 4 primary day-to-day destinations — overview
+// → reconcile (core, badge) → confirm the incoming transaction → dunning. Everything
+// else (settings/receivables/import/help/admin) folds into the Menu sheet, which
+// reuses the exact same NAV/ADMIN_NAV definitions. `nav.tab.bankTransactions` is a
+// tab-length label (取引 / Transactions) so 5 tabs never wrap on iPhone 13 (390px).
+const MOBILE_TABS: { to: string; labelKey: MessageKey; icon: string; end?: boolean }[] = [
+  { to: '/admin', labelKey: 'nav.dashboard', icon: 'grid', end: true },
+  { to: '/admin/reconciliation', labelKey: 'nav.reconciliation', icon: 'reconcile' },
+  { to: '/admin/bank-transactions', labelKey: 'nav.tab.bankTransactions', icon: 'table' },
+  { to: '/admin/dunning', labelKey: 'nav.dunning', icon: 'bell' },
+]
+const RECON_BADGE = NAV.find(n => n.to === '/admin/reconciliation')?.badge
+
 function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; label: string; badge?: number; end?: boolean }) {
   return (
     <NavLink
@@ -45,11 +59,54 @@ function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; la
   )
 }
 
+// The business + admin nav sections, shared by the desktop sidebar and the mobile
+// menu sheet so both stay in lock-step (single source of truth = NAV/ADMIN_NAV).
+function NavSections({ t, adminNav }: { t: (k: MessageKey) => string; adminNav: NavEntry[] }) {
+  return (
+    <>
+      <div className="side-sect">{t('nav.section.business')}</div>
+      {NAV.map(item => (
+        <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} badge={item.badge} end={item.end} />
+      ))}
+      {adminNav.length > 0 && (
+        <>
+          <div className="side-sect">{t('nav.section.admin')}</div>
+          {adminNav.map(item => (
+            <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} />
+          ))}
+        </>
+      )}
+    </>
+  )
+}
+
 export default function AppLayout() {
   const { t, locale, setLocale } = useTranslation()
   const navigate = useNavigate()
+  const location = useLocation()
   const admin = isAdmin()
   const adminNav = ADMIN_NAV.filter(item => !item.adminOnly || admin)
+
+  // Mobile menu sheet. Two flags so the sheet can animate in/out: `sheetMounted`
+  // drives the `hidden` attribute (in/out of the layer — the scrim must not be
+  // present while closed or it would swallow all taps), `sheetOpen` drives the
+  // `.open` class (transform/opacity transition). Never set display:none via a
+  // class — that kills the transition (documented pitfall in the design handoff).
+  const [sheetMounted, setSheetMounted] = useState(false)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  function openSheet() {
+    setSheetMounted(true)
+    requestAnimationFrame(() => setSheetOpen(true))
+  }
+  function closeSheet() {
+    setSheetOpen(false)
+    setTimeout(() => setSheetMounted(false), 240)
+  }
+  // The Menu tab reads active whenever the sheet is open or we're on a route that
+  // isn't one of the 4 primary tabs (settings/receivables/import/help/admin…).
+  const path = location.pathname
+  const primaryActive = MOBILE_TABS.some(tb => (tb.end ? path === tb.to : path.startsWith(tb.to)))
+  const menuActive = sheetMounted || !primaryActive
 
   // Load the session/org context (incl. the org's fiscal year-end month) once
   // per session and hold it in the query cache. Page content waits for it so
@@ -81,18 +138,7 @@ export default function AppLayout() {
           </div>
         </div>
         <nav className="side-nav">
-          <div className="side-sect">{t('nav.section.business')}</div>
-          {NAV.map(item => (
-            <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} badge={item.badge} end={item.end} />
-          ))}
-          {adminNav.length > 0 && (
-            <>
-              <div className="side-sect">{t('nav.section.admin')}</div>
-              {adminNav.map(item => (
-                <NavItem key={item.to} to={item.to} icon={item.icon} label={t(item.labelKey)} />
-              ))}
-            </>
-          )}
+          <NavSections t={t} adminNav={adminNav} />
         </nav>
         <div className="side-foot">
           <div className="side-user">
@@ -108,6 +154,10 @@ export default function AppLayout() {
 
       <div className="main">
         <header className="topbar">
+          <Link to="/admin" className="mbrand" aria-label="NeNe Clear">
+            <LogoMark height={24} className="logo-mark" />
+            <b>NeNe Clear</b>
+          </Link>
           <nav className="crumb">
             <span>NeNe Clear</span>
             <svg className="ic" style={{ width: 14, height: 14 }}><use href="#i-chev-r" /></svg>
@@ -137,6 +187,55 @@ export default function AppLayout() {
             {meQ.isFetched
               ? <Outlet />
               : <p className="muted" style={{ padding: 24 }}>{t('common.loading')}</p>}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile bottom-tab bar (<=820px, hidden on desktop via CSS). */}
+      <nav className="mnav" aria-label={t('crumb.menu')}>
+        {MOBILE_TABS.map(tb => (
+          <NavLink
+            key={tb.to}
+            to={tb.to}
+            end={tb.end}
+            className={({ isActive }) => ['mtab', isActive ? 'active' : ''].filter(Boolean).join(' ')}
+          >
+            <Icon name={tb.icon} />
+            {tb.to === '/admin/reconciliation' && RECON_BADGE !== undefined && (
+              <span className="mtab-badge">{RECON_BADGE}</span>
+            )}
+            <span>{t(tb.labelKey)}</span>
+          </NavLink>
+        ))}
+        <button
+          type="button"
+          className={['mtab', menuActive ? 'active' : ''].filter(Boolean).join(' ')}
+          onClick={openSheet}
+          aria-haspopup="dialog"
+          aria-expanded={sheetOpen}
+        >
+          <span className="mdots"><i /><i /><i /></span>
+          <span>{t('crumb.menu')}</span>
+        </button>
+      </nav>
+
+      {/* Menu sheet — folds the full nav (business + admin) + user/logout footer. */}
+      <div className={['msheet', sheetOpen ? 'open' : ''].filter(Boolean).join(' ')} hidden={!sheetMounted}>
+        <div className="msheet-scrim" onClick={closeSheet} />
+        <div className="msheet-panel" role="dialog" aria-modal="true" aria-label={t('crumb.menu')}>
+          <div className="msheet-grab" />
+          <nav className="msheet-nav" onClick={e => { if ((e.target as HTMLElement).closest('a')) closeSheet() }}>
+            <NavSections t={t} adminNav={adminNav} />
+          </nav>
+          <div className="msheet-foot">
+            <div className="avatar">AD</div>
+            <div className="who">
+              <b>{t('user.role.admin')}</b>
+              <span>admin@example.com</span>
+            </div>
+            <button className="logout" title={t('nav.logout')} aria-label={t('nav.logout')} onClick={handleLogout}>
+              <Icon name="logout" />
+            </button>
           </div>
         </div>
       </div>

--- a/frontend/src/shared/i18n/messages/en.ts
+++ b/frontend/src/shared/i18n/messages/en.ts
@@ -15,6 +15,7 @@ export const en: Record<MessageKey, string> = {
   'nav.dashboard': 'Dashboard',
   'nav.bankImport': 'Bank CSV Import',
   'nav.bankTransactions': 'Bank Transactions',
+  'nav.tab.bankTransactions': 'Transactions',
   'nav.reconciliation': 'Reconciliation',
   'nav.clientCredits': 'Client Credits',
   'nav.manualReceivables': 'Manual Receivables',

--- a/frontend/src/shared/i18n/messages/ja.ts
+++ b/frontend/src/shared/i18n/messages/ja.ts
@@ -11,6 +11,7 @@ export const ja = {
   'nav.dashboard': 'ダッシュボード',
   'nav.bankImport': '銀行CSV取込',
   'nav.bankTransactions': '銀行取引一覧',
+  'nav.tab.bankTransactions': '取引',
   'nav.reconciliation': '消込',
   'nav.clientCredits': '前受金',
   'nav.manualReceivables': '手入力売掛',

--- a/frontend/src/styles/design.css
+++ b/frontend/src/styles/design.css
@@ -959,4 +959,87 @@ tr.is-cursor, .is-cursor { background: var(--navy-100); box-shadow: inset 3px 0 
   .terms, .opt3, .kgrid, .deflist .row{ grid-template-columns:1fr; }
   .deflist .row{ gap:4px; }
 }
+
+/* ===== モバイルレスポンシブ (追加レイヤ / 既存テーマは据え置き) ==================
+   ClaudeDesign 指示書 2026-07-24 / fleet の invoice・deal「1カラム＋ボトムタブ＋
+   メニュー畳み」を踏襲。タブ/シートは Clear の濃紺(--side-bg)・朱バッジ(--bad)を
+   保持しブランドの見え方は変えない。ブレークポイント <=820px。
+   NOTE: 指示書 §3 の recon master-detail (.recon-split) は実 UI(タブ＋DataTable＋
+   マッチ Modal)に無いため未移植。DataTable は .tbl-wrap{overflow-x:auto}、Modal は
+   max-height:86vh でモバイル可 — シェル 1カラム化だけで「右端切断」は解消する。
+   ======================================================================= */
+.mnav, .mbrand{ display:none; }
+.side{ width:208px; }
+
+@media (max-width:820px){
+  .app{ flex-direction:column; height:100dvh; }
+  .side{ display:none; }
+  .main{ width:100%; min-width:0; }
+  .topbar{ padding:0 12px; gap:8px; }
+  .mbrand{ display:flex; align-items:center; gap:9px; flex:none; text-decoration:none; color:var(--ink); }
+  .mbrand .logo-mark{ width:24px; height:24px; }
+  .mbrand b{ font-size:14px; font-weight:700; letter-spacing:.01em; }
+  /* The desktop breadcrumb is a static "NeNe Clear › メニュー" placeholder (unlike
+     the design mock, whose JS rewrote it per view). On mobile the .mbrand + the
+     page H1 + the active bottom tab already say where you are, so hide it rather
+     than surface a misleading fixed label. */
+  .crumb{ display:none; }
+  .topbar .lang, .topbar .sep{ display:none; }
+  .topbar-r{ gap:4px; }
+  .page{ padding:16px 14px 92px; }
+  .page-head{ margin:-16px -14px 18px; padding:16px 14px 14px; }
+  .kpi-grid{ grid-template-columns:1fr !important; gap:12px; }
+  .kpi{ padding:16px 18px; }
+  .dash-cards{ grid-template-columns:1fr !important; gap:14px; }
+  .mnav{ display:flex; }
+}
+
+/* ボトムタブ (濃紺・primary 4 + メニュー) */
+.mnav{ position:fixed; left:0; right:0; bottom:0; z-index:60;
+  height:calc(58px + env(safe-area-inset-bottom)); padding-bottom:env(safe-area-inset-bottom);
+  background:var(--side-bg); border-top:1px solid var(--side-line); align-items:stretch; }
+.mtab{ flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:4px; color:var(--side-fg); background:none; border:0; cursor:pointer; font-size:10px;
+  font-weight:600; position:relative; padding:7px 2px 0; font-family:inherit; text-decoration:none;
+  white-space:nowrap; letter-spacing:-.02em; }
+.mtab .ic{ width:22px; height:22px; }
+.mtab > span{ max-width:100%; overflow:hidden; text-overflow:ellipsis; }
+.mtab.active{ color:var(--side-fg-strong); }
+.mtab.active:before{ content:""; position:absolute; top:0; left:50%; transform:translateX(-50%);
+  width:28px; height:3px; background:var(--side-active-bar); border-radius:0 0 2px 2px; }
+.mtab-badge{ position:absolute; top:3px; left:calc(50% + 6px); background:var(--bad); color:#fff;
+  border-radius:999px; min-width:17px; height:17px; padding:0 4px; font-size:10px; font-weight:700;
+  display:flex; align-items:center; justify-content:center; line-height:1; border:1.5px solid var(--side-bg); }
+.mdots{ display:flex; gap:3px; }
+.mdots i{ width:4px; height:4px; border-radius:999px; background:currentColor; }
+
+/* メニューシート (全ナビ畳み込み・濃紺ボトムシート) */
+.msheet{ position:fixed; inset:0; z-index:70; }
+.msheet[hidden]{ display:none; }
+.msheet-scrim{ position:absolute; inset:0; background:#0a1c3070; opacity:0; transition:opacity .2s; }
+.msheet.open .msheet-scrim{ opacity:1; }
+.msheet-panel{ position:absolute; left:0; right:0; bottom:0; max-height:88dvh; overflow-y:auto;
+  background:var(--side-bg); color:var(--side-fg); border-radius:16px 16px 0 0;
+  padding:10px 12px calc(20px + env(safe-area-inset-bottom)); transform:translateY(102%);
+  transition:transform .24s cubic-bezier(.2,.7,.3,1); box-shadow:0 -8px 32px #0006; }
+.msheet.open .msheet-panel{ transform:translateY(0); }
+.msheet-grab{ width:38px; height:4px; border-radius:999px; background:#ffffff30; margin:2px auto 12px; }
+.msheet .side-sect{ color:var(--side-fg); opacity:.7; font-size:11px; letter-spacing:.06em;
+  text-transform:uppercase; padding:10px 11px 6px; font-weight:600; }
+.msheet .nav-item{ display:flex; align-items:center; gap:12px; color:var(--side-fg);
+  text-decoration:none; padding:11px; border-radius:var(--radius-sm); font-size:14px; font-weight:500; }
+.msheet .nav-item .ic{ width:20px; height:20px; flex:none; }
+.msheet .nav-item.active{ background:var(--side-active-bg); color:var(--side-fg-strong); font-weight:700; }
+.msheet .nav-badge{ background:var(--bad); color:#fff; border-radius:999px; margin-left:auto;
+  padding:3px 7px; font-size:11px; font-weight:700; }
+.msheet-foot{ border-top:1px solid var(--side-line); margin-top:10px; padding:14px 11px 4px;
+  display:flex; align-items:center; gap:11px; }
+.msheet-foot .avatar{ width:34px; height:34px; border-radius:var(--radius-sm); background:var(--navy-500);
+  color:#fff; display:flex; align-items:center; justify-content:center; font-size:12px; font-weight:700; flex:none; }
+.msheet-foot .who b{ display:block; color:var(--side-fg-strong); font-size:13px; }
+.msheet-foot .who span{ font-size:11.5px; color:var(--side-fg); }
+.msheet-foot .logout{ margin-left:auto; background:#ffffff12; border:1px solid var(--side-line);
+  color:var(--side-fg-strong); border-radius:var(--radius-sm); width:38px; height:38px;
+  display:flex; align-items:center; justify-content:center; cursor:pointer; }
+.msheet-foot .logout .ic{ width:18px; height:18px; }
 }

--- a/tests/e2e/specs/17-mobile-responsive.spec.ts
+++ b/tests/e2e/specs/17-mobile-responsive.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, devices } from '@playwright/test'
+import { apiRoute, json, list, bypassLogin } from '../fixtures/helpers'
+
+// The reconciliation demo QR (行政書士/税理士 leaflet) lands on a phone, so the
+// <=820px shell must collapse the desktop sidebar to a bottom-tab bar. iPhone 13
+// (390×844) is the reference device in the design work order. Apply its viewport /
+// touch emulation onto the project's chromium engine — the repo (and CI) only
+// installs chromium, so we don't spread `devices['iPhone 13']` wholesale (that
+// would flip defaultBrowserType to webkit, which isn't installed).
+const iphone13 = devices['iPhone 13']
+test.use({
+  viewport: iphone13.viewport,
+  userAgent: iphone13.userAgent,
+  deviceScaleFactor: iphone13.deviceScaleFactor,
+  isMobile: iphone13.isMobile,
+  hasTouch: iphone13.hasTouch,
+})
+
+test.beforeEach(async ({ page }) => {
+  await bypassLogin(page)
+  // Broadly stub the list endpoints so each page renders its shell without
+  // falling through to the preview server. Empty is fine — these assert layout.
+  await apiRoute(page, '**/admin/bank-transactions/unmatched**', (route) => json(route, 200, list([])))
+  await apiRoute(page, '**/admin/bank-transactions**', (route) => json(route, 200, list([])))
+  await apiRoute(page, '**/admin/dunning-notices**', (route) => json(route, 200, list([])))
+  await apiRoute(page, '**/admin/reconciliations**', (route) => json(route, 200, list([])))
+})
+
+test.describe('Mobile responsive shell (<=820px)', () => {
+  test('sidebar collapses to a bottom-tab bar; no horizontal overflow', async ({ page }) => {
+    await page.goto('/admin')
+
+    // Desktop sidebar hidden; bottom tabs shown (the reported "サイドバー6割占拠" fix).
+    await expect(page.locator('.side')).toBeHidden()
+    await expect(page.locator('.mnav')).toBeVisible()
+
+    // 4 primary tabs + Menu = 5, none wrapping off-screen.
+    await expect(page.locator('.mnav .mtab')).toHaveCount(5)
+
+    // Reconciliation (the core action) carries the unmatched-count badge.
+    await expect(page.locator('.mnav a[href="/admin/reconciliation"] .mtab-badge')).toBeVisible()
+
+    // The document itself must not scroll sideways (the reported "右端で切断").
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    )
+    expect(overflow).toBeLessThanOrEqual(1)
+  })
+
+  test('Menu tab opens the sheet with the folded nav; a sheet link navigates and closes it', async ({ page }) => {
+    await page.goto('/admin')
+
+    const sheet = page.locator('.msheet')
+    await expect(sheet).toBeHidden()
+
+    await page.getByRole('button', { name: 'メニュー' }).click()
+    await expect(sheet).toBeVisible()
+
+    // The sheet folds in destinations that aren't primary tabs (e.g. 設定).
+    const settings = sheet.getByRole('link', { name: '設定' })
+    await expect(settings).toBeVisible()
+
+    await settings.click()
+    await page.waitForURL(/\/admin\/settings/)
+    await expect(sheet).toBeHidden()
+  })
+
+  test('bottom-tab navigation switches page and marks the tab active', async ({ page }) => {
+    await page.goto('/admin')
+
+    await page.locator('.mnav a[href="/admin/dunning"]').click()
+    await page.waitForURL(/\/admin\/dunning/)
+    await expect(page.locator('.mnav a[href="/admin/dunning"]')).toHaveClass(/active/)
+  })
+})


### PR DESCRIPTION
Closes #395

## 概要

`clear.ayane.co.jp/demo/standard` が iPhone 13 でデスクトップ2ペインのまま表示され、**サイドバー幅6割占拠・右端切断・ハンバーガー無し**になっていた崩れを是正する。ClaudeDesign 指示書（2026-07-24・hub 承認済み）に沿い、**既存テーマ不変のままレイアウトのみレスポンシブ化**。invoice/deal の「1カラム＋ボトムタブ＋メニュー畳み」を踏襲。

## 変更点

- `<=820px` でサイドバー(`.side`)を隠し、濃紺ボトムタブ(`.mnav`)を表示 = **ダッシュボード / 消込〔朱バッジ〕 / 取引 / 督促 / メニュー**
- 溢れる全ナビは「メニュー」→濃紺ボトムシート(`.msheet`)に畳む。サイドバーとシートは `NavSections` で単一定義を共有（DRY）。`hidden` 属性で在/不在・`.open` で transform（`display:none` 常時掛けは回避）
- topbar にモバイルブランド(`.mbrand`)、デスク幅サイドバー **236→208px**
- `viewport-fit=cover`（safe-area）、`nav.tab.bankTransactions`（取引）追加
- 指示書§3（消込 master-detail）は実 `ReconciliationPage`（タブ＋DataTable＋Modal）に 2ペインが存在しないため **N/A**（hub 承認）。DataTable は `overflow-x:auto`、Modal は `max-height:86vh` で既にモバイル可

## 検証

- `frontend` `npm run check` 緑（codegen / type-check / lint / **unit 92** / knip）
- 新規 `tests/e2e/specs/17-mobile-responsive.spec.ts`（**iPhone 13 / chromium**）**3/3**: サイドバー非表示・ボトムタブ5枠・消込バッジ・横スクロール無・メニューシート開閉・タブ遷移active
- iPhone 13 実寸スクショ4枚（dashboard / 消込 / 取引 / menu-sheet）で崩れ・右端切断なしを目視確認

## デプロイ

⚠ 本番 `clear.ayane.co.jp` への反映は **merge 後に施主GO**（本番反映は seam）。**士業channel 配布ゲート**（リーフレット QR 先の崩れ是正）＝本 PR。運用台帳: private `nene-origin` `_work/issues.md #66`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)