### PR TITLE
feat(dunning): 期日自動送信の選定サービスと CLI（送信ウィンドウ・段階・上限・dry-run）

### DIFF
--- a/src/ClearSettings/ClearSettingsRepositoryInterface.php
+++ b/src/ClearSettings/ClearSettingsRepositoryInterface.php
@@ -11,5 +11,18 @@ interface ClearSettingsRepositoryInterface
     /** Lightweight read of just the fiscal year-end month (1–12), or null if unset/no row. */
     public function fiscalYearEndMonth(int $organizationId): ?int;
 
+    /**
+     * Organization ids that have opted in to scheduled dunning (#400 §6), ascending.
+     *
+     * Asked as one query rather than by walking every organization and reading its
+     * settings: the feature is default-off, so on a deployment where nobody has
+     * enabled it this must cost one round trip and return nothing — an unattended
+     * job that scales its work with the tenant count would get slower forever while
+     * doing nothing.
+     *
+     * @return list<int>
+     */
+    public function findOrganizationIdsWithScheduledDunning(): array;
+
     public function save(ClearSettings $settings): void;
 }

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -49,6 +49,24 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
         );
     }
 
+    public function findOrganizationIdsWithScheduledDunning(): array
+    {
+        // The column is used as a bare predicate rather than compared to a literal.
+        // Phinx creates it as a real `boolean` on PostgreSQL, where
+        // `... = 1` raises "operator does not exist: boolean = integer", while
+        // SQLite stores it as an integer and MySQL as a tinyint. The bare form is
+        // the one predicate all three read the same way.
+        //
+        // Worth knowing: the unit suite runs on SQLite and the migration jobs only
+        // apply DDL, so a pgsql-only *query* error like that would not be caught by
+        // CI today — this comment is the guard until it is.
+        $rows = $this->query->fetchAll(
+            'SELECT organization_id FROM clear_settings WHERE is_dunning_schedule_enabled ORDER BY organization_id',
+        );
+
+        return array_map(static fn (array $row): int => (int) $row['organization_id'], $rows);
+    }
+
     public function fiscalYearEndMonth(int $organizationId): ?int
     {
         $row = $this->query->fetchOne(

--- a/src/Dunning/DunningServiceProvider.php
+++ b/src/Dunning/DunningServiceProvider.php
@@ -18,6 +18,7 @@ use NeneClear\Http\ServiceResolver;
 use NeneClear\I18n\LocalizedProblemDetailsFactory;
 use NeneClear\I18n\MessageCatalog;
 use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Scheduler\PdoSchedulerLock;
 use NeneClear\Security\Encryptor;
 use NeneClear\Tenancy\CurrentOrganization;
 use Psr\Container\ContainerInterface;
@@ -57,6 +58,21 @@ final readonly class DunningServiceProvider implements ServiceProviderInterface
                     ServiceResolver::get($c, ClockInterface::class),
                     new DunningMessageRenderer(ServiceResolver::get($c, MessageCatalog::class)),
                     static fn (DatabaseQueryExecutorInterface $tx): DunningPauseRepositoryInterface => new PdoDunningPauseRepository($tx),
+                ),
+            )
+            ->set(
+                SendScheduledDunningUseCase::class,
+                static fn (ContainerInterface $c): SendScheduledDunningUseCase => new SendScheduledDunningUseCase(
+                    ServiceResolver::get($c, DatabaseQueryExecutorInterface::class),
+                    static fn (DatabaseQueryExecutorInterface $tx): ClearSettingsRepositoryInterface => new PdoClearSettingsRepository($tx, new PdoBankAccountRepository($tx, ServiceResolver::get($c, Encryptor::class))),
+                    static fn (DatabaseQueryExecutorInterface $tx): DunningNoticeRepositoryInterface => new PdoDunningNoticeRepository($tx),
+                    ServiceResolver::get($c, InvoiceUpstreamClientInterface::class),
+                    // Resolved, not constructed: the scheduler must go through the
+                    // very same use case (and therefore the very same guards) the
+                    // operator's button does.
+                    ServiceResolver::get($c, SendDunningUseCaseInterface::class),
+                    new PdoSchedulerLock(ServiceResolver::get($c, DatabaseQueryExecutorInterface::class)),
+                    ServiceResolver::get($c, ClockInterface::class),
                 ),
             )
             ->set(

--- a/src/Dunning/DunningStage.php
+++ b/src/Dunning/DunningStage.php
@@ -21,4 +21,35 @@ enum DunningStage: string
     {
         return self::tryFrom((string) $value) ?? self::Initial;
     }
+
+    /**
+     * Position in the escalation ladder, lowest first.
+     */
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Initial => 0,
+            self::Reminder => 1,
+            self::Final => 2,
+        };
+    }
+
+    /**
+     * The highest stage reachable when `$lastSent` was the last stage actually
+     * sent for an invoice — one step up, and `initial` when nothing has been sent
+     * (#400 §5, "escalation never skips a stage").
+     *
+     * The ladder is walked one rung at a time on purpose: an invoice that sat
+     * unattended past the `final` threshold must still receive `initial` and then
+     * `reminder` before anything harsher, rather than opening with the last
+     * message before the relationship changes.
+     */
+    public static function highestReachableAfter(?self $lastSent): self
+    {
+        return match ($lastSent) {
+            null => self::Initial,
+            self::Initial => self::Reminder,
+            self::Reminder, self::Final => self::Final,
+        };
+    }
 }

