### PR TITLE
refactor(fsd): A2 F2 — entities を生成型へ接続し、knip の除外を解消する

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -5,11 +5,11 @@
   // `main.tsx` is the only file allowed to import it. Without this, knip loses
   // the `@import "tailwindcss"` inside it and reports tailwindcss as an unused
   // devDependency. This points the detector at the file that moved — it does not
-  // silence a finding (contrast the schema.gen.ts entry below, which does, and is
-  // scheduled for removal).
+  // silence a finding. (There used to be an `ignore` for schema.gen.ts here: that
+  // one *was* silencing — 2,900 generated lines with no consumer. A2 F2 connected
+  // it through the entities' api-types.ts, so the exemption is gone.)
   "entry": ["src/shared/ui/theme/index.css"],
   "project": ["src/**/*.{ts,tsx}", "src/shared/ui/theme/*.css"],
-  "ignore": ["src/shared/api/schema.gen.ts"],
   "ignoreExportsUsedInFile": true,
   "exclude": ["exports", "types"]
 }

--- a/frontend/src/entities/audit-event/api-types.ts
+++ b/frontend/src/entities/audit-event/api-types.ts
@@ -1,0 +1,12 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field the spec adds, removes or renames surfaces as a type error here instead
+ * of as `undefined` at runtime. Before A2 F2 these slices declared their own
+ * hand-written mirrors and `schema.gen.ts` — 2,900 generated, drift-checked
+ * lines — had zero consumers (#409).
+ */
+export type AuditEventDto = components['schemas']['AuditEvent']

--- a/frontend/src/entities/audit-event/model.ts
+++ b/frontend/src/entities/audit-event/model.ts
@@ -1,12 +1,22 @@
-// Domain model for the append-only audit trail. Mirrors the API JSON exactly
-// (snake_case; no renaming) — see docs/development/fsd-a2-entities.md §4.1
-// (transitional: the A1 codemod later introduces the camelCase model + mapper).
-// `AuditAction` stays a frontend-only display union (design §5, #317-C); whether
-// it becomes a registered spec enum is a #317 decision.
+// Domain model for the append-only audit trail.
+//
+// A2 F2: the shape is the OpenAPI contract type (`api-types.ts`), not a
+// hand-written mirror. Still snake_case; the camelCase model + mapper are a
+// later step (fsd-a2-entities.md §4.1). What changes is *where the truth lives*:
+// a spec change now breaks the build instead of silently disagreeing with the
+// server.
+//
+// One deliberate narrowing: the spec types `action` as a plain string, while the
+// UI switches on it to pick a label. `AuditAction` stays a frontend-only display
+// union (#317-C); whether it becomes a registered spec enum is a #317 decision.
+// Narrowing here — rather than re-declaring the whole record — keeps every other
+// field tied to the contract.
 
-// Append-only audit trail (terminology §2). `before` / `after` are the
-// sanitized snapshots; `metadata` carries extra context keys (e.g. the
-// targeted `invoice_id`) — each null when the event recorded none.
+import type { AuditEventDto } from './api-types'
+
+// Append-only audit trail (terminology §2). `before` / `after` are the sanitized
+// snapshots; `metadata` carries extra context keys (e.g. the targeted
+// `invoice_id`) — each null when the event recorded none.
 export type AuditAction =
   | 'bank_import'
   | 'bank_import_batch_reversed'
@@ -31,16 +41,4 @@ export type AuditAction =
   | 'mfa_enabled'
   | 'mfa_disabled'
 
-export interface AuditEvent {
-  audit_event_id: number
-  organization_id: number
-  action: AuditAction
-  // Subject record the event changed (terminology §audit entity types).
-  entity_type: string
-  entity_id: number | null
-  actor_id: number
-  occurred_at: string
-  before: Record<string, unknown> | null
-  after: Record<string, unknown> | null
-  metadata: Record<string, unknown> | null
-}
+export type AuditEvent = Omit<AuditEventDto, 'action'> & { action: AuditAction }

--- a/frontend/src/entities/bank-transaction/api-types.ts
+++ b/frontend/src/entities/bank-transaction/api-types.ts
@@ -1,0 +1,13 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field that the spec adds, removes or renames now surfaces as a type error here
+ * instead of as `undefined` at runtime. Before A2 F2 these slices declared their
+ * own hand-written mirrors of the JSON, and `schema.gen.ts` — 2,900 generated,
+ * drift-checked lines — had zero consumers (#409).
+ */
+export type BankTransactionDto = components['schemas']['BankTransaction']
+export type BankTransactionStatusDto = components['schemas']['BankTransactionStatus']

--- a/frontend/src/entities/bank-transaction/model.ts
+++ b/frontend/src/entities/bank-transaction/model.ts
@@ -1,14 +1,15 @@
-// Domain model for a bank transaction. Mirrors the API JSON exactly
-// (snake_case; no renaming) — see docs/development/fsd-a2-entities.md §4.1
-// (transitional: the A1 codemod later introduces the camelCase model + mapper).
+// Domain model for a bank transaction.
+//
+// A2 F2: the shape is no longer hand-written — it is the OpenAPI contract type
+// (`api-types.ts`). Still snake_case; the camelCase model + mapper are a later
+// step (fsd-a2-entities.md §4.1). What changes is *where the truth lives*: a
+// spec change now breaks the build instead of silently disagreeing with the
+// server. This slice's hand-written mirror happened to match — which is exactly
+// why removing it matters, because a mirror that matches today cannot tell you
+// when it stops. See #424 for a slice where it had stopped, unnoticed.
 
-export interface BankTransaction {
-  bank_transaction_id: number
-  organization_id: number
-  bank_import_batch_id: number
-  bank_account_id: number
-  value_date: string
-  amount_cents: number
-  counterparty_text: string
-  status: 'unmatched' | 'partially_matched' | 'matched' | 'voided'
-}
+import type { BankTransactionDto, BankTransactionStatusDto } from './api-types'
+
+export type BankTransactionStatus = BankTransactionStatusDto
+
+export type BankTransaction = BankTransactionDto

--- a/frontend/src/entities/clear-settings/api-types.ts
+++ b/frontend/src/entities/clear-settings/api-types.ts
@@ -1,0 +1,14 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field the spec adds, removes or renames surfaces as a type error here instead
+ * of as `undefined` at runtime. Before A2 F2 these slices declared their own
+ * hand-written mirrors and `schema.gen.ts` — 2,900 generated, drift-checked
+ * lines — had zero consumers (#409).
+ */
+export type ClearSettingsDto = components['schemas']['ClearSettings']
+export type BankAccountDto = components['schemas']['BankAccount']
+export type AccountTypeDto = components['schemas']['AccountType']

--- a/frontend/src/entities/clear-settings/index.ts
+++ b/frontend/src/entities/clear-settings/index.ts
@@ -1,1 +1,1 @@
-export type { ClearSettings, BankAccount } from './model'
+export type { ClearSettings, BankAccount, BankAccountDraft, AccountType } from './model'

--- a/frontend/src/entities/clear-settings/model.ts
+++ b/frontend/src/entities/clear-settings/model.ts
@@ -1,42 +1,37 @@
-// Domain models for the org's Clear settings and its bank accounts. Mirror the
-// API JSON exactly (snake_case; no renaming) — see
-// docs/development/fsd-a2-entities.md §4.1 (transitional: the A1 codemod later
-// introduces the camelCase model + mapper). `BankAccount` is co-located here
-// (not a sibling slice) because it is only ever used within settings + the CSV
-// column mapping, which keeps ClearSettings free of a sibling-entity import
+// Domain models for the org's Clear settings and its bank accounts.
+//
+// A2 F2: the shapes are the OpenAPI contract types (`api-types.ts`), not
+// hand-written mirrors. Still snake_case; the camelCase model + mapper are a
+// later step (fsd-a2-entities.md §4.1). `BankAccount` is co-located here (not a
+// sibling slice) because it is only ever used within settings + the CSV column
+// mapping, which keeps ClearSettings free of a sibling-entity import
 // (design §6.1, hub Q2).
+//
+// The scheduled-dunning fields (#400 §6) come along for free now: they are in
+// the contract, so they are in the type. No UI edits them yet — the settings
+// screen echoes them back untouched on save, because PUT /admin/clear-settings
+// is a FULL REPLACE (#284): a field left out of the body is reset to its
+// default, not preserved. Editing controls arrive with the A2 F4 rework.
 
-export interface ClearSettings {
-  organization_id: number
-  upstream_base_url: string
-  upstream_token_ref: string
-  dunning_min_interval_days: number
-  // Scheduled dunning (#400 §6). No UI edits these yet — the settings screen
-  // echoes them back untouched on save, because PUT /admin/clear-settings is a
-  // FULL REPLACE (#284): a field left out of the body is reset to its default,
-  // not preserved. Editing controls arrive with the A2 F4 settings rework.
-  is_dunning_schedule_enabled: boolean
-  dunning_initial_after_days: number
-  dunning_reminder_after_days: number
-  dunning_final_after_days: number
-  dunning_window_start_hour: number
-  dunning_window_end_hour: number
-  is_dunning_weekdays_only: boolean
-  dunning_max_per_run: number
-  fiscal_year_end_month: number | null
-  bank_accounts: BankAccount[]
-}
+import type { AccountTypeDto, BankAccountDto, ClearSettingsDto } from './api-types'
 
-export interface BankAccount {
-  bank_account_id?: number
-  bank_name: string
-  bank_branch: string
-  account_type: 'ordinary' | 'current'
-  account_number: string
-  csv_encoding?: string
-  csv_date_format?: string
-  csv_date_column?: number
-  csv_amount_column?: number
-  csv_counterparty_column?: number
-  csv_header_rows?: number
-}
+export type AccountType = AccountTypeDto
+
+export type ClearSettings = ClearSettingsDto
+
+export type BankAccount = BankAccountDto
+
+/**
+ * A bank account as the settings form holds it.
+ *
+ * The contract splits the two directions — `BankAccount` (returned, always
+ * carries `bank_account_id`) and `BankAccountInput` (sent, no id). The form sits
+ * between them: rows loaded from the server have an id, a row the operator just
+ * added does not yet. The hand-written type this replaces expressed that by
+ * marking the id optional on the single shape, which quietly also made *server*
+ * responses look like they might omit it.
+ *
+ * Modelled here rather than fixed in the spec: which of the two the settings
+ * screen should really use is a UI question, and A2 F4 reworks that screen.
+ */
+export type BankAccountDraft = Omit<BankAccount, 'bank_account_id'> & { bank_account_id?: number }

--- a/frontend/src/entities/dunning-notice/api-types.ts
+++ b/frontend/src/entities/dunning-notice/api-types.ts
@@ -1,0 +1,12 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field the spec adds, removes or renames surfaces as a type error here instead
+ * of as `undefined` at runtime. Before A2 F2 these slices declared their own
+ * hand-written mirrors and `schema.gen.ts` — 2,900 generated, drift-checked
+ * lines — had zero consumers (#409).
+ */
+export type DunningNoticeDto = components['schemas']['DunningNotice']

--- a/frontend/src/entities/dunning-notice/model.ts
+++ b/frontend/src/entities/dunning-notice/model.ts
@@ -1,18 +1,11 @@
-// Domain model for a dunning notice. Mirrors the API JSON exactly (snake_case;
-// no renaming) — see docs/development/fsd-a2-entities.md §4.1 (transitional: the
-// A1 codemod later introduces the camelCase model + mapper).
+// Domain model for a dunning notice.
+//
+// A2 F2: the shape is the OpenAPI contract type (`api-types.ts`), not a
+// hand-written mirror. Still snake_case; the camelCase model + mapper are a
+// later step (fsd-a2-entities.md §4.1). What changes is *where the truth lives*:
+// a spec change now breaks the build instead of silently disagreeing with the
+// server.
 
-export interface DunningNotice {
-  dunning_notice_id: number
-  organization_id: number
-  invoice_id: number
-  invoice_number: string
-  client_id: number
-  recipient_email: string
-  outstanding_at_send_cents: number
-  due_at: string | null
-  channel: string
-  template_version: string
-  sent_by: number
-  sent_at: string
-}
+import type { DunningNoticeDto } from './api-types'
+
+export type DunningNotice = DunningNoticeDto

--- a/frontend/src/entities/manual-receivable/api-types.ts
+++ b/frontend/src/entities/manual-receivable/api-types.ts
@@ -1,0 +1,13 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field the spec adds, removes or renames surfaces as a type error here instead
+ * of as `undefined` at runtime. Before A2 F2 these slices declared their own
+ * hand-written mirrors and `schema.gen.ts` — 2,900 generated, drift-checked
+ * lines — had zero consumers (#409).
+ */
+export type ManualReceivableDto = components['schemas']['ManualReceivable']
+export type ManualReceivableImportResultDto = components['schemas']['ManualReceivableImportResult']

--- a/frontend/src/entities/manual-receivable/model.ts
+++ b/frontend/src/entities/manual-receivable/model.ts
@@ -1,31 +1,18 @@
-// Domain models for manual receivables. Mirror the API JSON exactly (snake_case;
-// no renaming) — see docs/development/fsd-a2-entities.md §4.1 (transitional: the
-// A1 codemod later introduces the camelCase model + mapper).
+// Domain models for manual receivables.
+//
+// A2 F2: the shape is the OpenAPI contract type (`api-types.ts`), not a
+// hand-written mirror. Still snake_case; the camelCase model + mapper are a
+// later step (fsd-a2-entities.md §4.1). What changes is *where the truth lives*:
+// a spec change now breaks the build instead of silently disagreeing with the
+// server.
+
+import type { ManualReceivableDto, ManualReceivableImportResultDto } from './api-types'
 
 /**
  * A receivable entered directly in Clear, not sourced from NeNe Invoice
  * (ADR 0014). A reconciliation reference — NOT an issued invoice / 適格請求書 /
  * tax original. `*_cents` are integer cents (yen × 100), like everywhere else.
  */
-export interface ManualReceivable {
-  manual_receivable_id: number
-  organization_id: number
-  source: 'manual'
-  reference_number: string
-  client_name: string
-  recipient_email: string | null
-  total_cents: number
-  outstanding_cents: number
-  currency: string
-  issued_at: string | null
-  due_at: string | null
-  status: 'open' | 'partially_paid' | 'paid' | 'cancelled'
-  created_at: string
-  updated_at: string
-}
+export type ManualReceivable = ManualReceivableDto
 
-export interface ManualReceivableImportResult {
-  created: number
-  skipped: number
-  errors: { row: number; errors: { field: string; message: string }[] }[]
-}
+export type ManualReceivableImportResult = ManualReceivableImportResultDto

--- a/frontend/src/entities/reconciliation/api-types.ts
+++ b/frontend/src/entities/reconciliation/api-types.ts
@@ -1,0 +1,13 @@
+import type { components } from '@/shared/api/schema.gen'
+
+/**
+ * Wire types for this entity, taken from the OpenAPI contract.
+ *
+ * Importing the generated schema is what makes the contract *load-bearing*: a
+ * field the spec adds, removes or renames surfaces as a type error here instead
+ * of as `undefined` at runtime. Before A2 F2 these slices declared their own
+ * hand-written mirrors and `schema.gen.ts` — 2,900 generated, drift-checked
+ * lines — had zero consumers (#409).
+ */
+export type ReconciliationDto = components['schemas']['Reconciliation']
+export type ReconciliationAllocationDto = components['schemas']['ReconciliationAllocation']

--- a/frontend/src/entities/reconciliation/model.ts
+++ b/frontend/src/entities/reconciliation/model.ts
@@ -1,27 +1,26 @@
-// Domain model for a payment reconciliation and its allocations. Mirrors the
-// API JSON exactly (snake_case; no renaming) — see
-// docs/development/fsd-a2-entities.md §4.1 (transitional: the A1 codemod later
-// introduces the camelCase model + mapper).
+// Domain model for a payment reconciliation and its allocations.
+//
+// A2 F2: the shapes are the OpenAPI contract types (`api-types.ts`), not
+// hand-written mirrors. Still snake_case; the camelCase model + mapper are a
+// later step (fsd-a2-entities.md §4.1).
+//
+// 🔴 This slice is why F2 was worth doing. The hand-written `ReconciliationAllocation`
+// had drifted in BOTH directions and nothing could tell (#424):
+//
+//   - it omitted `source` and `manual_receivable_id`, which the API returns and
+//     the spec declares — so allocation code could not tell a manual receivable
+//     from an upstream invoice;
+//   - it declared `organization_id` and `payment_reconciliation_id`, which the
+//     API never sends, as non-optional `number`. TypeScript promised a number and
+//     runtime would have handed back `undefined`. Nothing read them yet, so the
+//     bug was still dormant — the compiler was guaranteeing something false and
+//     would have kept doing so until someone built a screen on it.
+//
+// Taking the generated types deletes both directions at once, which is the whole
+// argument for making the contract load-bearing rather than mirrored by hand.
 
-export interface ReconciliationAllocation {
-  reconciliation_allocation_id: number
-  organization_id: number
-  payment_reconciliation_id: number
-  invoice_id: number
-  amount_cents: number
-  payment_id: number | null
-  external_reference: string | null
-}
+import type { ReconciliationAllocationDto, ReconciliationDto } from './api-types'
 
-export interface Reconciliation {
-  payment_reconciliation_id: number
-  organization_id: number
-  bank_transaction_id: number
-  status: 'confirmed' | 'reversed'
-  reason_code: string | null
-  confirmed_by: number
-  confirmed_at: string
-  reversed_at: string | null
-  reversal_reason: string | null
-  allocations: ReconciliationAllocation[]
-}
+export type ReconciliationAllocation = ReconciliationAllocationDto
+
+export type Reconciliation = ReconciliationDto

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getClearSettings, updateClearSettings, testUpstreamConnection } from '@/shared/api/endpoints'
-import type { BankAccount, ClearSettings } from '@/entities/clear-settings'
+import type { BankAccountDraft, ClearSettings } from '@/entities/clear-settings'
 import { Button } from '@/shared/ui/button'
 import { Card, CardFoot } from '@/shared/ui/card'
 import { Icon } from '@/shared/ui/icon'
@@ -9,7 +9,7 @@ import { Notice } from '@/shared/ui/notice'
 import { PageHead } from '@/shared/ui/page-head'
 import { useTranslation } from '@/shared/i18n/use-translation'
 
-function emptyAccount(): BankAccount {
+function emptyAccount(): BankAccountDraft {
   return { bank_name: '', bank_branch: '', account_type: 'ordinary', account_number: '', csv_encoding: 'utf8', csv_date_format: 'Y/m/d', csv_date_column: 0, csv_amount_column: 1, csv_counterparty_column: 3, csv_header_rows: 1 }
 }
 
@@ -20,7 +20,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
   const [upstreamToken, setUpstreamToken] = useState(settings.upstream_token_ref)
   const [dunningInterval, setDunningInterval] = useState(settings.dunning_min_interval_days)
   const [fiscalMonth, setFiscalMonth] = useState<number | null>(settings.fiscal_year_end_month ?? null)
-  const [accounts, setAccounts] = useState<BankAccount[]>(settings.bank_accounts)
+  const [accounts, setAccounts] = useState<BankAccountDraft[]>(settings.bank_accounts)
   // Account numbers are masked by default; revealing one is an explicit per-row
   // action so the number isn't shown in plaintext on screen-share / over a
   // shoulder (#192). True server-side withholding is tracked separately.
@@ -81,7 +81,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
     finally { setTesting(false) }
   }
 
-  function updateAccount(i: number, field: keyof BankAccount, v: string | number) {
+  function updateAccount(i: number, field: keyof BankAccountDraft, v: string | number) {
     setAccounts(p => p.map((a, idx) => idx === i ? { ...a, [field]: v } : a))
   }
 


### PR DESCRIPTION
#409 **F2 の初弾**。設計 §4 で「entities 実質化」の最初の一手としていた部分です。**型のみの変更で、実行時の挙動は一切変わりません。**

## 進め方

コードを書く前に **interface 単位で drift を実測**しました（一致 **8** / drift **5** / 生成側になし 1）。そのうえで、**一致していた8 interface（6スライス）から接続**しています — 難しい部分の前に、装置が正しく動くことを確認する順序です。

- 各スライスに **`api-types.ts`** を新設し、`components['schemas'][...]` を re-export
- `model.ts` は手書きミラーをやめ、その DTO を型エイリアスする形へ
- **`audit-event` だけ意図的な narrowing を残しました** — 仕様は `action` を `string` としますが、UI は switch でラベルを選ぶため `AuditAction` は表示専用 union のままです（#317-C）。`Omit` して1フィールドだけ差し替えるので、**他のフィールドは契約に紐づいたまま**です

## 🔴 F2 の受入条件を満たしました

```diff
- "ignore": ["src/shared/api/schema.gen.ts"],
```

削除して **`npm run check` が緑**です。消費者ゼロだった **2,900行が6スライスから参照される**ようになりました。「除外が要らなくなったことで構造到達を示す」形（hub 承認の受入条件）です。

## 🔴 接続が実バグを2件炙り出しました

どちらも**従来の手書きミラーでは検出不能**だったものです。

### (1) `ReconciliationAllocation` が双方向に drift（#424 に記録済み）

手書き型は `source` / `manual_receivable_id` を落とし、逆に **API が決して返さない** `organization_id` / `payment_reconciliation_id` を **`number` 非オプショナル**で宣言していました。

**TypeScript が「必ず number がある」と保証しつつ、実行時は常に `undefined`** です。読む箇所が0件だったため未発現の潜在バグでしたが、allocation を表示する画面を作った瞬間に踏みます。生成型を採ることで**両方向が同時に消えます**。

### (2) `BankAccount` の request / response が潰れていた

契約は **`BankAccount`（返る・id 必須）と `BankAccountInput`（送る・id なし）を分けて**いるのに、手書き型が1つに潰して id を optional にしていました。結果、**サーバ応答まで「id が無いかもしれない」ように見えて**いました。

実態（保存済み行は id を持ち、追加直後の行は持たない）を **`BankAccountDraft`** として明示し、フォームはそれを使います。どちらを使うべきかは UI の問題で、**A2 F4 が同じ画面を作り直す**ので、そこでの判断に委ねます。

## 実測

`npm run check` 全緑（codegen:check / type-check / eslint / vitest **92** / knip）。

型のみの変更なので成果物は不変のはず、を実測しました:

| 成果物 | md5 | 判定 |
| --- | --- | --- |
| JS | `0b13201641606ee538b1170f60548804` | before == after ✅ |
| CSS | `6f4b52865ba3bd2e93d78d89ca951b5e` | before == after ✅ |

## 残り

drift 5件のうち**一方向の4件**（#424）、camelCase model + mapper + zod、queries / mutations / query-keys。

Refs #409, #424
