### PR TITLE
docs: `*_cents` の単位定義を規約に明記し、model.ts に逸脱の印を置く (#433)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ Entry point for AI agents working on **NeNe Clear** (public repo `nene-clear`).
 - **Follow NENE2 conventions** — comply with `docs/development/nene2-compliance.md`; reuse framework objects (`JsonResponseFactory`, `Router`, `PaginationQuery`, `BearerTokenMiddleware`, `DatabaseQueryExecutorInterface`, …), don't reinvent them
 - Namespace: `NeneClear\`; money: integer cents
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ## Framework
 
 [NENE2](https://github.com/hideyukiMORI/NENE2) — consumed from Packagist as a

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -95,6 +95,10 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 > [`../review/compliance.md`](../review/compliance.md) for any change in this area.
 
 - Store all amounts as **integer cents** (`amount_cents`, `remaining_cents`, `outstanding_at_send_cents`). Float / DECIMAL for money is prohibited.
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 - **No quote/invoice/tax/PDF logic** (ADR 0009). Invoice totals and tax are read from the Invoice upstream; Clear allocates known bank amounts and never recomputes them.
 - Allocation math is computed once in the UseCase; API responses and stored rows render the same values.
 - Imported bank lines are immutable; corrections via reversal import batch, not in-place edit. No hard delete of bank/match/dunning history.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -26,6 +26,10 @@ NeNe Clear coding standards split by surface. **Full policies live in the dedica
 - **OpenAPI** is the public API contract; MCP maps to the same HTTP operations
 - Application Problem Details `type`: `https://nene-clear.dev/problems/{problem-name}`
 - **Monetary values:** integer cents everywhere — no floats in DB or JSON
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 - **Placement violations block merge** — see backend standards
 - Public docs, OpenAPI text, and API error metadata: **English**
 - Issues, PRs, commits, `.cursor/rules/`: **English only** (ADR 0008)

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -63,6 +63,10 @@ Rules (MUST):
 - Money is integer cents end-to-end; format for display only at the view edge,
   never mutate the cents value.
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ## 4. Connection & API base
 
 - Dev: Vite **proxies `/api/*`** to the Docker backend.

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -119,6 +119,10 @@ Public OpenAPI summaries, descriptions, and examples: **English only**.
 
 Do not mix camelCase in public JSON. Do not use floats for money.
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ---
 
 ## 4. Problem Details and validation errors
@@ -145,6 +149,10 @@ Problem Details `title` and `detail`: English.
 | Foreign key column | `{singular_entity}_id` | `bank_import_batch_id`, `invoice_id` (upstream) |
 | Index names | `idx_{table}_{columns}` | `idx_bank_transactions_status` |
 | Unique constraints | `uniq_{table}_{columns}` | `uniq_bank_import_batches_file_hash` |
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
 
 SQL lives only in `Pdo*Repository` classes.
 

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -57,6 +57,10 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Language policy | **English** for repository docs, OpenAPI, API errors (ADR 0008); **Japanese permitted** for Issues, PRs, commit messages (ADR 0015); admin UI **ja + en** only (ADR 0005) |
 | Review checklists | `docs/review/` — task-specific lists for this product |
 
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 ## NeNe Clear–specific (not inherited)
 
 Record these in ADRs or product docs when they stabilize:

--- a/frontend/src/entities/manual-receivable/model.ts
+++ b/frontend/src/entities/manual-receivable/model.ts
@@ -1,3 +1,19 @@
+// FLEET CANON: `*_cents` is the currency's minor unit, not 1/100 of the display
+// amount. JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen
+// — never multiply by 100. ¥1,500 is stored as `1500`.
+//
+// CLEAR DOES NOT FOLLOW THAT CANON TODAY. Clear stores x100 values (see
+// `src/BankImport/BankCsvParser.php`, which multiplies parsed yen by 100). That
+// is a known deviation, not the standard — Clear's own glossary already lists
+// "reading `_cents` as 1/100 yen" as a misuse. Correction is tracked separately
+// as the fleet money-unit remediation (order 3 of: 0. define -> 1. deal ->
+// 2. serve -> 3. clear; Clear runs in production, so it is a wave of its own);
+// background in `_work/reports/2026-08-20-money-unit-archaeology.md`.
+//
+// DO NOT COPY THE "yen x 100, like everywhere else" WORDING BELOW. It states the
+// deviation as if it were the standard, and "like everywhere else" invites it to
+// spread.
+
 // Domain models for manual receivables.
 //
 // A2 F2: the shape is the OpenAPI contract type (`api-types.ts`), not a


### PR DESCRIPTION
Closes #433

## 何をしたか（**値は1行も触っていません。docs とコメントのみ**）

1. **正典の定義を規約文7箇所へ挿入** — `naming-conventions.md`（§JSON / §Database）・`backend-standards.md`・
   `coding-standards.md`・`frontend-standards.md`・`inheritance-from-nene2.md`・`AGENTS.md`。
   正本 `_work/reports/2026-08-20-money-unit-archaeology.md` §9-1 の**逐語コピー**（**言い換えていません**）。
2. 🔴 **`frontend/src/entities/manual-receivable/model.ts` の冒頭に「正典 ＋ 現状は違反 ＋ この文言をコピーするな」。**

## 🔴 本リポは「docs が正典・コードが違反」の型でした

| | 状態 |
|---|---|
| 🟢 `explanation/glossary.md:45` | 「one "cent" is one 円, so `amount_cents = 1000` means ¥1,000」＋ **誤用欄に「reading `_cents` as 1/100 yen」を名指し** |
| 🟢 `explanation/csv-export.md:28-30` | 「for JPY one unit = ¥1, so `amount_cents = 110000` is ¥110,000」 |
| 🔴 **コード** | **×100**。`src/BankImport/BankCsvParser.php:77` = `(int) $digits * 100`、frontend も各所で `Math.round(Number(v) * 100)` |
| 🔴 `frontend/src/entities/manual-receivable/model.ts:14` | **`*_cents` are integer cents (yen × 100), like everywhere else.** |

🔑 **本リポは「1/100円として読むのは誤用」と自艦の glossary で名指ししておきながら、コードがまさにその誤用をしています。**
⇒ **「定義が無かったから間違えた」は本リポには当てはまりません。定義はあった。読まれなかっただけです。**

（艦隊横断で見ると、**正しい定義を持っていた艦は6艦中5艦**でした。決定要因は定義の有無ではなく
**「実装者が定義を読んだか、コードをコピーしたか」**です。）

## 🔑 なぜ ② がこの PR の本体なのか

`model.ts:14` の文言は、**逸脱を「これが標準だ」という形でコメントに固定**しています。
そして **`like everywhere else` が、そのまま伝播を促します**。

実際、艦隊では **`nene-serve` の `format-money.ts` が `nene-deal` から逐語コピー**されて生まれており
（冒頭6行が完全一致）、**逸脱はコードのコピーで伝播しました**。
⇒ **「この文言をコピーするな」の一行が、正典の3行より直接効きます。**

**コードは1行も変えていません。** 既存のコメントは現状の挙動の説明として残し、**冒頭で逸脱と明示**しました。

## 🔴 数値例を**あえて直していません**

`glossary.md:45` と `csv-export.md:28-30` の数値（`110000` = ¥110,000）は**正典としては正しい**のですが、
**現在のコードはそれに従っていません**。

⇒ **数値とコードは是正波で同時に直します**（施主裁定の是正順 = 0.定義 → 1.`deal` → 2.`serve` → **3.本リポ**。
🔴 **本リポは本番稼働中につき単独の波**）。**doc だけ先に動かすと、どちらの向きでも窓が開きます。**

🔑 `nene-serve` との対比: serve は **docs が現状（×100）を正確に説明していた**ので、数値を直すと**嘘になる**ケースでした。
本リポは **docs が正典を書いていて現状と食い違っている**ケースです。
**向きは逆ですが、「doc だけ先に動かさない」で同じ結論になります。**

## 射程外

- **実装の是正**（×100 → 1:1）— 別の board 行（順序3・単独の波）
- `docs/review/*.md` — 「integer であること」の確認であって単位定義ではない
- `docs/openapi/openapi.yaml` — 是正波の射程

🤖 Generated with [Claude Code](https://claude.com/claude-code)
