### PR TITLE
feat(dunning): 自動送信の設定読み取りと時刻/段階の判定ロジック（PR A・送信はしない）

### DIFF
--- a/src/ClearSettings/ClearSettings.php
+++ b/src/ClearSettings/ClearSettings.php
@@ -18,6 +18,15 @@ final readonly class ClearSettings
         public int $dunningMinIntervalDays,
         public ?int $fiscalYearEndMonth = null,
         public array $bankAccounts = [],
+        /**
+         * Scheduled dunning (#400). Read-only for now: the repository loads these
+         * from `clear_settings` but does NOT write them, because
+         * `PUT /admin/clear-settings` is a full replace (#284) and its request
+         * cannot carry them yet. Including them in the UPDATE would let an
+         * unrelated settings save silently switch the schedule back off. The
+         * write path lands with the settings API/UI (design §11 step 4).
+         */
+        public DunningSchedule $dunningSchedule = new DunningSchedule(),
     ) {
     }
 }

--- a/src/ClearSettings/DunningSchedule.php
+++ b/src/ClearSettings/DunningSchedule.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\ClearSettings;
+
+/**
+ * Per-organization schedule for unattended dunning (#400,
+ * `docs/development/dunning-scheduler-design.md`).
+ *
+ * This object says *when* a run may send and at which escalation stage. It says
+ * nothing about whether a particular invoice may be dunned — every safety guard
+ * (upstream status, pause, minimum interval) stays in
+ * {@see \NeneClear\Dunning\SendDunningUseCase}, which the scheduler must call.
+ *
+ * Defaults mirror the migration defaults, so an organization that has never
+ * touched its settings behaves exactly as before: disabled.
+ */
+final readonly class DunningSchedule
+{
+    public function __construct(
+        public bool $isEnabled = false,
+        public int $initialAfterDays = 3,
+        public int $reminderAfterDays = 14,
+        public int $finalAfterDays = 30,
+        public int $windowStartHour = 9,
+        public int $windowEndHour = 18,
+        public bool $isWeekdaysOnly = true,
+        public int $maxPerRun = 50,
+    ) {
+    }
+}

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -18,7 +18,9 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
     public function findByOrganization(int $organizationId): ?ClearSettings
     {
         $row = $this->query->fetchOne(
-            'SELECT organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month '
+            'SELECT organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, '
+            . 'is_dunning_schedule_enabled, dunning_initial_after_days, dunning_reminder_after_days, dunning_final_after_days, '
+            . 'dunning_window_start_hour, dunning_window_end_hour, is_dunning_weekdays_only, dunning_max_per_run '
             . 'FROM clear_settings WHERE organization_id = ?',
             [$organizationId],
         );
@@ -34,6 +36,16 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
             dunningMinIntervalDays: (int) $row['dunning_min_interval_days'],
             fiscalYearEndMonth: isset($row['fiscal_year_end_month']) ? (int) $row['fiscal_year_end_month'] : null,
             bankAccounts: $this->bankAccounts->findByOrganization($organizationId),
+            dunningSchedule: new DunningSchedule(
+                isEnabled: (bool) $row['is_dunning_schedule_enabled'],
+                initialAfterDays: (int) $row['dunning_initial_after_days'],
+                reminderAfterDays: (int) $row['dunning_reminder_after_days'],
+                finalAfterDays: (int) $row['dunning_final_after_days'],
+                windowStartHour: (int) $row['dunning_window_start_hour'],
+                windowEndHour: (int) $row['dunning_window_end_hour'],
+                isWeekdaysOnly: (bool) $row['is_dunning_weekdays_only'],
+                maxPerRun: (int) $row['dunning_max_per_run'],
+            ),
         );
     }
 
@@ -47,6 +59,15 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
         return $row !== null && isset($row['fiscal_year_end_month']) ? (int) $row['fiscal_year_end_month'] : null;
     }
 
