### PR TITLE
ci: MySQL の migration を検証する mysql-migrate ジョブを足す

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -48,9 +48,72 @@ jobs:
       - name: Run checks
         run: composer check
 
-  # Validates that every Phinx migration applies cleanly on PostgreSQL. The unit
-  # suite builds its own SQLite schema, so this is the regression guard for the
-  # pgsql adapter (DB_ADAPTER=pgsql) and the RETURNING id / boolean SQL paths.
+  # ---------------------------------------------------------------------------
+  # What the migration jobs below verify — and what they do not
+  #
+  # Clear supports three Phinx adapters (phinx.php): sqlite, mysql, pgsql. DDL
+  # behaviour differs between them (defaults on TEXT columns, change_column type
+  # conversions, how booleans are stored, index-name length limits), so a
+  # migration can be green on one adapter and fail on another.
+  #
+  # Verified here: every migration applies **forward**, in order, on an **empty**
+  # database, for each adapter that a deployment can actually use.
+  #   - backend-check  → sqlite (the unit suite builds its own schema)
+  #   - mysql-migrate  → mysql 8.4  (the docker-compose default; Tier A default)
+  #   - postgres-migrate → postgres 17 (the optional DB_ADAPTER=pgsql path)
+  #
+  # NOT verified here, and deliberately out of scope for this job: rollback
+  # (`migrations:rollback`), migrating over a database that already holds
+  # production data, and any data-migration semantics beyond DDL applying. If
+  # you add a migration that rewrites existing rows, those paths still need a
+  # human check — a green pipeline here does not cover them.
+  #
+  # The MySQL image is pinned to the same version as docker-compose.yml
+  # (mysql:8.4). If one moves, move the other, or the job stops standing in for
+  # the environment it is meant to protect.
+  # ---------------------------------------------------------------------------
+
+  mysql-migrate:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: nene_clear
+          MYSQL_USER: nene_clear
+          MYSQL_PASSWORD: nene_clear
+          MYSQL_ROOT_PASSWORD: root_secret
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot_secret"
+          --health-interval 5s --health-timeout 5s --health-retries 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_mysql, mbstring
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Migrate on MySQL
+        env:
+          DB_ADAPTER: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: nene_clear
+          DB_USER: nene_clear
+          DB_PASSWORD: nene_clear
+        run: composer migrations:migrate
+
   postgres-migrate:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 問題

`backend-ci.yml` のジョブは **`backend-check`（SQLite）** と **`postgres-migrate`（PostgreSQL 17）** の 2 本で、**MySQL に対して migration を回すジョブがありませんでした**。

一方 MySQL は:

- `docker-compose.yml` の**既定サービス**（ホストポート 3383・`CLAUDE.md` のポートレジストリ記載）
- `phinx.php` の **Tier A 既定アダプタ**（PostgreSQL は optional な代替）

＝ **本番相当のアダプタだけが CI で守られていない**状態でした。

migration の DDL はアダプタごとに挙動が違う（TEXT 列への default、`change_column` の型変換、boolean の実体、index 名の長さ制限）ため、**MySQL でしか落ちない migration が PR 緑のまま `main` に入り、本番 migrate で初めて落ちる**構造です。

#403（期日自動送信の migration）では 3 アダプタを手元で実測して回避しましたが、それは**「人が覚えていれば防げる」だけで、仕組みでは防げていません**。本 PR はそこを埋めます。

## 変更

`postgres-migrate` と同型の **`mysql-migrate`** を 1 本追加しました（`mysql:8.4` / `pdo_mysql` / `DB_ADAPTER=mysql` / `DB_PORT=3306`）。

image は **`docker-compose.yml` と同じ `mysql:8.4` に固定**し、「片方だけ動かすとこのジョブが守るべき環境の代役でなくなる」旨をコメントに残しました。

## 🔴 あわせて「CI が何を検証しているか」を明示

hub から共有された横断論点（**E2E が何に対して緑なのか固定されていない**／8 艦が dev サーバを見ていて本番バンドル未検証）と接続する形にしています。ジョブ群の頭にコメントブロックを置き、**検証するもの**と**検証しないもの**を書き分けました:

**検証する** — 全 migration が**空の DB** に対して**順方向**に適用されること。deployment が実際に選べる 3 アダプタすべて（sqlite / mysql 8.4 / postgres 17）で。

**検証しない（意図的に射程外）** — `migrations:rollback`・**本番データが入った DB への適用**・DDL が通ることを超えたデータ移行の意味論。既存行を書き換える migration を足したときは、ここが緑でも人の確認が要ります。

緑が何を保証**しない**かを書いておかないと、次に読む人は「CI が通ったから安全」と読みます。それが今回の穴の作られ方そのものでした。

## 検証

このジョブ自体が検証です — **本 PR の CI で `mysql-migrate` が実際に緑になることが、28 本の migration が MySQL で通ることの初の機械的証明**になります（これまでは #403 時点の手元実測が唯一の根拠でした）。

## フリート

board 行66 で「**clear が自艦 issue 起票 → 参照実装 → 他艦は次波**」と位置づけられています。本 PR がその参照実装です。records も #1019 で同じ指摘（「CI は MySQL を立てない」）を受けており、構造的な穴です。

Closes #404
