### PR TITLE
feat(dunning): 送った stage を記録する（#400 §5 の前提条件）

### DIFF
--- a/database/migrations/20260804120000_add_stage_to_dunning_notices.php
+++ b/database/migrations/20260804120000_add_stage_to_dunning_notices.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Record which escalation stage a dunning notice was sent at (#414).
+ *
+ * Until now the stage picked the template and was then discarded, so nothing in
+ * the record said whether a customer had already received a `final` demand. That
+ * is a gap in the trail for the manual path (ADR 0011 tone discipline) and a hard
+ * blocker for scheduled dunning (#400 §5: a stage is only reachable once the
+ * previous one has actually been sent).
+ *
+ * Rows that predate this column take the `initial` default. That default is a
+ * storage requirement, NOT a claim about what was sent — those sends have no
+ * recorded stage, and nothing may read them as "initial was sent". Back-filling
+ * them would mean guessing which stage went out, which is precisely the guessing
+ * #414 exists to stop.
+ */
+final class AddStageToDunningNotices extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('dunning_notices')
+            ->addColumn('stage', 'string', ['limit' => 32, 'default' => 'initial', 'after' => 'template_version'])
+            ->update();
+    }
+}

--- a/docs/explanation/terminology.md
+++ b/docs/explanation/terminology.md
@@ -187,7 +187,7 @@ login). New events MUST map to one of these registered `entity_type` values:
 | Outstanding at send (dunning) | `outstanding_at_send_cents` | `outstanding_cents`, `balance_cents` |
 | Dunning recipient | `recipient_email` | `email`, `to` |
 | Dunning template version | `template_version` | `template`, `version` |
-| Dunning escalation stage (send request; values `initial` / `reminder` / `final`) | `stage` | `level`, `step`, `tier` |
+| Dunning escalation stage (send request, `dunning_notices` column, and `dunning_sent` audit `after`; values `initial` / `reminder` / `final`) | `stage` | `level`, `step`, `tier` |
 | Credit remaining balance | `remaining_cents` | `balance_cents`, `left_cents` |
 | Manual receivable document number | `reference_number` | `invoice_number` (it is **not** an invoice — X1), `ref_no`, `doc_no` |
 | Manual receivable payer name | `client_name` | `payer`, `customer_name`, `client` |

--- a/src/Dunning/DunningNotice.php
+++ b/src/Dunning/DunningNotice.php
@@ -21,6 +21,17 @@ final readonly class DunningNotice
         public ?string $dueAt,
         public string $channel,
         public string $templateVersion,
+        /**
+         * Escalation stage this notice was sent at (#414).
+         *
+         * ⚠️ Rows written before #414 have no recorded stage and take the column
+         * default, so this reads `initial` for them. That is the storage default,
+         * NOT evidence that `initial` was sent — the operator may have chosen any
+         * stage. Do not treat a pre-#414 row as proof of which stage went out; the
+         * `dunning_sent` audit event carries `stage` only from #414 onward, and its
+         * absence there is the reliable marker.
+         */
+        public DunningStage $stage,
         public int $sentBy,
         public string $sentAt,
         public ?int $id = null,

--- a/src/Dunning/PdoDunningNoticeRepository.php
+++ b/src/Dunning/PdoDunningNoticeRepository.php
@@ -9,7 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 final readonly class PdoDunningNoticeRepository implements DunningNoticeRepositoryInterface
 {
     private const string COLUMNS = 'id, organization_id, invoice_id, invoice_number, client_id, '
-        . 'recipient_email, outstanding_cents, due_at, channel, template_version, sent_by, sent_at';
+        . 'recipient_email, outstanding_cents, due_at, channel, template_version, stage, sent_by, sent_at';
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
@@ -20,8 +20,8 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
     {
         return $this->query->insert(
             'INSERT INTO dunning_notices (organization_id, invoice_id, invoice_number, client_id, '
-            . 'recipient_email, outstanding_cents, due_at, channel, template_version, sent_by, sent_at) '
-            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            . 'recipient_email, outstanding_cents, due_at, channel, template_version, stage, sent_by, sent_at) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $notice->organizationId,
                 $notice->invoiceId,
@@ -32,6 +32,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
                 $notice->dueAt,
                 $notice->channel,
                 $notice->templateVersion,
+                $notice->stage->value,
                 $notice->sentBy,
                 $notice->sentAt,
             ],
@@ -153,6 +154,7 @@ final readonly class PdoDunningNoticeRepository implements DunningNoticeReposito
             dueAt: isset($row['due_at']) ? (string) $row['due_at'] : null,
             channel: (string) $row['channel'],
             templateVersion: (string) $row['template_version'],
+            stage: DunningStage::fromString(isset($row['stage']) ? (string) $row['stage'] : null),
             sentBy: (int) $row['sent_by'],
             sentAt: (string) $row['sent_at'],
             id: (int) $row['id'],

--- a/src/Dunning/SendDunningUseCase.php
+++ b/src/Dunning/SendDunningUseCase.php
@@ -81,6 +81,7 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
             dueAt: $invoice->dueAt,
             channel: $this->mailer->channel(),
             templateVersion: DunningMessageRenderer::TEMPLATE_VERSION,
+            stage: $input->stage,
             sentBy: $input->actorUserId,
             sentAt: $nowStr,
         );
@@ -114,6 +115,9 @@ final readonly class SendDunningUseCase implements SendDunningUseCaseInterface
                         'outstanding_at_send_cents' => $invoice->outstandingCents,
                         'channel' => $this->mailer->channel(),
                         'template_version' => DunningMessageRenderer::TEMPLATE_VERSION,
+                        // Recorded from #414 onward. Its absence marks a send that
+                        // predates the column — not `initial`.
+                        'stage' => $input->stage->value,
                     ],
                     // `trigger` is written on both paths from #400 onward, so an
                     // unattended send is tellable from an operator's. It cannot be