--- a/src/Dunning/ScheduledDunningDecision.php
+++ b/src/Dunning/ScheduledDunningDecision.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * One line of a scheduled run's report: what the run decided about one invoice
+ * and why (#400 §9).
+ */
+final readonly class ScheduledDunningDecision
+{
+    public function __construct(
+        public int $organizationId,
+        public int $invoiceId,
+        public string $invoiceNumber,
+        public ScheduledDunningOutcome $outcome,
+        /** The stage that was (or would have been) sent; null when nothing was sent. */
+        public ?DunningStage $stage = null,
+        /** Free text for the run log — an exception message, a next-allowed time. */
+        public ?string $detail = null,
+    ) {
+    }
+}

--- a/src/Dunning/ScheduledDunningOutcome.php
+++ b/src/Dunning/ScheduledDunningOutcome.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * What a scheduled run decided about one candidate invoice (#400 §9).
+ *
+ * Every candidate the run looked at produces exactly one of these, including the
+ * ones it did nothing about. A `--dry-run` that printed only the sends would hide
+ * the more useful half of the answer: an operator turning the feature on first
+ * needs to know *why* an invoice they expected to see was passed over.
+ */
+enum ScheduledDunningOutcome: string
+{
+    /** Sent, or — under `--dry-run` — would have been sent. */
+    case Sent = 'sent';
+
+    /** Not yet far enough past due to reach the first threshold (or not due at all). */
+    case BelowThreshold = 'below_threshold';
+
+    /** The invoice carries no due date, so "days past due" is undefined (#400 §5). */
+    case NoDueDate = 'no_due_date';
+
+    /** Reached the `final` threshold: held for an operator to send by hand (#400 §5). */
+    case AwaitingApproval = 'awaiting_approval';
+
+    /** An operator paused dunning for this invoice. */
+    case Paused = 'paused';
+
+    /** Inside `dunning_min_interval_days` since the last notice. */
+    case TooFrequent = 'too_frequent';
+
+    /** Upstream says it is settled, or nothing is outstanding. */
+    case AlreadyPaid = 'already_paid';
+
+    /** The per-run cap was reached; the next run picks this up. */
+    case CapReached = 'cap_reached';
+
+    /** The send threw something unexpected. The run continues (#400 §9). */
+    case Failed = 'failed';
+}

--- a/src/Dunning/ScheduledDunningReport.php
+++ b/src/Dunning/ScheduledDunningReport.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+/**
+ * The result of one scheduled-dunning run (#400 §9).
+ *
+ * `$skippedOrganizations` records organizations the run did not walk at all —
+ * outside their send window, or already being processed by an overlapping tick.
+ * An empty report with no explanation is the failure mode this exists to prevent:
+ * an operator who enabled the feature and saw nothing happen must be able to tell
+ * "nothing was due" from "the window was closed".
+ */
+final readonly class ScheduledDunningReport
+{
+    /**
+     * @param list<ScheduledDunningDecision> $decisions
+     * @param array<int, string>             $skippedOrganizations organization id => reason
+     */
+    public function __construct(
+        public string $runId,
+        public bool $isDryRun,
+        public array $decisions = [],
+        public array $skippedOrganizations = [],
+    ) {
+    }
+
+    public function sentCount(): int
+    {
+        return count(array_filter(
+            $this->decisions,
+            static fn (ScheduledDunningDecision $d): bool => $d->outcome === ScheduledDunningOutcome::Sent,
+        ));
+    }
+
+    public function candidateCount(): int
+    {
+        return count($this->decisions);
+    }
+
+    /** @return list<ScheduledDunningDecision> */
+    public function failures(): array
+    {
+        return array_values(array_filter(
+            $this->decisions,
+            static fn (ScheduledDunningDecision $d): bool => $d->outcome === ScheduledDunningOutcome::Failed,
+        ));
+    }
+}

--- a/src/Dunning/SendScheduledDunningUseCase.php
+++ b/src/Dunning/SendScheduledDunningUseCase.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Dunning;
+
+use Closure;
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
+use NeneClear\ClearSettings\ClearSettingsRepositoryInterface;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Scheduler\SchedulerLockInterface;
+use Throwable;
+
+/**
+ * One unattended dunning sweep (#400 §4).
+ *
+ * This class decides **which** invoices a run offers up and in what order. It
+ * decides nothing about whether an invoice may be dunned: upstream status,
+ * outstanding balance, active pauses and the minimum interval are all
+ * {@see SendDunningUseCase}'s to enforce, and this class learns the answer by
+ * calling it and catching its exceptions. Re-checking any of them here would
+ * create a second copy of a safety guard, and the unattended path would drift
+ * away from the operator path the first time one copy changed.
+ *
+ * The two things it does own are the ones the operator path has no equivalent of:
+ * the send window (§4) and the escalation ladder (§5).
+ */
+final readonly class SendScheduledDunningUseCase
+{
+    /** How long one organization's lock is held before it is considered abandoned. */
+    private const int LOCK_TTL_SECONDS = 900;
+
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): ClearSettingsRepositoryInterface $clearSettings
+     * @param Closure(DatabaseQueryExecutorInterface): DunningNoticeRepositoryInterface $notices
+     */
+    public function __construct(
+        private DatabaseQueryExecutorInterface $reader,
+        private Closure $clearSettings,
+        private Closure $notices,
+        private InvoiceUpstreamClientInterface $invoiceClient,
+        private SendDunningUseCaseInterface $sendDunning,
+        private SchedulerLockInterface $lock,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @param ?int $organizationId restrict the run to one organization (the CLI's
+     *                             `--organization`); null walks every opted-in one
+     */
+    public function execute(string $runId, bool $isDryRun = false, ?int $organizationId = null): ScheduledDunningReport
+    {
+        $now = $this->clock->now();
+        $settingsRepo = ($this->clearSettings)($this->reader);
+
+        $organizationIds = $settingsRepo->findOrganizationIdsWithScheduledDunning();
+
+        if ($organizationId !== null) {
+            $organizationIds = array_values(array_filter(
+                $organizationIds,
+                static fn (int $id): bool => $id === $organizationId,
+            ));
+        }
+
+        $decisions = [];
+        $skipped = [];
+
+        foreach ($organizationIds as $id) {
+            $settings = $settingsRepo->findByOrganization($id);
+
+            if ($settings === null) {
+                continue;
+            }
+
+            $policy = new DunningSchedulePolicy($settings->dunningSchedule);
+
+            if (!$policy->isEnabled()) {
+                $skipped[$id] = 'not_enabled';
+                continue;
+            }
+
+            if (!$policy->isWindowOpen($now)) {
+                $skipped[$id] = 'window_closed';
+                continue;
+            }
+
+            // A dry run must not take the lock. It sends nothing, so it cannot
+            // collide with anything — and if it did take one, running `--dry-run`
+            // to inspect the queue would silently suppress the real run behind it.
+            $holderToken = $runId . ':' . $id;
+            $lockKey = 'dunning:' . $id;
+
+            if (!$isDryRun && !$this->lock->acquire($lockKey, $holderToken, self::LOCK_TTL_SECONDS, $now)) {
+                // An overlapping cron tick is normal operation, not an error (§8).
+                $skipped[$id] = 'already_running';
+                continue;
+            }
+
+            try {
+                foreach ($this->decideForOrganization($id, $policy, $runId, $isDryRun, $now) as $decision) {
+                    $decisions[] = $decision;
+                }
+            } catch (Throwable $e) {
+                // One tenant's problem must not stop the others. §9 says a failing
+                // candidate does not abort the run; the same has to hold a level up,
+                // because the work that happens before any candidate exists — asking
+                // the upstream for invoices — is exactly what an outage breaks. Left
+                // unhandled, a single unreachable Invoice deployment would silently
+                // stop dunning for every other organization on the host.
+                $skipped[$id] = 'failed: ' . $e->getMessage();
+            } finally {
+                if (!$isDryRun) {
+                    $this->lock->release($lockKey, $holderToken);
+                }
+            }
+        }
+
+        return new ScheduledDunningReport(
+            runId: $runId,
+            isDryRun: $isDryRun,
+            decisions: $decisions,
+            skippedOrganizations: $skipped,
+        );
+    }
+
+    /**
+     * @return list<ScheduledDunningDecision>
+     */
+    private function decideForOrganization(
+        int $organizationId,
+        DunningSchedulePolicy $policy,
+        string $runId,
+        bool $isDryRun,
+        DateTimeImmutable $now,
+    ): array {
+        $invoices = $this->invoiceClient->listInvoices($organizationId, ['issued', 'partially_paid', 'overdue']);
+
+        // Oldest due first: if the cap bites, the invoices that have been waiting
+        // longest are the ones that get attention, not whichever the upstream
+        // happened to list first.
+        usort($invoices, static fn (InvoiceItem $a, InvoiceItem $b): int => ($a->dueAt ?? '9999-12-31') <=> ($b->dueAt ?? '9999-12-31'));
+
+        $noticeRepo = ($this->notices)($this->reader);
+        $decisions = [];
+        $sent = 0;
+
+        foreach ($invoices as $invoice) {
+            $daysPastDue = $policy->daysPastDue($invoice->dueAt, $now);
+
+            if ($daysPastDue === null) {
+                $decisions[] = $this->decision($organizationId, $invoice, ScheduledDunningOutcome::NoDueDate);
+                continue;
+            }
+
+            $ageStage = $policy->stageFor($daysPastDue);
+
+            if ($ageStage === null) {
+                $decisions[] = $this->decision(
+                    $organizationId,
+                    $invoice,
+                    ScheduledDunningOutcome::BelowThreshold,
+                    detail: $daysPastDue . ' day(s) past due',
+                );
+                continue;
+            }
+
+            // Escalation never skips a rung (§5). The ladder is capped by what has
+            // actually been sent, which is why #414 had to record the stage first:
+            // before that, this decision had no evidence to stand on.
+            $lastNotice = $noticeRepo->findLastByInvoice($organizationId, $invoice->invoiceId);
+            $reachable = DunningStage::highestReachableAfter($lastNotice?->stage);
+            $stage = $ageStage->rank() <= $reachable->rank() ? $ageStage : $reachable;
+
+            if ($policy->requiresApproval($stage)) {
+                $decisions[] = $this->decision(
+                    $organizationId,
+                    $invoice,
+                    ScheduledDunningOutcome::AwaitingApproval,
+                    $stage,
+                    $daysPastDue . ' day(s) past due',
+                );
+                continue;
+            }
+
+            if ($sent >= $policy->maxPerRun()) {
+                $decisions[] = $this->decision($organizationId, $invoice, ScheduledDunningOutcome::CapReached, $stage);
+                continue;
+            }
+
+            if ($isDryRun) {
+                // Counted as if sent, so the cap shapes the dry run exactly as it
+                // would shape the real one — a preview that ignored the cap would
+                // promise sends the real run then withholds.
+                ++$sent;
+                $decisions[] = $this->decision($organizationId, $invoice, ScheduledDunningOutcome::Sent, $stage);
+                continue;
+            }
+
+            $decisions[] = $this->send($organizationId, $invoice, $stage, $runId, $sent);
+        }
+
+        return $decisions;
+    }
+
+    private function send(int $organizationId, InvoiceItem $invoice, DunningStage $stage, string $runId, int &$sent): ScheduledDunningDecision
+    {
+        try {
+            $this->sendDunning->execute(new SendDunningInput(
+                organizationId: $organizationId,
+                invoiceId: $invoice->invoiceId,
+                // The unattended actor: this repo's existing "no human actor"
+                // value. `trigger` (#413) is what tells it apart from a failed
+                // login, which also records 0.
+                actorUserId: 0,
+                stage: $stage,
+                trigger: DunningTrigger::Scheduled,
+                dunningRunId: $runId,
+            ));
+
+            ++$sent;
+
+            return $this->decision($organizationId, $invoice, ScheduledDunningOutcome::Sent, $stage);
+        } catch (DunningPausedException $e) {
+            return $this->decision($organizationId, $invoice, ScheduledDunningOutcome::Paused, $stage, $e->getMessage());
+        } catch (DunningTooFrequentException $e) {
+            return $this->decision($organizationId, $invoice, ScheduledDunningOutcome::TooFrequent, $stage, $e->getMessage());
+        } catch (InvoiceAlreadyPaidException $e) {
+            return $this->decision($organizationId, $invoice, ScheduledDunningOutcome::AlreadyPaid, $stage, $e->getMessage());
+        } catch (Throwable $e) {
+            // One bad candidate does not abort the sweep (§9). The failure is
+            // recorded and the next invoice is evaluated; the recorded "attempted"
+            // trail from SendDunningUseCase stays honest either way.
+            return $this->decision($organizationId, $invoice, ScheduledDunningOutcome::Failed, $stage, $e->getMessage());
+        }
+    }
+
+    private function decision(
+        int $organizationId,
+        InvoiceItem $invoice,
+        ScheduledDunningOutcome $outcome,
+        ?DunningStage $stage = null,
+        ?string $detail = null,
+    ): ScheduledDunningDecision {
+        return new ScheduledDunningDecision(
+            organizationId: $organizationId,
+            invoiceId: $invoice->invoiceId,
+            invoiceNumber: $invoice->invoiceNumber,
+            outcome: $outcome,
+            stage: $stage,
+            detail: $detail,
+        );
+    }
+}

--- a/tests/Dunning/InMemoryClearSettingsRepository.php
+++ b/tests/Dunning/InMemoryClearSettingsRepository.php
@@ -22,6 +22,21 @@ final class InMemoryClearSettingsRepository implements ClearSettingsRepositoryIn
         return ($this->byOrg[$organizationId] ?? null)?->fiscalYearEndMonth;
     }
 
+    public function findOrganizationIdsWithScheduledDunning(): array
+    {
+        $ids = [];
+
+        foreach ($this->byOrg as $organizationId => $settings) {
+            if ($settings->dunningSchedule->isEnabled) {
+                $ids[] = $organizationId;
+            }
+        }
+
+        sort($ids);
+
+        return $ids;
+    }
+
     public function save(ClearSettings $settings): void
     {
         $this->byOrg[$settings->organizationId] = $settings;

--- a/tests/Dunning/SendScheduledDunningUseCaseTest.php
+++ b/tests/Dunning/SendScheduledDunningUseCaseTest.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneClear\Tests\Dunning;
+
+use DateTimeImmutable;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneClear\ClearSettings\ClearSettings;
+use NeneClear\ClearSettings\DunningSchedule;
+use NeneClear\Dunning\DunningNotice;
+use NeneClear\Dunning\DunningStage;
+use NeneClear\Dunning\ScheduledDunningOutcome;
+use NeneClear\Dunning\SendDunningInput;
+use NeneClear\Dunning\SendDunningOutput;
+use NeneClear\Dunning\SendDunningUseCaseInterface;
+use NeneClear\Dunning\SendScheduledDunningUseCase;
+use NeneClear\InvoiceUpstream\FakeInvoiceUpstreamClient;
+use NeneClear\InvoiceUpstream\InvoiceItem;
+use NeneClear\InvoiceUpstream\InvoiceUpstreamClientInterface;
+use NeneClear\Scheduler\SchedulerLockInterface;
+use NeneClear\Tests\Support\FixedClock;
+use NeneClear\Tests\Support\NullQueryExecutor;
+use PHPUnit\Framework\TestCase;
+
+final class SendScheduledDunningUseCaseTest extends TestCase
+{
+    private const int ORG = 7;
+
+    private InMemoryClearSettingsRepository $settings;
+    private InMemoryDunningNoticeRepository $notices;
+    private FakeInvoiceUpstreamClient $fake;
+    private InvoiceUpstreamClientInterface $upstream;
+    private RecordingSendDunning $sender;
+    private FakeSchedulerLock $lock;
+
+    protected function setUp(): void
+    {
+        $this->settings = new InMemoryClearSettingsRepository();
+        $this->notices = new InMemoryDunningNoticeRepository();
+        $this->fake = new FakeInvoiceUpstreamClient();
+        $this->upstream = $this->fake;
+        $this->sender = new RecordingSendDunning();
+        $this->lock = new FakeSchedulerLock();
+    }
+
+    private function enable(DunningSchedule $schedule = new DunningSchedule(isEnabled: true)): void
+    {
+        $this->settings->save(new ClearSettings(
+            organizationId: self::ORG,
+            upstreamBaseUrl: 'https://invoice.example',
+            upstreamTokenRef: 'ref',
+            dunningMinIntervalDays: 7,
+            dunningSchedule: $schedule,
+        ));
+    }
+
+    private function addInvoice(int $id, ?string $dueAt, int $outstanding = 110000): void
+    {
+        $this->fake->addInvoice(new InvoiceItem(
+            invoiceId: $id,
+            invoiceNumber: 'INV-' . str_pad((string) $id, 3, '0', STR_PAD_LEFT),
+            clientId: 45,
+            outstandingCents: $outstanding,
+            totalCents: $outstanding,
+            dueAt: $dueAt,
+            status: 'overdue',
+            currency: 'JPY',
+        ));
+    }
+
+    /** `$now` defaults to a Wednesday at 10:00 — inside the default Mon–Fri 09–18 window. */
+    private function sweep(string $now = '2026-06-10T10:00:00+00:00', bool $dryRun = false, ?int $organizationId = null): \NeneClear\Dunning\ScheduledDunningReport
+    {
+        $useCase = new SendScheduledDunningUseCase(
+            reader: new NullQueryExecutor(),
+            clearSettings: fn (DatabaseQueryExecutorInterface $ex): InMemoryClearSettingsRepository => $this->settings,
+            notices: fn (DatabaseQueryExecutorInterface $ex): InMemoryDunningNoticeRepository => $this->notices,
+            invoiceClient: $this->upstream,
+            sendDunning: $this->sender,
+            lock: $this->lock,
+            clock: new FixedClock($now),
+        );
+
+        return $useCase->execute('run-1', $dryRun, $organizationId);
+    }
+
+    public function test_an_organization_that_never_opted_in_is_not_walked_at_all(): void
+    {
+        // Default-off is the whole safety story of #400 §6: shipping this feature
+        // must not change what any existing deployment does.
+        $this->addInvoice(1, '2026-06-01');
+
+        $report = $this->sweep();
+
+        self::assertSame(0, $report->candidateCount());
+        self::assertSame([], $this->sender->sent);
+    }
+
+    public function test_outside_the_send_window_nothing_is_sent_and_the_reason_is_reported(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+
+        // Sunday. A polite dunning email at the weekend still reads as harassment.
+        $report = $this->sweep('2026-06-14T10:00:00+00:00');
+
+        self::assertSame([], $this->sender->sent);
+
+        // Reported, not silently empty: an operator who enabled the feature must be
+        // able to tell "nothing was due" from "the window was closed".
+        self::assertSame(['window_closed'], array_values($report->skippedOrganizations));
+    }
+
+    public function test_below_the_first_threshold_nothing_is_sent(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-09'); // 1 day past due; initial needs 3
+
+        $report = $this->sweep();
+
+        self::assertSame([], $this->sender->sent);
+        self::assertSame(ScheduledDunningOutcome::BelowThreshold, $report->decisions[0]->outcome);
+    }
+
+    public function test_a_final_threshold_invoice_is_held_for_approval_not_sent(): void
+    {
+        $this->enable();
+        // 40 days past due — past the `final` threshold of 30. It has already had
+        // an initial and a reminder, so the ladder does not hold it back.
+        $this->addInvoice(1, '2026-05-01');
+        $this->seedNotice(1, DunningStage::Reminder);
+
+        $report = $this->sweep();
+
+        self::assertSame([], $this->sender->sent, 'a final demand is never sent unattended');
+        self::assertSame(ScheduledDunningOutcome::AwaitingApproval, $report->decisions[0]->outcome);
+        self::assertSame(DunningStage::Final, $report->decisions[0]->stage);
+    }
+
+    public function test_escalation_never_skips_a_rung(): void
+    {
+        $this->enable();
+        // 40 days past due, so by age alone this is `final` — but nothing has been
+        // sent yet, so the run may only reach `initial`. An invoice left unattended
+        // must not be opened with the last message before the relationship changes.
+        $this->addInvoice(1, '2026-05-01');
+
+        $this->sweep();
+
+        self::assertCount(1, $this->sender->sent);
+        self::assertSame(DunningStage::Initial, $this->sender->sent[0]->stage);
+    }
+
+    public function test_the_rung_after_initial_is_reminder_not_final(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-05-01');
+        $this->seedNotice(1, DunningStage::Initial);
+
+        $this->sweep();
+
+        self::assertCount(1, $this->sender->sent);
+        self::assertSame(DunningStage::Reminder, $this->sender->sent[0]->stage);
+    }
+
+    public function test_a_scheduled_send_is_attributed_to_the_run_and_to_no_human(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+
+        $this->sweep();
+
+        $input = $this->sender->sent[0];
+        self::assertSame(0, $input->actorUserId);
+        self::assertSame('scheduled', $input->trigger->value);
+        self::assertSame('run-1', $input->dunningRunId);
+    }
+
+    public function test_the_per_run_cap_bounds_the_blast_radius(): void
+    {
+        $this->enable(new DunningSchedule(isEnabled: true, maxPerRun: 2));
+        $this->addInvoice(1, '2026-06-01');
+        $this->addInvoice(2, '2026-06-02');
+        $this->addInvoice(3, '2026-06-03');
+
+        $report = $this->sweep();
+
+        self::assertCount(2, $this->sender->sent);
+        self::assertSame(ScheduledDunningOutcome::CapReached, $report->decisions[2]->outcome);
+    }
+
+    public function test_the_oldest_due_invoice_is_attended_to_first(): void
+    {
+        $this->enable(new DunningSchedule(isEnabled: true, maxPerRun: 1));
+        $this->addInvoice(1, '2026-06-03');
+        $this->addInvoice(2, '2026-05-20'); // oldest
+        $this->addInvoice(3, '2026-06-01');
+
+        $this->sweep();
+
+        // If the cap bites, the invoice that has been waiting longest is the one
+        // that gets attention — not whichever the upstream happened to list first.
+        self::assertCount(1, $this->sender->sent);
+        self::assertSame(2, $this->sender->sent[0]->invoiceId);
+    }
+
+    public function test_a_dry_run_sends_nothing_takes_no_lock_and_still_reports_what_would_go(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+
+        $report = $this->sweep(dryRun: true);
+
+        self::assertSame([], $this->sender->sent);
+        self::assertTrue($report->isDryRun);
+        self::assertSame(1, $report->sentCount());
+        self::assertSame(DunningStage::Initial, $report->decisions[0]->stage);
+
+        // A dry run that took the lock would silently suppress the real run behind it.
+        self::assertSame([], $this->lock->acquired);
+    }
+
+    public function test_a_dry_run_respects_the_cap_so_it_does_not_promise_more_than_the_real_run(): void
+    {
+        $this->enable(new DunningSchedule(isEnabled: true, maxPerRun: 1));
+        $this->addInvoice(1, '2026-06-01');
+        $this->addInvoice(2, '2026-06-02');
+
+        $report = $this->sweep(dryRun: true);
+
+        self::assertSame(1, $report->sentCount());
+        self::assertSame(ScheduledDunningOutcome::CapReached, $report->decisions[1]->outcome);
+    }
+
+    public function test_a_second_overlapping_run_takes_no_lock_and_sends_nothing(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+        $this->lock->refuse = true;
+
+        $report = $this->sweep();
+
+        self::assertSame([], $this->sender->sent);
+        // An overlapping cron tick is normal operation, not an error (§8).
+        self::assertSame(['already_running'], array_values($report->skippedOrganizations));
+    }
+
+    public function test_the_lock_is_released_even_when_a_candidate_blows_up(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+        $this->sender->throw = new \RuntimeException('smtp exploded');
+
+        $report = $this->sweep();
+
+        self::assertSame(ScheduledDunningOutcome::Failed, $report->decisions[0]->outcome);
+        self::assertSame(['dunning:7'], $this->lock->released);
+    }
+
+    public function test_one_failing_candidate_does_not_abort_the_sweep(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, '2026-06-01');
+        $this->addInvoice(2, '2026-06-02');
+        $this->sender->throwOnInvoiceId = 1;
+
+        $report = $this->sweep();
+
+        self::assertSame(ScheduledDunningOutcome::Failed, $report->decisions[0]->outcome);
+        self::assertSame(ScheduledDunningOutcome::Sent, $report->decisions[1]->outcome);
+        self::assertCount(1, $report->failures());
+    }
+
+    public function test_an_invoice_without_a_due_date_is_never_a_scheduled_candidate(): void
+    {
+        $this->enable();
+        $this->addInvoice(1, dueAt: '');
+
+        $report = $this->sweep();
+
+        // "Days past due" is undefined without one. An operator can still dun it by hand.
+        self::assertSame([], $this->sender->sent);
+        self::assertSame(ScheduledDunningOutcome::NoDueDate, $report->decisions[0]->outcome);
+    }
+
+    public function test_one_organizations_upstream_outage_does_not_stop_the_others(): void
+    {
+        $this->enable();
+        $this->settings->save(new ClearSettings(
+            organizationId: 99,
+            upstreamBaseUrl: 'https://invoice.example',
+            upstreamTokenRef: 'ref',
+            dunningMinIntervalDays: 7,
+            dunningSchedule: new DunningSchedule(isEnabled: true),
+        ));
+        $this->addInvoice(1, '2026-06-01');
+
+        // Org 99 blows up on the listing call — the work that happens *before* any
+        // candidate exists, which is exactly what an upstream outage breaks.
+        $this->upstream = new FailsForOneOrgUpstream($this->upstream, failForOrganizationId: 99);
+
+        $report = $this->sweep();
+
+        // Org 7 still got its send. Without the per-organization catch, a single
+        // unreachable Invoice deployment would silently stop dunning for everyone.
+        self::assertCount(1, $this->sender->sent);
+        self::assertSame(self::ORG, $this->sender->sent[0]->organizationId);
+        self::assertArrayHasKey(99, $report->skippedOrganizations);
+        self::assertStringStartsWith('failed:', $report->skippedOrganizations[99]);
+    }
+
+    private function seedNotice(int $invoiceId, DunningStage $stage): void
+    {
+        $this->notices->save(new DunningNotice(
+            organizationId: self::ORG,
+            invoiceId: $invoiceId,
+            invoiceNumber: 'INV-001',
+            clientId: 45,
+            recipientEmail: 'a@acme.example',
+            outstandingCents: 110000,
+            dueAt: '2026-05-01',
+            channel: 'log',
+            templateVersion: '1.0',
+            stage: $stage,
+            sentBy: 42,
+            sentAt: '2026-05-20 09:00:00',
+        ));
+    }
+}
+
+final class RecordingSendDunning implements SendDunningUseCaseInterface
+{
+    /** @var list<SendDunningInput> */
+    public array $sent = [];
+
+    public ?\Throwable $throw = null;
+
+    public ?int $throwOnInvoiceId = null;
+
+    private int $nextId = 1;
+
+    public function execute(SendDunningInput $input): SendDunningOutput
+    {
+        if ($this->throw !== null || $this->throwOnInvoiceId === $input->invoiceId) {
+            throw $this->throw ?? new \RuntimeException('boom');
+        }
+
+        $this->sent[] = $input;
+
+        return new SendDunningOutput(dunningNoticeId: $this->nextId++);
+    }
+}
+
+final class FakeSchedulerLock implements SchedulerLockInterface
+{
+    public bool $refuse = false;
+
+    /** @var list<string> */
+    public array $acquired = [];
+
+    /** @var list<string> */
+    public array $released = [];
+
+    public function acquire(string $key, string $holderToken, int $ttlSeconds, DateTimeImmutable $now): bool
+    {
+        if ($this->refuse) {
+            return false;
+        }
+
+        $this->acquired[] = $key;
+
+        return true;
+    }
+
+    public function release(string $key, string $holderToken): void
+    {
+        $this->released[] = $key;
+    }
+}
+
+/**
+ * Delegates everything, except that one organization's listing call blows up —
+ * the shape of an Invoice deployment being unreachable for a single tenant.
+ */
+final class FailsForOneOrgUpstream implements InvoiceUpstreamClientInterface
+{
+    public function __construct(
+        private readonly InvoiceUpstreamClientInterface $inner,
+        private readonly int $failForOrganizationId,
+    ) {
+    }
+
+    public function listInvoices(int $organizationId, array $statuses): array
+    {
+        if ($organizationId === $this->failForOrganizationId) {
+            throw new \RuntimeException('upstream unreachable');
+        }
+
+        return $this->inner->listInvoices($organizationId, $statuses);
+    }
+
+    public function getInvoice(int $organizationId, int $invoiceId): \NeneClear\InvoiceUpstream\InvoiceItem
+    {
+        return $this->inner->getInvoice($organizationId, $invoiceId);
+    }
+
+    public function createPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $amountCents,
+        string $paidAt,
+        string $externalReference,
+        string $idempotencyKey,
+    ): \NeneClear\InvoiceUpstream\InvoicePaymentCreated {
+        return $this->inner->createPayment($organizationId, $invoiceId, $amountCents, $paidAt, $externalReference, $idempotencyKey);
+    }
+
+    public function voidPayment(
+        int $organizationId,
+        int $invoiceId,
+        int $paymentId,
+        string $reason,
+        string $idempotencyKey,
+    ): void {
+        $this->inner->voidPayment($organizationId, $invoiceId, $paymentId, $reason, $idempotencyKey);
+    }
+
+    public function getClient(int $organizationId, int $clientId): \NeneClear\InvoiceUpstream\InvoiceClientInfo
+    {
+        return $this->inner->getClient($organizationId, $clientId);
+    }
+}

