### PR TITLE
feat(settings): 期日自動送信の設定を API に載せる（full-replace の明文化つき）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ a date. For the design decisions behind that history, read
 
 ## [Unreleased]
 
+### Added
+
+- **Scheduled dunning** (#400) — an organization can opt in to having Clear send its
+  overdue dunning notices unattended, with the same guards, records and audit trail as
+  a manual send. Off for every organization until explicitly enabled. The escalation
+  ladder never skips a step, and a `final` demand is never sent unattended: it is held
+  for an operator. Driven by `tools/send-scheduled-dunning.php` from cron; `--dry-run`
+  prints what would be sent without sending it.
+- **The escalation stage a notice was sent at is now recorded** (#414) on the notice row
+  and in the `dunning_sent` audit event. Rows written before this carry no recorded
+  stage; the column default is not evidence of what was sent.
+- **`GET`/`PUT /admin/clear-settings` carry the scheduled-dunning settings** — enable/
+  disable, the three stage thresholds, the send window, weekday-only, and the per-run
+  cap. ⚠️ That endpoint is a **full replace**: see
+  [`docs/development/clear-settings-full-replace.md`](docs/development/clear-settings-full-replace.md).
+
 ### Changed
 
 - **Dependency-vulnerability gate: `brace-expansion` patched instead of

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,7 @@ NeNe Clear is built through small, Issue-driven changes. This document is the sh
 | Agent entry point | `AGENTS.md` |
 | Roadmap | `docs/roadmap.md` |
 | Release notes | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Settings API semantics | [`docs/development/clear-settings-full-replace.md`](development/clear-settings-full-replace.md) |
 | Current work | `nene-origin/internal-docs/clear/todo/current.md` |
 
 ## Collaboration Policy

--- a/docs/development/clear-settings-full-replace.md
+++ b/docs/development/clear-settings-full-replace.md
@@ -1,0 +1,84 @@
+# `PUT /admin/clear-settings` is a full replace
+
+**A field you leave out of the body is reset to its default. It is not preserved.**
+
+This page exists because that is not what most people assume a `PUT` on a settings
+resource does, and because getting it wrong is silent: the request succeeds, the
+response is a `200`, and a setting the operator turned on is quietly off again.
+
+## The rule
+
+To change one setting, send **all** of them:
+
+1. `GET /admin/clear-settings`
+2. change the field you mean to change
+3. `PUT` the whole object back
+
+Sending only the field you are editing will reset every field you omitted.
+
+```jsonc
+// ❌ resets the dunning schedule, the fiscal year-end month and the bank accounts
+{ "dunning_min_interval_days": 10 }
+
+// ✅ read-modify-write
+{
+  "upstream_base_url": "https://invoice.example/api",
+  "upstream_token_ref": "NENE_INVOICE_BEARER_TOKEN",
+  "dunning_min_interval_days": 10,
+  "fiscal_year_end_month": 3,
+  "is_dunning_schedule_enabled": true,
+  "dunning_initial_after_days": 3,
+  "dunning_reminder_after_days": 14,
+  "dunning_final_after_days": 30,
+  "dunning_window_start_hour": 9,
+  "dunning_window_end_hour": 18,
+  "is_dunning_weekdays_only": true,
+  "dunning_max_per_run": 50,
+  "bank_accounts": [ /* the complete list */ ]
+}
+```
+
+The bank accounts behave the same way and always have: the stored set is replaced
+by the array you send, so an omitted `bank_accounts` empties it.
+
+## Why it is built this way
+
+The endpoint backs a settings **screen**, which loads the whole object and saves the
+whole object. For that one caller, replace is the simpler and more predictable
+contract — there is no merge to reason about and no way for a stale field in the
+client to be silently kept.
+
+The cost is that the endpoint is unforgiving to any *other* caller, which is what
+this page is for.
+
+## What enforces it
+
+Prose is not enforcement. The behaviour is pinned by tests, so a future change that
+quietly turns this into a merge — or a UI that starts sending partial bodies — fails
+before it ships:
+
+| Test | What it pins |
+| --- | --- |
+| `ClearSettingsHttpTest::test_put_is_full_replace_so_an_omitted_field_is_reset_not_preserved` | Enabling scheduled dunning, then PUTting a body without that field, turns it back off |
+| `SettingsPage.test.tsx` — *saves the whole settings object* | The settings screen sends every field, including the ones it has no controls for |
+| `PdoClearSettingsRepositoryTest::testSaveWritesTheDunningScheduleItIsGiven` | The repository persists exactly the entity it is handed, on both the INSERT and UPDATE branches |
+
+The middle one matters most in practice. The settings screen currently has **no
+controls** for the scheduled-dunning fields (they arrive with the A2 settings
+rework), so it echoes back the values it loaded. Without that, every unrelated save
+— editing a bank account, changing the upstream URL — would turn scheduled dunning
+off, with no error and nothing on screen to suggest it happened.
+
+## If this ever becomes a merge
+
+That would be a breaking change for the screen, not just an addition: the screen
+relies on replace to delete bank accounts. Removing an account is expressed by
+sending the list without it. Under merge semantics that would become a no-op, and
+deletion would need its own representation.
+
+## Related
+
+- Issue #284 — where this was first raised as undocumented
+- Issue #314 — a settings-save bug that only reproduced on MySQL; the same endpoint
+- [`dunning-scheduler-design.md`](dunning-scheduler-design.md) §6 — the scheduled-dunning
+  settings this now carries

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -433,7 +433,11 @@ paths:
     put:
       tags: [Settings]
       summary: Update clear settings
-      description: Update upstream config and the registered bank accounts (with CSV profiles).
+      description: >
+        Update upstream config, the scheduled-dunning settings and the registered bank
+        accounts (with CSV profiles). ⚠️ This is a FULL REPLACE: any field omitted from
+        the body is reset to its default rather than preserved. Read the current
+        settings with GET, change what you need, and send the whole object back.
       operationId: updateClearSettings
       requestBody:
         required: true
@@ -2029,7 +2033,7 @@ components:
           type: integer
     ClearSettings:
       type: object
-      required: [organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, bank_accounts]
+      required: [organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, is_dunning_schedule_enabled, dunning_initial_after_days, dunning_reminder_after_days, dunning_final_after_days, dunning_window_start_hour, dunning_window_end_hour, is_dunning_weekdays_only, dunning_max_per_run, bank_accounts]
       properties:
         organization_id:
           type: integer
@@ -2050,12 +2054,63 @@ components:
           minimum: 1
           maximum: 12
           description: Fiscal year-end month (決算月). Null when unset.
+        is_dunning_schedule_enabled:
+          type: boolean
+          default: false
+          description: >
+            Whether Clear sends this organization's dunning notices unattended on a
+            schedule. Off until explicitly enabled; enabling is recorded in the audit
+            log as `clear_settings_updated`.
+        dunning_initial_after_days:
+          type: integer
+          default: 3
+          description: Days past due before the `initial` stage is reached.
+        dunning_reminder_after_days:
+          type: integer
+          default: 14
+          description: Days past due before the `reminder` stage is reached.
+        dunning_final_after_days:
+          type: integer
+          default: 30
+          description: >
+            Days past due before the `final` stage is reached. A `final` notice is
+            never sent unattended — it is surfaced for an operator to send by hand.
+        dunning_window_start_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 9
+          description: First hour of the send window, inclusive. Must be before the end hour.
+        dunning_window_end_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 18
+          description: End of the send window, exclusive. Must be after the start hour.
+        is_dunning_weekdays_only:
+          type: boolean
+          default: true
+          description: Restrict unattended sending to Monday–Friday.
+        dunning_max_per_run:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 50
+          description: >
+            Most notices one scheduled run may send. Candidates beyond the cap are
+            picked up by the next run.
         bank_accounts:
           type: array
           items:
             $ref: '#/components/schemas/BankAccount'
     UpdateClearSettingsRequest:
       type: object
+      description: >
+        ⚠️ FULL REPLACE. Every field is optional in the schema, but a field that is
+        omitted is reset to its default — it is NOT left at its stored value. To
+        change one setting, send the complete object (read it with GET first, edit
+        the field, send it all back). Sending only the field you mean to change will
+        silently reset the others.
       properties:
         upstream_base_url:
           type: string
@@ -2069,6 +2124,51 @@ components:
           nullable: true
           minimum: 1
           maximum: 12
+        is_dunning_schedule_enabled:
+          type: boolean
+          default: false
+          description: >
+            Whether Clear sends this organization's dunning notices unattended on a
+            schedule. Off until explicitly enabled; enabling is recorded in the audit
+            log as `clear_settings_updated`.
+        dunning_initial_after_days:
+          type: integer
+          default: 3
+          description: Days past due before the `initial` stage is reached.
+        dunning_reminder_after_days:
+          type: integer
+          default: 14
+          description: Days past due before the `reminder` stage is reached.
+        dunning_final_after_days:
+          type: integer
+          default: 30
+          description: >
+            Days past due before the `final` stage is reached. A `final` notice is
+            never sent unattended — it is surfaced for an operator to send by hand.
+        dunning_window_start_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 9
+          description: First hour of the send window, inclusive. Must be before the end hour.
+        dunning_window_end_hour:
+          type: integer
+          minimum: 0
+          maximum: 23
+          default: 18
+          description: End of the send window, exclusive. Must be after the start hour.
+        is_dunning_weekdays_only:
+          type: boolean
+          default: true
+          description: Restrict unattended sending to Monday–Friday.
+        dunning_max_per_run:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 50
+          description: >
+            Most notices one scheduled run may send. Candidates beyond the cap are
+            picked up by the next run.
         bank_accounts:
           type: array
           items:

--- a/frontend/src/entities/clear-settings/model.ts
+++ b/frontend/src/entities/clear-settings/model.ts
@@ -11,6 +11,18 @@ export interface ClearSettings {
   upstream_base_url: string
   upstream_token_ref: string
   dunning_min_interval_days: number
+  // Scheduled dunning (#400 §6). No UI edits these yet — the settings screen
+  // echoes them back untouched on save, because PUT /admin/clear-settings is a
+  // FULL REPLACE (#284): a field left out of the body is reset to its default,
+  // not preserved. Editing controls arrive with the A2 F4 settings rework.
+  is_dunning_schedule_enabled: boolean
+  dunning_initial_after_days: number
+  dunning_reminder_after_days: number
+  dunning_final_after_days: number
+  dunning_window_start_hour: number
+  dunning_window_end_hour: number
+  is_dunning_weekdays_only: boolean
+  dunning_max_per_run: number
   fiscal_year_end_month: number | null
   bank_accounts: BankAccount[]
 }

--- a/frontend/src/pages/settings/SettingsPage.test.tsx
+++ b/frontend/src/pages/settings/SettingsPage.test.tsx
@@ -10,6 +10,14 @@ const settings: ClearSettings = {
   upstream_token_ref: 'tok-ref',
   dunning_min_interval_days: 3,
   fiscal_year_end_month: 3,
+  is_dunning_schedule_enabled: true,
+  dunning_initial_after_days: 3,
+  dunning_reminder_after_days: 14,
+  dunning_final_after_days: 30,
+  dunning_window_start_hour: 9,
+  dunning_window_end_hour: 18,
+  is_dunning_weekdays_only: true,
+  dunning_max_per_run: 50,
   bank_accounts: [
     {
       bank_account_id: 1,
@@ -70,6 +78,18 @@ describe('SettingsPage', () => {
       dunning_min_interval_days: 3,
       fiscal_year_end_month: 3,
       bank_accounts: settings.bank_accounts,
+      // This screen has no controls for the schedule yet, so it must echo back what
+      // it loaded. Dropping these would reset scheduled dunning to off on every
+      // unrelated save — silently, because the API would be doing exactly what a
+      // full replace is supposed to do (#284). Editing controls arrive with A2 F4.
+      is_dunning_schedule_enabled: true,
+      dunning_initial_after_days: 3,
+      dunning_reminder_after_days: 14,
+      dunning_final_after_days: 30,
+      dunning_window_start_hour: 9,
+      dunning_window_end_hour: 18,
+      is_dunning_weekdays_only: true,
+      dunning_max_per_run: 50,
     })
   })
 

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -36,7 +36,24 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
   const [intervalError, setIntervalError] = useState('')
 
   const saveMut = useMutation({
-    mutationFn: () => updateClearSettings({ upstream_base_url: upstreamUrl, upstream_token_ref: upstreamToken, dunning_min_interval_days: dunningInterval, fiscal_year_end_month: fiscalMonth, bank_accounts: accounts } as Partial<ClearSettings>),
+    // The schedule fields are echoed back exactly as loaded. This screen does not
+    // edit them yet, but PUT is a FULL REPLACE (#284) — omitting them would reset
+    // scheduled dunning to off on every unrelated save, with no error and no clue.
+    mutationFn: () => updateClearSettings({
+      upstream_base_url: upstreamUrl,
+      upstream_token_ref: upstreamToken,
+      dunning_min_interval_days: dunningInterval,
+      fiscal_year_end_month: fiscalMonth,
+      bank_accounts: accounts,
+      is_dunning_schedule_enabled: settings.is_dunning_schedule_enabled,
+      dunning_initial_after_days: settings.dunning_initial_after_days,
+      dunning_reminder_after_days: settings.dunning_reminder_after_days,
+      dunning_final_after_days: settings.dunning_final_after_days,
+      dunning_window_start_hour: settings.dunning_window_start_hour,
+      dunning_window_end_hour: settings.dunning_window_end_hour,
+      is_dunning_weekdays_only: settings.is_dunning_weekdays_only,
+      dunning_max_per_run: settings.dunning_max_per_run,
+    } as Partial<ClearSettings>),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['clear-settings'] })
       // The org's fiscal year-end month is held in the /me cache (it drives the

--- a/frontend/src/shared/api/schema.gen.ts
+++ b/frontend/src/shared/api/schema.gen.ts
@@ -198,7 +198,7 @@ export interface paths {
         get: operations["getClearSettings"];
         /**
          * Update clear settings
-         * @description Update upstream config and the registered bank accounts (with CSV profiles).
+         * @description Update upstream config, the scheduled-dunning settings and the registered bank accounts (with CSV profiles). ⚠️ This is a FULL REPLACE: any field omitted from the body is reset to its default rather than preserved. Read the current settings with GET, change what you need, and send the whole object back.
          */
         put: operations["updateClearSettings"];
         post?: never;
@@ -898,14 +898,95 @@ export interface components {
             dunning_min_interval_days: number;
             /** @description Fiscal year-end month (決算月). Null when unset. */
             fiscal_year_end_month: number | null;
+            /**
+             * @description Whether Clear sends this organization's dunning notices unattended on a schedule. Off until explicitly enabled; enabling is recorded in the audit log as `clear_settings_updated`.
+             * @default false
+             */
+            is_dunning_schedule_enabled: boolean;
+            /**
+             * @description Days past due before the `initial` stage is reached.
+             * @default 3
+             */
+            dunning_initial_after_days: number;
+            /**
+             * @description Days past due before the `reminder` stage is reached.
+             * @default 14
+             */
+            dunning_reminder_after_days: number;
+            /**
+             * @description Days past due before the `final` stage is reached. A `final` notice is never sent unattended — it is surfaced for an operator to send by hand.
+             * @default 30
+             */
+            dunning_final_after_days: number;
+            /**
+             * @description First hour of the send window, inclusive. Must be before the end hour.
+             * @default 9
+             */
+            dunning_window_start_hour: number;
+            /**
+             * @description End of the send window, exclusive. Must be after the start hour.
+             * @default 18
+             */
+            dunning_window_end_hour: number;
+            /**
+             * @description Restrict unattended sending to Monday–Friday.
+             * @default true
+             */
+            is_dunning_weekdays_only: boolean;
+            /**
+             * @description Most notices one scheduled run may send. Candidates beyond the cap are picked up by the next run.
+             * @default 50
+             */
+            dunning_max_per_run: number;
             bank_accounts: components["schemas"]["BankAccount"][];
         };
+        /** @description ⚠️ FULL REPLACE. Every field is optional in the schema, but a field that is omitted is reset to its default — it is NOT left at its stored value. To change one setting, send the complete object (read it with GET first, edit the field, send it all back). Sending only the field you mean to change will silently reset the others. */
         UpdateClearSettingsRequest: {
             /** Format: uri */
             upstream_base_url?: string;
             upstream_token_ref?: string;
             dunning_min_interval_days?: number;
             fiscal_year_end_month?: number | null;
+            /**
+             * @description Whether Clear sends this organization's dunning notices unattended on a schedule. Off until explicitly enabled; enabling is recorded in the audit log as `clear_settings_updated`.
+             * @default false
+             */
+            is_dunning_schedule_enabled: boolean;
+            /**
+             * @description Days past due before the `initial` stage is reached.
+             * @default 3
+             */
+            dunning_initial_after_days: number;
+            /**
+             * @description Days past due before the `reminder` stage is reached.
+             * @default 14
+             */
+            dunning_reminder_after_days: number;
+            /**
+             * @description Days past due before the `final` stage is reached. A `final` notice is never sent unattended — it is surfaced for an operator to send by hand.
+             * @default 30
+             */
+            dunning_final_after_days: number;
+            /**
+             * @description First hour of the send window, inclusive. Must be before the end hour.
+             * @default 9
+             */
+            dunning_window_start_hour: number;
+            /**
+             * @description End of the send window, exclusive. Must be after the start hour.
+             * @default 18
+             */
+            dunning_window_end_hour: number;
+            /**
+             * @description Restrict unattended sending to Monday–Friday.
+             * @default true
+             */
+            is_dunning_weekdays_only: boolean;
+            /**
+             * @description Most notices one scheduled run may send. Candidates beyond the cap are picked up by the next run.
+             * @default 50
+             */
+            dunning_max_per_run: number;
             bank_accounts?: components["schemas"]["BankAccountInput"][];
         };
         UpstreamConnectionTestResponse: {

--- a/src/ClearSettings/ClearSettingsResponse.php
+++ b/src/ClearSettings/ClearSettingsResponse.php
@@ -17,6 +17,14 @@ final readonly class ClearSettingsResponse
             'upstream_token_ref' => $settings->upstreamTokenRef,
             'dunning_min_interval_days' => $settings->dunningMinIntervalDays,
             'fiscal_year_end_month' => $settings->fiscalYearEndMonth,
+            'is_dunning_schedule_enabled' => $settings->dunningSchedule->isEnabled,
+            'dunning_initial_after_days' => $settings->dunningSchedule->initialAfterDays,
+            'dunning_reminder_after_days' => $settings->dunningSchedule->reminderAfterDays,
+            'dunning_final_after_days' => $settings->dunningSchedule->finalAfterDays,
+            'dunning_window_start_hour' => $settings->dunningSchedule->windowStartHour,
+            'dunning_window_end_hour' => $settings->dunningSchedule->windowEndHour,
+            'is_dunning_weekdays_only' => $settings->dunningSchedule->isWeekdaysOnly,
+            'dunning_max_per_run' => $settings->dunningSchedule->maxPerRun,
             'bank_accounts' => array_map(
                 static fn ($account): array => [
                     'bank_account_id' => $account->id,

--- a/src/ClearSettings/PdoClearSettingsRepository.php
+++ b/src/ClearSettings/PdoClearSettingsRepository.php
@@ -102,13 +102,16 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
 
         if ($exists) {
             $this->query->execute(
-                'UPDATE clear_settings SET upstream_base_url = ?, upstream_token_ref = ?, dunning_min_interval_days = ?, fiscal_year_end_month = ? '
+                'UPDATE clear_settings SET upstream_base_url = ?, upstream_token_ref = ?, dunning_min_interval_days = ?, fiscal_year_end_month = ?, '
+                . 'is_dunning_schedule_enabled = ?, dunning_initial_after_days = ?, dunning_reminder_after_days = ?, dunning_final_after_days = ?, '
+                . 'dunning_window_start_hour = ?, dunning_window_end_hour = ?, is_dunning_weekdays_only = ?, dunning_max_per_run = ? '
                 . 'WHERE organization_id = ?',
                 [
                     $settings->upstreamBaseUrl,
                     $settings->upstreamTokenRef,
                     $settings->dunningMinIntervalDays,
                     $settings->fiscalYearEndMonth,
+                    ...self::scheduleParams($settings->dunningSchedule),
                     $settings->organizationId,
                 ],
             );
@@ -117,15 +120,50 @@ final readonly class PdoClearSettingsRepository implements ClearSettingsReposito
         }
 
         $this->query->execute(
-            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month) '
-            . 'VALUES (?, ?, ?, ?, ?)',
+            'INSERT INTO clear_settings (organization_id, upstream_base_url, upstream_token_ref, dunning_min_interval_days, fiscal_year_end_month, '
+            . 'is_dunning_schedule_enabled, dunning_initial_after_days, dunning_reminder_after_days, dunning_final_after_days, '
+            . 'dunning_window_start_hour, dunning_window_end_hour, is_dunning_weekdays_only, dunning_max_per_run) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $settings->organizationId,
                 $settings->upstreamBaseUrl,
                 $settings->upstreamTokenRef,
                 $settings->dunningMinIntervalDays,
                 $settings->fiscalYearEndMonth,
+                ...self::scheduleParams($settings->dunningSchedule),
             ],
         );
+    }
+
+    /**
+     * Schedule columns in the order both statements above bind them.
+     *
+     * 🔴 Booleans are bound as **0/1 integers, never as PHP bools**. PDO renders a
+     * bound `false` as an empty string, which SQLite happily stores while both
+     * other adapters reject it outright:
+     *
+     *   mysql  — Incorrect integer value: '' for column 'is_dunning_weekdays_only'
+     *   pgsql  — invalid input syntax for type boolean: ""
+     *
+     * Measured 2026-08-04 against sqlite / mysql 8.4 / postgres 17. This is exactly
+     * the hole #417 describes: the unit suite runs on SQLite and the migration jobs
+     * only apply DDL, so the bool-bound version passed all 13 settings tests here
+     * and would still have 500'd on every non-SQLite deployment. Re-verify by hand
+     * when touching these binds, until #417 lands a query-level CI job.
+     *
+     * @return list<int|null>
+     */
+    private static function scheduleParams(DunningSchedule $schedule): array
+    {
+        return [
+            (int) $schedule->isEnabled,
+            $schedule->initialAfterDays,
+            $schedule->reminderAfterDays,
+            $schedule->finalAfterDays,
+            $schedule->windowStartHour,
+            $schedule->windowEndHour,
+            (int) $schedule->isWeekdaysOnly,
+            $schedule->maxPerRun,
+        ];
     }
 }

--- a/src/ClearSettings/UpdateClearSettingsHandler.php
+++ b/src/ClearSettings/UpdateClearSettingsHandler.php
@@ -50,9 +50,71 @@ final readonly class UpdateClearSettingsHandler
             }
         }
 
+        // Scheduled dunning (#400 §6). Every key is optional and falls back to the
+        // DunningSchedule default — but this endpoint is **full-replace** (#284):
+        // omitting a key resets it to that default, it does not preserve whatever
+        // is stored. A client that wants to change one field must send them all.
+        $defaults = new DunningSchedule();
+
+        $intSetting = static function (string $key, int $default, int $min, int $max) use ($body, &$errors): int {
+            $raw = $body[$key] ?? $default;
+
+            if (!is_numeric($raw)) {
+                $errors[] = new ValidationError($key, $key . ' must be a number.', 'invalid');
+
+                return $default;
+            }
+
+            $value = (int) $raw;
+
+            if ($value < $min || $value > $max) {
+                $errors[] = new ValidationError($key, sprintf('%s must be between %d and %d.', $key, $min, $max), 'invalid');
+
+                return $default;
+            }
+
+            return $value;
+        };
+
+        $boolSetting = static fn (string $key, bool $default): bool => isset($body[$key])
+            ? filter_var($body[$key], FILTER_VALIDATE_BOOL)
+            : $default;
+
+        $initialAfterDays = $intSetting('dunning_initial_after_days', $defaults->initialAfterDays, 0, 3650);
+        $reminderAfterDays = $intSetting('dunning_reminder_after_days', $defaults->reminderAfterDays, 0, 3650);
+        $finalAfterDays = $intSetting('dunning_final_after_days', $defaults->finalAfterDays, 0, 3650);
+        $windowStartHour = $intSetting('dunning_window_start_hour', $defaults->windowStartHour, 0, 23);
+        $windowEndHour = $intSetting('dunning_window_end_hour', $defaults->windowEndHour, 0, 23);
+        $maxPerRun = $intSetting('dunning_max_per_run', $defaults->maxPerRun, 1, 1000);
+
+        // Rejected rather than quietly reordered. A window whose start is not before
+        // its end never opens (DunningSchedulePolicy treats it as closed), so an
+        // operator who saved one would see dunning silently stop with no error to
+        // explain it — the failure mode this whole feature is most likely to hit.
+        if ($windowStartHour >= $windowEndHour) {
+            $errors[] = new ValidationError('dunning_window_start_hour', 'dunning_window_start_hour must be before dunning_window_end_hour.', 'invalid');
+        }
+
+        // Likewise: non-ascending thresholds would let `stageFor()` pick a harsher
+        // stage than the invoice's age has earned.
+        if (!($initialAfterDays <= $reminderAfterDays && $reminderAfterDays <= $finalAfterDays)) {
+            $errors[] = new ValidationError('dunning_reminder_after_days', 'Dunning stage thresholds must ascend: initial <= reminder <= final.', 'invalid');
+        }
+
         if ($errors !== []) {
             throw new ValidationException($errors);
         }
+
+        $dunningSchedule = new DunningSchedule(
+            isEnabled: $boolSetting('is_dunning_schedule_enabled', $defaults->isEnabled),
+            initialAfterDays: $initialAfterDays,
+            reminderAfterDays: $reminderAfterDays,
+            finalAfterDays: $finalAfterDays,
+            windowStartHour: $windowStartHour,
+            windowEndHour: $windowEndHour,
+            isWeekdaysOnly: $boolSetting('is_dunning_weekdays_only', $defaults->isWeekdaysOnly),
+            maxPerRun: $maxPerRun,
+        );
 
         $rawAccounts = is_array($body['bank_accounts'] ?? null) ? $body['bank_accounts'] : [];
         $newAccounts = [];
@@ -87,6 +149,7 @@ final readonly class UpdateClearSettingsHandler
             fiscalYearEndMonth: $fiscalYearEndMonth,
             bankAccounts: $newAccounts,
             actorUserId: AuthContext::userId($request),
+            dunningSchedule: $dunningSchedule,
         ));
 
         return $this->response->create(ClearSettingsResponse::toArray($updated));

