### PR TITLE
docs(review): database.md のチェックリストに `*_cents` の単位定義を添える（#435）

### DIFF
--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -8,6 +8,11 @@ Source policies: `docs/development/backend-standards.md`, `docs/development/nami
 
 - [ ] Migration file name follows `YYYYMMDDHHMMSS_snake_description.php`.
 - [ ] Table names plural snake_case; money columns use `*_cents` integer.
+
+> `cents` = the currency's **minor unit**, not 1/100 of the display amount.
+> **JPY has zero decimal places (ISO 4217), so `*_cents` stores whole yen — never multiply by 100.**
+> Example: ¥1,500 is stored as `1500`. A value like `116480` means ¥116,480, not ¥1,164.80.
+
 - [ ] Foreign keys named `{entity}_id`.
 - [ ] SQL only in `Pdo*Repository` classes.
 - [ ] Schema snapshot updated under `database/schema/` when applicable.


### PR DESCRIPTION
Closes #435

板 L93 の残り。**`origin/main` で全数を測り直した結果**、fleet 全体で残っていたのは4ファイルで、本 PR はそのうち1つです。

## この艦の現状（`origin/main` で実測・2026-08-23）

| 場所 | |
|---|---|
| `docs/development/naming-conventions.md` / `docs/inheritance-from-nene2.md` / `docs/development/frontend-standards.md` / `AGENTS.md` | 🟢 **#434 で挿入済み** |
| **`docs/review/database.md:10`** | 🔴 **未挿入** |

## なぜ1箇所でも残すと問題か

§9-3 の教訓:

> ⚠️ **順序0 は「1艦1箇所」ではない。** clear は4箇所。**1箇所だけ直すと、残りが古い定義を教え続ける。**

この文書は **migration / repository / schema 変更のときに読むチェックリスト**で、いまはこうです:

```
- [ ] Table names plural snake_case; money columns use `*_cents` integer.
```

🔴 **「`*_cents` を使え」とは書いてあるが、「JPY では円をそのまま入れる」が書いていません。** ⇒ **migration を書く人が、まさにここで単位を決めます。**

## 射程

**この1ファイルだけ**（共通化・税率は fleet 完了後の待ち行列）。