+    /**
+     * Deliberately does NOT persist {@see ClearSettings::$dunningSchedule} (#400).
+     * `PUT /admin/clear-settings` is a full replace (#284) and its request body
+     * cannot carry the schedule columns yet, so writing them here would let a
+     * save of *unrelated* settings reset an enabled schedule back to the column
+     * defaults — silently, because the operator only edited a bank account. The
+     * columns keep their stored values until the settings API and UI learn about
+     * them (design §11 step 4), which is also when this method starts writing them.
+     */
     public function save(ClearSettings $settings): void
     {
         // Upsert without a destructive DELETE. Decide insert-vs-update by an

--- a/src/Dunning/DunningSchedulePolicy.php
+++ b/src/Dunning/DunningSchedulePolicy.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use DateTimeImmutable;
+use NeneClear\ClearSettings\DunningSchedule;
+
+/**
+ * The *timing* decisions of scheduled dunning (#400): may a run send right now,
+ * and which escalation stage does an invoice's age call for.
+ *
+ * This class decides nothing about eligibility. Whether a given invoice may be
+ * dunned at all — upstream status and outstanding balance, an active pause, the
+ * minimum interval since the last notice — is decided by
+ * {@see SendDunningUseCase}, and the scheduler learns the answer by calling it
+ * and catching its exceptions. Duplicating any of those checks here would create
+ * a second implementation of a safety guard, which is exactly how an unattended
+ * path drifts away from the operator path.
+ */
+final readonly class DunningSchedulePolicy
+{
+    public function __construct(private DunningSchedule $schedule)
+    {
+    }
+
+    /**
+     * Is `$now` inside the organization's send window?
+     *
+     * The window is a range of whole hours: `[startHour, endHour)`. 09–18 means a
+     * send may start at 09:00:00 and no later than 17:59:59. A window that wraps
+     * midnight (start > end) is treated as closed rather than guessed at — the
+     * settings UI does not offer it, and silently inventing overnight sending is
+     * the opposite of what the window exists for.
+     */
+    public function isWindowOpen(DateTimeImmutable $now): bool
+    {
+        if ($this->schedule->windowStartHour >= $this->schedule->windowEndHour) {
+            return false;
+        }
+
+        if ($this->schedule->isWeekdaysOnly && (int) $now->format('N') >= 6) {
+            return false;
+        }
+
+        $hour = (int) $now->format('G');
+
+        return $hour >= $this->schedule->windowStartHour && $hour < $this->schedule->windowEndHour;
+    }
+
+    /**
+     * The stage an invoice this far past due has reached, or null if it has not
+     * reached the first threshold yet (including anything not yet due).
+     *
+     * Thresholds are read highest-first so that a misconfiguration where the
+     * thresholds are not ascending still escalates monotonically instead of
+     * picking a random stage.
+     */
+    public function stageFor(int $daysPastDue): ?DunningStage
+    {
+        if ($daysPastDue >= $this->schedule->finalAfterDays) {
+            return DunningStage::Final;
+        }
+
+        if ($daysPastDue >= $this->schedule->reminderAfterDays) {
+            return DunningStage::Reminder;
+        }
+
+        if ($daysPastDue >= $this->schedule->initialAfterDays) {
+            return DunningStage::Initial;
+        }
+
+        return null;
+    }
+
+    /**
+     * Whole days between an invoice's due date and `$now`, or null when the
+     * invoice carries no due date at all.
+     *
+     * `InvoiceItem::$dueAt` is nullable by the Invoice contract — an invoice may
+     * be issued without one. "Days past due" is undefined for those, so they are
+     * never scheduled candidates. An operator can still dun them by hand.
+     */
+    public function daysPastDue(?string $dueAt, DateTimeImmutable $now): ?int
+    {
+        if ($dueAt === null || trim($dueAt) === '') {
+            return null;
+        }
+
+        $due = DateTimeImmutable::createFromFormat('Y-m-d', substr(trim($dueAt), 0, 10));
+
+        if ($due === false) {
+            return null;
+        }
+
+        $days = (int) $due->setTime(0, 0)->diff($now->setTime(0, 0))->format('%r%a');
+
+        return $days;
+    }
+
+    /**
+     * A `final` notice is never sent unattended: it is surfaced for an operator
+     * to send by hand (design §5, pending an owner decision). Loosening this is a
+     * one-line change; the reverse would not be, because messages already sent
+     * cannot be recalled.
+     */
+    public function requiresApproval(DunningStage $stage): bool
+    {
+        return $stage === DunningStage::Final;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->schedule->isEnabled;
+    }
+
+    public function maxPerRun(): int
+    {
+        return $this->schedule->maxPerRun;
+    }
+}

--- a/tests/Database/PdoClearSettingsRepositoryTest.php
+++ b/tests/Database/PdoClearSettingsRepositoryTest.php
@@ -63,6 +63,77 @@ final class PdoClearSettingsRepositoryTest extends TestCase
     }
 
     /**
+     * Saving unrelated settings must not disturb the dunning schedule (#400).
+     *
+     * `PUT /admin/clear-settings` is a full replace (#284) and its request body
+     * cannot carry the schedule columns yet, so the repository deliberately
+     * leaves them out of the UPDATE/INSERT. Without that, an operator who
+     * enables scheduled dunning and later edits a bank account would silently
+     * turn it back off — with no error and no audit trace of the change. This
+     * test is the guard: adding the columns to the write path must fail here
+     * until the settings API and UI can carry them.
+     */
+    public function testSavingUnrelatedSettingsLeavesTheDunningScheduleIntact(): void
+    {
+        $repo = new PdoClearSettingsRepository($this->real, new PdoBankAccountRepository($this->real));
+
+        $repo->save(new ClearSettings(
+            organizationId: 42,
+            upstreamBaseUrl: 'https://invoice.example',
+            upstreamTokenRef: 'NENE_INVOICE_BEARER_TOKEN',
+            dunningMinIntervalDays: 7,
+        ));
+
+        // The operator turns the schedule on (today: by hand; later: via the settings UI).
+        $this->real->execute(
+            'UPDATE clear_settings SET is_dunning_schedule_enabled = 1, dunning_max_per_run = 25, '
+            . 'dunning_window_start_hour = 10 WHERE organization_id = ?',
+            [42],
+        );
+
+        // …then saves an unrelated change. The entity carries default schedule values.
+        $repo->save(new ClearSettings(
+            organizationId: 42,
+            upstreamBaseUrl: 'https://invoice.example/v2',
+            upstreamTokenRef: 'NENE_INVOICE_BEARER_TOKEN',
+            dunningMinIntervalDays: 10,
+        ));
+
+        $reloaded = $repo->findByOrganization(42);
+
+        self::assertNotNull($reloaded);
+        self::assertSame('https://invoice.example/v2', $reloaded->upstreamBaseUrl, 'the intended change must land');
+        self::assertSame(10, $reloaded->dunningMinIntervalDays);
+        self::assertTrue($reloaded->dunningSchedule->isEnabled, 'the schedule must survive an unrelated save');
+        self::assertSame(25, $reloaded->dunningSchedule->maxPerRun);
+        self::assertSame(10, $reloaded->dunningSchedule->windowStartHour);
+    }
+
+    public function testScheduleDefaultsAreReadBackForAnUntouchedOrganization(): void
+    {
+        $repo = new PdoClearSettingsRepository($this->real, new PdoBankAccountRepository($this->real));
+
+        $repo->save(new ClearSettings(
+            organizationId: 43,
+            upstreamBaseUrl: '',
+            upstreamTokenRef: '',
+            dunningMinIntervalDays: 7,
+        ));
+
+        $schedule = $repo->findByOrganization(43)?->dunningSchedule;
+
+        self::assertNotNull($schedule);
+        self::assertFalse($schedule->isEnabled, 'scheduled dunning is off until explicitly enabled');
+        self::assertSame(3, $schedule->initialAfterDays);
+        self::assertSame(14, $schedule->reminderAfterDays);
+        self::assertSame(30, $schedule->finalAfterDays);
+        self::assertSame(9, $schedule->windowStartHour);
+        self::assertSame(18, $schedule->windowEndHour);
+        self::assertTrue($schedule->isWeekdaysOnly);
+        self::assertSame(50, $schedule->maxPerRun);
+    }
+
+    /**
      * Wraps a real executor but reports 0 affected rows for every UPDATE, the
      * way MySQL reports a no-op UPDATE. The wrapped statement still runs, so the
      * existence check and the eventual INSERT observe real SQLite state.

--- a/tests/Dunning/DunningSchedulePolicyTest.php
+++ b/tests/Dunning/DunningSchedulePolicyTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use DateTimeImmutable;
+use NeneClear\ClearSettings\DunningSchedule;
+use NeneClear\Dunning\DunningSchedulePolicy;
+use NeneClear\Dunning\DunningStage;
+use PHPUnit\Framework\TestCase;
+
+final class DunningSchedulePolicyTest extends TestCase
+{
+    private function policy(
+        int $startHour = 9,
+        int $endHour = 18,
+        bool $weekdaysOnly = true,
+        int $initial = 3,
+        int $reminder = 14,
+        int $final = 30,
+    ): DunningSchedulePolicy {
+        return new DunningSchedulePolicy(new DunningSchedule(
+            isEnabled: true,
+            initialAfterDays: $initial,
+            reminderAfterDays: $reminder,
+            finalAfterDays: $final,
+            windowStartHour: $startHour,
+            windowEndHour: $endHour,
+            isWeekdaysOnly: $weekdaysOnly,
+        ));
+    }
+
+    /** 2026-07-29 is a Wednesday; 2026-08-01 a Saturday, 2026-08-02 a Sunday. */
+    public function testWindowIsOpenInsideBusinessHoursOnAWeekday(): void
+    {
+        self::assertTrue($this->policy()->isWindowOpen(new DateTimeImmutable('2026-07-29 09:00:00')));
+        self::assertTrue($this->policy()->isWindowOpen(new DateTimeImmutable('2026-07-29 17:59:59')));
+    }
+
+    public function testWindowIsClosedBeforeStartAndFromEndHourOnward(): void
+    {
+        self::assertFalse($this->policy()->isWindowOpen(new DateTimeImmutable('2026-07-29 08:59:59')));
+        // 18:00 is outside: the window is [start, end).
+        self::assertFalse($this->policy()->isWindowOpen(new DateTimeImmutable('2026-07-29 18:00:00')));
+        self::assertFalse($this->policy()->isWindowOpen(new DateTimeImmutable('2026-07-29 03:00:00')));
+    }
+
+    public function testWindowIsClosedAtTheWeekendWhenWeekdaysOnly(): void
+    {
+        self::assertFalse($this->policy()->isWindowOpen(new DateTimeImmutable('2026-08-01 10:00:00')));
+        self::assertFalse($this->policy()->isWindowOpen(new DateTimeImmutable('2026-08-02 10:00:00')));
+    }
+
+    public function testWeekendIsAllowedWhenWeekdaysOnlyIsOff(): void
+    {
+        $policy = $this->policy(weekdaysOnly: false);
+
+        self::assertTrue($policy->isWindowOpen(new DateTimeImmutable('2026-08-01 10:00:00')));
+    }
+
+    /**
+     * A wrapping window (22:00–06:00) is treated as closed rather than guessed
+     * at. Sending overnight because the settings were nonsense is worse than
+     * sending nothing.
+     */
+    public function testWrappingWindowIsTreatedAsClosed(): void
+    {
+        $policy = $this->policy(startHour: 22, endHour: 6);
+
+        self::assertFalse($policy->isWindowOpen(new DateTimeImmutable('2026-07-29 23:00:00')));
+        self::assertFalse($policy->isWindowOpen(new DateTimeImmutable('2026-07-29 05:00:00')));
+        self::assertFalse($policy->isWindowOpen(new DateTimeImmutable('2026-07-29 12:00:00')));
+    }
+
+    public function testStageThresholdsEscalateOnTheirExactBoundaries(): void
+    {
+        $policy = $this->policy();
+
+        self::assertNull($policy->stageFor(0));
+        self::assertNull($policy->stageFor(2));
+        self::assertSame(DunningStage::Initial, $policy->stageFor(3));
+        self::assertSame(DunningStage::Initial, $policy->stageFor(13));
+        self::assertSame(DunningStage::Reminder, $policy->stageFor(14));
+        self::assertSame(DunningStage::Reminder, $policy->stageFor(29));
+        self::assertSame(DunningStage::Final, $policy->stageFor(30));
+        self::assertSame(DunningStage::Final, $policy->stageFor(365));
+    }
+
+    public function testInvoiceNotYetDueHasNoStage(): void
+    {
+        self::assertNull($this->policy()->stageFor(-5));
+    }
+
+    /**
+     * Thresholds are per-organization settings, so they can be saved in a
+     * non-ascending order. Escalation must stay monotonic instead of picking a
+     * stage at random.
+     */
+    public function testNonAscendingThresholdsStillEscalateMonotonically(): void
+    {
+        $policy = $this->policy(initial: 30, reminder: 14, final: 3);
+
+        self::assertSame(DunningStage::Final, $policy->stageFor(3));
+        self::assertSame(DunningStage::Final, $policy->stageFor(40));
+    }
+
+    public function testDaysPastDueCountsWholeCalendarDays(): void
+    {
+        $policy = $this->policy();
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+
+        self::assertSame(0, $policy->daysPastDue('2026-07-29', $now));
+        self::assertSame(1, $policy->daysPastDue('2026-07-28', $now));
+        self::assertSame(30, $policy->daysPastDue('2026-06-29', $now));
+        self::assertSame(-2, $policy->daysPastDue('2026-07-31', $now));
+    }
+
+    public function testDaysPastDueIgnoresTheTimeOfDay(): void
+    {
+        $policy = $this->policy();
+
+        // Due late on the 28th, now early on the 29th: one calendar day, not zero.
+        self::assertSame(
+            1,
+            $policy->daysPastDue('2026-07-28 23:59:59', new DateTimeImmutable('2026-07-29 00:01:00')),
+        );
+    }
+
+    /**
+     * `InvoiceItem::$dueAt` is nullable by the Invoice contract. "Days past due"
+     * is undefined without a due date, so such invoices are never scheduled
+     * candidates — an operator can still dun them by hand.
+     */
+    public function testInvoiceWithoutADueDateHasNoDaysPastDue(): void
+    {
+        $policy = $this->policy();
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+
+        self::assertNull($policy->daysPastDue(null, $now));
+        self::assertNull($policy->daysPastDue('', $now));
+        self::assertNull($policy->daysPastDue('   ', $now));
+        self::assertNull($policy->daysPastDue('not-a-date', $now));
+    }
+
+    public function testFinalStageRequiresApprovalAndOthersDoNot(): void
+    {
+        $policy = $this->policy();
+
+        self::assertTrue($policy->requiresApproval(DunningStage::Final));
+        self::assertFalse($policy->requiresApproval(DunningStage::Initial));
+        self::assertFalse($policy->requiresApproval(DunningStage::Reminder));
+    }
+
+    public function testDefaultsAreDisabledAndMatchTheMigration(): void
+    {
+        $schedule = new DunningSchedule();
+        $policy = new DunningSchedulePolicy($schedule);
+
+        self::assertFalse($policy->isEnabled());
+        self::assertSame(50, $policy->maxPerRun());
+        self::assertSame(3, $schedule->initialAfterDays);
+        self::assertSame(14, $schedule->reminderAfterDays);
+        self::assertSame(30, $schedule->finalAfterDays);
+        self::assertSame(9, $schedule->windowStartHour);
+        self::assertSame(18, $schedule->windowEndHour);
+        self::assertTrue($schedule->isWeekdaysOnly);
+    }
+}


