### PR TITLE
chore(deps): security lockfile sweep — nanoid + js-yaml (GHSA-2v37-7h3g-55p8, GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4206,9 +4206,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1199,9 +1199,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.17",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
-      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
+      "version": "1.34.19",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.19.tgz",
+      "integrity": "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1210,7 +1210,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.1",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -3601,9 +3601,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Two independent audit-ci findings, both closed via lockfile-only bumps (no `package.json` change):

- **nanoid** 3.3.16 (frontend/package-lock.json) was below the patch floor for [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (HIGH, `size=0` causes an infinite loop). Dev dependency path only: nene2-standards -> postcss -> nanoid. Not part of the production bundle. nanoid 3.3.16 -> 3.3.18.
- **js-yaml** was in the vulnerable 4.0.0-4.3.0 range for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (HIGH, quadratic CPU consumption in `!!omap` resolution, CVE-2026-59870). Dev dependency path only: openapi-typescript -> @redocly/openapi-core -> js-yaml. Not part of the production bundle. @redocly/openapi-core 1.34.17 -> 1.34.19, which pulls in js-yaml 4.3.1. This was the advisory actually keeping the audit-ci gate red on this PR (a separate issue from the nanoid bump above).

react-router GHSA-qwww-vcr4-c8h2 is **not touched** here — it's already an argued, dated entry in `frontend/audit-ci.jsonc`'s allowlist, owned by a separate lane (react-router v8 migration wave).

## Test plan
- [x] `git diff --name-only` confirms only `frontend/package-lock.json` changed across both commits
- [x] `package.json` has no diff
- [x] nanoid resolved version is now 3.3.18 (>= 3.3.17 patch floor)
- [x] @redocly/openapi-core resolved version is now 1.34.19 (above the 1.34.8-1.34.18 vulnerable range), js-yaml resolved version is now 4.3.1 (above the 4.0.0-4.3.0 vulnerable range)
- [x] `npx audit-ci --config audit-ci.jsonc` passes locally (only the pre-existing allowlisted react-router warning remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)