### PR TITLE
feat(scheduler): 未監視 run の排他ロック（B1・原子的取得＋TTL・3アダプタ実測）

### DIFF
--- a/database/migrations/20260729140000_create_scheduler_locks_table.php
+++ b/database/migrations/20260729140000_create_scheduler_locks_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateSchedulerLocksTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Mutual exclusion for unattended runs (#400). Generic on purpose — the
+        // scope lives in `lock_key` (e.g. `dunning:42`), not in the table name,
+        // so a later scheduled job does not have to borrow a dunning-named lock.
+        //
+        // `lock_key` is the primary key: taking the lock is a single INSERT that
+        // either succeeds or violates the key. Reading first and then inserting
+        // would reopen the check-then-act window this table exists to close.
+        //
+        // `expires_at` is the crash valve: a run killed mid-flight never releases
+        // its lock, so an expired row may be reclaimed — by the same atomic
+        // statement, never by a "clean up then insert" pair.
+        $this->table('scheduler_locks', ['id' => false, 'primary_key' => ['lock_key']])
+            ->addColumn('lock_key', 'string', ['limit' => 128, 'null' => false])
+            ->addColumn('holder_token', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('acquired_at', 'datetime', ['null' => false])
+            ->addColumn('expires_at', 'datetime', ['null' => false])
+            ->addIndex(['expires_at'])
+            ->create();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -251,6 +251,25 @@ the feature existed, and must not be read as "scheduled". The unattended actor v
 **not** new — a scheduled send records `actor_id = 0`, the existing "no human actor" value
 (§3, and the `AuditEvent.actor_id` contract in `openapi.yaml`).
 
+### Scheduler locks (#400)
+
+Mutual exclusion for unattended runs, held in the database so that two overlapping cron
+ticks cannot do the same work twice. Deliberately **generic**: the table is not
+dunning-specific, because the next scheduled job would otherwise be forced to reuse a lock
+named after dunning. Scope is expressed in the key, not the table name.
+
+| Term | Canonical | Never |
+| --- | --- | --- |
+| Lock table | `scheduler_locks` | `dunning_scheduler_locks`, `locks`, `job_locks`, `cron_locks` |
+| Lock name (scoped, e.g. `dunning:42`) | `lock_key` | `name`, `key`, `lock_name` |
+| Who holds it (one run's random token) | `holder_token` | `owner`, `holder`, `pid`, `run_id` (that is `dunning_run_id`, a different thing) |
+| Taken / expiry timestamps | `acquired_at`, `expires_at` | `locked_at`, `created_at`, `ttl`, `valid_until` |
+
+The lock is taken by an **atomic** insert against the primary key — never by reading first
+and then inserting, which reopens the check-then-act window the lock exists to close.
+`expires_at` exists so a run killed mid-flight (no chance to release) cannot block the job
+forever; reclaiming an expired lock is the same atomic statement.
+
 ---
 
 ## 4. Problem Details type slugs (kebab-case)

--- a/src/Scheduler/PdoSchedulerLock.php
+++ b/src/Scheduler/PdoSchedulerLock.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Scheduler;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Throwable;
+
+/**
+ * {@see SchedulerLockInterface} on the `scheduler_locks` table (#400).
+ *
+ * The lock is held in the database rather than in a pid or lock file because
+ * production is shared hosting: the filesystem is not a reliable arbiter there,
+ * while the database is the one component every run certainly shares.
+ *
+ * A native advisory lock (MySQL `GET_LOCK`, PostgreSQL `pg_advisory_lock`) would
+ * self-release on disconnect, but it does not exist in SQLite — so "two runs
+ * never send the same notice" could not be *proved by a test*. An exclusion
+ * mechanism that is only believed to work is the worst kind, because its failure
+ * shows up as a real email that cannot be recalled. Hence a table, which behaves
+ * identically on all three adapters and is exercised by the suite.
+ */
+final readonly class PdoSchedulerLock implements SchedulerLockInterface
+{
+    public function __construct(private DatabaseQueryExecutorInterface $query)
+    {
+    }
+
+    public function acquire(string $key, string $holderToken, int $ttlSeconds, DateTimeImmutable $now): bool
+    {
+        $nowStr = $now->format('Y-m-d H:i:s');
+        $expiresAt = $now->modify('+' . $ttlSeconds . ' seconds')->format('Y-m-d H:i:s');
+
+        // Step 1 — reclaim: a single conditional UPDATE. Only a row that has
+        // actually expired matches, and only one caller can win it, because the
+        // UPDATE re-evaluates the condition under the row lock. This is not a
+        // check-then-act: nothing is read and then acted upon.
+        $reclaimed = $this->query->execute(
+            'UPDATE scheduler_locks SET holder_token = ?, acquired_at = ?, expires_at = ? '
+            . 'WHERE lock_key = ? AND expires_at <= ?',
+            [$holderToken, $nowStr, $expiresAt, $key, $nowStr],
+        );
+
+        if ($reclaimed > 0) {
+            return true;
+        }
+
+        // Step 2 — first taker: a single INSERT against the primary key. If a
+        // live lock exists (or a competitor inserted first), the key violation is
+        // the answer, not an error to report.
+        try {
+            $this->query->execute(
+                'INSERT INTO scheduler_locks (lock_key, holder_token, acquired_at, expires_at) VALUES (?, ?, ?, ?)',
+                [$key, $holderToken, $nowStr, $expiresAt],
+            );
+
+            return true;
+        } catch (Throwable) {
+            // Held by someone else. MySQL reports a no-op UPDATE as 0 affected
+            // rows even when the row matched, so a reclaim that changed nothing
+            // can also land here; either way the answer is the same.
+            return false;
+        }
+    }
+
+    public function release(string $key, string $holderToken): void
+    {
+        $this->query->execute(
+            'DELETE FROM scheduler_locks WHERE lock_key = ? AND holder_token = ?',
+            [$key, $holderToken],
+        );
+    }
+}

--- a/src/Scheduler/SchedulerLockInterface.php
+++ b/src/Scheduler/SchedulerLockInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Scheduler;
+
+use DateTimeImmutable;
+
+/**
+ * Mutual exclusion for unattended runs (#400,
+ * `docs/development/dunning-scheduler-design.md` §8).
+ *
+ * A cron tick that overlaps a still-running previous tick is normal operation,
+ * not an error: the second run simply does nothing. What must never happen is
+ * two runs doing the same work — for dunning that means a duplicate email, which
+ * cannot be recalled once sent.
+ */
+interface SchedulerLockInterface
+{
+    /**
+     * Take `$key` for `$ttlSeconds`, or report that someone else holds it.
+     *
+     * Implementations MUST take the lock with a single atomic statement. An
+     * expired lock may be reclaimed by the same statement — a run that was killed
+     * mid-flight never got to release it, and must not block the job forever.
+     *
+     * @param string $holderToken identifies this run, so only it can release the lock
+     */
+    public function acquire(string $key, string $holderToken, int $ttlSeconds, DateTimeImmutable $now): bool;
+
+    /**
+     * Release `$key`, but only if `$holderToken` still holds it.
+     *
+     * The token check matters: without it, a run that overran its TTL would
+     * release the lock its successor is legitimately holding.
+     */
+    public function release(string $key, string $holderToken): void;
+}

--- a/tests/Database/PdoSchedulerLockTest.php
+++ b/tests/Database/PdoSchedulerLockTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Database;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneClear\Scheduler\PdoSchedulerLock;
+use NeneClear\Tests\Support\SchemaFixture;
+use PHPUnit\Framework\TestCase;
+
+final class PdoSchedulerLockTest extends TestCase
+{
+    private string $dbPath;
+    private DatabaseQueryExecutorInterface $query;
+    private PdoSchedulerLock $lock;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/' . uniqid('scheduler-lock-', true) . '.sqlite';
+        $this->query = DatabaseTestKit::sqlite($this->dbPath)->queryExecutor;
+        SchemaFixture::createSchedulerLocks($this->query);
+        $this->lock = new PdoSchedulerLock($this->query);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    /**
+     * The point of the lock: an overlapping cron tick must find the door shut.
+     * The caller treats that as normal operation (exit 0), not as an error.
+     */
+    public function testSecondRunCannotTakeALockThatIsHeld(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+
+        self::assertTrue($this->lock->acquire('dunning:42', 'run-one', 900, $now));
+        self::assertFalse($this->lock->acquire('dunning:42', 'run-two', 900, $now->modify('+1 second')));
+    }
+
+    public function testDifferentKeysDoNotBlockEachOther(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+
+        self::assertTrue($this->lock->acquire('dunning:42', 'run-one', 900, $now));
+        self::assertTrue($this->lock->acquire('dunning:43', 'run-two', 900, $now));
+    }
+
+    /**
+     * A run killed mid-flight never releases its lock. Without expiry the job
+     * would be blocked forever by a process that no longer exists.
+     */
+    public function testAnExpiredLockCanBeReclaimed(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+
+        self::assertTrue($this->lock->acquire('dunning:42', 'crashed-run', 900, $now));
+
+        // 14 minutes later the 15-minute lock is still live.
+        self::assertFalse($this->lock->acquire('dunning:42', 'next-run', 900, $now->modify('+14 minutes')));
+
+        // Past the TTL it may be taken over.
+        self::assertTrue($this->lock->acquire('dunning:42', 'next-run', 900, $now->modify('+16 minutes')));
+    }
+
+    /**
+     * Two runs racing for the *same expired* lock: exactly one may win. The
+     * reclaim is a single conditional UPDATE, so the loser's condition no longer
+     * matches once the winner has moved `expires_at` forward.
+     */
+    public function testOnlyOneRunWinsAContestedReclaim(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+        $this->lock->acquire('dunning:42', 'crashed-run', 900, $now);
+
+        $later = $now->modify('+16 minutes');
+        $first = $this->lock->acquire('dunning:42', 'run-a', 900, $later);
+        $second = $this->lock->acquire('dunning:42', 'run-b', 900, $later);
+
+        self::assertTrue($first);
+        self::assertFalse($second, 'a reclaimed lock must not be handed to a second run');
+
+        $row = $this->query->fetchOne('SELECT holder_token FROM scheduler_locks WHERE lock_key = ?', ['dunning:42']);
+        self::assertNotNull($row);
+        self::assertSame('run-a', $row['holder_token']);
+    }
+
+    public function testReleaseLetsTheNextRunTakeIt(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+        $this->lock->acquire('dunning:42', 'run-one', 900, $now);
+
+        $this->lock->release('dunning:42', 'run-one');
+
+        self::assertTrue($this->lock->acquire('dunning:42', 'run-two', 900, $now->modify('+1 second')));
+    }
+
+    /**
+     * A run that overran its TTL must not release the lock its successor is
+     * legitimately holding — hence the holder check on release.
+     */
+    public function testReleaseByANonHolderDoesNothing(): void
+    {
+        $now = new DateTimeImmutable('2026-07-29 10:00:00');
+        $this->lock->acquire('dunning:42', 'run-one', 900, $now);
+
+        $this->lock->release('dunning:42', 'someone-else');
+
+        self::assertFalse($this->lock->acquire('dunning:42', 'run-two', 900, $now->modify('+1 second')));
+    }
+}

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -238,6 +238,18 @@ final class SchemaFixture
         );
     }
 
+    public static function createSchedulerLocks(DatabaseQueryExecutorInterface $query): void
+    {
+        $query->execute(
+            'CREATE TABLE scheduler_locks (
+                lock_key TEXT PRIMARY KEY NOT NULL,
+                holder_token TEXT NOT NULL,
+                acquired_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL
+            )'
+        );
+    }
+
     public static function createDunningNotices(DatabaseQueryExecutorInterface $query): void
     {
         $query->execute(


### PR DESCRIPTION
Refs #400。設計書 §8。統合リナ裁定（ロックテーブル方式・テーブル名は汎用 `scheduler_locks`）の実装。

**B を2つに割りました**: これは **B1（排他のみ）**。B2（ランナー＋CLI＋`--dry-run`）は次の PR です。
B1 は「排他が本当に効くか」、B2 は「ガードを再実装していないか」と、レビューで見る観点が別なので混ぜません。

## 方式選択の根拠（§8 の設計根拠として残します）

ネイティブの advisory lock（MySQL `GET_LOCK` / PostgreSQL `pg_advisory_lock`）は接続断で自動解放される利点がありますが、
**SQLite に存在しません**。つまり「二重起動で同じ督促を送らない」ことを**テストで証明できない**。

排他は「効いているつもりで効いていない」が最悪の壊れ方で、しかもその失敗は**取り消せない実メール**として外に出ます。
よって、3アダプタで同一に動き**テストで実証できる**テーブル方式を採ります。代償（プロセス強制終了時の取り残し）は TTL で処理します。

## 原子性（check-then-act を作らない）

| 操作 | 実装 |
| --- | --- |
| 期限切れロックの**奪取** | 条件つき UPDATE **1文**（`WHERE lock_key = ? AND expires_at <= ?`）。行ロック下で条件が再評価されるので勝てるのは1本 |
| **新規取得** | 主キーへの INSERT **1文**。生きたロックがあればキー違反が「取れなかった」の答えそのもの |

どちらも「読んでから書く」形になっていません。

**解放は保持者トークンを照合**します。TTL を超過した古い run が、正当に動いている後続のロックを解放してしまうのを防ぐためです。

## テスト6本〔実測・緑〕

1. 保持中は2本目が取れない（＝重なった cron tick は何もしない）
2. 別キーは干渉しない（org 単位のスコープ）
3. **TTL 切れは奪取できる**（強制終了した run に永久ブロックされない）
4. **奪取の競合で1本しか勝てない**（勝者トークンが格納されていることまで検証）
5. 解放後は次の run が取れる
6. **非保持者による解放は無効**

## 用語登録（binding・先行）

`terminology.md` に「### Scheduler locks (#400)」を追加。`lock_key` / `holder_token` / `acquired_at` / `expires_at`。
**テーブル名は dunning 固有にしません** — スコープは `lock_key`（`dunning:42` 形式）で切ります。
将来の別ジョブが「dunning という名前の汎用ロック」を借りる羽目にならないためです。

## 検証〔実測〕

- migration を **3アダプタで実行**（SQLite / MySQL 3383 / PostgreSQL 5483）— いずれも成功
- `composer check` 全項目緑（**484 tests / 7467 assertions**・analyse / cs / openapi / mcp / spec-parity / conformance）