### PR DESCRIPTION
Refs #400。設計書 §11 **ステップ3 の前半（PR A）**。統合リナ承認済みの A/B 分割のうち、**送信しない純ロジック**だけを先に出します。

- **A（この PR）**: 設定の読み取り／送信ウィンドウ判定／ステージ判定 — **一通も送らない**
- **B（次）**: DB ロック＋ランナー＋CLI 入口＋`--dry-run`

## 変更

| ファイル | 役割 |
| --- | --- |
| `src/ClearSettings/DunningSchedule.php`（新規） | 8設定の値オブジェクト。**既定値は migration と一致**（＝無効） |
| `src/ClearSettings/ClearSettings.php` | `dunningSchedule` を追加（既定値つき＝既存の呼び出しは無変更で通る） |
| `src/ClearSettings/PdoClearSettingsRepository.php` | **読み取りのみ**マッピング（下記） |
| `src/Dunning/DunningSchedulePolicy.php`（新規） | ウィンドウ判定・ステージ判定・超過日数・`final` の承認要否 |
| `tests/Dunning/DunningSchedulePolicyTest.php`（新規） | 13 tests |
| `tests/Database/PdoClearSettingsRepositoryTest.php` | 回帰ガード2本を追加 |

## 🔴 設定保存の罠と、その対処（設計書に無かった論点）

