### PR TITLE
fix(a11y): アイコン 114箇所に「装飾か内容か」を宣言させる（#440）

### DIFF
--- a/frontend/src/app/layout/AppLayout.tsx
+++ b/frontend/src/app/layout/AppLayout.tsx
@@ -52,7 +52,7 @@ function NavItem({ to, icon, label, badge, end }: { to: string; icon: string; la
       end={end}
       className={({ isActive }) => ['nav-item', isActive ? 'active' : ''].filter(Boolean).join(' ')}
     >
-      <Icon name={icon} />
+      <Icon decorative name={icon} />
       {label}
       {badge !== undefined && <span className="nav-badge">{badge}</span>}
     </NavLink>
@@ -160,7 +160,7 @@ export default function AppLayout() {
           </Link>
           <nav className="crumb">
             <span>NeNe Clear</span>
-            <svg className="ic" style={{ width: 14, height: 14 }}><use href="#i-chev-r" /></svg>
+            <Icon decorative name="chev-r" style={{ width: 14, height: 14 }} />
             <b>{t('crumb.menu')}</b>
           </nav>
           <div className="topbar-r">
@@ -178,7 +178,7 @@ export default function AppLayout() {
             </button>
             <span className="sep" />
             <button className="iconbtn" title={t('nav.logout')} onClick={handleLogout}>
-              <Icon name="logout" />
+              <Icon decorative name="logout" />
             </button>
           </div>
         </header>
@@ -200,7 +200,7 @@ export default function AppLayout() {
             end={tb.end}
             className={({ isActive }) => ['mtab', isActive ? 'active' : ''].filter(Boolean).join(' ')}
           >
-            <Icon name={tb.icon} />
+            <Icon decorative name={tb.icon} />
             {tb.to === '/admin/reconciliation' && RECON_BADGE !== undefined && (
               <span className="mtab-badge">{RECON_BADGE}</span>
             )}
@@ -234,7 +234,7 @@ export default function AppLayout() {
               <span>admin@example.com</span>
             </div>
             <button className="logout" title={t('nav.logout')} aria-label={t('nav.logout')} onClick={handleLogout}>
-              <Icon name="logout" />
+              <Icon decorative name="logout" />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
+++ b/frontend/src/pages/accept-invite/AcceptInvitePage.tsx
@@ -89,7 +89,7 @@ export default function AcceptInvitePage() {
             <>
               <Notice variant="ok">{t('acceptInvite.success')}</Notice>
               <Button variant="primary" style={{ justifyContent: 'center', padding: '11px', marginTop: 16, width: '100%' }} onClick={() => navigate('/admin')}>
-                <Icon name="login" />{t('acceptInvite.toLogin')}
+                <Icon decorative name="login" />{t('acceptInvite.toLogin')}
               </Button>
             </>
           )}
@@ -99,7 +99,7 @@ export default function AcceptInvitePage() {
               <div className="field">
                 <label>{t('acceptInvite.password')}</label>
                 <div className="inp-icon">
-                  <Icon name="lock" />
+                  <Icon decorative name="lock" />
                   <input
                     className="inp" type="password" name="password"
                     value={password} onChange={e => setPassword(e.target.value)}
@@ -110,7 +110,7 @@ export default function AcceptInvitePage() {
               <div className="field">
                 <label>{t('acceptInvite.passwordConfirm')}</label>
                 <div className="inp-icon">
-                  <Icon name="lock" />
+                  <Icon decorative name="lock" />
                   <input
                     className="inp" type="password" name="password_confirm"
                     value={confirm} onChange={e => setConfirm(e.target.value)}
@@ -119,7 +119,7 @@ export default function AcceptInvitePage() {
                 </div>
               </div>
               <Button variant="primary" type="submit" disabled={submitting} style={{ justifyContent: 'center', padding: '11px' }}>
-                <Icon name="check" />{submitting ? t('common.processing') : t('acceptInvite.submit')}
+                <Icon decorative name="check" />{submitting ? t('common.processing') : t('acceptInvite.submit')}
               </Button>
               {error && <Notice variant="bad">{error}</Notice>}
             </form>

--- a/frontend/src/pages/audit/AuditLogPage.tsx
+++ b/frontend/src/pages/audit/AuditLogPage.tsx
@@ -152,8 +152,8 @@ export default function AuditLogPage() {
         </FilterField>
         <div className="filter-actions">
           <span className="filter-count">{t('filter.count', { n: total })}</span>
-          <Button variant="ghost" size="sm" onClick={clear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-          <Button variant="primary" size="sm" onClick={search}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          <Button variant="ghost" size="sm" onClick={clear}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={search}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
         </div>
       </FilterBar>
 

--- a/frontend/src/pages/bank-import/BankImportPage.tsx
+++ b/frontend/src/pages/bank-import/BankImportPage.tsx
@@ -45,7 +45,7 @@ function ReverseModal({ batch, onClose }: ReverseModalProps) {
         <>
           <Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>
           <Button variant="danger" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}>
-            <Icon name="trash" size="sm" />{mut.isPending ? t('common.processing') : t('bankImport.reverse')}
+            <Icon decorative name="trash" size="sm" />{mut.isPending ? t('common.processing') : t('bankImport.reverse')}
           </Button>
         </>
       }
@@ -130,7 +130,7 @@ export default function BankImportPage() {
       <PageHead title={t('bankImport.title')} sub={t('bankImport.subtitle')} />
 
       <Card pad="none" className="min-w-0" style={{ maxWidth: 760 }}>
-        <CardHead><h2><Icon name="cloud-up" />{t('bankImport.upload')}</h2></CardHead>
+        <CardHead><h2><Icon decorative name="cloud-up" />{t('bankImport.upload')}</h2></CardHead>
         <CardBody className="stack">
           <form onSubmit={handleUpload} className="stack">
             <div className="field" style={{ maxWidth: 380 }}>
@@ -147,7 +147,7 @@ export default function BankImportPage() {
             <div className="field">
               <label>{t('bankImport.file')}</label>
               <div className="dropzone">
-                <span className="dz-ic"><Icon name="file" /></span>
+                <span className="dz-ic"><Icon decorative name="file" /></span>
                 <div style={{ flex: 1 }}>
                   <input ref={fileRef} type="file" accept=".csv" style={{ fontSize: 13 }} />
                   <small style={{ display: 'block', marginTop: 4 }}>{t('bankImport.dropHint')}</small>
@@ -157,7 +157,7 @@ export default function BankImportPage() {
             {uploadMsg && <Notice variant={uploadMsg.ok ? 'ok' : 'bad'}>{uploadMsg.text}</Notice>}
             <div className="row">
               <Button variant="primary" type="submit" disabled={uploadMut.isPending}>
-                <Icon name="import" />{uploadMut.isPending ? t('common.importing') : t('bankImport.submit')}
+                <Icon decorative name="import" />{uploadMut.isPending ? t('common.importing') : t('bankImport.submit')}
               </Button>
               <span className="faint" style={{ fontSize: 12 }}>{t('bankImport.dedupeHint')}</span>
             </div>
@@ -168,7 +168,7 @@ export default function BankImportPage() {
       <FilterBar className="mt-x-md">
         <FilterField label={t('table.fileName')}>
           <div className="inp-icon">
-            <Icon name="search" />
+            <Icon decorative name="search" />
             <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 160 }} placeholder={t('common.search')} value={fileName} onChange={e => setFileName(e.target.value)} />
           </div>
         </FilterField>
@@ -195,13 +195,13 @@ export default function BankImportPage() {
         </FilterField>
         <div className="filter-actions">
           <span className="filter-count">{t('filter.count', { n: batchTotal })}</span>
-          <Button variant="ghost" size="sm" onClick={clearBatches}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-          <Button variant="primary" size="sm" onClick={searchBatches}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          <Button variant="ghost" size="sm" onClick={clearBatches}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={searchBatches}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
         </div>
       </FilterBar>
 
       <Card pad="none" className="min-w-0">
-        <CardHead><h2><Icon name="clock" />{t('bankImport.batches')}</h2></CardHead>
+        <CardHead><h2><Icon decorative name="clock" />{t('bankImport.batches')}</h2></CardHead>
         <DataTable>
           <thead>
             <tr>
@@ -225,7 +225,7 @@ export default function BankImportPage() {
                 <td className="row-act">
                   {b.status === 'imported' && (
                     <Button variant="ghost-danger" size="sm" onClick={() => setReverseTarget(b)}>
-                      <Icon name="trash" size="sm" />{t('bankImport.reverse')}
+                      <Icon decorative name="trash" size="sm" />{t('bankImport.reverse')}
                     </Button>
                   )}
                 </td>

--- a/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
+++ b/frontend/src/pages/bank-transactions/BankTransactionsPage.tsx
@@ -76,7 +76,7 @@ export default function BankTransactionsPage() {
         sub={t('bankTransaction.subtitle')}
         actions={
           <Button variant="ghost" onClick={() => void downloadCsv(bankTransactionsExportPath(txFilter), 'bank-transactions.csv')}>
-            <Icon name="export" />{t('export.csv')}
+            <Icon decorative name="export" />{t('export.csv')}
           </Button>
         }
       />
@@ -105,11 +105,11 @@ export default function BankTransactionsPage() {
         </FilterField>
         <FilterField label={t('table.counterparty')}>
           <div className="inp-icon">
-            <Icon name="search" />
+            <Icon decorative name="search" />
             <input className="inp" data-kbd="search" placeholder={t('common.search')} style={{ paddingLeft: 32 }} value={counterparty} onChange={e => setCounterparty(e.target.value)} />
           </div>
         </FilterField>
-        <Button variant="primary" onClick={search}><Icon name="search" />{t('common.search')}</Button>
+        <Button variant="primary" onClick={search}><Icon decorative name="search" />{t('common.search')}</Button>
       </FilterBar>
 
       <Card pad="none" className="min-w-0">

--- a/frontend/src/pages/client-credits/ClientCreditsPage.tsx
+++ b/frontend/src/pages/client-credits/ClientCreditsPage.tsx
@@ -41,7 +41,7 @@ function ApplyModal({ credit, onClose }: { credit: ClientCredit; onClose: () => 
         <>
           <Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>
           <Button variant="primary" disabled={!invoiceId || mut.isPending} onClick={() => mut.mutate()}>
-            <Icon name="link" />{mut.isPending ? t('common.processing') : t('clientCredit.apply')}
+            <Icon decorative name="link" />{mut.isPending ? t('common.processing') : t('clientCredit.apply')}
           </Button>
         </>
       }
@@ -132,7 +132,7 @@ export default function ClientCreditsPage() {
         ]} />}
         actions={
           <Button variant="ghost" onClick={() => void downloadCsv(clientCreditsExportPath(creditFilter), 'client-credits.csv')}>
-            <Icon name="export" />{t('export.csv')}
+            <Icon decorative name="export" />{t('export.csv')}
           </Button>
         }
       />
@@ -140,7 +140,7 @@ export default function ClientCreditsPage() {
       <FilterBar>
         <FilterField label={t('table.client')}>
           <div className="inp-icon">
-            <Icon name="search" />
+            <Icon decorative name="search" />
             <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={f.clientId} onChange={e => set('clientId')(e.target.value)} />
           </div>
         </FilterField>
@@ -174,8 +174,8 @@ export default function ClientCreditsPage() {
         </FilterField>
         <div className="filter-actions">
           <span className="filter-count">{t('filter.count', { n: total })}</span>
-          <Button variant="ghost" size="sm" onClick={clear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-          <Button variant="primary" size="sm" onClick={search}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          <Button variant="ghost" size="sm" onClick={clear}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={search}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
         </div>
       </FilterBar>
 
@@ -207,7 +207,7 @@ export default function ClientCreditsPage() {
                 <td className="row-act">
                   {c.status === 'open' && (
                     <Button variant="primary" size="sm" onClick={() => setApplyTarget(c)}>
-                      <Icon name="link" size="sm" />{t('clientCredit.apply')}
+                      <Icon decorative name="link" size="sm" />{t('clientCredit.apply')}
                     </Button>
                   )}
                 </td>

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -36,30 +36,30 @@ export default function DashboardPage() {
         <Kpi
           accent="accent"
           testId="kpi-unmatched"
-          icon={<Icon name="reconcile" />}
+          icon={<Icon decorative name="reconcile" />}
           label={t('dashboard.kpi.unmatched')}
           value={<>{unmatchedQ.isLoading ? '…' : unmatchedTotal}{unit && <small>{unit}</small>}</>}
-          sub={<><Icon name="yen" size="sm" />{t('dashboard.kpi.unmatchedSub')}</>}
+          sub={<><Icon decorative name="yen" size="sm" />{t('dashboard.kpi.unmatchedSub')}</>}
         />
         <Kpi
           accent="bad"
-          icon={<Icon name="alert" style={{ color: 'var(--bad)' }} />}
+          icon={<Icon decorative name="alert" style={{ color: 'var(--bad)' }} />}
           label={t('dashboard.kpi.overdue')}
           value={<>5{unit && <small>{unit}</small>}</>}
-          sub={<><Icon name="clock" size="sm" />{t('dashboard.kpi.overdueSub')}</>}
+          sub={<><Icon decorative name="clock" size="sm" />{t('dashboard.kpi.overdueSub')}</>}
         />
         <Kpi
-          icon={<Icon name="check" />}
+          icon={<Icon decorative name="check" />}
           label={t('dashboard.kpi.cleared')}
           value={<span className="tnum">¥4,820,000</span>}
-          sub={<><Icon name="trend" size="sm" />{t('dashboard.kpi.clearedSub')}</>}
+          sub={<><Icon decorative name="trend" size="sm" />{t('dashboard.kpi.clearedSub')}</>}
         />
         <Kpi
           accent="warn"
-          icon={<Icon name="credit" style={{ color: 'var(--warn)' }} />}
+          icon={<Icon decorative name="credit" style={{ color: 'var(--warn)' }} />}
           label={t('dashboard.kpi.credit')}
           value={<span className="tnum">¥45,000</span>}
-          sub={<><Icon name="info" size="sm" />{t('dashboard.kpi.creditSub')}</>}
+          sub={<><Icon decorative name="info" size="sm" />{t('dashboard.kpi.creditSub')}</>}
         />
       </KpiGrid>
 
@@ -67,9 +67,9 @@ export default function DashboardPage() {
         {/* Unmatched transactions */}
         <Card pad="none" className="min-w-0 mt-x-md">
           <CardHead>
-            <h2><Icon name="reconcile" />{t('dashboard.unmatched')}</h2>
+            <h2><Icon decorative name="reconcile" />{t('dashboard.unmatched')}</h2>
             <Button variant="link" onClick={() => navigate('/admin/reconciliation')}>
-              {t('dashboard.viewAll')} <Icon name="chev-r" size="sm" />
+              {t('dashboard.viewAll')} <Icon decorative name="chev-r" size="sm" />
             </Button>
           </CardHead>
           <DataTable>
@@ -88,7 +88,7 @@ export default function DashboardPage() {
                   <td className="strong">{tx.counterparty_text}</td>
                   <td className="row-act">
                     <Button variant="primary" size="sm" onClick={() => navigate('/admin/reconciliation')}>
-                      <Icon name="check" size="sm" />{t('reconciliation.confirm')}
+                      <Icon decorative name="check" size="sm" />{t('reconciliation.confirm')}
                     </Button>
                   </td>
                 </tr>
@@ -100,9 +100,9 @@ export default function DashboardPage() {
         {/* Recent dunning */}
         <Card pad="none" className="min-w-0 mt-x-md">
           <CardHead>
-            <h2><Icon name="bell" />{t('dashboard.recentDunning')}</h2>
+            <h2><Icon decorative name="bell" />{t('dashboard.recentDunning')}</h2>
             <Button variant="link" onClick={() => navigate('/admin/dunning')}>
-              {t('dashboard.toDunning')} <Icon name="chev-r" size="sm" />
+              {t('dashboard.toDunning')} <Icon decorative name="chev-r" size="sm" />
             </Button>
           </CardHead>
           <DataTable>

--- a/frontend/src/pages/dunning/DunningPage.tsx
+++ b/frontend/src/pages/dunning/DunningPage.tsx
@@ -44,7 +44,7 @@ function SendModal({ invoice, onClose }: { invoice: UpstreamInvoice; onClose: ()
   })
   return (
     <Modal open onClose={onClose} title={t('dunning.confirmSend')} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={mut.isPending} onClick={() => mut.mutate()}><Icon name="send" />{mut.isPending ? t('common.sending') : t('dunning.send')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="send" />{mut.isPending ? t('common.sending') : t('dunning.send')}</Button></>}
     >
       <div className="kv">
         <div className="kv-row"><span className="k">{t('table.invoice')}</span><span className="v mono">{invoice.invoice_number}</span></div>
@@ -97,7 +97,7 @@ function PauseModal({ invoiceId, onClose }: { invoiceId: number; onClose: () => 
   })
   return (
     <Modal open onClose={onClose} title={t('dunning.confirmPause')} sub={t('dunning.pauseTarget', { id: invoiceId })} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="warn" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon name="pause" />{mut.isPending ? t('common.processing') : t('dunning.pauseAction')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="warn" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="pause" />{mut.isPending ? t('common.processing') : t('dunning.pauseAction')}</Button></>}
     >
       <div className="field"><label>{t('dunning.pauseReason')}</label><input className="inp" placeholder={t('dunning.pauseReasonPlaceholder')} value={reason} onChange={e => setReason(e.target.value)} /></div>
       <Notice variant="warn">{t('dunning.pauseWarn')}</Notice>
@@ -169,7 +169,7 @@ export default function DunningPage() {
         sub={t('dunning.subtitle')}
         actions={
           <Button variant="ghost" onClick={() => void downloadCsv(dunningNoticesExportPath(noticesFilter), 'dunning-notices.csv')}>
-            <Icon name="export" />{t('export.csv')}
+            <Icon decorative name="export" />{t('export.csv')}
           </Button>
         }
       />
@@ -179,7 +179,7 @@ export default function DunningPage() {
         <Card pad="none" className="min-w-0" style={{ borderColor: 'var(--warn-line)', background: 'var(--warn-bg)', marginBottom: 20 }}>
           <div style={{ padding: '14px 18px' }}>
             <div className="row" style={{ color: 'var(--warn)', fontWeight: 700, fontSize: 13, marginBottom: 10 }}>
-              <Icon name="pause" /> {t('dunning.pausedBanner', { count: activePauses.size })}
+              <Icon decorative name="pause" /> {t('dunning.pausedBanner', { count: activePauses.size })}
             </div>
             <div className="wrapw">
               {(pausesQ.data?.items ?? []).map(p => (
@@ -187,7 +187,7 @@ export default function DunningPage() {
                   <b className="mono">{t('table.invoice')} #{p.invoice_id}</b>
                   <span className="faint">{p.paused_reason}</span>
                   <Button variant="link" onClick={() => resumeMut.mutate(p.invoice_id)}>
-                    <Icon name="refresh" size="sm" />{t('dunning.resume')}
+                    <Icon decorative name="refresh" size="sm" />{t('dunning.resume')}
                   </Button>
                 </span>
               ))}
@@ -199,7 +199,7 @@ export default function DunningPage() {
       {/* Eligible invoices */}
       <Card pad="none" className="min-w-0">
         <CardHead>
-          <h2><Icon name="alert" />{t('dunning.eligibleInvoices')}</h2>
+          <h2><Icon decorative name="alert" />{t('dunning.eligibleInvoices')}</h2>
           <p>{t('dunning.eligibleSubtitle')}</p>
         </CardHead>
         <DataTable>
@@ -223,12 +223,12 @@ export default function DunningPage() {
                   <td style={{ color: daysNum > 0 ? (daysNum > 14 ? 'var(--bad)' : 'var(--warn)') : 'var(--muted)', fontWeight: 600 }}>{elap}</td>
                   <td className="row-act">
                     {paused
-                      ? <Badge variant="warn"><Icon name="pause" size="sm" />{t('dunning.paused')}</Badge>
-                      : <Button variant="primary" size="sm" onClick={() => setSendTarget(inv)}><Icon name="send" size="sm" />{t('dunning.send')}</Button>
+                      ? <Badge variant="warn"><Icon decorative name="pause" size="sm" />{t('dunning.paused')}</Badge>
+                      : <Button variant="primary" size="sm" onClick={() => setSendTarget(inv)}><Icon decorative name="send" size="sm" />{t('dunning.send')}</Button>
                     }
                     {!paused && (
                       <Button variant="ghost-warn" size="sm" onClick={() => setPauseTarget(inv.invoice_id)}>
-                        <Icon name="pause" size="sm" />{t('dunning.pause')}
+                        <Icon decorative name="pause" size="sm" />{t('dunning.pause')}
                       </Button>
                     )}
                   </td>
@@ -243,13 +243,13 @@ export default function DunningPage() {
       <FilterBar className="mt-x-md">
         <FilterField label={t('table.invoiceNumber')}>
           <div className="inp-icon">
-            <Icon name="search" />
+            <Icon decorative name="search" />
             <input className="inp" data-kbd="search" style={{ paddingLeft: 32, width: 150 }} placeholder={t('common.search')} value={hInvoice} onChange={e => setHInvoice(e.target.value)} />
           </div>
         </FilterField>
         <FilterField label={t('table.recipient')}>
           <div className="inp-icon">
-            <Icon name="search" />
+            <Icon decorative name="search" />
             <input className="inp" style={{ paddingLeft: 32, width: 170 }} placeholder={t('common.search')} value={hEmail} onChange={e => setHEmail(e.target.value)} />
           </div>
         </FilterField>
@@ -262,13 +262,13 @@ export default function DunningPage() {
         </FilterField>
         <div className="filter-actions">
           <span className="filter-count">{t('filter.count', { n: hTotal })}</span>
-          <Button variant="ghost" size="sm" onClick={hClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-          <Button variant="primary" size="sm" onClick={hSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+          <Button variant="ghost" size="sm" onClick={hClear}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+          <Button variant="primary" size="sm" onClick={hSearch}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
         </div>
       </FilterBar>
 
       <Card pad="none" className="min-w-0">
-        <CardHead><h2><Icon name="clock" />{t('dunning.history')}</h2></CardHead>
+        <CardHead><h2><Icon decorative name="clock" />{t('dunning.history')}</h2></CardHead>
         <DataTable>
           <thead>
             <tr>

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -35,18 +35,18 @@ export default function HelpPage() {
         <div className="hero-grid" />
         <div className="hero-inner">
           <div className="eyebrow">
-            <Icon name="help" />
+            <Icon decorative name="help" />
             {pick(HELP_LABELS.eyebrow)}
           </div>
           <h1>{pick(HELP_LABELS.heroTitle)}</h1>
           <p>{pick(HELP_LABELS.heroLede)}</p>
           <div className="hero-meta">
             <span className="hero-chip">
-              <Icon name="reconcile" />
+              <Icon decorative name="reconcile" />
               {pick(HELP_LABELS.chipReconcile)}
             </span>
             <span className="hero-chip">
-              <Icon name="shield" />
+              <Icon decorative name="shield" />
               {pick(HELP_LABELS.chipSelfhost)}
             </span>
             <span className="hero-chip">
@@ -79,7 +79,7 @@ export default function HelpPage() {
                 <span className="hsec-no">{String(i + 1).padStart(2, '0')}</span>
                 <h2>
                   {s.icon !== undefined && (
-                    <span className="hsec-ic"><Icon name={s.icon} /></span>
+                    <span className="hsec-ic"><Icon decorative name={s.icon} /></span>
                   )}
                   {pick(s.title)}
                   {s.admin === true && <span className="tag-admin">{pick(HELP_LABELS.adminBadge)}</span>}
@@ -89,14 +89,14 @@ export default function HelpPage() {
                 <Block key={bi} block={block} pick={pick} />
               ))}
               <a className="backtop" href="#help-top" onClick={onBackToTop}>
-                <Icon name="arrow-up" />
+                <Icon decorative name="arrow-up" />
                 {pick(HELP_LABELS.backToToc)}
               </a>
             </section>
           ))}
 
           <div className="help-foot">
-            <div className="hf-ic"><Icon name="mail" /></div>
+            <div className="hf-ic"><Icon decorative name="mail" /></div>
             <div>
               <div className="hf-t">{pick(HELP_LABELS.footTitle)}</div>
               <div className="hf-d"><Rich text={pick(HELP_LABELS.footDesc)} /></div>
@@ -252,7 +252,7 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
     case 'note':
       return (
         <div className={block.tone === 'warn' ? 'note warn' : 'note'}>
-          <span className="note-ic"><Icon name={block.tone === 'warn' ? 'alert' : 'info'} /></span>
+          <span className="note-ic"><Icon decorative name={block.tone === 'warn' ? 'alert' : 'info'} /></span>
           <span>
             {block.title !== undefined && <span className="nt">{pick(block.title)}</span>}
             <Rich text={pick(block.text)} />
@@ -301,7 +301,7 @@ function Block({ block, pick }: { block: HelpBlock; pick: (b: Bi) => string }): 
               <summary>
                 <span className="q">Q</span>
                 <span className="qt">{pick(it.q)}</span>
-                <span className="chev" aria-hidden="true"><Icon name="chev-d" /></span>
+                <span className="chev" aria-hidden="true"><Icon decorative name="chev-d" /></span>
               </summary>
               <div className="fa-body"><Rich text={pick(it.a)} /></div>
             </details>

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -45,15 +45,15 @@ export default function LoginPage() {
         </div>
         <div className="feats">
           <div className="feat">
-            <span className="fi"><Icon name="reconcile" size="sm" /></span>
+            <span className="fi"><Icon decorative name="reconcile" size="sm" /></span>
             {t('login.feature.reconcile')}
           </div>
           <div className="feat">
-            <span className="fi"><Icon name="bell" size="sm" /></span>
+            <span className="fi"><Icon decorative name="bell" size="sm" /></span>
             {t('login.feature.dunning')}
           </div>
           <div className="feat">
-            <span className="fi"><Icon name="shield" size="sm" /></span>
+            <span className="fi"><Icon decorative name="shield" size="sm" /></span>
             {t('login.feature.control')}
           </div>
         </div>
@@ -70,7 +70,7 @@ export default function LoginPage() {
             <div className="field">
               <label>{t('login.email')}</label>
               <div className="inp-icon">
-                <Icon name="mail" />
+                <Icon decorative name="mail" />
                 <input
                   className="inp"
                   type="email" name="email"
@@ -85,7 +85,7 @@ export default function LoginPage() {
             <div className="field">
               <label>{t('login.password')}</label>
               <div className="inp-icon">
-                <Icon name="lock" />
+                <Icon decorative name="lock" />
                 <input
                   className="inp"
                   type="password" name="password"
@@ -97,7 +97,7 @@ export default function LoginPage() {
               </div>
             </div>
             <Button variant="primary" type="submit" disabled={loading} style={{ justifyContent: 'center', padding: '11px' }}>
-              <Icon name="login" />
+              <Icon decorative name="login" />
               {loading ? t('common.checking') : t('login.submit')}
             </Button>
             {error && <Notice variant="bad">{error}</Notice>}

--- a/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
+++ b/frontend/src/pages/manual-receivables/ManualReceivablesPage.tsx
@@ -58,7 +58,7 @@ function CreateModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Modal open onClose={onClose} title={t('manualReceivables.create')} sub={t('manualReceivables.createSub')}
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={!valid || mut.isPending} onClick={() => mut.mutate()}><Icon name="plus" />{mut.isPending ? t('common.saving') : t('manualReceivables.create')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={!valid || mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="plus" />{mut.isPending ? t('common.saving') : t('manualReceivables.create')}</Button></>}
     >
       <NotOriginalNotice />
       <div className="field">
@@ -81,7 +81,7 @@ function CreateModal({ onClose }: { onClose: () => void }) {
       </div>
       <div className="field">
         <label>{t('manualReceivables.recipientEmail')}</label>
-        <div className="inp-icon"><Icon name="mail" /><input className="inp" type="email" style={{ paddingLeft: 34 }} value={email} onChange={e => setEmail(e.target.value)} placeholder={t('manualReceivables.emailPlaceholder')} /></div>
+        <div className="inp-icon"><Icon decorative name="mail" /><input className="inp" type="email" style={{ paddingLeft: 34 }} value={email} onChange={e => setEmail(e.target.value)} placeholder={t('manualReceivables.emailPlaceholder')} /></div>
         <span className="hint">{t('manualReceivables.emailHint')}</span>
       </div>
       {error && <Notice variant="bad">{error}</Notice>}
@@ -104,7 +104,7 @@ function ImportModal({ onClose }: { onClose: () => void }) {
 
   return (
     <Modal open onClose={onClose} title={t('manualReceivables.import')} sub={t('manualReceivables.importSub')}
-      footer={<><Button variant="ghost" onClick={onClose}>{result ? t('common.close') : t('common.cancel')}</Button>{!result && <Button variant="primary" disabled={!file || mut.isPending} onClick={() => mut.mutate()}><Icon name="import" />{mut.isPending ? t('common.processing') : t('manualReceivables.import')}</Button>}</>}
+      footer={<><Button variant="ghost" onClick={onClose}>{result ? t('common.close') : t('common.cancel')}</Button>{!result && <Button variant="primary" disabled={!file || mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="import" />{mut.isPending ? t('common.processing') : t('manualReceivables.import')}</Button>}</>}
     >
       <NotOriginalNotice />
       <p className="muted" style={{ fontSize: 12.5, lineHeight: 1.8 }}>{t('manualReceivables.importColumns')}</p>
@@ -165,8 +165,8 @@ export default function ManualReceivablesPage() {
         title={t('manualReceivables.title')}
         sub={t('manualReceivables.subtitle')}
         actions={<>
-          <Button variant="ghost" onClick={() => setShowImport(true)}><Icon name="import" />{t('manualReceivables.import')}</Button>
-          <Button variant="primary" onClick={() => setShowCreate(true)}><Icon name="plus" />{t('manualReceivables.create')}</Button>
+          <Button variant="ghost" onClick={() => setShowImport(true)}><Icon decorative name="import" />{t('manualReceivables.import')}</Button>
+          <Button variant="primary" onClick={() => setShowCreate(true)}><Icon decorative name="plus" />{t('manualReceivables.create')}</Button>
         </>}
       />
 

--- a/frontend/src/pages/reconciliation/ReconciliationPage.tsx
+++ b/frontend/src/pages/reconciliation/ReconciliationPage.tsx
@@ -100,14 +100,14 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
         <>
           <Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>
           <Button variant="primary" type="submit" disabled={confirmMut.isPending}>
-            <Icon name="check" />{confirmMut.isPending ? t('common.processing') : t('reconciliation.confirm')}
+            <Icon decorative name="check" />{confirmMut.isPending ? t('common.processing') : t('reconciliation.confirm')}
           </Button>
         </>
       }
     >
       {/* Suggestions */}
       <div className="sugg">
-        <div className="sugg-h"><Icon name="reconcile" size="sm" />{t('reconciliation.suggestions')}</div>
+        <div className="sugg-h"><Icon decorative name="reconcile" size="sm" />{t('reconciliation.suggestions')}</div>
         {suggestQ.isLoading && <p className="muted" style={{ fontSize: 12, margin: 0 }}>{t('reconciliation.searchingSuggestions')}</p>}
         {suggestQ.data?.upstream_unavailable && (
           <Notice variant="warn">{t('reconciliation.upstreamUnavailable')}</Notice>
@@ -148,13 +148,13 @@ function ConfirmModal({ tx, onClose }: { tx: BankTransaction; onClose: () => voi
               </div>
               {allocs.length > 1 && (
                 <Button variant="ghost" size="sm" style={{ height: 36 }} onClick={() => setAllocs(p => p.filter((_, j) => j !== i))}>
-                  <Icon name="x" size="sm" />
+                  <Icon decorative name="x" size="sm" />
                 </Button>
               )}
             </div>
           ))}
           <Button variant="link" onClick={() => setAllocs(p => [...p, { source: 'invoice_upstream', invoice_id: 0, amount_cents: 0 }])}>
-            <Icon name="plus" size="sm" />{t('reconciliation.addAllocation')}
+            <Icon decorative name="plus" size="sm" />{t('reconciliation.addAllocation')}
           </Button>
         </div>
       </div>
@@ -186,7 +186,7 @@ function ReverseModal({ recon, onClose }: { recon: Reconciliation; onClose: () =
   })
   return (
     <Modal open onClose={onClose} title={t('reconciliation.confirmReverse')} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon name="refresh" size="sm" />{mut.isPending ? t('common.processing') : t('reconciliation.reverse')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={!reason.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="refresh" size="sm" />{mut.isPending ? t('common.processing') : t('reconciliation.reverse')}</Button></>}
     >
       <div className="field"><label>{t('reconciliation.reversalReason')}</label><input className="inp" value={reason} onChange={e => setReason(e.target.value)} /></div>
       {mut.isError && <Notice variant="bad">{mut.error.message}</Notice>}
@@ -283,15 +283,15 @@ export default function ReconciliationPage() {
         ]} />}
         actions={
           <Button variant="ghost" onClick={() => void downloadCsv(reconciliationsExportPath(reconFilter), 'reconciliations.csv')}>
-            <Icon name="export" />{t('export.csv')}
+            <Icon decorative name="export" />{t('export.csv')}
           </Button>
         }
       />
 
       <Tabs
         tabs={[
-          { key: 'unmatched', label: <><Icon name="reconcile" size="sm" />{t('reconciliation.tab.unmatched')}</> },
-          { key: 'history', label: <><Icon name="clock" size="sm" />{t('reconciliation.tab.history')}</> },
+          { key: 'unmatched', label: <><Icon decorative name="reconcile" size="sm" />{t('reconciliation.tab.unmatched')}</> },
+          { key: 'history', label: <><Icon decorative name="clock" size="sm" />{t('reconciliation.tab.history')}</> },
         ]}
         active={tab}
         onChange={setTab}
@@ -315,14 +315,14 @@ export default function ReconciliationPage() {
           </FilterField>
           <FilterField label={t('table.counterparty')}>
             <div className="inp-icon">
-              <Icon name="search" />
+              <Icon decorative name="search" />
               <input className="inp" data-kbd="search" placeholder={t('common.search')} style={{ paddingLeft: 32 }} value={uCounterparty} onChange={e => setUCounterparty(e.target.value)} />
             </div>
           </FilterField>
           <div className="filter-actions">
             <span className="filter-count">{t('filter.count', { n: uTotal })}</span>
-            <Button variant="ghost" size="sm" onClick={uClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-            <Button variant="primary" size="sm" onClick={uSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+            <Button variant="ghost" size="sm" onClick={uClear}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+            <Button variant="primary" size="sm" onClick={uSearch}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
           </div>
         </FilterBar>
         <Card pad="none" className="min-w-0">
@@ -346,7 +346,7 @@ export default function ReconciliationPage() {
                   <td><Badge variant="info">{t('reconciliation.hasCandidates')}</Badge></td>
                   <td className="row-act">
                     <Button variant="primary" size="sm" onClick={() => setMatchTarget(tx)}>
-                      <Icon name="check" size="sm" />{t('reconciliation.confirm')}
+                      <Icon decorative name="check" size="sm" />{t('reconciliation.confirm')}
                     </Button>
                   </td>
                 </tr>
@@ -380,8 +380,8 @@ export default function ReconciliationPage() {
           </FilterField>
           <div className="filter-actions">
             <span className="filter-count">{t('filter.count', { n: hTotal })}</span>
-            <Button variant="ghost" size="sm" onClick={hClear}><Icon name="refresh" size="sm" />{t('filter.clear')}</Button>
-            <Button variant="primary" size="sm" onClick={hSearch}><Icon name="search" size="sm" />{t('common.search')}</Button>
+            <Button variant="ghost" size="sm" onClick={hClear}><Icon decorative name="refresh" size="sm" />{t('filter.clear')}</Button>
+            <Button variant="primary" size="sm" onClick={hSearch}><Icon decorative name="search" size="sm" />{t('common.search')}</Button>
           </div>
         </FilterBar>
         <Card pad="none" className="min-w-0">
@@ -406,7 +406,7 @@ export default function ReconciliationPage() {
                   <td className="row-act">
                     {r.status === 'confirmed' && (
                       <Button variant="ghost-danger" size="sm" onClick={() => setReverseTarget(r)}>
-                        <Icon name="refresh" size="sm" />{t('reconciliation.reverse')}
+                        <Icon decorative name="refresh" size="sm" />{t('reconciliation.reverse')}
                       </Button>
                     )}
                   </td>

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -90,21 +90,21 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
     <Card pad="none" className="min-w-0" style={{ maxWidth: 780 }}>
       {/* Section: API */}
       <div className="set-sect">
-        <h3><Icon name="plug" />{t('settings.section.api')}</h3>
+        <h3><Icon decorative name="plug" />{t('settings.section.api')}</h3>
         <div className="form-grid" style={{ gridTemplateColumns: '1fr' }}>
           <div className="field"><label>{t('settings.upstreamUrl')}</label><input className="inp" type="url" value={upstreamUrl} onChange={e => setUpstreamUrl(e.target.value)} /></div>
           <div className="field"><label>{t('settings.upstreamToken')}</label><input className="inp mono" type="password" value={upstreamToken} onChange={e => setUpstreamToken(e.target.value)} /></div>
           <div className="row">
-            <Button variant="ghost" onClick={handleTest} disabled={testing}><Icon name="refresh" />{testing ? t('common.checking') : t('settings.testConnection')}</Button>
-            {testResult === 'ok' && <span className="row" style={{ color: 'var(--ok)', fontWeight: 600, fontSize: '12.5px', gap: 6 }}><Icon name="check" size="sm" />{t('settings.connectionOk')}</span>}
-            {testResult === 'fail' && <span className="row" style={{ color: 'var(--bad)', fontWeight: 600, fontSize: '12.5px', gap: 6 }}><Icon name="x" size="sm" />{t('settings.connectionFail')}</span>}
+            <Button variant="ghost" onClick={handleTest} disabled={testing}><Icon decorative name="refresh" />{testing ? t('common.checking') : t('settings.testConnection')}</Button>
+            {testResult === 'ok' && <span className="row" style={{ color: 'var(--ok)', fontWeight: 600, fontSize: '12.5px', gap: 6 }}><Icon decorative name="check" size="sm" />{t('settings.connectionOk')}</span>}
+            {testResult === 'fail' && <span className="row" style={{ color: 'var(--bad)', fontWeight: 600, fontSize: '12.5px', gap: 6 }}><Icon decorative name="x" size="sm" />{t('settings.connectionFail')}</span>}
           </div>
         </div>
       </div>
 
       {/* Section: Dunning */}
       <div className="set-sect">
-        <h3><Icon name="bell" />{t('settings.section.dunning')}</h3>
+        <h3><Icon decorative name="bell" />{t('settings.section.dunning')}</h3>
         <div className="form-row">
           <div className="field">
             <label>{t('settings.dunningInterval')}</label>
@@ -116,7 +116,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
 
       {/* Section: Fiscal year */}
       <div className="set-sect">
-        <h3><Icon name="calendar" />{t('settings.section.fiscal')}</h3>
+        <h3><Icon decorative name="calendar" />{t('settings.section.fiscal')}</h3>
         <div className="form-row">
           <div className="field">
             <label>{t('settings.fiscalYearEndMonth')}</label>
@@ -140,9 +140,9 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
       {/* Section: Bank accounts */}
       <div className="set-sect">
         <h3 className="spread" style={{ display: 'flex' }}>
-          <span className="row" style={{ gap: 8 }}><Icon name="building" />{t('settings.section.banks')}</span>
+          <span className="row" style={{ gap: 8 }}><Icon decorative name="building" />{t('settings.section.banks')}</span>
           <Button variant="ghost" size="sm" onClick={() => setAccounts(p => [...p, emptyAccount()])}>
-            <Icon name="plus" size="sm" />{t('settings.addBankAccount')}
+            <Icon decorative name="plus" size="sm" />{t('settings.addBankAccount')}
           </Button>
         </h3>
         {accounts.length === 0 && <p className="faint" style={{ fontSize: 12 }}>{t('settings.noBankAccounts')}</p>}
@@ -178,7 +178,7 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
             <div className="spread" style={{ marginTop: 12 }}>
               <span />
               <Button variant="link" style={{ color: 'var(--bad)' }} onClick={() => setAccounts(p => p.filter((_, j) => j !== i))}>
-                <Icon name="trash" size="sm" />{t('settings.removeBankAccount')}
+                <Icon decorative name="trash" size="sm" />{t('settings.removeBankAccount')}
               </Button>
             </div>
           </div>
@@ -187,12 +187,12 @@ function SettingsForm({ settings }: { settings: ClearSettings }) {
 
       <CardFoot>
         {saved
-          ? <div className="notice ok" style={{ border: 0, background: 'transparent', padding: 0 }}><Icon name="check" size="sm" /><span>{t('settings.saved')}</span></div>
+          ? <div className="notice ok" style={{ border: 0, background: 'transparent', padding: 0 }}><Icon decorative name="check" size="sm" /><span>{t('settings.saved')}</span></div>
           : <span />
         }
         {saveMut.isError && <Notice variant="bad">{saveMut.error.message}</Notice>}
         <Button variant="primary" disabled={saveMut.isPending} onClick={handleSave}>
-          <Icon name="check" />{saveMut.isPending ? t('common.saving') : t('settings.save')}
+          <Icon decorative name="check" />{saveMut.isPending ? t('common.saving') : t('settings.save')}
         </Button>
       </CardFoot>
     </Card>

--- a/frontend/src/pages/users/UsersPage.tsx
+++ b/frontend/src/pages/users/UsersPage.tsx
@@ -41,11 +41,11 @@ function InviteModal({ onClose }: { onClose: () => void }) {
   })
   return (
     <Modal open onClose={onClose} title={t('users.invite')} sub={t('users.inviteModal.subtitle')} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={!email.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon name="send" />{mut.isPending ? t('common.sending') : t('users.inviteSubmit')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="primary" disabled={!email.trim() || mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="send" />{mut.isPending ? t('common.sending') : t('users.inviteSubmit')}</Button></>}
     >
       <div className="field">
         <label>{t('users.email')}</label>
-        <div className="inp-icon"><Icon name="mail" /><input className="inp" type="email" placeholder="user@example.com" style={{ paddingLeft: 34 }} value={email} onChange={e => setEmail(e.target.value)} /></div>
+        <div className="inp-icon"><Icon decorative name="mail" /><input className="inp" type="email" placeholder="user@example.com" style={{ paddingLeft: 34 }} value={email} onChange={e => setEmail(e.target.value)} /></div>
       </div>
       <div className="field">
         <label>{t('users.role')}</label>
@@ -72,7 +72,7 @@ function DeleteModal({ user, onClose }: { user: User; onClose: () => void }) {
   })
   return (
     <Modal open onClose={onClose} title={t('users.confirmDelete')} sub={user.email} size="narrow"
-      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={mut.isPending} onClick={() => mut.mutate()}><Icon name="trash" />{mut.isPending ? t('common.processing') : t('users.delete')}</Button></>}
+      footer={<><Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button><Button variant="danger" disabled={mut.isPending} onClick={() => mut.mutate()}><Icon decorative name="trash" />{mut.isPending ? t('common.processing') : t('users.delete')}</Button></>}
     >
       {mut.isError && <Notice variant="bad">{mut.error.message}</Notice>}
     </Modal>
@@ -98,7 +98,7 @@ export default function UsersPage() {
       <PageHead
         title={t('users.title')}
         sub={t('users.subtitle')}
-        actions={<Button variant="primary" onClick={() => setShowInvite(true)}><Icon name="plus" />{t('users.invite')}</Button>}
+        actions={<Button variant="primary" onClick={() => setShowInvite(true)}><Icon decorative name="plus" />{t('users.invite')}</Button>}
       />
 
       <Card pad="none" className="min-w-0">
@@ -116,7 +116,7 @@ export default function UsersPage() {
                 <td className="muted">—</td>
                 <td className="row-act">
                   <Button variant="ghost-danger" size="sm" onClick={() => setDeleteTarget(u)}>
-                    <Icon name="trash" size="sm" />{t('users.delete')}
+                    <Icon decorative name="trash" size="sm" />{t('users.delete')}
                   </Button>
                 </td>
               </tr>

--- a/frontend/src/shared/ui/data-table/DataTable.tsx
+++ b/frontend/src/shared/ui/data-table/DataTable.tsx
@@ -102,11 +102,11 @@ export function Pager({ offset, pageSize, total, onOffsetChange }: PagerProps) {
       <span>{t('common.pagination.showing', { from: offset + 1, to: Math.min(offset + pageSize, total), total })}</span>
       <div className="pager">
         <button aria-label={t('common.pagination.prev')} onClick={() => onOffsetChange(Math.max(0, offset - pageSize))} disabled={current === 1}>
-          <Icon name="chev-l" size="sm" />
+          <Icon decorative name="chev-l" size="sm" />
         </button>
         <span className="cur">{current} / {totalPages}</span>
         <button aria-label={t('common.pagination.next')} onClick={() => onOffsetChange(offset + pageSize)} disabled={current >= totalPages}>
-          <Icon name="chev-r" size="sm" />
+          <Icon decorative name="chev-r" size="sm" />
         </button>
       </div>
     </div>

--- a/frontend/src/shared/ui/date-picker/DatePicker.tsx
+++ b/frontend/src/shared/ui/date-picker/DatePicker.tsx
@@ -96,15 +96,15 @@ export function DatePicker({ value, onChange, placeholder = 'YYYY/MM/DD', ariaLa
         onChange={(e) => onChange(autoformat(e.target.value))}
       />
       <button type="button" className="date-btn" tabIndex={-1} aria-label="カレンダーを開く" onClick={openPopover}>
-        <Icon name="calendar" size="sm" />
+        <Icon decorative name="calendar" size="sm" />
       </button>
 
       {open && (
         <div className="dp-pop" style={{ top: pos.top, left: pos.left }}>
           <div className="dp-head">
-            <button type="button" className="dp-nav" aria-label="前の月" onClick={() => shiftMonth(-1)}><Icon name="chev-l" size="sm" /></button>
+            <button type="button" className="dp-nav" aria-label="前の月" onClick={() => shiftMonth(-1)}><Icon decorative name="chev-l" size="sm" /></button>
             <span className="dp-title">{view.y}年 {pad(view.m)}月</span>
-            <button type="button" className="dp-nav" aria-label="次の月" onClick={() => shiftMonth(1)}><Icon name="chev-r" size="sm" /></button>
+            <button type="button" className="dp-nav" aria-label="次の月" onClick={() => shiftMonth(1)}><Icon decorative name="chev-r" size="sm" /></button>
           </div>
           <div className="dp-wd">{WD.map((w, i) => <span key={w} className={i === 0 ? 'sun' : i === 6 ? 'sat' : ''}>{w}</span>)}</div>
           <div className="dp-grid">
@@ -120,7 +120,7 @@ export function DatePicker({ value, onChange, placeholder = 'YYYY/MM/DD', ariaLa
           </div>
           <div className="dp-foot">
             <button type="button" className="dp-today" onClick={() => { onChange(fmt(t.getFullYear(), t.getMonth() + 1, t.getDate())); setOpen(false) }}>
-              <Icon name="calendar" size="sm" />今日
+              <Icon decorative name="calendar" size="sm" />今日
             </button>
           </div>
         </div>

--- a/frontend/src/shared/ui/icon/Icon.tsx
+++ b/frontend/src/shared/ui/icon/Icon.tsx
@@ -1,13 +1,28 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, SVGProps } from 'react'
 
 type IconSize = 'sm' | 'md' | 'lg'
 
-interface IconProps {
+interface IconBase {
+  /** Sprite symbol id, without the `i-` prefix (see `index.html`). */
   name: string
   size?: IconSize
   className?: string
   style?: CSSProperties
 }
+
+/** The icon carries meaning of its own, so it needs a localized name. */
+interface MeaningfulIcon extends IconBase {
+  label: string
+  decorative?: never
+}
+
+/** The icon repeats something already in the text, so it is hidden from assistive tech. */
+interface DecorativeIcon extends IconBase {
+  decorative: true
+  label?: never
+}
+
+export type IconProps = MeaningfulIcon | DecorativeIcon
 
 const sizeClass: Record<IconSize, string> = {
   sm: 'ic ic-sm',
@@ -15,9 +30,42 @@ const sizeClass: Record<IconSize, string> = {
   lg: 'ic ic-lg',
 }
 
-export function Icon({ name, size = 'md', className, style }: IconProps) {
+/**
+ * A sprite icon, plus the one thing an icon must always say: whether it is
+ * content or decoration.
+ *
+ * `label` and `decorative` are mutually exclusive and one of them is required,
+ * enforced by the type — the same contract as `@hideyukimori/nene2-ui`'s `Icon`.
+ * An icon that renders without saying which it is leaves assistive technology to
+ * guess, and the page looks entirely correct either way, which is why the gap
+ * survives review. Across the fleet 101 of 222 inline `<svg>` elements are in
+ * that state (kit measurement, 2026-08-23); before this type existed all 114 of
+ * Clear's call sites were too.
+ *
+ * Every one of those 114 turned out to be decoration. That is not an assumption:
+ * all 439 rendered instances were audited in a real browser across 13 screens
+ * (2026-08-27, #440) by asking, per icon, whether its labelling ancestor already
+ * carried text or an accessible name. 414 did; the remaining 25 sit beside a
+ * label, a KPI caption, a feature description or a note body that names them.
+ * **Not one icon was found alone inside an unnamed control** — so nothing here is
+ * load-bearing for a screen reader, and `decorative` is a finding rather than a
+ * default.
+ *
+ * The artwork stays local on purpose: the kit ships none and takes on no icon
+ * library. Its `Icon` is the semantics around an icon, not the icon. Swapping to
+ * it is held back only by size — the kit hardcodes `h-4/5/6` (16/20/24px) where
+ * Clear draws 15/18/22px, and has no slot to hold that (fleet-tooling #494).
+ */
+export function Icon({ name, size = 'md', className, style, ...meaning }: IconProps) {
+  // `focusable="false"` is for IE/Edge-legacy, which put SVG in the tab order;
+  // harmless elsewhere and cheap insurance for a sprite used 114 times.
+  const a11y: SVGProps<SVGSVGElement> =
+    'label' in meaning && meaning.label !== undefined
+      ? { role: 'img', 'aria-label': meaning.label }
+      : { 'aria-hidden': true, focusable: 'false' }
+
   return (
-    <svg className={[sizeClass[size], className].filter(Boolean).join(' ')} style={style}>
+    <svg className={[sizeClass[size], className].filter(Boolean).join(' ')} style={style} {...a11y}>
       <use href={`#i-${name}`} />
     </svg>
   )

--- a/frontend/src/shared/ui/info-dot/InfoDot.tsx
+++ b/frontend/src/shared/ui/info-dot/InfoDot.tsx
@@ -23,7 +23,7 @@ export function InfoDot({ label, entries }: InfoDotProps) {
   return (
     <span className="infodot">
       <button type="button" className="infodot-btn" aria-label={label}>
-        <Icon name="info" size="sm" />
+        <Icon decorative name="info" size="sm" />
       </button>
       <span className="infodot-pop" role="tooltip">
         <dl className="glossary">

--- a/frontend/src/shared/ui/modal/Modal.tsx
+++ b/frontend/src/shared/ui/modal/Modal.tsx
@@ -88,7 +88,7 @@ export function Modal({ open, onClose, title, sub, children, footer, size = 'def
           <h3>{title}</h3>
           {sub && <p>{sub}</p>}
         </div>
-        <button type="button" className="x" onClick={onClose}><Icon name="x" /></button>
+        <button type="button" className="x" onClick={onClose}><Icon decorative name="x" /></button>
       </div>
       <div className="modal-body">{children}</div>
       <div className="modal-foot">{footer}</div>

--- a/frontend/src/shared/ui/notice/Notice.tsx
+++ b/frontend/src/shared/ui/notice/Notice.tsx
@@ -19,7 +19,7 @@ interface NoticeProps {
 export function Notice({ variant, children, className }: NoticeProps) {
   return (
     <div className={['notice', variant, className].filter(Boolean).join(' ')}>
-      <Icon name={iconName[variant]} />
+      <Icon decorative name={iconName[variant]} />
       <span>{children}</span>
     </div>
   )


### PR DESCRIPTION
キットの `Icon` は `label` と `decorative` を**排他かつ必須**にしています。その契約を先に自艦の `Icon` へ入れます。**部品の載せ替えそのものは保留**します（理由は末尾）。追跡は #440。

## 何が問題だったか（実測）

13画面を実ブラウザで描画して数えたところ、clear の **439インスタンスは `aria-hidden` も `role` も1つも持っていませんでした**。キットの docstring が「フリート 222 の `<svg>` のうち **101** が同じ状態」と書いている、その 101 側でした。

> they do not say whether they are decoration or content, so assistive technology is left to guess, and the page looks entirely correct either way.

**画面はどちらでも正しく見える**ので、レビューで見つかりません。

## 114箇所すべて `decorative` — これは既定ではなく所見です

横着ではないことを示すため、439インスタンスを1つずつ「**名前を与える祖先が既にテキストか `aria-label` を持っているか**」で判定しました:

| 分類 | 件数 |
| --- | --- |
| 祖先にテキストあり | 361 |
| 祖先に名前あり（`aria-label` / `title`） | 34 |
| 親にテキストあり | 19 |
| 制御でない場所に単独 → 個別確認 | 25 |

🔴 **名前を持たない制御の中に単独で居るアイコンは 0件。** icon-only ボタンの問題は存在しませんでした。

単独の25件も、隣が名前を与えていました（実測した文脈）:

- `.inp-icon`（mail / lock / search・5件）… 入力欄のラベルが祖父要素（「メールアドレス」「パスワード」「請求書番号」…）
- `.kpi-ic`（dashboard・4件）… KPI の見出し（「未消込の取引」「延滞請求（督促対象）」…）
- `.fi`（login・3件）… 機能説明文（「銀行CSVの自動突合と消込候補のサジェスト」…）
- `.note-ic` / `.hf-ic`（help・7件）… 注記の本文そのもの
- 他 6件も同様

⇒ **読み上げの担い手になっているアイコンは1つもありません。**

## 🔴 `<Icon>` だけ数えると 11件取りこぼしました

`decorative` を114箇所に入れた後で測り直したら、**428/439 しか宣言を持っていませんでした**。残る11は `AppLayout.tsx:163` の**生の `<svg className="ic">`**（パンくずの区切り）で、部品を通っていなかったものです。⇒ `Icon` 経由に直して **439/439**。

`LogoMark` は元から `aria-hidden` を持っていました（`.ic` を持たないので監査のセレクタにも掛からず、二重に見えていませんでした）。

🔑 キット自身の docstring が「**Searching for one spelling of a thing that has several always undercounts**」と書いているのと同じことを、その直後に踏みました。**「宣言を入れた」で終わらせず、入った数を測ったから見つかりました。**

## 載せ替えを保留した理由 → fleet-tooling #494

キットの `Icon` はサイズを `h-4/5/6`（16/20/24px）で**ハードコード**しており、上書き点がありません（`themes/default.css` に `slot-icon` を grep して **0件**）。clear は 15/18/22px。

| size | clear | キット | 差 |
| --- | --- | --- | --- |
| sm | 15px | 16px | +1 |
| md | **18px** | **20px** | **+2** |
| lg | 22px | 24px | +2 |

個々の差は ±2px で nene-deal §8-5 の snap 範囲ですが、**439インスタンス＝アプリで最も広い視覚面が一斉に 11% 大きくなる**ので、1部品の snap とは意味が違うと判断しました。さらに `svg.ic` は `stroke-width` と `flex:none` も持つため載せ替えても `.ic` は残り、そこに `h-5 w-5` が utilities 層から勝つので **legacy 側で寸法を保つ手もありません**。

⇒ **fleet-tooling #494** で上書き点を要求しました。契約（`label` XOR `decorative`）はもう合っているので、スロットが入ればそのまま移せます。

## 測定

- **computed 値の差分 0件 / 3,444ノード / 13画面**。両側とも 3,444 ノードを実測したことを確認済み（「差分ゼロ」が「測っていない」ではないこと）
- `aria-hidden` を持つインスタンス **0 → 439**
- `npm run check` **EXIT=0**（92 tests / 14 files・source-probe OK）

Refs #440
