### PR TITLE
feat(dunning): 送信のきっかけを監査に記録する（trigger を両パスへ・#400 §7）

### DIFF
--- a/src/Dunning/DunningTrigger.php
+++ b/src/Dunning/DunningTrigger.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * What initiated a dunning send (#400 §7, `terminology.md` — Scheduled dunning).
+ *
+ * Written into the `dunning_sent` audit event's `metadata` on **both** paths, so
+ * an unattended send is distinguishable from one an operator performed. The
+ * scheduled path records `actor_id = 0` — this repo's existing "no human actor"
+ * value — and `actor_id` alone cannot carry the distinction, because a failed
+ * login records 0 as well. `trigger` is what separates those inside that shared
+ * value.
+ *
+ * Rows written before #400 carry no `trigger` at all. Absence means "unknown,
+ * predates the feature" and MUST NOT be read as either value.
+ */
+enum DunningTrigger: string
+{
+    case Manual = 'manual';
+    case Scheduled = 'scheduled';
+}

--- a/src/Dunning/SendDunningInput.php
+++ b/src/Dunning/SendDunningInput.php
@@ -6,11 +6,21 @@ namespace NeneClear\Dunning;
 
 final readonly class SendDunningInput
 {
+    /**
+     * @param DunningTrigger $trigger      what initiated this send (#400 §7); recorded in the
+     *                                     audit event's `metadata`. Defaults to `manual` so the
+     *                                     operator path needs no change at its call sites.
+     * @param ?string        $dunningRunId identifies the scheduler run that produced this send,
+     *                                     so every notice from one sweep can be found together.
+     *                                     Null on the manual path, where there is no run.
+     */
     public function __construct(
         public int $organizationId,
         public int $invoiceId,
         public int $actorUserId,
         public DunningStage $stage = DunningStage::Initial,
+        public DunningTrigger $trigger = DunningTrigger::Manual,
+        public ?string $dunningRunId = null,
     ) {
     }
 }

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -115,10 +115,18 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                         'channel' => $this->mailer->channel(),
                         'template_version' => DunningMessageRenderer::TEMPLATE_VERSION,
                     ],
-                    metadata: [
+                    // `trigger` is written on both paths from #400 onward, so an
+                    // unattended send is tellable from an operator's. It cannot be
+                    // inferred from `actor_id`: a scheduled send records 0, and so
+                    // does a failed login. `dunning_run_id` is omitted entirely on
+                    // the manual path rather than written as null — there is no run,
+                    // and a null would read as "a run that lost its id".
+                    metadata: array_filter([
                         'dunning_notice_id' => $noticeId,
                         'invoice_id' => $input->invoiceId,
-                    ],
+                        'trigger' => $input->trigger->value,
+                        'dunning_run_id' => $input->dunningRunId,
+                    ], static fn (mixed $value): bool => $value !== null),
                 ));
 
                 return $noticeId;

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -8,6 +8,7 @@ use NeneClear\ClearSettings\ClearSettings;
 use NeneClear\Dunning\DunningMessageRenderer;
 use NeneClear\Dunning\DunningStage;
 use NeneClear\Dunning\DunningTooFrequentException;
+use NeneClear\Dunning\DunningTrigger;
 use NeneClear\Dunning\InvoiceAlreadyPaidException;
 use NeneClear\Dunning\SendDunningInput;
 use NeneClear\Dunning\SendDunningUseCase;
@@ -114,6 +115,46 @@ final class SendDunningUseCaseTest extends TestCase
 
         self::assertCount(1, $this->audit->events);
         self::assertSame('dunning_sent', $this->audit->events[0]->action);
+    }
+
+    public function test_manual_send_is_marked_manual_and_carries_no_run_id(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $this->useCase->execute($this->input());
+
+        $metadata = $this->audit->events[0]->metadata;
+        self::assertIsArray($metadata);
+        self::assertSame('manual', $metadata['trigger']);
+
+        // Omitted, not null: there is no run, and a null would read as "a run that
+        // lost its id".
+        self::assertArrayNotHasKey('dunning_run_id', $metadata);
+    }
+
+    public function test_scheduled_send_is_marked_scheduled_and_carries_its_run_id(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $this->useCase->execute(new SendDunningInput(
+            organizationId: 7,
+            invoiceId: 1,
+            actorUserId: 0,
+            trigger: DunningTrigger::Scheduled,
+            dunningRunId: 'run-abc123',
+        ));
+
+        $metadata = $this->audit->events[0]->metadata;
+        self::assertIsArray($metadata);
+        self::assertSame('scheduled', $metadata['trigger']);
+        self::assertSame('run-abc123', $metadata['dunning_run_id']);
+
+        // `actor_id = 0` is the existing "no human actor" value and is NOT what
+        // makes a send identifiable as scheduled — a failed login records 0 too.
+        // `trigger` is what separates them inside that shared value.
+        self::assertSame(0, $this->audit->events[0]->actorId);
     }
 
     public function test_paid_invoice_throws(): void


### PR DESCRIPTION
#400（督促の期日自動送信）の前提部品。**送信はまだしません** — 無人送信を「人が押した送信」と区別できるようにするところまでです。

## なぜ `actor_id` では足りないのか

設計 §7 の要点はここです。自動送信は **`actor_id = 0`**（本リポの既存の「人の実行者なし」値）を記録しますが、**ログイン失敗も 0 を記録します**（`src/Auth/LoginUseCase.php`）。つまり `actor_id` だけでは「無人の送信」と「認証されていないイベント」が同じ値に潰れます。

同じ値の中で両者を分けるのが **`metadata.trigger`** です。

## 変更

- **`DunningTrigger` enum** を追加（`manual` / `scheduled` — 用語登録どおりの値）
- **`SendDunningInput`** に `trigger`（既定 `manual`）と `dunningRunId`（既定 `null`）を追加。既定値のおかげで**手動パスの呼び出し側は無変更**
- **`dunning_sent` の `metadata`** に `trigger` を記録。`dunning_run_id` は**手動パスではキーごと出しません** — `null` で書くと「run はあったが id を失った」と読めるため、「run が無い」は不在で表します

## テスト

| テスト | 何を固定するか |
| --- | --- |
| `test_manual_send_is_marked_manual_and_carries_no_run_id` | 手動＝`trigger=manual`、かつ `dunning_run_id` キーが**無い** |
| `test_scheduled_send_is_marked_scheduled_and_carries_its_run_id` | 自動＝`trigger=scheduled` ＋ run id。**`actor_id=0` でも区別が付く**ことを明示的に固定 |

## 過去データの読み方

#400 より前に書かれた行は `trigger` を**持ちません**。その不在は「**不明・機能以前**」であって「`scheduled`」と読んではいけません（`terminology.md` にも明記済み・enum の docblock にも書きました）。黙って `?? 'manual'` で埋めると、機能以前の行が「人が送った」ことになります。

## 実測

`composer check` 全緑 — PHPUnit **486**・PHPStan level 8 **0 error**・OpenAPI・MCP catalog・spec-parity・conformance。

**OpenAPI / migration / フロントの変更はゼロ**です（設計 §7 が「no migration, no OpenAPI change, no frontend change」を狙って `actor_id = 0` + `metadata` を選んだとおり）。

## 次

選定サービス ＋ CLI（`tools/send-scheduled-dunning.php`）を別 PR で。この PR 単体では**送信の挙動は一切変わりません**。

Refs #400