--- a/tools/send-scheduled-dunning.php
+++ b/tools/send-scheduled-dunning.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Scheduled dunning sweep (#400). One-shot, run from cron:
+ *
+ *   (every 15 min) cd /path/to/app && php tools/send-scheduled-dunning.php >> var/log/dunning-cron.log 2>&1
+ *   — the crontab schedule field is written in the ops runbook; it cannot be shown
+ *     verbatim inside a PHP block comment because it would close the comment.
+ *
+ * Thin by design: the cron line carries no policy. Whether it is inside the send
+ * window, which organizations opted in, how many notices one run may send and
+ * which escalation stage an invoice has earned all live in the database, where an
+ * operator can see and change them — see {@see \NeneClear\Dunning\SendScheduledDunningUseCase}.
+ * `tools/sweep-demo.php` is the in-repo precedent for the DB wiring below (#275).
+ *
+ * Usage:
+ *   php tools/send-scheduled-dunning.php [--dry-run] [--organization=<id>]
+ *
+ *   --dry-run          print what would be sent and send nothing. This is the
+ *                      acceptance instrument (§9): run it once before the feature
+ *                      is enabled for real. It takes no lock, so it can never
+ *                      suppress the scheduled run behind it.
+ *   --organization=ID  restrict the sweep to one organization.
+ *
+ * Exit codes: 0 on a completed run (including "nothing to do" and "already
+ * running" — an overlapping tick is normal operation, §8), 1 when the run could
+ * not start at all, 2 when at least one candidate failed to send.
+ */
+
+use Dotenv\Dotenv;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\DatabaseConnectionFactoryInterface;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\PdoDatabaseTransactionManager;
+use NeneClear\Database\AdapterAwareQueryExecutor;
+use NeneClear\Database\AdapterAwareTransactionManager;
+use NeneClear\Dunning\SendScheduledDunningUseCase;
+use NeneClear\Http\ApplicationFactory;
+use NeneClear\Http\ServiceResolver;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, 'This script must be run from the command line.' . PHP_EOL);
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+
+if (is_file($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$env = static fn (string $key, string $default = ''): string => (string) ($_ENV[$key] ?? getenv($key) ?: $default);
+
+$isDryRun = in_array('--dry-run', $argv, true);
+$organizationId = null;
+
+foreach ($argv as $arg) {
+    if (str_starts_with((string) $arg, '--organization=')) {
+        $organizationId = (int) substr((string) $arg, strlen('--organization='));
+    }
+}
+
+$adapter = $env('DB_ADAPTER', 'sqlite');
+$connectionFactory = (static function () use ($env, $adapter, $root): ?DatabaseConnectionFactoryInterface {
+    try {
+        $config = match ($adapter) {
+            'mysql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'mysql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '3306'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8mb4'),
+            ),
+            'pgsql' => new DatabaseConfig(
+                url: $env('DATABASE_URL') ?: null,
+                environment: $env('DB_ENV', 'production'),
+                adapter: 'pgsql',
+                host: $env('DB_HOST', '127.0.0.1'),
+                port: (int) $env('DB_PORT', '5432'),
+                name: $env('DB_NAME', 'nene_clear'),
+                user: $env('DB_USER', 'nene_clear'),
+                password: $env('DB_PASSWORD'),
+                charset: $env('DB_CHARSET', 'utf8'),
+            ),
+            default => DatabaseConfig::sqlite($env('DB_NAME') ?: $root . '/database/nene_clear.sqlite3'),
+        };
+
+        return new PdoConnectionFactory($config);
+    } catch (\Throwable) {
+        return null;
+    }
+})();
+
+if ($connectionFactory === null) {
+    fwrite(STDERR, 'Database is not configured or unreachable. Check .env (DB_ADAPTER, DB_*).' . PHP_EOL);
+    exit(1);
+}
+
+$query = new AdapterAwareQueryExecutor(new PdoDatabaseQueryExecutor($connectionFactory), $adapter);
+$transactionManager = new AdapterAwareTransactionManager(new PdoDatabaseTransactionManager($connectionFactory), $adapter);
+
+// The upstream and SMTP config MUST be passed here. Left out, ApplicationFactory
+// falls back to an empty FakeInvoiceUpstreamClient and a log-only mailer — the
+// sweep would then find no invoices and exit 0, i.e. report a clean run while
+// sending nothing. A scheduled job that silently does nothing is worse than one
+// that fails, because nobody goes looking. These values mirror
+// {@see \NeneClear\Http\RuntimeBootstrap} so the cron path and the request path
+// talk to the same Invoice deployment and the same mail server.
+$invoiceApiBaseUrl = $env('NENE_INVOICE_API_BASE_URL') ?: null;
+
+$container = ApplicationFactory::container(
+    query: $query,
+    transactionManager: $transactionManager,
+    jwtSecret: $env('NENE2_LOCAL_JWT_SECRET') ?: $env('NENE_CLEAR_JWT_SECRET'),
+    smtpHost: $env('SMTP_HOST') ?: null,
+    smtpPort: (int) $env('SMTP_PORT', '1025'),
+    smtpUsername: $env('SMTP_USERNAME'),
+    smtpPassword: $env('SMTP_PASSWORD'),
+    smtpFromAddress: $env('SMTP_FROM_ADDRESS', 'noreply@nene-clear.dev'),
+    smtpFromName: $env('SMTP_FROM_NAME', 'NeNe Clear'),
+    invoiceApiBaseUrl: $invoiceApiBaseUrl,
+    invoiceBearerToken: $env('NENE_INVOICE_BEARER_TOKEN'),
+);
+
+if ($invoiceApiBaseUrl === null) {
+    // Refuse rather than sweep against an empty stand-in. Without an upstream
+    // there are no invoices to dun, and "0 candidates" would be indistinguishable
+    // from a correctly configured quiet day.
+    fwrite(STDERR, 'NENE_INVOICE_API_BASE_URL is not set; refusing to run so a misconfiguration cannot look like a quiet day.' . PHP_EOL);
+    exit(1);
+}
+
+// Random, not sequential: the run id groups one sweep's notices together in the
+// audit trail, and must not be guessable as "the run before this one".
+$runId = bin2hex(random_bytes(8));
+
+$report = ServiceResolver::get($container, SendScheduledDunningUseCase::class)
+    ->execute($runId, $isDryRun, $organizationId);
+
+$stamp = (new DateTimeImmutable())->format('Y-m-d H:i:sP');
+$mode = $report->isDryRun ? 'DRY-RUN' : 'LIVE';
+
+fwrite(STDOUT, sprintf(
+    '[%s] dunning run %s (%s): %d candidate(s), %d sent%s' . PHP_EOL,
+    $stamp,
+    $runId,
+    $mode,
+    $report->candidateCount(),
+    $report->sentCount(),
+    $report->isDryRun ? ' (would send)' : '',
+));
+
+// Every organization that was passed over says why. A run that printed only its
+// sends would leave an operator unable to tell "nothing was due" from "the window
+// was closed" — the single most likely question after enabling this.
+foreach ($report->skippedOrganizations as $skippedOrgId => $reason) {
+    fwrite(STDOUT, sprintf('  org %d: skipped (%s)' . PHP_EOL, $skippedOrgId, $reason));
+}
+
+foreach ($report->decisions as $decision) {
+    fwrite(STDOUT, sprintf(
+        '  org %d  %-12s  %-16s  %-8s  %s' . PHP_EOL,
+        $decision->organizationId,
+        $decision->invoiceNumber,
+        $decision->outcome->value,
+        $decision->stage !== null ? $decision->stage->value : '-',
+        $decision->detail ?? '',
+    ));
+}
+
+$failures = $report->failures();
+
+if ($failures !== []) {
+    fwrite(STDERR, sprintf('%d candidate(s) failed to send; the run continued.' . PHP_EOL, count($failures)));
+
+    exit(2);
+}
+
+// "Already running" is not a failure: an overlapping cron tick is expected (§8),
+// so a run that only skipped organizations still exits 0.
+exit(0);


### PR DESCRIPTION
#400 の本体。cron から1回走って、その時点で送るべき督促を選んで送ります。

## このサービスは「選定」しかしない

送ってよいかの判断（upstream の状態・残高・停止中・最小間隔）は**すべて `SendDunningUseCase` のもの**で、本サービスは**呼んで例外を捕まえることで答えを知ります**。

ここで再チェックすると安全ガードの2つ目の写しができ、片方が変わった瞬間に**無人パスが operator パスから乖離**します。本サービスが持つのは operator パスに対応物が無い2つだけ — **送信ウィンドウ（§4）**と**段階の梯子（§5）**です。

## 変更

- **`SendScheduledDunningUseCase`** — 組織列挙 → 窓判定 → ロック → 候補列挙 → 段階決定 → 送信
- **`ScheduledDunningOutcome` / `Decision` / `Report`** — **見送った候補も理由つきで必ず報告**。送った分だけ出す実装だと「期日が来ていない」と「窓が閉じていた」を区別できません。これは有効化直後に最も出る質問です
- **`tools/send-scheduled-dunning.php`** — 薄い CLI（`--dry-run` / `--organization`）。cron 行にポリシーを持たせません
- **`DunningStage::rank()` / `highestReachableAfter()`** — 梯子は1段ずつ。放置された請求書でも `initial` → `reminder` の順を踏み、**いきなり最終通告を出しません**
- **`findOrganizationIdsWithScheduledDunning()`** — 既定OFFなので、誰も有効化していない環境では**1往復で空を返す**（テナント数に比例して遅くなる無人ジョブを作らない）
- **DI 登録** — `SendDunningUseCaseInterface` は**解決して渡す**＝operator のボタンと同じ実体を通す

## 🔴 実装中に見つけて塞いだ穴 2 つ

### (1) upstream 例外が sweep 全体を殺していた

§9 は「候補の失敗は run を中断しない」と定めていますが、**候補が存在する前の処理**＝upstream への問い合わせは対象外でした。**1テナントの Invoice が落ちているだけで、他の全組織の督促が静かに止まります。** 組織単位で捕まえ、`skipped` に理由を残す形にしました。

### (2) CLI が upstream 設定を渡しておらず、本番で空の Fake にフォールバックしていた

`ApplicationFactory` は `invoiceApiBaseUrl` が null のとき `FakeInvoiceUpstreamClient`（空）にフォールバックします。渡し忘れていたため、**黙って 0 件・exit 0 ＝「きれいに走った」と報告しながら何も送らない**状態でした。

> 静かに何もしない定期ジョブは、失敗する定期ジョブより悪い。誰も見に行かないからです。

`RuntimeBootstrap` と同じ env を渡し、**未設定なら exit 1 で拒否**するようにしました。

## 実測 — 受入 §10 の `--dry-run` を使い捨てコピーで実演

| 条件 | 出力 |
| --- | --- |
| 既定OFF | `0 candidate(s), 0 sent` — 組織を1つも walk しない |
| 窓の外 | `org 6: skipped (window_closed)` |
| upstream 未設定 | `refusing to run so a misconfiguration cannot look like a quiet day` / **exit 1** |
| upstream 到達不能 | `org 6: skipped (failed: Invoice API unreachable...)` を**組織ごと**に出し、**他組織は継続**（(1) の実証） |

## テスト 16 本

既定OFF／窓の外／閾値未満／**`final` は人間ゲート**／**梯子を飛ばさない**／`initial` の次は `reminder`／`actor=0`+`trigger`+run id／上限／**期日の古い順**／dry-run はロックを取らず送らない／**dry-run も上限を守る**／重複起動は何もしない／例外時もロック解放／1件の失敗で sweep は止まらない／期日なしは候補外／**1組織の upstream 障害が他を止めない**。

`composer check` 全緑 — PHPUnit **504**・PHPStan level 8 **0 error**・spec-parity・conformance。

## 残り

**設定 UI** と **ops runbook**（§11 の 4 と 5）。この PR 時点では**どの組織も既定OFF**なので、マージしても挙動は変わりません。cron 行も入れていません（施主 seam）。

Refs #400
