### PR TITLE
refactor(ui): Card をキットへ載せ替え、スロットで旧意匠に寄せる（W1a・#440）

### DIFF
--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { listAuditEvents } from '@/shared/api/endpoints'
 import type { AuditEvent, AuditAction } from '@/entities/audit-event'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow, Pager, SortableTh, nextSort } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { DatePicker } from '@/shared/ui/date-picker'
@@ -157,7 +157,7 @@ export default function AuditLogPage() {
         </div>
       </FilterBar>
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <DataTable>
           <thead>
             <tr>

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -4,7 +4,8 @@ import { listBankImportBatches, importBankCsv, reverseBankImportBatch, getClearS
 import { describeApiError } from '@/shared/api/client'
 import type { BankImportBatch } from '@/entities/bank-import-batch'
 import { Button } from '@/shared/ui/button'
-import { Card, CardHead, CardBody } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
+import { CardHead, CardBody } from '@/shared/ui/card'
 import { DataTable, TableStateRow, SortableTh, nextSort, Pager } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { DatePicker } from '@/shared/ui/date-picker'
@@ -128,7 +129,7 @@ export default function BankImportPage() {
     <>
       <PageHead title={t('bankImport.title')} sub={t('bankImport.subtitle')} />
 
-      <Card style={{ maxWidth: 760 }}>
+      <Card pad="none" className="min-w-0" style={{ maxWidth: 760 }}>
         <CardHead><h2><Icon name="cloud-up" />{t('bankImport.upload')}</h2></CardHead>
         <CardBody className="stack">
           <form onSubmit={handleUpload} className="stack">
@@ -164,7 +165,7 @@ export default function BankImportPage() {
         </CardBody>
       </Card>
 
-      <FilterBar>
+      <FilterBar className="mt-x-md">
         <FilterField label={t('table.fileName')}>
           <div className="inp-icon">
             <Icon name="search" />
@@ -199,7 +200,7 @@ export default function BankImportPage() {
         </div>
       </FilterBar>
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <CardHead><h2><Icon name="clock" />{t('bankImport.batches')}</h2></CardHead>
         <DataTable>
           <thead>

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -4,7 +4,7 @@ import { listBankTransactions, bankTransactionsExportPath } from '@/shared/api/e
 import { downloadCsv } from '@/shared/lib/download'
 import type { BankTransaction } from '@/entities/bank-transaction'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow, Pager, SortableTh, nextSort } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { FilterBar, FilterField } from '@/shared/ui/filter-bar'
@@ -112,7 +112,7 @@ export default function BankTransactionsPage() {
         <Button variant="primary" onClick={search}><Icon name="search" />{t('common.search')}</Button>
       </FilterBar>
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <DataTable>
           <thead>
             <tr>

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -4,7 +4,7 @@ import { listClientCredits, applyClientCredit, clientCreditsExportPath } from '@
 import { downloadCsv } from '@/shared/lib/download'
 import type { ClientCredit } from '@/entities/client-credit'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow, SortableTh, nextSort, Pager } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { DatePicker } from '@/shared/ui/date-picker'
@@ -179,7 +179,7 @@ export default function ClientCreditsPage() {
         </div>
       </FilterBar>
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <DataTable>
           <thead>
             <tr>

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { listUnmatchedTransactions, listDunningNotices } from '@/shared/api/endpoints'
 import { Button } from '@/shared/ui/button'
-import { Card, CardHead } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
+import { CardHead } from '@/shared/ui/card'
 import { DataTable, TableStateRow } from '@/shared/ui/data-table'
 import { Icon } from '@/shared/ui/icon'
 import { Kpi, KpiGrid } from '@/shared/ui/kpi'
@@ -64,7 +65,7 @@ export default function DashboardPage() {
 
       <div className="dash-cards" style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1.5fr) minmax(0,1fr)', gap: 20, alignItems: 'start' }}>
         {/* Unmatched transactions */}
-        <Card>
+        <Card pad="none" className="min-w-0 mt-x-md">
           <CardHead>
             <h2><Icon name="reconcile" />{t('dashboard.unmatched')}</h2>
             <Button variant="link" onClick={() => navigate('/admin/reconciliation')}>
@@ -97,7 +98,7 @@ export default function DashboardPage() {
         </Card>
 
         {/* Recent dunning */}
-        <Card>
+        <Card pad="none" className="min-w-0 mt-x-md">
           <CardHead>
             <h2><Icon name="bell" />{t('dashboard.recentDunning')}</h2>
             <Button variant="link" onClick={() => navigate('/admin/dunning')}>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -8,7 +8,8 @@ import { downloadCsv } from '@/shared/lib/download'
 import type { UpstreamInvoice } from '@/entities/upstream-invoice'
 import { Badge } from '@/shared/ui/badge'
 import { Button } from '@/shared/ui/button'
-import { Card, CardHead } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
+import { CardHead } from '@/shared/ui/card'
 import { DataTable, TableStateRow, SortableTh, nextSort, Pager } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { DatePicker } from '@/shared/ui/date-picker'
@@ -175,7 +176,7 @@ export default function DunningPage() {
 
       {/* Pause banner */}
       {activePauses.size > 0 && (
-        <div className="card" style={{ borderColor: 'var(--warn-line)', background: 'var(--warn-bg)', marginBottom: 20 }}>
+        <Card pad="none" className="min-w-0" style={{ borderColor: 'var(--warn-line)', background: 'var(--warn-bg)', marginBottom: 20 }}>
           <div style={{ padding: '14px 18px' }}>
             <div className="row" style={{ color: 'var(--warn)', fontWeight: 700, fontSize: 13, marginBottom: 10 }}>
               <Icon name="pause" /> {t('dunning.pausedBanner', { count: activePauses.size })}
@@ -192,11 +193,11 @@ export default function DunningPage() {
               ))}
             </div>
           </div>
-        </div>
+        </Card>
       )}
 
       {/* Eligible invoices */}
-      <Card>
+      <Card pad="none" className="min-w-0">
         <CardHead>
           <h2><Icon name="alert" />{t('dunning.eligibleInvoices')}</h2>
           <p>{t('dunning.eligibleSubtitle')}</p>
@@ -239,7 +240,7 @@ export default function DunningPage() {
       </Card>
 
       {/* History */}
-      <FilterBar>
+      <FilterBar className="mt-x-md">
         <FilterField label={t('table.invoiceNumber')}>
           <div className="inp-icon">
             <Icon name="search" />
@@ -266,7 +267,7 @@ export default function DunningPage() {
         </div>
       </FilterBar>
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <CardHead><h2><Icon name="clock" />{t('dunning.history')}</h2></CardHead>
         <DataTable>
           <thead>

--- a/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
+++ b/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
@@ -6,7 +6,7 @@ import {
 import { describeApiError } from '@/shared/api/client'
 import type { ManualReceivable, ManualReceivableImportResult } from '@/entities/manual-receivable'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow } from '@/shared/ui/data-table'
 import { Icon } from '@/shared/ui/icon'
 import { Modal } from '@/shared/ui/modal'
@@ -172,7 +172,7 @@ export default function ManualReceivablesPage() {
 
       <NotOriginalNotice />
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <DataTable>
           <thead>
             <tr>

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -12,7 +12,7 @@ import type { AllocationInput, MatchSuggestion } from '@/shared/api/endpoints'
 import { describeApiError } from '@/shared/api/client'
 import { Badge } from '@/shared/ui/badge'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow, SortableTh, nextSort, Pager } from '@/shared/ui/data-table'
 import type { SortState } from '@/shared/ui/data-table'
 import { DatePicker } from '@/shared/ui/date-picker'
@@ -325,7 +325,7 @@ export default function ReconciliationPage() {
             <Button variant="primary" size="sm" onClick={uSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
           </div>
         </FilterBar>
-        <Card>
+        <Card pad="none" className="min-w-0">
           <DataTable>
             <thead>
               <tr>
@@ -384,7 +384,7 @@ export default function ReconciliationPage() {
             <Button variant="primary" size="sm" onClick={hSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
           </div>
         </FilterBar>
-        <Card>
+        <Card pad="none" className="min-w-0">
           <DataTable>
             <thead>
               <tr>

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -3,7 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getClearSettings, updateClearSettings, testUpstreamConnection } from '@/shared/api/endpoints'
 import type { BankAccountDraft, ClearSettings } from '@/entities/clear-settings'
 import { Button } from '@/shared/ui/button'
-import { Card, CardFoot } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
+import { CardFoot } from '@/shared/ui/card'
 import { Icon } from '@/shared/ui/icon'
 import { Notice } from '@/shared/ui/notice'
 import { PageHead } from '@/shared/ui/page-head'
@@ -86,7 +87,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
   }
 
   return (
-    <Card style={{ maxWidth: 780 }}>
+    <Card pad="none" className="min-w-0" style={{ maxWidth: 780 }}>
       {/* Section: API */}
       <div className="set-sect">
         <h3><Icon name="plug" />{t('settings.section.api')}</h3>

--- a/frontend/src/pages/users/UsersPage.tsx
+++ b/frontend/src/pages/users/UsersPage.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listUsers, createUser, deleteUser } from '@/shared/api/endpoints'
 import type { User } from '@/entities/user'
 import { Button } from '@/shared/ui/button'
-import { Card } from '@/shared/ui/card'
+import { Card } from '@hideyukimori/nene2-ui'
 import { DataTable, TableStateRow } from '@/shared/ui/data-table'
 import { Icon } from '@/shared/ui/icon'
 import { Modal } from '@/shared/ui/modal'
@@ -101,7 +101,7 @@ export default function UsersPage() {
         actions={<Button variant="primary" onClick={() => setShowInvite(true)}><Icon name="plus" />{t('users.invite')}</Button>}
       />
 
-      <Card>
+      <Card pad="none" className="min-w-0">
         <DataTable>
           <thead>
             <tr><th>{t('table.email')}</th><th>{t('table.role')}</th><th>{t('table.status')}</th><th>{t('table.lastLogin')}</th><th /></tr>

--- a/frontend/src/shared/ui/card/Card.tsx
+++ b/frontend/src/shared/ui/card/Card.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from 'react'
 
-interface CardProps { children: ReactNode; className?: string; style?: React.CSSProperties }
-
-export function Card({ children, className, style }: CardProps) {
-  return <div className={['card', className].filter(Boolean).join(' ')} style={style}>{children}</div>
-}
+/*
+ * `Card` itself now comes from `@hideyukimori/nene2-ui` (W1a, #440) — the kit
+ * owns the bounded surface (background, border, radius). What stays here are the
+ * three parts the kit has no equivalent for; they are plain elements carrying
+ * legacy classes, and none of them is a descendant selector of `.card`, so they
+ * are unaffected by the surface moving.
+ */
 
 interface CardHeadProps {
   children: ReactNode

--- a/frontend/src/shared/ui/card/index.ts
+++ b/frontend/src/shared/ui/card/index.ts
@@ -1,1 +1,1 @@
-export { Card, CardHead, CardBody, CardFoot } from './Card'
+export { CardHead, CardBody, CardFoot } from './Card'

--- a/frontend/src/shared/ui/theme/design.css
+++ b/frontend/src/shared/ui/theme/design.css
@@ -260,13 +260,28 @@ svg.ic-lg{ width:22px; height:22px; }
 .btn-link:hover{ color:var(--navy-700); text-decoration:underline; }
 
 /* ───────── Cards / sections ───────── */
-.card{ background:var(--surface); border:1px solid var(--line); border-radius:var(--radius);
-  box-shadow:var(--shadow); min-width:0; }
-.card + .card{ margin-top:20px; }
-/* Two-column dashboard cards: grid items don't collapse margins, so the second
-   card inherits 20px from `.card + .card` while the first has none, dropping the
-   right card. Give both the same top offset so their top edges align. */
-.dash-cards > .card{ margin-top:20px; }
+/* `.card` moved to the kit (W1a, #440). Its three sibling-spacing rules went with
+   it, because each of them keyed on the class that no longer exists:
+     .card + .card         → only ever fired inside .dash-cards (measured: one
+     .dash-cards > .card      adjacency, DashboardPage). Both said margin-top:20px
+                              and both existed to offset the block below the KPI
+                              row, so the offset now sits on the container itself
+                              . Both are now `mt-x-md` on the two cards.
+                              ⚠️ Moving this to `.dash-cards` does NOT work: as a
+                              normal-flow block its margin-top collapses with the
+                              KPI row's margin-bottom and the cards rise 20px
+                              (measured). Grid items' margins do not collapse,
+                              which is why the offset belongs on them.
+     .card + .filterbar    → 22px, TWO occurrences (BankImportPage, DunningPage —
+                              the first count of one was wrong and cost the
+                              dunning filter bar all 22px until the computed diff
+                              caught it). Both are now `mt-x-md` at the call site
+                              (20px; a 2px snap onto the kit's scale, which has no
+                              22px step).
+   `min-width: 0` was also on `.card`; the kit does not set it, so every call site
+   passes `min-w-0` — a card holds tables that have to be allowed to shrink.
+   The head/body/foot parts below are NOT descendant selectors of `.card`, so the
+   surface moving does not touch them. */
 .card-head{ display:flex; align-items:center; justify-content:space-between; gap:12px;
   padding:14px 18px; border-bottom:1px solid var(--line); }
 .card-head h2{ margin:0; font-size:14px; font-weight:700; color:var(--ink);
@@ -597,7 +612,6 @@ hr.div{ border:0; border-top:1px solid var(--line); margin:0; }
 .filter-actions{ display:flex; align-items:center; gap:10px; margin-left:auto; align-self:flex-end; }
 .filter-count{ font-size:12px; color:var(--muted); white-space:nowrap; }
 .filter-count b{ color:var(--ink); font-variant-numeric:tabular-nums; font-weight:700; }
-.card + .filterbar{ margin-top:22px; }
 
 /* sortable table headers */
 table.tbl thead th.sortable{ cursor:pointer; user-select:none; -webkit-user-select:none; }

--- a/frontend/src/shared/ui/theme/index.css
+++ b/frontend/src/shared/ui/theme/index.css
@@ -30,6 +30,9 @@
  * nobody chose (nene-vault #481).
  */
 @import "@hideyukimori/nene2-ui/themes/default.css";
+/* Slot overrides aim the kit at Clear's design. Read AFTER the kit's theme so
+   the later `@theme` wins; see kit-slots.css for what may be written here. */
+@import "./kit-slots.css";
 @import "./design.css";
 
 /*

--- a/frontend/src/shared/ui/theme/kit-slots.css
+++ b/frontend/src/shared/ui/theme/kit-slots.css
@@ -1,0 +1,51 @@
+/*
+ * nene2-ui slot overrides — the layer that aims the kit at Clear's design (W1, #440).
+ *
+ * Kit components are never edited. Where Clear's design differs from a kit
+ * default, the difference is absorbed here, at the override point the kit
+ * provides. Read after the kit's own theme (see `index.css`), so these win.
+ *
+ * ── Two rules this file follows ─────────────────────────────────────────────
+ *
+ * 1. ONLY write a slot whose value differs from the kit default. Accepting a
+ *    default means writing nothing. Restating a default silently pins a number
+ *    nobody chose, and the day the kit fixes its scale, Clear would not move
+ *    with it (nene-vault #481).
+ *
+ * 2. "Resolves to the same value today" is NOT the same as "is the same
+ *    reference". A row whose expression differs from the kit's but happens to
+ *    compute to the same colour stays: it points the kit at CLEAR's token, so
+ *    Clear keeps its own design if the kit ever changes that default. Only a row
+ *    that repeats the kit's own expression is a permanent no-op and must go
+ *    (nene-deal §8-9).
+ *
+ * ── Card (W1a) — measured 2026-08-27 against nene2-ui 0.19.1 ────────────────
+ *
+ *   slot                          kit default              Clear (theme a)   →
+ *   --radius-x-slot-card          --radius-x-md   =  8px   --radius = 0px    → write
+ *   --color-x-slot-card-bg        --color-surface-raised   --surface #ffffff → write*
+ *   --color-x-slot-card-border    --color-border           --line   #dce3ec  → write
+ *   shadow (`raised` prop)        off by default           --shadow: none    → nothing
+ *
+ *   * Same colour today (both are pure white) but a different reference, so
+ *     rule 2 keeps it. `--color-surface-raised` is the kit's raised surface;
+ *     Clear's equivalent is `--surface`. ⚠️ The names cross: Clear's `--surface`
+ *     is the white one and `--surface-2` is the tinted one, while the kit has
+ *     `--color-surface` tinted and `--color-surface-raised` white. Mapping these
+ *     by name turns white into off-white.
+ *
+ *   Clear's card carries no padding of its own — the padding lives in
+ *   `.card-head` / `.card-body` / `.card-foot`, which stay local. The kit pads
+ *   by default (`pad="sm"`), so every call site passes `pad="none"`. There is
+ *   deliberately no `--spacing-x-slot-card-pad` in the kit; padding is per
+ *   instance, so it cannot be handled from this file.
+ *
+ * Slots for components Clear has not swapped yet are NOT written here. A slot
+ * value that nothing renders cannot be verified, and an unverified value reads
+ * as a decision that was checked.
+ */
+@theme {
+  --radius-x-slot-card: var(--radius-x-none);
+  --color-x-slot-card-bg: var(--surface);
+  --color-x-slot-card-border: var(--line);
+}


### PR DESCRIPTION
W1a の第1便。`Card` の器を `@hideyukimori/nene2-ui` に載せ替え、差分を `kit-slots.css` で吸収します。追跡は #440。

## 変えたもの

- **呼び出し15箇所**（`<Card>` 14 ＋ 督促の一時停止バナーが生の `<div className="card">` だった1箇所）。全部に `pad="none"` と `min-w-0`。
  - `pad="none"` … clear のカードは padding を持たず、padding は `.card-head`(14px 18px) / `.card-body`(18px) / `.card-foot`(12px 18px) 側にあります。キットは既定 `pad="sm"`(16px)。キットには `--spacing-x-slot-card-pad` が意図的に無く（padding は per instance）、この層からは扱えません。
- **`CardHead` / `CardBody` / `CardFoot` はローカルに残します。** キットに対応物がありません。いずれも `.card` の**子孫セレクタではない**ので、器が移っても影響しません（全数確認: `.card .xxx` の形は 0件）。
- **ローカルの `Card` は削除**（ゲート② 橋を残さない）。
- **`kit-slots.css` を新設。書いたのは既定と違う3行だけ**:

| slot | キット既定 | clear（theme a） | |
| --- | --- | --- | --- |
| `--radius-x-slot-card` | `--radius-x-md` = 8px | `--radius` = **0px** | 書く |
| `--color-x-slot-card-bg` | `--color-surface-raised` | `--surface` #ffffff | 書く※ |
| `--color-x-slot-card-border` | `--color-border` | `--line` #dce3ec | 書く |
| 影（`raised` prop） | 既定 off | `--shadow: none` | **書かない** |

※ 今日は同じ色（どちらも純白）ですが**参照が違う**ので nene-deal §8-9 に従い残します。⚠️ `--surface` の名前は**交差**しています — clear の `--surface` が純白で `--surface-2` が淡色、キットは `--color-surface` が淡色で `--color-surface-raised` が純白。名前で写像すると白が薄い色になります。

## 🔴 測定で回帰3件を捕まえ、直してから出しています

13画面 **3,444ノード**の computed 値を before/after で突き合わせました。**クラス名ではなく DOM パスで対応付けています** — クラス名はこの変更で変わるものなので、それを鍵にすると別のノードと比べるか、何とも比べずに「差分なし」を報告します。

1. **`.card + .filterbar` の 22px を「1箇所」と数え、実際は 2箇所だった。** dunning の filter bar が 22px を丸ごと失っていました。
2. **`.dash-cards{ margin-top }` への移設は効かない。** 通常フローのブロックなので KPI 行の `margin-bottom` と**相殺**し、カードが 20px 迫り上がりました（実測）。グリッドアイテムのマージンは相殺しないので、元の規則はそこに置いていたわけです。⇒ 2枚のカードに `mt-x-md` を戻しました。
3. **`min-width: 0` は `.card` にあり、キットは設定しない。** 全呼び出しに `min-w-0` を戻しました。

## 残る差分（意図したもの・目視束の「キット既定に任せた箇所」に載せます）

- **カード自身の `display: block→flex` / `flexDirection: row→column`** ＝ キットの `Card` の形そのもの。子が block box から flex item になるため、子の `min-width` の computed が `0px→auto` に変わります。
  **観測可能な影響はありません**: 375px / 1440px の全10画面で、ページの横スクロールは **0px**、はみ出し要素の顔ぶれも before と**完全一致**（表は従来どおり親のスクローラ内に収まっています）。
- **filter bar の上マージン 22px→20px**（2箇所）。キットの段に 22px は無いので **2px の snap**。

**色・枠・角丸・影・padding の差分は 0件。**

## 数字

- `npm run check` **EXIT=0**（92 tests / 14 files・source-probe OK）
- `design.css` 1,045→**1,059行**・507→**510規則**・行頭クラス **198**（不変）。増えたのは撤去の経緯を書いたコメントで、規則の増加は `.dash-cards` の1件分ではなく整理の結果です
- 変更15ファイル・+116 / −42

## 検査器の側で踏んだこと（次艦向け）

はみ出し検査を書いたとき、**全画面がタイムアウトしているのに「はみ出しなし」と出力しました**。原因は2つで、どちらも「不在検査に陽性対照が無い」型です:

- 375px では `.side-nav` が隠れる（モバイルシェルが `.mnav` に替わる）ので、アンカーが永久に visible にならない
- **`<main>` 要素は存在しない**（レイアウトは `div.main`）。`document.querySelectorAll('main *')` は常に 0件を返し、「はみ出しゼロ」に見える

⇒ 検査器に「1画面も測れていないなら失敗」「走査根が空なら失敗」を入れてから測り直しました。さらに before/after の比較でも、`cd` の位置違いで `git checkout` が silently 失敗し、**after が before の再測になっていた**のを取り違えかけました（`git -C` の絶対パスに変更・ビルド出力の CSS ファイル名が別物であることを確認してから測定）。

Refs #440
