### PR TITLE
build(ui): nene2-ui 0.19.1 を導入し、@source の消失を検出する source-probe を置く（#440）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@hideyukimori/nene2-client": "^1.1.0",
+        "@hideyukimori/nene2-ui": "^0.19.1",
         "@tanstack/react-query": "^5.90.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -711,6 +712,16 @@
       "engines": {
         "node": ">=22 <25",
         "npm": ">=10 <12"
+      }
+    },
+    "node_modules/@hideyukimori/nene2-ui": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.19.1.tgz",
+      "integrity": "sha512-L7FTqRiRktYY6kZa9DLF40KB3oGV+NLlUNXAQSnsoW2ypA5dE04i+D3g9+poKow3N1x9nbzUBYLpp06RFTmoGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=19",
+        "tailwindcss": ">=4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4985,7 +4996,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,13 +19,15 @@
     "knip": "knip",
     "codegen": "openapi-typescript ../docs/openapi/openapi.yaml -o src/shared/api/schema.gen.ts",
     "codegen:check": "node scripts/check-codegen.mjs",
+    "source-probe": "node scripts/source-probe.mjs",
     "audit": "audit-ci --config audit-ci.jsonc",
-    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run test:run && npm run knip"
+    "check": "npm run codegen:check && npm run type-check && npm run lint && npm run test:run && npm run knip && npm run build && npm run source-probe"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@hideyukimori/nene2-client": "^1.1.0",
+    "@hideyukimori/nene2-ui": "^0.19.1",
     "@tanstack/react-query": "^5.90.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/frontend/scripts/source-probe.mjs
+++ b/frontend/scripts/source-probe.mjs
@@ -1,0 +1,64 @@
+/**
+ * Fails if the built stylesheet does not contain nene2-ui's sentinel class.
+ *
+ * Why this check exists. Tailwind v4's content detection does not walk
+ * `node_modules`, and every class the kit ships lives in its `dist/`. Drop the
+ * `@source` line from `src/shared/ui/theme/index.css` and the build stays green
+ * while generating NONE of them. Measured on nene-vault 2026-08-23 (#387):
+ * 47,075 bytes of CSS instead of 59,597, with every gap, focus ring and
+ * disabled treatment missing. Type-check passed. Every test passed — jsdom does
+ * not compute styles, so no test can see it. On screen the only symptom is
+ * "the kit does not seem to do anything".
+ *
+ * This is an absence test, so it needs a positive control: a check that can only
+ * ever report "not found" is indistinguishable from a check that is not looking.
+ * The control here is structural rather than a second fixture. The sentinel
+ * resolves to `padding: 0px`, is applied to nothing, and exists in the kit's
+ * `dist` and nowhere else — so it can reach our CSS only by way of Tailwind
+ * having scanned the kit. If Tailwind emitted it, it scanned the kit; if it did
+ * not, it did not. A missing `dist/` and an empty `dist/` are reported as their
+ * own failures and never as "class absent", so "no stylesheet at all" can never
+ * be mistaken for "the @source line is fine".
+ *
+ * Verified against a mutation before being trusted: removing the `@source` line
+ * turns this check red, and restoring it turns it green (2026-08-27, #440).
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { SOURCE_PROBE_CLASS } from '@hideyukimori/nene2-ui'
+
+// The backend-served build. `vite.config.ts` sets `outDir: '../public_html/assets'`
+// and Vite appends its default `assetsDir: 'assets'`, so the stylesheet lands one
+// level deeper than the outDir reads — `public_html/assets/assets/`. (The e2e and
+// measurement builds pass their own --outDir on purpose and are not checked here.)
+const assets = join(import.meta.dirname, '..', '..', 'public_html', 'assets', 'assets')
+
+let files
+try {
+  files = readdirSync(assets).filter((f) => f.endsWith('.css'))
+} catch {
+  console.error(`source-probe: ${assets} not found — run \`npm run build\` first.`)
+  process.exit(1)
+}
+
+if (files.length === 0) {
+  console.error('source-probe: no stylesheet in public_html/assets — run `npm run build` first.')
+  process.exit(1)
+}
+
+const missing = files.filter(
+  (f) => !readFileSync(join(assets, f), 'utf8').includes(`.${SOURCE_PROBE_CLASS}`),
+)
+
+if (missing.length === files.length) {
+  console.error(
+    `source-probe: .${SOURCE_PROBE_CLASS} is in no stylesheet (${files.join(', ')}).\n` +
+      "  @hideyukimori/nene2-ui is not in Tailwind's @source, so none of its classes were\n" +
+      '  generated. Restore the @source line in src/shared/ui/theme/index.css.',
+  )
+  process.exit(1)
+}
+
+console.log(
+  `source-probe: OK (.${SOURCE_PROBE_CLASS} present in ${files.length - missing.length}/${files.length})`,
+)

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -9,4 +9,52 @@
  */
 @layer theme, base, legacy, components, utilities;
 @import "tailwindcss";
