### PR TITLE
chore(deps): brace-expansion を patch 版へ（lockfile のみ・allowlist 追加ゼロ＋死んだ例外を削除）

### DIFF
--- a/docs/development/dependency-audit.md
+++ b/docs/development/dependency-audit.md
@@ -58,15 +58,33 @@ Both must print `true`.
 
 | Advisory | Package | Why it does not apply here | Expires |
 | --- | --- | --- | --- |
-| [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) | `react-router` (7.12.0–8.2.0) | The admin console is a **static SPA built by Vite**, served as files from `public_html/assets/`; the PHP front controller never renders a React route. Routing is `createBrowserRouter` with element-only routes — **no RSC mode, no server components, no server-side route `action`/`loader`, no `@react-router/dev` runtime**. The advisory's attack path (a server executing a route action before returning 400) has no counterpart in a client-only bundle. Measured 2026-07-29 in this tree: `grep -cE '\b(action\|loader):' frontend/src/app/router.tsx` = **0**, and `grep -rniE '@react-router/(dev\|node\|serve)\|react-router/server\|createStaticHandler\|rsc' frontend/src` returns **no match**. | **2026-08-31** |
-| [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | `brace-expansion` 2.1.3 (≤5.0.7) | The fix (5.0.8) is taken where adoptable — `brace-expansion@5` is overridden, covering the `minimatch@10` chain under eslint 10. There is no patched 2.x release, and forcing 5.0.8 into it breaks `minimatch@5` (see above). The one vulnerable copy left is **dev-only**: `npm ls brace-expansion --omit=dev --all` is empty, and it is reached only by `openapi-typescript` → `@redocly/openapi-core` → `minimatch@5.1.9` — codegen running over our own committed `docs/openapi/openapi.yaml`. The advisory needs an attacker-supplied brace pattern; ours are literals in committed files. | **2026-08-31** |
+| [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) | `react-router` (≥ 7.12.0, < 8.3.0) | The admin console is a **static SPA built by Vite**, served as files from `public_html/assets/`; the PHP front controller never renders a React route. Routing is `createBrowserRouter` with element-only routes — **no RSC mode, no server components, no server-side route `action`/`loader`, no `@react-router/dev` runtime**. The advisory's attack path (a server executing a route action before returning 400) has no counterpart in a client-only bundle. Re-measured 2026-08-04 in this tree: `grep -cE '\b(action\|loader):' frontend/src/app/router.tsx` = **0**, and `grep -rniE '@react-router/(dev\|node\|serve)\|react-router/server\|createStaticHandler\|rsc' frontend/src` returns **no match**. | **2026-08-31** |
 
-For `react-router` there is **no fix available in the 7.x line**: `react-router-dom` ends at
-7.18.1 (the version this repo is on), and the fix lands in `react-router` v8 (≥ 8.2.1) — a
-different package and a breaking upgrade. That exception is removed by the **react-router v8
-migration wave** (bundled with the NENE2 RR8 re-evaluation). The `brace-expansion` exception is
-removed when `openapi-typescript` / `@redocly/openapi-core` move off `minimatch@5`; note this
-repo is already on eslint 10, so — unlike nene-invoice — no eslint-major wave is involved.
+This is the only exception. For `react-router` there is **no fix available in the 7.x line**:
+the newest 7.x is `react-router-dom` 7.18.2 and it is still inside the vulnerable range (this
+repo is on 7.18.1), while the fix lands in `react-router` v8 — a different package and a
+breaking upgrade. Read from the GitHub Advisory API on 2026-08-04, the first patched version is
+**8.3.0**; it was 8.2.1 when this entry was first written, which is why the range is restated
+here rather than carried forward. That exception is removed by the **react-router v8 migration
+wave** (bundled with the NENE2 RR8 re-evaluation).
+
+### Removed exceptions
+
+- **GHSA-mh99-v99m-4gvg** (`brace-expansion`) — removed 2026-08-04 (#407). The entry argued
+  that the 2.x branch had no patched release, so `minimatch@5.1.9`'s `brace-expansion@2.1.3`
+  had to be tolerated. Re-read from the GitHub Advisory API: mh99's 2.x fix is **2.1.3** — the
+  version this tree was already on — so the entry had stopped matching anything and was
+  silently dead. Its successor **GHSA-rgw5-rvv9-x895** widened the range (< 1.1.18 / < 2.1.4 /
+  < 5.0.9) and *is* fully fixable here, so it was taken as a patch rather than allowlisted:
+  a lockfile-only bump to `brace-expansion` **2.1.4 + 5.0.9**, with no `package.json` change
+  (the `"brace-expansion@5": "^5.0.8"` caret already covered 5.0.9) and **no new allowlist
+  entry**. `fast-uri` — the other advisory in the fleet wave (GHSA-7p8r-x3mc-p8w7) — is not a
+  dependency of this tree (`npm ls fast-uri --all` is empty), so no action was needed for it.
+  The two-chain check above was re-run after the bump and both still print `true`.
+
+A dead exception is worse than a loud one: it reads as a live risk that somebody decided to
+accept. When an advisory stops firing, delete the entry and say why here — do not leave it
+parked "just in case".
 
 ## Fleet note
 

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -16,11 +16,13 @@
   "critical": true,
   "allowlist": [
     // GHSA-qwww-vcr4-c8h2 — react-router "RSC Mode CSRF Bypass Allows Action Execution Before
-    // 400 Response" (high). Vulnerable range 7.12.0–8.2.0; there is NO fix in the 7.x line
-    // (react-router-dom stops at 7.18.1, which we are on; the fix is react-router v8 >= 8.2.1,
-    // a different package and a breaking upgrade).
+    // 400 Response" (high). Vulnerable range >= 7.12.0, < 8.3.0; there is NO fix in the 7.x line
+    // (the newest 7.x is react-router-dom 7.18.2 and it is still inside the range; the fix is
+    // react-router v8 >= 8.3.0, a different package and a breaking upgrade). Re-read from the
+    // GitHub Advisory API on 2026-08-04 — the first patched version moved 8.2.1 → 8.3.0 since
+    // this entry was written, which is why the range above is restated rather than copied.
     //
-    // Why it does not apply here (measured 2026-07-29 in THIS tree, not copied from a sibling):
+    // Why it does not apply here (re-measured 2026-08-04 in THIS tree, not copied from a sibling):
     // the Clear admin console is a **static SPA built by Vite** and served as files from
     // `public_html/assets/` — the PHP front controller never renders a React route. Routing is
     // `createBrowserRouter` with element-only routes: `grep -cE '\b(action|loader):'
@@ -34,33 +36,16 @@
     // re-argued in a PR — not silently extended.
     "GHSA-qwww-vcr4-c8h2",
 
-    // GHSA-mh99-v99m-4gvg — brace-expansion "DoS via unbounded expansion length" (high).
-    // Vulnerable range <=5.0.7; the fix is 5.0.8. We TAKE that fix where it is adoptable —
-    // `"brace-expansion@5": "^5.0.8"` in overrides, which covers the `minimatch@10` chain
-    // under eslint 10 / @typescript-eslint. It is NOT adoptable on the 2.x branch: there is
-    // no patched 2.x release, and forcing 5.0.8 into it breaks the consumer.
-    //
-    // Measured here 2026-07-29 (this repo, not inherited): a *flat* `"brace-expansion":
-    // "^5.0.8"` override was tried first and silently broke `@redocly/openapi-core`'s
-    // `minimatch@5.1.9` — brace-expansion 5 exports a named `expand`, while minimatch 5 does
-    // `require('brace-expansion')` and calls the module itself, so any brace pattern died
-    // with `TypeError: expand is not a function` (minimatch.js:119). Nothing in `npm run
-    // check` exercises that path, so the suite stayed green: a false green. Scoping the
-    // override to `brace-expansion@5` restores it — `minimatch@5.1.9` + `brace-expansion@2.1.3`
-    // now evaluates `a{b,c}d` correctly (true for `abd`, false for `axd`), and the eslint
-    // chain still gets the patched 5.0.8.
-    //
-    // Why the residual risk is acceptable here (measured 2026-07-29): brace-expansion is
-    // **dev-only** in this tree — `npm ls brace-expansion --omit=dev --all` is empty, so it is
-    // in no shipped bundle and on no request path. The one vulnerable copy left is 2.1.3,
-    // reached only through `openapi-typescript` → `@redocly/openapi-core` → `minimatch@5.1.9`,
-    // i.e. the codegen tool running over our own committed `docs/openapi/openapi.yaml`. The
-    // advisory needs an attacker-supplied brace pattern; ours are literals in committed files.
-    //
-    // Expiry: 2026-08-31. Removed when `openapi-typescript` / `@redocly/openapi-core` move off
-    // `minimatch@5` (or by an upstream 2.x backport, if one appears). Note this repo is
-    // already on eslint 10, so — unlike nene-invoice — no eslint-major wave is involved.
-    // Re-check at expiry; do not extend by reflex.
-    "GHSA-mh99-v99m-4gvg",
+    // Removed 2026-08-04 (#407): GHSA-mh99-v99m-4gvg (brace-expansion) — the entry argued that
+    // the 2.x branch had no patched release, so `minimatch@5.1.9`'s `brace-expansion@2.1.3` had
+    // to be tolerated. Re-read from the GitHub Advisory API on 2026-08-04: mh99's 2.x fix is
+    // **2.1.3**, i.e. the version this tree was already on, so the entry had stopped matching
+    // anything and was silently dead. The successor advisory GHSA-rgw5-rvv9-x895 widened the
+    // range (< 1.1.18 / < 2.1.4 / < 5.0.9) and *is* fully fixable here, so it was taken as a
+    // patch rather than allowlisted: lockfile-only bump to brace-expansion 2.1.4 + 5.0.9, no
+    // `package.json` change (the `"brace-expansion@5": "^5.0.8"` caret already covered 5.0.9),
+    // no new allowlist entry. The #399 false-green trap was re-checked after the bump —
+    // `minimatch@5.1.9` + `brace-expansion@2.1.4` still evaluates `a{b,c}d` correctly
+    // (true for `abd`, false for `axd`).
   ],
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1228,9 +1228,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2544,9 +2544,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 何をしたか

`GHSA-rgw5-rvv9-x895`（brace-expansion・high）を **allowlist ではなく修正版の採用**で解消しました。艦隊最終形（全系列 patch bump・allowlist 追加ゼロ）に一致します。

- **lockfile のみ更新**: `brace-expansion` 2.1.3 → **2.1.4** / 5.0.8 → **5.0.9**
- **`package.json` は無変更**。既存 overrides の `"brace-expansion@5": "^5.0.8"` が caret なので 5.0.9 は既に範囲内でした（issue の外部実測どおり）
- lockfile 差分は**当該 2 パッケージのみ**（6行）

## 副産物: 死んでいた allowlist を 1 件削除

`GHSA-mh99-v99m-4gvg` の例外を削除しました。GitHub Advisory API の一次情報を読み直したところ **mh99 の 2.x patched = 2.1.3**、つまり**本 tree は既にその版**でした。エントリの根拠「2.x には patch 版が存在しない」は書かれた時点はともかく**現在は誤り**で、実際 `npm audit` にも mh99 は出ていません＝何にもマッチしない死んだ例外でした。

> 死んだ例外は、うるさい例外より悪い。「誰かがリスクを承知で受け入れた」ように読めるからです。

結果、**本 tree の allowlist は react-router 1件のみ**に縮小しました。

## fast-uri

`GHSA-7p8r-x3mc-p8w7` は**本 tree の依存に存在しません**（`npm ls fast-uri --all` が空）。対応不要です。

## react-router の例外は維持（ただし記述を訂正）

`GHSA-qwww-vcr4-c8h2` は 7.x 系に fix が無いため維持。ただし一次情報で **first patched が 8.2.1 → 8.3.0 へ動いていた**ため、脆弱範囲を `>= 7.12.0, < 8.3.0` に記載し直しました（7.x の最新 7.18.2 も依然として範囲内）。主張は**本 tree で再実測**（写経なし）:

- `grep -cE '\b(action|loader):' src/app/router.tsx` = **0**
- `grep -rniE '@react-router/(dev|node|serve)|react-router/server|createStaticHandler|rsc' src` = **0 件**

## 実測（すべて本 tree）

| 検査 | 結果 |
| --- | --- |
| `npm audit` high | brace-expansion ×2 が**消滅**、残りは react-router のみ |
| `audit-ci`（本番設定） | **exit=0**（緑） |
| `audit-ci`（**陰性対照**＝allowlist 除去） | **exit=1** ＝ ゲートが生きていることを証明 |
| #399 の false-green 罠の再検査 | minimatch@5.1.9 + brace-expansion@**2.1.4** で `a{b,c}d` → abd=**true** / axd=**false**。minimatch@10 側も **true** |
| `npm run check` | **全緑**（type-check / eslint / vitest **92** / knip） |

`#399` で踏んだ「override が consumer を壊しても check は緑のまま」という罠があるため、bump 後に両 chain を直接叩き直しています。

Closes #407