--- a/src/ClearSettings/UpdateClearSettingsInput.php
+++ b/src/ClearSettings/UpdateClearSettingsInput.php
@@ -23,6 +23,13 @@ final readonly class UpdateClearSettingsInput
         public ?int $fiscalYearEndMonth,
         public array $bankAccounts,
         public int $actorUserId,
+        /**
+         * Scheduled-dunning settings (#400 §6). Defaulted so the field can be
+         * added without touching every construction site — but note the endpoint
+         * itself is full-replace (#284): a PUT that omits these keys resets them
+         * to the defaults below, it does not leave the stored values alone.
+         */
+        public DunningSchedule $dunningSchedule = new DunningSchedule(),
     ) {
     }
 }

--- a/src/ClearSettings/UpdateClearSettingsUseCase.php
+++ b/src/ClearSettings/UpdateClearSettingsUseCase.php
@@ -61,6 +61,7 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
                     upstreamTokenRef: $input->upstreamTokenRef,
                     dunningMinIntervalDays: $input->dunningMinIntervalDays,
                     fiscalYearEndMonth: $input->fiscalYearEndMonth,
+                    dunningSchedule: $input->dunningSchedule,
                 ));
 
                 $updated = $settingsRepo->findByOrganization($input->organizationId)
@@ -70,6 +71,7 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
                         upstreamTokenRef: $input->upstreamTokenRef,
                         dunningMinIntervalDays: $input->dunningMinIntervalDays,
                         fiscalYearEndMonth: $input->fiscalYearEndMonth,