+
+/*
+ * nene2-ui's theme (W1, #440).
+ *
+ * The kit defines 208 tokens, almost all of them slots Clear does not have
+ * (`--color-x-slot-*`, `--text-x-slot-*`, `--radius-x-*`). Kit components only
+ * ever reach those slots through Tailwind utilities, so WITHOUT this import a
+ * kit component renders unstyled.
+ *
+ * Order: the kit's theme first, Clear's `design.css` after. Measured before
+ * wiring this up: the two files share ZERO token names (kit 208, Clear 58, no
+ * overlap), so nothing here is contested today — the order is the safe default
+ * rather than a fix for a known collision. Clear's own tokens (`--ok`,
+ * `--navy-*`, …) stay authoritative for the legacy layer either way.
+ *
+ * Do NOT copy the kit's default values into Clear. Where Clear's design differs
+ * from a kit default, the difference belongs in a slot override (W1b), and only
+ * for values that actually differ — restating a default silently pins a number
+ * nobody chose (nene-vault #481).
+ */
+@import "@hideyukimori/nene2-ui/themes/default.css";
 @import "./design.css";
+
+/*
+ * REQUIRED. Tailwind v4's automatic content detection does not walk
+ * `node_modules`, and every class the kit ships lives in its `dist/`. Remove
+ * this line and the build stays GREEN while generating none of them. Type-check
+ * passes, tests pass (jsdom computes no styles), and the only symptom on screen
+ * is "the kit does not seem to do anything".
+ *
+ * Do NOT try to detect that by comparing build sizes. Measured here on
+ * 2026-08-27 (#440), all three builds from the same tree:
+ *
+ *     before the kit                470,535 bytes
+ *     kit installed, no @source     479,325 bytes   (+8,790)
+ *     kit installed, with @source   516,174 bytes   (+36,849)
+ *
+ * The +8,790 comes from the theme import above, which lands whether or not
+ * Tailwind ever scans the kit. So the stylesheet DOES grow while zero kit
+ * utilities exist — a size check would have said "wired up" and been wrong.
+ * (nene-deal recorded the no-@source build as byte-identical to the pre-kit
+ * one; that holds only when the theme import is absent too. Same trap, worse
+ * disguise.)
+ *
+ * `npm run source-probe` is the check that actually looks. Verified by mutation
+ * before being trusted: deleting this line turns it red, restoring it turns it
+ * green.
+ */
+@source "../../../../node_modules/@hideyukimori/nene2-ui/dist";


### PR DESCRIPTION
W1（nene2-ui キット載せ替え）の**導入便**。追跡は #440。

🔴 **部品の置換は1つも行っていません。** `src/` からのキット import は **0**、Button 関連ファイルは不触（fleet-tooling #487 で `Button` の API が2軸へ変わる裁定が出たため、Button の載せ替えは保留中）。この PR が変えるのは「キットが配線されている状態」だけです。

## 何を入れ、何を入れなかったか

**入れた**: `@hideyukimori/nene2-ui@0.19.1`（`npm ls` で実版を確認・`package.json` を読まない）。