`PUT /admin/clear-settings` は **full-replace**（#284）です。新8列を**そのまま UPDATE 文に足すと**こうなります:

1. 運用者が自動送信を ON にする
2. 後日、UI で銀行口座や上流 URL だけ直して保存する
3. リクエストは新項目を運べない（API も UI も未対応＝ステップ4）ので **自動送信が黙って OFF に戻る**

エラーも出ず、監査にも「変えた」と残らない。**「設定を保存しただけ」なので誰も気づきません。**

設計書 §6 の「既定 OFF・既存の挙動を変えない」は **migration では守れていたが、保存経路では守れていなかった** — この型は他艦が設定項目を足すときにも踏みます。

**対処**: リポジトリは新8列を**読むだけ**にし、`UPDATE` / `INSERT` には含めません。書き込みは、API と UI が値を運べるようになるステップ4で明示的に足します。意図はコードのドックブロックにも書きました。

**そして、それをテストで固定しました** — `testSavingUnrelatedSettingsLeavesTheDunningScheduleIntact`。
スケジュールを ON にしてから無関係な設定を保存し、**ON のまま残ること**を検証します。将来この列を書き込み経路へ足すと**このテストが落ちます**（＝API/UI が運べるようになるまで足せない、という意図をテストで表現）。

## 判断が入ったところ（レビュー観点）