--- a/tests/Database/PdoDunningNoticeRepositoryTest.php
+++ b/tests/Database/PdoDunningNoticeRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Testing\DatabaseTestKit;
 use NeneClear\Dunning\DunningNotice;
 use NeneClear\Dunning\DunningNoticeFilter;
+use NeneClear\Dunning\DunningStage;
 use NeneClear\Dunning\PdoDunningNoticeRepository;
 use NeneClear\Tests\Support\SchemaFixture;
 use PHPUnit\Framework\TestCase;
@@ -38,9 +39,9 @@ final class PdoDunningNoticeRepositoryTest extends TestCase
         }
     }
 
-    private function seed(string $invoiceNumber, string $email, int $outstanding, string $sentAt, int $sentBy, int $orgId = 7): void
+    private function seed(string $invoiceNumber, string $email, int $outstanding, string $sentAt, int $sentBy, int $orgId = 7, DunningStage $stage = DunningStage::Initial): int
     {
-        $this->repo->save(new DunningNotice(
+        return $this->repo->save(new DunningNotice(
             organizationId: $orgId,
             invoiceId: 1,
             invoiceNumber: $invoiceNumber,
@@ -50,9 +51,23 @@ final class PdoDunningNoticeRepositoryTest extends TestCase
             dueAt: '2026-04-30',
             channel: 'log',
             templateVersion: '1.0',
+            stage: $stage,
             sentBy: $sentBy,
             sentAt: $sentAt,
         ));
+    }
+
+    public function test_stage_round_trips_through_the_database(): void
+    {
+        // The point of #414: which stage went out must survive the write. Before
+        // this column the stage only picked a template and was then discarded, so
+        // nothing could tell whether a customer had already had a `final` demand.
+        $id = $this->seed('INV-500', 'z@acme.example', 70000, '2026-05-10 09:00:00', sentBy: 1, stage: DunningStage::Final);
+
+        $stored = $this->repo->findById(7, $id);
+
+        self::assertNotNull($stored);
+        self::assertSame(DunningStage::Final, $stored->stage);
     }
 
     public function test_text_amount_and_actor_filters(): void

--- a/tests/Dunning/InMemoryDunningNoticeRepository.php
+++ b/tests/Dunning/InMemoryDunningNoticeRepository.php
@@ -28,6 +28,7 @@ final class InMemoryDunningNoticeRepository implements DunningNoticeRepositoryIn
             dueAt: $notice->dueAt,
             channel: $notice->channel,
             templateVersion: $notice->templateVersion,
+            stage: $notice->stage,
             sentBy: $notice->sentBy,
             sentAt: $notice->sentAt,
             id: $id,

--- a/tests/Dunning/SendDunningUseCaseTest.php
+++ b/tests/Dunning/SendDunningUseCaseTest.php
@@ -117,6 +117,31 @@ final class SendDunningUseCaseTest extends TestCase
         self::assertSame('dunning_sent', $this->audit->events[0]->action);
     }
 
+    public function test_the_stage_that_was_sent_is_recorded_on_the_notice_and_in_the_audit(): void
+    {
+        $this->addInvoice(1);
+        $this->addClient();
+
+        $output = $this->useCase->execute(new SendDunningInput(
+            organizationId: 7,
+            invoiceId: 1,
+            actorUserId: 42,
+            stage: DunningStage::Reminder,
+        ));
+
+        // #414: before this, the stage picked a template and was then discarded,
+        // so nothing in the record said which escalation step a customer had
+        // received. Scheduled dunning (#400 §5) cannot decide "the next stage"
+        // without it, and guessing is not acceptable for a final demand.
+        $notice = $this->notices->findById(7, $output->dunningNoticeId);
+        self::assertNotNull($notice);
+        self::assertSame(DunningStage::Reminder, $notice->stage);
+
+        $after = $this->audit->events[0]->after;
+        self::assertIsArray($after);
+        self::assertSame('reminder', $after['stage']);
+    }
+
     public function test_manual_send_is_marked_manual_and_carries_no_run_id(): void
     {
         $this->addInvoice(1);

--- a/tests/Support/SchemaFixture.php
+++ b/tests/Support/SchemaFixture.php
@@ -264,6 +264,7 @@ final class SchemaFixture
                 due_at TEXT NOT NULL,
                 channel TEXT NOT NULL DEFAULT \'log\',
                 template_version TEXT NOT NULL DEFAULT \'1.0\',
+                stage TEXT NOT NULL DEFAULT \'initial\',
                 sent_by INTEGER NOT NULL,
                 sent_at TEXT NOT NULL,
                 created_at TEXT


### PR DESCRIPTION
#400（期日自動送信）の実装中に見つかった、**設計 §5 の実装不能な前提**を解消します。hub 裁定 (a)（2026-08-05）。

## 問題

設計 §5 は「**段階を飛ばさない** — 前の段階が実際に送られて初めて次の段階に到達できる」と定めていますが、**送った stage がどこにも残っていませんでした**。

| 場所 | 変更前 |
| --- | --- |
| `dunning_notices` テーブル | ❌ 列が無い |
| `DunningNotice` 値オブジェクト | ❌ フィールドが無い |
| `dunning_sent` 監査の `after` | ❌ `channel` / `template_version` 等のみ |

`SendDunningInput::$stage` は**レンダラがテンプレートを選ぶためだけに使われ、そのまま捨てられていました**。`template_version`（`1.0`）はテンプレート**世代**であって段階ではありません。

## 自動送信だけの問題ではありませんでした

**手動パスにも既に穴がありました。** 今日でも「この請求書に `final`（最終通告）を送ったか」を記録から判定できません。督促は段階が上がるほど関係を変える文面になる（ADR 0011 のトーン規律）ため、これは自動化以前に**証跡として不足**しています。

## 「送信回数で代用」を採らなかった理由

手動パスは operator が段階を**任意に選べます**（`initial` を2回、いきなり `final` もあり得る）。件数と段階は一致しません。推定した段階で「次は `final`」と判断して送るのは、**推測にもとづいて最終通告を出す**ことになります。送信済みのメールは取り消せません。

## 変更

- **migration**: `dunning_notices.stage`（varchar 32・既定 `initial`・`template_version` の後ろ）
- `DunningNotice` に `stage` フィールド、`PdoDunningNoticeRepository` の読み書き
- **`dunning_sent` 監査の `after` に `stage`**
- テスト用 SQLite スキーマと InMemory リポジトリを追随
- 用語登録の説明を実態へ拡張（`stage` の**綴りは既登録で不変** — 射程が「送信リクエスト」から永続列・監査キーへ広がったことを記載）

## 🔴 既存行は遡及しません

既定値 `initial` は **保存上の既定であって「`initial` を送った」証拠ではありません**。operator は任意の段階を選べたので、**後から推測して書くのは本 issue が禁じている行為そのもの**です。

値オブジェクトと migration の両方に警告を残しました。監査 `after` 側は #414 以降にしか `stage` を持たないので、**その不在が信頼できる目印**です（`trigger` #413 と同じ扱い）。

## テスト

| テスト | 何を固定するか |
| --- | --- |
| `test_stage_round_trips_through_the_database` | `final` が DB 往復で保たれる |
| `test_the_stage_that_was_sent_is_recorded_on_the_notice_and_in_the_audit` | 手動送信で選んだ `reminder` が **notice 行と監査 `after` の両方**に残る |
| 既存 485 本 | 無傷 |

## 実測

`composer check` 全緑 — PHPUnit **488**（7,481 assertions）・PHPStan level 8 **0 error**・OpenAPI・MCP catalog・spec-parity・conformance。

🟢 本 migration は **#404 で `mysql-migrate` が required に入って以降で最初のもの** ＝ **3アダプタとも CI が守る初のケース**です。

## 意図的に外したもの

**CSV エクスポート（`ExportDunningNoticesCsvHandler`）に `stage` 列は足していません。** 出力列を増やすのは連携先の契約変更になるため、本 PR の射程（記録すること）とは分けます。証跡として operator に見せる価値はあるので、必要なら別 issue で。

Closes #414
Refs #400, #194