**入れなかった**（指示書 §2 は版を列挙していますが、clear には要りませんでした）:

| | 理由 |
| --- | --- |
| `nene2-standards` | clear に `lint:styles` が無い（deal は stylelint 設定に使っている） |
| `nene2-tokens` | clear に `tokens:validate` も `check:registries` も無い |
| — 両方に共通 | 入れると **`knip` が未使用依存として弾く**。`check` に knip が入っているので CI が赤になる |
| `nene2-i18n` | W1 の射程外（別発令） |
| `nene2-client` 1.1.0→1.4.0 | 意匠と無関係。**目視1回で通す波にリスクを足さない**ので別便 |

キット本体は依存を持たず、peer は `react>=19` / `tailwindcss>=4` のみ。clear は react 19.2.6 / tailwindcss 4.3.0 で充足（実測）。

## `theme/index.css`

1. `@import "@hideyukimori/nene2-ui/themes/default.css"` — キット部品はスロット（`--color-x-slot-*` 等）を Tailwind utility 経由でしか参照しないので、これが無いと**素の見た目**になります。
   配線前に実測: **キット 208 トークンと clear 58 トークンで名前の衝突は 0**。順序（キット theme が先・`design.css` が後）は既知の衝突への対処ではなく安全側の既定です。
2. `@source "../../../../node_modules/@hideyukimori/nene2-ui/dist"` — Tailwind v4 は `node_modules` を歩きません。

## 🔴 サイズ比較では検出できない（実測した）

同一ツリーからの3ビルド:

| ビルド | CSS |
| --- | --- |
| キット導入前（`3566eec`） | **470,535 bytes** |
| 導入・`@source` **無し** | **479,325 bytes**（+8,790） |
| 導入・`@source` **あり** | **516,174 bytes**（+36,849） |

+8,790 は theme import の分で、**Tailwind がキットを走査したかどうかに関係なく載ります**。⇒ キットのクラスが 0 個でも CSS は太るので、**サイズ比較は「配線済み」と誤答します**。

⚠️ deal は「`@source` が無いと出力が導入前と byte 一致」と記録していますが、**それは theme import も無い場合にだけ成り立ちます**。同じ罠の、より見つけにくい形です。

## `scripts/source-probe.mjs`（陽性対照つき）

キットの `SOURCE_PROBE_CLASS` がビルド後の CSS に在るかを見ます。`check` の `build` の後に置きました。

**これは不在検査なので陽性対照が要ります**（「見つからない」しか言えない検査は、探していない検査と区別が付かない）。ここでは対照を第2の fixture ではなく**構造**で取っています: sentinel は `padding: 0px` に解決され、どこにも適用されておらず、キットの `dist` にしか存在しない ⇒ **Tailwind がキットを走査した場合にのみ** 我々の CSS に現れます。さらに `dist/` 不在と空 `dist/` は「クラスが無い」ではなく**各々の失敗**として報告するので、「スタイルシートが無い」を「`@source` は無事」と取り違えることがありません。

**変異検査で赤にできることを確認してから緑を採用しました**: `@source` 行を削ると `EXIT=1`（正しいメッセージ）、戻すと `EXIT=0`。
おまけに実地でも効きました——最初に出力パスを誤って書いたとき、本検査は「クラスが無い」ではなく**「スタイルシートが無い」と正しく別扱いで落ちました**（`vite.config.ts` の `outDir: '../public_html/assets'` に Vite 既定の `assetsDir: 'assets'` が付くので、実際の出力は `public_html/assets/assets/` です）。

## 数字

- `npm run check` **EXIT=0**（`codegen:check` → `type-check` → `lint` → `test:run` → `knip` → `build` → `source-probe`）
- **92 tests / 14 files** passed
- `design.css` **不変**（1,045行 / 507規則 / クラス名 267）— `registries.jsonc` が無く `check:registries` が走らないため、W1 中は各 PR に実測で書きます
- build: `3566eec` からの差分のみ・作業木は本 PR の4ファイル以外 clean

Refs #440
