### PR TITLE
CI: 週次 schedule ハーネスを Frontend CI に追加

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,6 +8,37 @@ on:
     branches:
       - main
 
+  # Weekly schedule: re-runs this same CI (incl. the dependency audit below)
+  # on a cadence so a newly published advisory against an already-merged
+  # lockfile gets caught even without a new PR. Cron minute is staggered
+  # across the fleet to avoid a simultaneous-firing herd; do not change
+  # without checking the other repos' cron minutes.
+  #
+  # KNOWN LIMITATION: GitHub disables scheduled workflows automatically
+  # after 60 days with no repository activity. A dormant repo (the ones
+  # that most need this check) can have its schedule silently stopped.
+  # There is no in-repo fix; catching this requires an external poller.
+  schedule:
+    - cron: '5 0 * * 1' # Monday 00:05 UTC = 09:05 JST
+
+  # Manual trigger, with an opt-in switch to validate the failure-notification
+  # path (see the "Simulate failure" step and the notify-failure job) without
+  # waiting for a real failure or the next scheduled run.
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail frontend-check to validate the failure-notification path'
+        type: boolean
+        default: false
+
+concurrency:
+  # github.event_name is part of the group so that a scheduled or manually
+  # dispatched run is not cancelled by a concurrent push run (observed
+  # failure mode when event_name was omitted: the non-push run gets
+  # silently cancelled and looks like it never ran).
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   frontend-check:
     runs-on: ubuntu-latest
@@ -18,6 +49,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Simulate failure (validation only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -42,3 +77,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    needs: [frontend-check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 nene-clear: 週次 CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi


### PR DESCRIPTION
## 何を足したか

`frontend-ci.yml`（依存監査 `audit-ci` を含む本体 CI）に以下を追加:

1. `schedule`（週次 cron）
2. `workflow_dispatch`（`simulate_failure` 入力つき — ハーネス自体の検証用踏み台）
3. `concurrency` group に `github.event_name` を含める（push による cancel を防ぐ）
4. `frontend-check` 先頭に `simulate_failure` 踏み台（`if: inputs.simulate_failure` / `run: exit 1`）
5. `notify-failure` ジョブ（`needs: [frontend-check]`）— schedule 実行が失敗したときだけ Issue を起票/追記

`backend-ci.yml` には `composer audit` 相当の依存監査が存在しないため対象外とした
（`composer check` = phpunit + phpstan + php-cs-fixer + openapi/mcp/spec-parity/conformance のみ）。

## 割り当てた cron

`5 0 * * 1`（月曜 00:05 UTC = 09:05 JST）。フリート内で同時発火しないよう艦ごとに
分をずらす配布方針に従った（既使用: 00=origin/fleet-tooling, 30=nene2-python,
40=records-commercial）。

## 60日自動無効化の限界

GitHub は public repo で 60 日間リポジトリ活動が無いと scheduled workflow を
自動的に無効化する。ワークフロー内にコメントで明記した。これを塞ぐには
リポジトリの外から見る装置（最新 run の日時をポーリング）が要る。この PR は
その装置ではない。

参照: `_work/handoff-nene2-python-2026-08-12-schedule-rollout-note.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>