1. **折り返すウィンドウ（22:00–06:00 のような設定）は「閉」**として扱います。深夜送信を防ぐ仕組みなのに、設定が壊れたときに深夜へ送っては本末転倒なので、推測して動くより何もしない方に倒しました。
2. **閾値が昇順でない設定でも段階が逆流しない**ようにしました（上位段階から評価）。閾値は組織ごとに保存できる以上、順序の崩れた値は入りえます。テスト済み。
3. **期日 `null` の請求書は対象外**。`InvoiceItem::$dueAt` は Invoice 契約上 nullable で、期日が無ければ「何日超過」が定義できません。手動送信は従来どおり可能です。

## ガードを再実装していないこと（設計書 §2 の原則）

`DunningSchedulePolicy` は**時刻と段階しか決めません**。上流ステータス・残高・督促停止・最小間隔の判定は**一切持っていません** — それらは `SendDunningUseCase` の担当で、B のランナーが**ユースケースを呼んで例外で受ける**形にします。クラスのドックブロックにもその線引きを明記しました。

## 検証〔実測〕

- 新規テスト **13 tests / 42 assertions** 緑、設定リポジトリ回帰ガード込みで **16 tests / 59 assertions** 緑
- `composer check` 全項目緑（test / analyse / cs / openapi / mcp / spec-parity / conformance）