+                        dunningSchedule: $input->dunningSchedule,
                     );
 
                 $auditRecorder->record(new AuditEvent(
@@ -101,6 +103,16 @@ final readonly class UpdateClearSettingsUseCase implements UpdateClearSettingsUs
             'upstream_token_ref' => $settings->upstreamTokenRef,
             'dunning_min_interval_days' => $settings->dunningMinIntervalDays,
             'fiscal_year_end_month' => $settings->fiscalYearEndMonth,
+            // Turning unattended dunning on or off is exactly the kind of change an
+            // audit trail exists for, so the whole schedule goes into the snapshot.
+            'is_dunning_schedule_enabled' => $settings->dunningSchedule->isEnabled,
+            'dunning_initial_after_days' => $settings->dunningSchedule->initialAfterDays,
+            'dunning_reminder_after_days' => $settings->dunningSchedule->reminderAfterDays,
+            'dunning_final_after_days' => $settings->dunningSchedule->finalAfterDays,
+            'dunning_window_start_hour' => $settings->dunningSchedule->windowStartHour,
+            'dunning_window_end_hour' => $settings->dunningSchedule->windowEndHour,
+            'is_dunning_weekdays_only' => $settings->dunningSchedule->isWeekdaysOnly,
+            'dunning_max_per_run' => $settings->dunningSchedule->maxPerRun,
             'bank_account_numbers' => array_map(
                 static fn ($account): string => self::maskAccountNumber($account->accountNumber),
                 $settings->bankAccounts,

--- a/tests/Database/PdoClearSettingsRepositoryTest.php
+++ b/tests/Database/PdoClearSettingsRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Testing\DatabaseTestKit;
 use NeneClear\BankImport\PdoBankAccountRepository;
 use NeneClear\ClearSettings\ClearSettings;
+use NeneClear\ClearSettings\DunningSchedule;
 use NeneClear\ClearSettings\PdoClearSettingsRepository;
 use NeneClear\Tests\Support\SchemaFixture;
 use PHPUnit\Framework\TestCase;
@@ -63,17 +64,27 @@ final class PdoClearSettingsRepositoryTest extends TestCase
     }
 
     /**
-     * Saving unrelated settings must not disturb the dunning schedule (#400).
+     * `save()` writes the whole row, dunning schedule included (#400).
      *
-     * `PUT /admin/clear-settings` is a full replace (#284) and its request body
-     * cannot carry the schedule columns yet, so the repository deliberately
-     * leaves them out of the UPDATE/INSERT. Without that, an operator who
-     * enables scheduled dunning and later edits a bank account would silently
-     * turn it back off — with no error and no audit trace of the change. This
-     * test is the guard: adding the columns to the write path must fail here
-     * until the settings API and UI can carry them.
+     * ⚠️ This **reverses** the guard #403 put here. That guard existed for one
+     * stated reason: the settings API could not yet carry the schedule columns, so
+     * a save built from a request body would have wiped whatever an operator had
+     * set by hand. Its docblock said so explicitly — "adding the columns to the
+     * write path must fail here **until the settings API and UI can carry them**".
+     *
+     * The API now carries them, so the condition is met and the guard is retired:
+     * the repository persists exactly the entity it is handed, which is what makes
+     * `PUT /admin/clear-settings` behave as the full replace it is documented to be
+     * (#284). Leaving the columns out of the write path would instead mean the
+     * endpoint could never turn scheduled dunning on at all.
+     *
+     * The corresponding risk moved rather than vanished — a caller that builds a
+     * `ClearSettings` without the schedule now resets it. That is pinned from the
+     * outside by
+     * `ClearSettingsHttpTest::test_put_is_full_replace_so_an_omitted_field_is_reset_not_preserved`,
+     * and the one screen that saves settings echoes the loaded values back.
      */
-    public function testSavingUnrelatedSettingsLeavesTheDunningScheduleIntact(): void
+    public function testSaveWritesTheDunningScheduleItIsGiven(): void
     {
         $repo = new PdoClearSettingsRepository($this->real, new PdoBankAccountRepository($this->real));
 
@@ -82,31 +93,32 @@ final class PdoClearSettingsRepositoryTest extends TestCase
             upstreamBaseUrl: 'https://invoice.example',
             upstreamTokenRef: 'NENE_INVOICE_BEARER_TOKEN',
             dunningMinIntervalDays: 7,
+            dunningSchedule: new DunningSchedule(isEnabled: true, windowStartHour: 10, maxPerRun: 25),
         ));
 
-        // The operator turns the schedule on (today: by hand; later: via the settings UI).
-        $this->real->execute(
-            'UPDATE clear_settings SET is_dunning_schedule_enabled = 1, dunning_max_per_run = 25, '
-            . 'dunning_window_start_hour = 10 WHERE organization_id = ?',
-            [42],
-        );
+        $inserted = $repo->findByOrganization(42);
+        self::assertNotNull($inserted);
+        self::assertTrue($inserted->dunningSchedule->isEnabled, 'INSERT must persist the schedule');
+        self::assertSame(25, $inserted->dunningSchedule->maxPerRun);
+        self::assertSame(10, $inserted->dunningSchedule->windowStartHour);
 
-        // …then saves an unrelated change. The entity carries default schedule values.
+        // Same again on the UPDATE branch (the row now exists), and with the flag
+        // going the other way — `false` is the value PDO renders as an empty string
+        // if it is bound as a bool, which SQLite tolerates and MySQL/PostgreSQL do not.
         $repo->save(new ClearSettings(
             organizationId: 42,
             upstreamBaseUrl: 'https://invoice.example/v2',
             upstreamTokenRef: 'NENE_INVOICE_BEARER_TOKEN',
             dunningMinIntervalDays: 10,
+            dunningSchedule: new DunningSchedule(isEnabled: false, maxPerRun: 3),
         ));
 
-        $reloaded = $repo->findByOrganization(42);
-
-        self::assertNotNull($reloaded);
-        self::assertSame('https://invoice.example/v2', $reloaded->upstreamBaseUrl, 'the intended change must land');
-        self::assertSame(10, $reloaded->dunningMinIntervalDays);
-        self::assertTrue($reloaded->dunningSchedule->isEnabled, 'the schedule must survive an unrelated save');
-        self::assertSame(25, $reloaded->dunningSchedule->maxPerRun);
-        self::assertSame(10, $reloaded->dunningSchedule->windowStartHour);
+        $updated = $repo->findByOrganization(42);
+        self::assertNotNull($updated);
+        self::assertSame('https://invoice.example/v2', $updated->upstreamBaseUrl, 'the intended change must land');
+        self::assertSame(10, $updated->dunningMinIntervalDays);
+        self::assertFalse($updated->dunningSchedule->isEnabled, 'UPDATE must persist the schedule too');
+        self::assertSame(3, $updated->dunningSchedule->maxPerRun);
     }
 
     public function testScheduleDefaultsAreReadBackForAnUntouchedOrganization(): void

