### PR TITLE
docs(openapi): X-Authorization ミラーヘッダを API 契約に明記する（#284 後半）

### DIFF
--- a/docs/development/clear-settings-full-replace.md
+++ b/docs/development/clear-settings-full-replace.md
@@ -38,6 +38,11 @@ Sending only the field you are editing will reset every field you omitted.
 }
 ```
 
+> **Calling this from shared hosting?** Send the token in `X-Authorization` as well as
+> `Authorization` — HETEML-class hosts strip the standard header, and the resulting
+> `401` looks like a bad token rather than a lost one. See the `bearerAuth` description
+> in [`../openapi/openapi.yaml`](../openapi/openapi.yaml).
+
 The bank accounts behave the same way and always have: the stored set is replaced
 by the array you send, so an omitted `bank_accounts` empties it.
 

--- a/docs/development/scheduled-dunning-runbook.md
+++ b/docs/development/scheduled-dunning-runbook.md
@@ -121,6 +121,19 @@ PUT  /admin/clear-settings          # send it back with is_dunning_schedule_enab
 Sending only `{"is_dunning_schedule_enabled": true}` will reset every other setting to
 its default. This is the single most likely mistake on this page.
 
+> **On this host, send the token twice.** HETEML-class shared hosting strips the
+> standard `Authorization` header before it reaches PHP, so a `curl` that sets only
+> `Authorization: Bearer <token>` gets a 401 that looks like a bad token. Send the
+> mirror as well and both environments work:
+>
+> ```
+> -H "Authorization: Bearer $TOKEN" -H "X-Authorization: Bearer $TOKEN"
+> ```
+>
+> The mirror is used **only** when `Authorization` did not survive the hop, so
+> sending both is always safe. The admin SPA does the same on every request. Details
+> in the `bearerAuth` description in [`docs/openapi/openapi.yaml`](../openapi/openapi.yaml).
+
 ### The settings
 
 | Setting | Default | What it does |
@@ -219,6 +232,7 @@ unrelated to the schedule: pause it, and every path — scheduled or manual — 
 | `org N: skipped (failed: … unreachable)` | The Invoice API is down or the URL is wrong. Other organizations still ran |
 | Invoices stuck at `awaiting_approval` | Working as designed. `final` needs a person |
 | Scheduled dunning turned itself off | Almost certainly a partial `PUT` — see [full replace](clear-settings-full-replace.md). The audit log will show the `clear_settings_updated` event that did it |
+| `401` from `curl` with a token you know is good | This host strips `Authorization`. Send `X-Authorization` as well — see §3 |
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1637,7 +1637,38 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
-      description: HS256 JWT for operator/service authentication (BearerTokenMiddleware).
+      description: >
+        HS256 JWT for operator/service authentication (BearerTokenMiddleware).
+        Send it as `Authorization: Bearer <token>`.
+
+
+        **On shared hosting, send `X-Authorization: Bearer <token>` as well.** Some
+        hosts (HETEML-class Tier A) have a front proxy that strips the standard
+        `Authorization` header before it reaches PHP — custom headers pass through,
+        `Authorization` does not, and no `.htaccess` `E=HTTP_AUTHORIZATION` or
+        `CGIPassAuth` trick recovers it. Clear therefore accepts a mirror of the same
+        value in `X-Authorization`, and adopts it **only when `Authorization` is
+        absent or empty**. Where the standard header arrives, the mirror is ignored
+        and behaviour is byte-for-byte identical, so it is safe to send both always.
+        The admin SPA does exactly that.
+
+
+        The header name is fixed — it is a wiring contract with
+        `@hideyukimori/nene2-client` (NENE2 ADR 0019), not a per-deployment setting.
+        The receiving side is opt-in per deployment
+        (`enableAuthorizationHeaderFallback`, on for this app): adopting a
+        client-controlled header as `Authorization` changes the trust boundary, so a
+        deployment whose gateway strips `Authorization` deliberately must not gain a
+        bypass surface by accident.
+    bearerAuthMirror:
+      type: apiKey
+      in: header
+      name: X-Authorization
+      description: >
+        Mirror of the `Authorization` header, for hosts that strip the standard one
+        (see `bearerAuth`). Same `Bearer <token>` value. Never the *only* credential
+        a client sends — send both; this one is used only if `Authorization` did not
+        survive the hop.
 
   parameters:
     IdPath:


### PR DESCRIPTION
#284 の後半。前半（full-replace の明文化）は PR #419 で完了済みです。

## 問題

`X-Authorization` の**実装は存在するのに、API ドキュメントには 0 件**でした（唯一の言及は監査記録で、API 利用者が読む場所ではありません）。

共有ホスティングで `Authorization` が剥がれる環境の利用者は、ミラーヘッダの存在を知らないと認証に失敗します。しかも返るのは `401` なので、**「トークンが間違っている」ように見えて「ヘッダが消えた」とは分かりません**。

> 実装があるのに文書に無いのは、利用者からは「機能が無い」のと区別できません。

## 変更

- **OpenAPI `bearerAuth` の description** — 剥がれる理由（front proxy がカスタムヘッダは通すが `Authorization` は通さず、`.htaccess` の `E=HTTP_AUTHORIZATION` も `CGIPassAuth` も効かない）、ミラーの送り方、そして **`Authorization` が不在／空のときだけ採用する＝常に両方送って安全**であること
- **`bearerAuthMirror` scheme を追加** — `X-Authorization` を機械可読な形でも公開
- ヘッダ名が固定である理由（`@hideyukimori/nene2-client` との配線契約・NENE2 ADR 0019）と、受け口が deployment ごとの **opt-in** である理由（client 制御ヘッダを `Authorization` として採用するのは信頼境界の変更なので、意図的に剥がすゲートウェイ配下で暗黙にバイパス面を得てはならない）

## 🔴 実装を読んで書きました（推測していません）

`vendor/hideyukimori/nene2` の `AuthorizationHeaderFallbackMiddleware::apply()` を実読しました:

```php
if ($request->getHeaderLine('Authorization') !== '') {
    return $request;          // 標準ヘッダが届いていれば素通し＝バイト不変
}
```

「両方送っても安全」は仕様の言い換えではなく、この分岐の帰結です。

## 利用者が実際に踏む場所にも書きました

これが今回いちばん重要な点です。**昨日書いた2つの文書が、API 直叩きの導線を作っていました**:

- **`scheduled-dunning-runbook` §3** は「設定 UI がまだ無いので **API で有効化せよ**」と書いています。そしてその相手が **HETEML ＝ `Authorization` を剥がすホストそのもの**です。`curl` の例と、トラブルシュート表に「**良いはずのトークンで 401**」の行を追加しました
- **`clear-settings-full-replace`** も `PUT` の例を示す文書なので、同じ注意を追加

OpenAPI に書くだけでは、runbook の手順どおりに操作した施主が 401 で止まります。**穴を塞ぐ場所と、人が落ちる場所は違いました。**

## 実測

`composer check` 全緑（OpenAPI 契約検証・MCP catalog・spec-parity・conformance を含む）。

Closes #284
