### PR TITLE
docs(env): `NENE_CLEAR_DEMO_UPSTREAM` の警告文に公開デモ設置を例外として明記する（#437）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,17 @@ NENE_CLEAR_ENCRYPTION_KEY=
 # --- Demo deployment (#260, docs/demo.md) --------------------------------------
 # NENE_CLEAR_DEMO_UPSTREAM=1 pre-populates the standalone fake Invoice upstream
 # with T-relative demo invoices (upstream match suggestions + live dunning sends
-# work without a real NeNe Invoice). Only effective while
-# NENE_INVOICE_API_BASE_URL is empty; never enable on a production install.
+# work without a real NeNe Invoice).
+#
+# The guard is NENE_INVOICE_API_BASE_URL, not APP_ENV: the fixture is injected
+# only while that URL is empty, so an install wired to a real NeNe Invoice
+# ignores this flag even when it is set (src/Http/RuntimeBootstrap.php).
+#
+# Never enable it on an install that serves a real organization's real
+# receivables -- the suggestions it produces are fabricated. The one intended
+# exception is a public demo deployment, which may legitimately run with
+# APP_ENV=production on a public domain while having no upstream Invoice at
+# all; that is the configuration docs/demo.md describes.
 NENE_CLEAR_DEMO_UPSTREAM=
 
 # Fixed hand-out credentials used by tools/seed-demo.php (reset = rerun).


### PR DESCRIPTION
`.env.example` の `NENE_CLEAR_DEMO_UPSTREAM` の警告文だけを直す docs 便。板 L92（`due:2026-08-27`）の出口で、選択肢 (a) を採る。

## なぜ

警告文は **never enable on a production install** と書いているが、本番の clear.ayane.co.jp は `APP_ENV=production` かつ `NENE_CLEAR_DEMO_UPSTREAM=1` で動いている（2026-08-20 hub 実測）。
これは公開デモとして**意図した設置**で、フラグが無いと upstream の照合候補も督促送信のショーケースも成立しない。⇒ 直すべきは設置ではなく警告文のほう。

さらに、警告文は**実装のガードを取り違えている**。`src/Http/RuntimeBootstrap.php:230`:

```php
if ($env('NENE_CLEAR_DEMO_UPSTREAM') !== '1' || $invoiceApiBaseUrl !== null) {
```

fixture が差し込まれるのは **`NENE_INVOICE_API_BASE_URL` が空のときだけ**。実 Invoice を設定した設置では、フラグが 1 でも fixture は無効。守っているのは `APP_ENV` ではない。

`docs/demo.md` は §1 で `NENE_CLEAR_DEMO_UPSTREAM=1` を設定させるが `APP_ENV` には一言も触れていないので、「デモを本番ドメインに置く」と決めた読者はこの警告と正面衝突する。

## 何を変えたか（`.env.example` の +11 / -2 のみ）

1. **ガードが何かを明示** — 効くのは URL が空のときだけ、と実装を指して書く。
2. **禁止の対象を言い直す** — `APP_ENV` の値ではなく「実組織の実債権を扱う設置」。生成される候補は捏造だから、という理由も添えた。
3. **公開デモ設置を唯一の例外として明記** — `APP_ENV=production` の公開ドメインで upstream Invoice を持たない構成があり得ること、それが `docs/demo.md` の構成であること。

## やっていないこと

- **`.env` 本体・値・コードは触っていない。**
- (b)（デモ設置を `APP_ENV=production` 以外にする）は採らない。本番ドメインの公開デモは正当な用途で、`APP_ENV` を下げると他の production 挙動まで巻き添えになる。
- W1（nene2-ui キット載せ替え）とは**別便・別枝**。W1 の before build を汚さないため。

## 出所

板 L92（`@dev` `+nene-clear` `due:2026-08-27`）／hub の GO 2026-08-27 16:16 JST（clear の repo-status で今日 due と判明 → hub へ照会 → (a) で GO）。

Closes #437
