### PR TITLE
chore(deps): react-router 7.18.1→7.18.2 ＋ GHSA-qwww-vcr4-c8h2 の allowlist 撤去（#431）

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -15,6 +15,31 @@
   "high": true,
   "critical": true,
   "allowlist": [
+    // Removed 2026-08-15 (#431): GHSA-qwww-vcr4-c8h2 (react-router, high) is REMOVED, not
+    // renewed — and not for the reason this entry anticipated. Its stated removal condition was
+    // the react-router v8 migration; what actually removed it was a change on the advisory's
+    // side. On **2026-08-07T18:16:54Z the advisory itself was updated**: the single
+    // 7.x-through-8.x range was split in two and a 7.x fix appeared. Re-read from the primary
+    // source on 2026-08-15:
+    //   gh api /advisories/GHSA-qwww-vcr4-c8h2
+    //     { react-router, ">= 7.12.0, < 7.18.2", first_patched 7.18.2 }
+    //     { react-router, ">= 8.0.0,  < 8.3.0",  first_patched 8.3.0  }
+    // This PR moves this tree to react-router 7.18.2, lockfile-only — no `package.json` change,
+    // the existing caret already covered it. Measured in THIS tree, before and after:
+    // `npm audit` high 2 -> 0; lockfile `packages` 403 -> 403 (unchanged);
+    // 2 entries moved, all upgrades, no downgrades.
+    //
+    // The lesson, kept because the next entry inherits it: this exception was written *well* —
+    // the advisory was re-read at authoring time and the "does not apply here" argument was
+    // measured against this codebase. It was still invalidated days later by a change on the
+    // advisory's side, and nothing in this file would have said so. **An expiry date catches an
+    // entry that runs out; it does not catch an entry that stops being true.** While an id sits
+    // in this list the audit gate is silent about it, so "CI is green" and "we are not exposed"
+    // are not the same statement. Re-read the advisory when you touch this file, not at expiry.
+    //
+    // Kept below, verbatim: the measurement this entry carried. It applies again when this tree
+    // moves to react-router v8 — the v8 range (>= 8.0.0, < 8.3.0) is still open. What follows
+    // was true when it was written; the "no fix in the 7.x line" part is what 08-07 changed.
     // GHSA-qwww-vcr4-c8h2 — react-router "RSC Mode CSRF Bypass Allows Action Execution Before
     // 400 Response" (high). Vulnerable range >= 7.12.0, < 8.3.0; there is NO fix in the 7.x line
     // (the newest 7.x is react-router-dom 7.18.2 and it is still inside the range; the fix is
@@ -34,7 +59,6 @@
     // Expiry: 2026-08-31. Removed by the react-router v8 migration wave (bundled with the
     // NENE2 RR8 re-evaluation). If that wave slips past the expiry, the entry must be
     // re-argued in a PR — not silently extended.
-    "GHSA-qwww-vcr4-c8h2",
 
     // Removed 2026-08-04 (#407): GHSA-mh99-v99m-4gvg (brace-expansion) — the entry argued that
     // the 2.x branch had no patched release, so `minimatch@5.1.9`'s `brace-expansion@2.1.3` had

--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -59,7 +59,6 @@
     // Expiry: 2026-08-31. Removed by the react-router v8 migration wave (bundled with the
     // NENE2 RR8 re-evaluation). If that wave slips past the expiry, the entry must be
     // re-argued in a PR — not silently extended.
-
     // Removed 2026-08-04 (#407): GHSA-mh99-v99m-4gvg (brace-expansion) — the entry argued that
     // the 2.x branch had no patched release, so `minimatch@5.1.9`'s `brace-expansion@2.1.3` had
     // to be tolerated. Re-read from the GitHub Advisory API on 2026-08-04: mh99's 2.x fix is

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4585,9 +4585,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4607,12 +4607,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Closes #431

`GHSA-qwww-vcr4-c8h2`（react-router・high）の **lockfile bump ＋ allowlist 撤去**を1PRで。
発令＝統合リナ（hub）裁定 2026-08-15／実施＝fleet-tooling／正本＝`_work/reports/2026-08-14-react-router-advisory-range-shift.md` §4。

## 1. なぜ撤去できるのか（advisory を一次情報で読み直した）

```
gh api /advisories/GHSA-qwww-vcr4-c8h2        # 2026-08-15 実測
  severity=high  published=2026-07-24T16:44:43Z  updated=2026-08-07T18:16:54Z
  react-router  >= 7.12.0, < 7.18.2  first_patched=7.18.2
  react-router  >= 8.0.0,  < 8.3.0  first_patched=8.3.0
```

エントリは「**7.x 系に修正版が無い・修正は v8 への破壊的移行**」を根拠に書かれていた。これは**執筆時点では正しかった**。
**2026-08-07T18:16:54Z に advisory 側が更新**され、単一だったレンジが2本に分割されて **7.x の修正版 7.18.2 が生まれた**。
⇒ 例外が想定した解除条件**ではない理由**で例外が不要になった。

## 2. lockfile の変更（判例44 の4点・全数）

| 項目 | 値 |
| --- | --- |
| ① `packages` 件数 | **403 → 403（不変・縮小なし）** |
| ② 版が動いたエントリ（**全数**） | **react-router 7.18.1→7.18.2 ／ react-router-dom 7.18.1→7.18.2（2件）** — **すべて ↑昇格・降格0・追加0・消失0** |
| ③ workspaces / 複数 lockfile | `packages[""].workspaces` = **なし**。第2 lockfile `tests/e2e/package-lock.json` を確認済み（packages 5・react-router 系エントリ **なし**＝射程外） |
| ④ `package.json` | **無変更**（既存の caret 範囲内で 7.18.2 に到達） |

手順: `npm update react-router react-router-dom --package-lock-only`（`origin/main` の clone 上）。

## 3. ゲートの実測（前後・陰性対照つき）

| | before | after |
| --- | --- | --- |
| `npm audit` high | **2** | **0** |
| `npm audit` 全体 | high 2 / total 2 | 0件 |

🔴 **対照実験（この緑が空虚でないことの証明）**: fleet-tooling が clear の木で
**「allowlist は撤去済み × lockfile は 7.18.1 のまま」**（＝手2だけ）を実際に走らせた結果、
`audit-ci` は **exit 1・high 2 件**で落ちた〔実測〕。
⇒ **手1（bump）だけ、手2（撤去）だけ、どちらも成立しない**ことを機械で確認したうえでの1PRです。

## 4. 何を残したか（EX-9・救出記述）

`audit-ci.jsonc` のエントリは**消さずに `Removed 2026-08-15` の形へ書き換え**、この艦が測った
「当てはまらない理由」の実測値を**そのまま残しています**。**v8 のレンジ（>= 8.0.0, < 8.3.0）はまだ開いている**ので、
v8 へ上げるときに同じ測定が再び効きます。

🔑 **次のエントリが継承する教訓**（ファイル内にも残した）:
この例外は **EX-9 を満たして書かれていた**（執筆時に advisory を読み直し、当てはまらない理由をこの木で実測していた）。
それでも数日後に advisory 側の変更で無効化され、**このファイルの中の何もそれを教えなかった**。
**expiry は「切れたら気づく」仕掛けであって「途中で無効化されたら気づく」仕掛けではない。**
id が載っている間ゲートは沈黙するので、**「CI が緑」と「露出していない」は別の主張**。

## 5. マージ後の完了判定（hub 指示）

**allowlist の不在ではなく、Dependabot alert の消失で取ること。**
この艦の open alert は現在 **`GHSA-qwww-vcr4-c8h2` 1件**〔2026-08-15 実測・`gh api repos/{owner}/{repo}/dependabot/alerts?state=open`〕。
**allowlist を消しただけで bump が効いていなければ alert は残る**ので、消失が「効いた」ことの証拠になります。
陽性対照 = **nene-payout**（08-14 に同じ撤去を完了・open alert **0件**）。

---

⚠️ **マージは施主／hub の手番**です。fleet-tooling は PR まで。