--- a/tests/Http/ClearSettingsHttpTest.php
+++ b/tests/Http/ClearSettingsHttpTest.php
@@ -233,4 +233,114 @@ final class ClearSettingsHttpTest extends TestCase
 
         self::assertSame(422, $response->getStatusCode());
     }
+
+    public function test_scheduled_dunning_is_off_by_default(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $settings = $this->decode($this->get($token, '/admin/clear-settings'));
+
+        // #400 §6: shipping this must not change what an existing deployment does.
+        self::assertFalse($settings['is_dunning_schedule_enabled']);
+        self::assertSame(3, $settings['dunning_initial_after_days']);
+        self::assertSame(14, $settings['dunning_reminder_after_days']);
+        self::assertSame(30, $settings['dunning_final_after_days']);
+        self::assertSame(9, $settings['dunning_window_start_hour']);
+        self::assertSame(18, $settings['dunning_window_end_hour']);
+        self::assertTrue($settings['is_dunning_weekdays_only']);
+        self::assertSame(50, $settings['dunning_max_per_run']);
+    }
+
+    public function test_put_saves_the_dunning_schedule_and_get_reflects_it(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $saved = $this->decode($this->put($token, '/admin/clear-settings', [
+            'dunning_min_interval_days' => 7,
+            'is_dunning_schedule_enabled' => true,
+            'dunning_initial_after_days' => 5,
+            'dunning_reminder_after_days' => 20,
+            'dunning_final_after_days' => 45,
+            'dunning_window_start_hour' => 10,
+            'dunning_window_end_hour' => 17,
+            'is_dunning_weekdays_only' => false,
+            'dunning_max_per_run' => 25,
+        ]));
+
+        self::assertTrue($saved['is_dunning_schedule_enabled']);
+        self::assertSame(45, $saved['dunning_final_after_days']);
+
+        $fetched = $this->decode($this->get($token, '/admin/clear-settings'));
+        self::assertTrue($fetched['is_dunning_schedule_enabled']);
+        self::assertSame(10, $fetched['dunning_window_start_hour']);
+        self::assertFalse($fetched['is_dunning_weekdays_only']);
+        self::assertSame(25, $fetched['dunning_max_per_run']);
+    }
+
+    /**
+     * 🔴 The #284 landmine, pinned by a test rather than only by prose.
+     *
+     * This endpoint is FULL-REPLACE. A PUT that omits a field resets it to the
+     * default — it does not leave the stored value alone. A client that reads the
+     * settings, changes one field and PUTs only that field will silently switch
+     * scheduled dunning back off.
+     *
+     * Documented in `docs/development/clear-settings-full-replace.md`, but prose
+     * is not enforcement: whoever writes the settings UI next (A2 F4) has to be
+     * stopped by something that fails, not by something they might not read.
+     */
+    public function test_put_is_full_replace_so_an_omitted_field_is_reset_not_preserved(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $this->put($token, '/admin/clear-settings', [
+            'dunning_min_interval_days' => 7,
+            'is_dunning_schedule_enabled' => true,
+            'dunning_max_per_run' => 25,
+        ]);
+
+        self::assertTrue($this->decode($this->get($token, '/admin/clear-settings'))['is_dunning_schedule_enabled']);
+
+        // A "partial" update that only touches the cap. The schedule flag is not
+        // in the body — so it goes back to its default (off).
+        $after = $this->decode($this->put($token, '/admin/clear-settings', [
+            'dunning_min_interval_days' => 7,
+            'dunning_max_per_run' => 10,
+        ]));
+
+        self::assertSame(10, $after['dunning_max_per_run']);
+        self::assertFalse(
+            $after['is_dunning_schedule_enabled'],
+            'PUT is full-replace: an omitted field is reset to its default, not preserved.',
+        );
+    }
+
+    public function test_a_window_that_never_opens_is_rejected(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        // start >= end means DunningSchedulePolicy treats the window as closed, so
+        // saving it would silently stop dunning with nothing to explain why.
+        $response = $this->put($token, '/admin/clear-settings', [
+            'dunning_min_interval_days' => 7,
+            'dunning_window_start_hour' => 18,
+            'dunning_window_end_hour' => 9,
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_non_ascending_stage_thresholds_are_rejected(): void
+    {
+        $token = $this->tokenFor('admin@acme.example');
+
+        $response = $this->put($token, '/admin/clear-settings', [
+            'dunning_min_interval_days' => 7,
+            'dunning_initial_after_days' => 30,
+            'dunning_reminder_after_days' => 14,
+            'dunning_final_after_days' => 3,
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
#400 の設定 UI を出す前段。**API 面のみで UI はありません** — UI は A2 F4 で `SettingsPage` を分解する波と同じ PR 群に載せます（直前に足すと F4 でもう一度触ることになり、差分レビューが2回とも濁るため・hub 裁定）。

## 何が足りなかったか

設定8列は #403 で DB に入っていましたが、**API 面にはどこにも出ていませんでした** — ハンドラも OpenAPI もフロント型も未対応。それを縦に1枚通します。

- **ハンドラ** — 8項目の解析と検証。**窓が開かない設定（start >= end）と昇順でない閾値は 422 で拒否**します。黙って直すと「督促が静かに止まる」＝この機能で最も踏みやすい失敗になるので、エラーにして気づかせます
- **ユースケース** — 保存と監査 `after` への収載（有効化／無効化こそ監査の対象）
- **レスポンス / OpenAPI / フロント型** — 8項目を公開。`required` にも収載
- **`docs/development/clear-settings-full-replace.md`** を新設（#284 の明文化）

## 🔴 実装中に見つけて塞いだ穴 2 つ

### (1) `save()` が schedule 列を書いていなかった

#403 は**読み**だけを実装しており、`PdoClearSettingsRepository::save()` は 8 列を書いていませんでした。UPDATE / INSERT 両方に追加しています。

これに伴い、#403 が置いたガードテスト（「無関係な save で schedule を保持する」）を**反転**させました。そのガードの docblock 自身が条件を書いていたためです:

> adding the columns to the write path must fail here **until the settings API and UI can carry them**

API 側の条件が本 PR で満たされたので、ガードは役目を終えます。経緯はテストの docblock に残しました。書かなければ、後で読む人には「なぜ前任者の意図を覆したのか」が分かりません。

### (2) 🔴 boolean を PHP bool でバインドすると MySQL / PostgreSQL 双方で落ちる

PDO は `false` を**空文字**にレンダリングします。SQLite だけがそれを黙って受け入れます:

```
mysql — Incorrect integer value: '' for column 'is_dunning_weekdays_only'
pgsql — invalid input syntax for type boolean: ""
```

つまり **SQLite の 13 テストは全部緑のまま、非 SQLite の全デプロイで 500 になる**状態でした。`(int)` キャストに直し、**3アダプタで INSERT / UPDATE / 読み戻し / 列挙述語を実測確認**しています。

これは **#417 が記述している穴そのものの実例**です（クエリが SQLite でしか実行されない）。その旨をコード側にも残しました。#417 が無ければ、この教訓は次に踏むまで残りません。

## full-replace の地雷は、文書ではなくテストで固定（hub 指摘）

| テスト | 何を止めるか |
| --- | --- |
| `ClearSettingsHttpTest::test_put_is_full_replace_...` | 有効化 → 当該フィールドを含まない PUT → **off に戻る**ことを負テストで証明 |
| `SettingsPage.test.tsx` — *saves the whole settings object* | 編集 UI が無いまま**読み込んだ schedule を送り返す**ことを固定 |
| `PdoClearSettingsRepositoryTest::testSaveWritesTheDunningScheduleItIsGiven` | INSERT / UPDATE 両分岐で渡されたとおり保存 |

**2つ目が実務上いちばん効きます。** この画面には schedule の操作 UI がまだ無いので、読み込んだ値をそのまま送り返させています。これが無いと、銀行口座を編集しただけで自動送信が off になります — エラーも出ず、画面にも何も出ずに。

## 実測

| 検査 | 結果 |
| --- | --- |
| `composer check` | **全緑** — PHPUnit **512**・PHPStan 0 error・OpenAPI・MCP catalog・spec-parity・conformance |
| `npm run check` | **全緑** — codegen:check・type-check・eslint・vitest **92**・knip |
| MySQL 8.4 / PostgreSQL 17 実機 | INSERT・UPDATE・読み戻し・列挙述語すべて正 |

`codegen:check` が OpenAPI 変更を検出したので `schema.gen.ts` を再生成しています（ゲートは正しく動いています）。

Refs #400, #284
