### PR TITLE
test(qa): W1 の目視束を作る生成器を置き、SP で 15ボタンが折り返す退行を塞ぐ（#440）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 /frontend/node_modules/
 /frontend/apps/*/dist/
 /frontend/dist-e2e/
+# Owner-review bundles are per-wave and disposable — the generator and the README
+# are what persist; the verdict goes on the wave's tracking issue (#440).
+/docs/qa/owner-review/*/
 /sec-router.php
 /composer.local.json
 /.claude/settings.local.json

--- a/docs/qa/owner-review/README.md
+++ b/docs/qa/owner-review/README.md
@@ -1,0 +1,94 @@
+# Owner-review material — the shape (#440)
+
+**What this is.** The material the owner looks at before a UI-kit migration wave is
+deployed. Fleet ruling 2026-08-23: the design-preservation constraint is lifted, and in
+exchange **every ship's migration passes the owner's visual check before it goes to
+production — once per wave, not once per PR.** The acceptance criterion, in the owner's
+words: *"アプリケーションが正常に動くこと、人間が見てインターフェースが整っていること"* —
+it works, and it looks put together. Not "it is identical", not "it conforms".
+
+**What it is not.** Not a comparison tool and not a gate that decides anything. It measures
+nothing and reports no differences; it shows pictures, and a person decides.
+
+## Run
+
+Two builds are served side by side, so the run needs two preview servers. No PHP backend
+and no database: every API call is fulfilled in the browser from `review-fixtures.mjs`.
+
+```bash
+# 1. the `after` side — the candidate (this working tree)
+(cd frontend && npm run build -- --base=/ --outDir=dist-e2e \
+   && npx vite preview --outDir dist-e2e --port 4182 --strictPort)
+
+# 2. the `before` side — the wave's baseline commit, in its own worktree
+git worktree add /tmp/clear-before <before-commit>
+(cd /tmp/clear-before/frontend && npm ci && npm run build -- --base=/ --outDir=dist-e2e \
+   && npx vite preview --outDir dist-e2e --port 4181 --strictPort)
+
+# 3. capture
+cd tests/e2e
+CLEAR_OWNER_REVIEW_BEFORE_REPO=/tmp/clear-before \
+CLEAR_OWNER_REVIEW_AT="$(date)" \
+npm run owner-review
+```
+
+| variable | default | is |
+| --- | --- | --- |
+| `CLEAR_OWNER_REVIEW_BEFORE_URL` | `http://localhost:4181` | preview server for the `before` column |
+| `CLEAR_OWNER_REVIEW_AFTER_URL` | `http://localhost:4182` | preview server for the `after` column |
+| `CLEAR_OWNER_REVIEW_BEFORE_REPO` | this repo | worktree the `before` provenance is read from |
+| `CLEAR_OWNER_REVIEW_DIR` | `w1` | output directory name under `docs/qa/owner-review/` |
+| `CLEAR_OWNER_REVIEW_AT` | *(none)* | capture time; pass the raw `date` output, do not reformat it |
+| `CLEAR_OWNER_REVIEW_PROD_NOTE` | *(none)* | one line saying what production was serving at run time |
+
+Output: `docs/qa/owner-review/<dir>/index.html` + 52 PNGs + `meta.json`
+(13 screens × 2 viewports × 2 sides). **Gitignored** — the bundle is per-wave and
+disposable; the generator and this file are what persist.
+
+## Read
+
+| column | is |
+| --- | --- |
+| **before** | the build at the wave's baseline commit, named in `meta.json` (`before.head`) |
+| **after** | the candidate, named in `meta.json` (`after.head`) |
+
+Both columns render the **same fixture data**, so anything that differs in the picture is a
+difference in the chrome — buttons, cards, badges, tables, spacing — and never in the rows.
+Look at the container, not at the content.
+
+**Neither column is production.** Unlike nene-vault's bundle, this one does not photograph
+the live site: `clear.ayane.co.jp` answers every SPA path with `401` unless a real session
+is seated, and there is no demo seat to borrow. What production was serving at run time is
+recorded in `meta.json` (`production.note`) instead — establish how far it is from the
+`before` column before reading a row as "this is what changes for users".
+
+A cell reading **not captured** carries the reason. It is reported, never dropped: a screen
+that could not be reached is a finding, not a blank.
+
+## Record
+
+The owner's verdict is **GO / NG per screen, on the wave's tracking issue** (for W1: #440),
+with the `meta.json` values (`before.head`, `after.head`, kit version) quoted so the verdict
+is tied to what was looked at. An NG is fixed by slot values or `className` and the **same
+bundle is regenerated** — not by reverting the migration, and not by adding a second bundle
+next to the first. An NG that the kit has to absorb becomes an issue on the kit
+(DoD step 3), not a special case on the screen.
+
+## Guards
+
+- **Unstyled build** (the `@source` regression: nene-vault #387, clear #440). The kit's
+  sentinel class must be present in the stylesheet the browser actually loaded, checked on
+  the first `after` screen before anything else is trusted. `npm run source-probe` checks the
+  build on disk; this checks the build that is being photographed, which can be an older
+  `outDir` than the one just built. Only the `after` side is guarded — `before` predates the
+  kit and is expected not to carry it.
+- **Session seating** (nene-deal §8-5). A seated screen that fell back to the login form is
+  recorded as *not captured*, never saved as a picture. Without this the bundle silently
+  becomes thirteen photographs of the login screen.
+- **Nothing captured** fails the run. Partial capture is reported in the table.
+
+## For another wave
+
+Point `CLEAR_OWNER_REVIEW_DIR` at a new name and `CLEAR_OWNER_REVIEW_BEFORE_REPO` at the new
+baseline. `SCREENS` in `tests/e2e/capture-owner-review.mjs` is the list from the tracking
+issue, in the order the owner reads it there; keep the two viewports and the two columns.

--- a/docs/qa/owner-review/README.md
+++ b/docs/qa/owner-review/README.md
@@ -50,7 +50,16 @@ disposable; the generator and this file are what persist.
 | column | is |
 | --- | --- |
 | **before** | the build at the wave's baseline commit, named in `meta.json` (`before.head`) |
-| **after** | the candidate, named in `meta.json` (`after.head`) |
+| **after** | the candidate, named in `meta.json` (`after.head`) **plus `after.uncommitted`** |
+
+🔴 **A commit SHA alone does not identify what was photographed.** Read `uncommitted`
+beside every `head`: it lists the files that differed from that commit when the picture was
+taken, and the page repeats it above the frames. Capturing a dirty tree is normal — a fix
+lands with the wave — but a verdict recorded against the bare SHA names a build that renders
+differently from what the owner approved. Measured here on 2026-08-27 (#440): W1's `after`
+column was captured from `08f3bc9` carrying an uncommitted `nowrap` fix, and the first
+`meta.json` recorded only `08f3bc9`. Tie the verdict to the commit the reviewed tree
+actually became.
 
 Both columns render the **same fixture data**, so anything that differs in the picture is a
 difference in the chrome — buttons, cards, badges, tables, spacing — and never in the rows.

--- a/frontend/src/shared/ui/theme/kit-slots.css
+++ b/frontend/src/shared/ui/theme/kit-slots.css
@@ -94,6 +94,36 @@
  *    lighter `--color-warn` the kit had to use `--color-on-warn` (a dark brown)
  *    because white measured 3.48:1 there (fleet, #487).
  */
+/* ── Stopgap, NOT a slot — remove when the kit ships it (fleet #501) ────────
+ *
+ * The kit's `Button` sets no `white-space`, so its label wraps. Clear's `.btn`
+ * carried `white-space: nowrap` (`design.css:241` before W1a), and dropping it
+ * broke 15 buttons at SP 375×812 — measured across 168 buttons on 13 screens,
+ * before (`3566eec`) vs after (`08f3bc9`): 「督促を送信」「消込を確定」「停止」
+ * each go 26px → 70px (four lines), CSV出力 34px → 46px. PC 1440×900: zero.
+ * Japanese has no word boundaries to break on, so a wrap splits mid-word
+ * (「消込を / 確定」).
+ *
+ * This is the ONE rule in this file that names a kit class rather than a slot
+ * the kit offers, and it is deliberately quarantined here so it is easy to
+ * delete: `rounded-x-slot-button` is in `Button`'s `BASE_CLASS`, so it marks
+ * every kit button and nothing else. The alternative was `className` on 69 call
+ * sites — the same "the ship works around the kit" shape the kit's own Button
+ * comment calls an asymmetry it fixed for `inline-flex`.
+ *
+ * `components`, not `utilities`, so `className="whitespace-normal"` still wins
+ * at a call site that wants a wrapping label.
+ *
+ * 🔴 When nene2-ui ships nowrap on Button (fleet #501), delete this block —
+ *    do not leave it "just in case". A stopgap nobody removes becomes the
+ *    ship's own quiet fork of the kit.
+ */
+@layer components {
+  .rounded-x-slot-button {
+    white-space: nowrap;
+  }
+}
+
 @theme {
   --radius-x-slot-button: var(--radius-x-none);
   --font-weight-x-slot-button: var(--font-weight-semibold);

--- a/tests/e2e/capture-owner-review.mjs
+++ b/tests/e2e/capture-owner-review.mjs
@@ -65,6 +65,21 @@ const SCREENS = [
 ]
 
 const git = (repo, ...args) => execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' }).trim()
+
+/**
+ * Files that differ from HEAD, as `git status --porcelain` lines.
+ *
+ * 🔴 A commit SHA alone does NOT identify what was photographed. Measured here
+ * on 2026-08-27 (#440): the `after` column was captured from a tree carrying an
+ * uncommitted fix, and `meta.json` recorded the bare HEAD — so the provenance
+ * named a build that renders differently from the pictures the owner approved.
+ * The bundle exists to tie a verdict to a build; a SHA that silently omits the
+ * working tree unties it. Recorded, and surfaced on the page, rather than
+ * refused: capturing a dirty tree is normal (a fix goes in with the wave), it
+ * just may not be reported as if it were the commit.
+ */
+const dirty = (repo) => git(repo, 'status', '--porcelain').split('\n').filter(Boolean)
+
 const pkgVersion = (repo, name) => {
   try {
     return JSON.parse(readFileSync(join(repo, 'frontend/node_modules', name, 'package.json'), 'utf8')).version
@@ -178,12 +193,14 @@ const meta = {
   before: {
     head: git(BEFORE_REPO, 'rev-parse', 'HEAD'),
     subject: git(BEFORE_REPO, 'log', '-1', '--format=%s'),
+    uncommitted: dirty(BEFORE_REPO),
     'nene2-ui': pkgVersion(BEFORE_REPO, '@hideyukimori/nene2-ui'),
     url: BEFORE_URL,
   },
   after: {
     head: git(REPO, 'rev-parse', 'HEAD'),
     subject: git(REPO, 'log', '-1', '--format=%s'),
+    uncommitted: dirty(REPO),
     'nene2-ui': pkgVersion(REPO, '@hideyukimori/nene2-ui'),
     url: AFTER_URL,
   },
@@ -201,6 +218,13 @@ writeFileSync(`${OUT}/meta.json`, JSON.stringify(meta, null, 2) + '\n')
 
 // ── the page the owner reads ─────────────────────────────────────────────────
 const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+// Says so on the page, not only in meta.json: the reader has to know the column
+// is the commit PLUS these files, or the verdict names the wrong build.
+const uncommittedNote = (side) =>
+  side.uncommitted?.length
+    ? `<br><b class="warn">＋ 未コミットの変更 ${side.uncommitted.length} 件</b>` +
+      `<br><span class="files">${side.uncommitted.map((l) => esc(l)).join('<br>')}</span>`
+    : ''
 const cellHtml = (side, screen, vp) => {
   const cell = `${side.key}-${screen.key}-${vp.key}`
   if (notes[cell]) return `<div class="miss"><b>not captured</b><span>${esc(notes[cell])}</span></div>`
@@ -232,6 +256,8 @@ const page = `<!doctype html>
  table.meta th,table.meta td{ border:1px solid var(--line); padding:6px 12px; text-align:left; font-size:12.5px }
  table.meta th{ background:#eef2f7; font-weight:600; white-space:nowrap }
  code{ font-family:ui-monospace,monospace; font-size:12px }
+ .warn{ color:#8c2c1e }
+ .files{ font-family:ui-monospace,monospace; font-size:11px; color:var(--muted) }
  nav.toc{ display:flex; flex-wrap:wrap; gap:8px; margin:0 0 28px }
  nav.toc a{ background:#fff; border:1px solid var(--line); padding:5px 11px; border-radius:999px;
    text-decoration:none; color:inherit; font-size:12.5px }
@@ -254,8 +280,8 @@ const page = `<!doctype html>
   見るのはボタン・カード・バッジ・表・余白といった「器」で、行の中身ではありません。
   判定は「同一かどうか」ではなく <b>動いていること／人が見て整っていること</b>（08-23 施主裁定）。</p>
  <table class="meta">
-  <tr><th>before</th><td><code>${esc(meta.before.head.slice(0, 7))}</code> ${esc(meta.before.subject)}<br>nene2-ui: ${meta.before['nene2-ui'] ?? '未導入'}</td></tr>
-  <tr><th>after</th><td><code>${esc(meta.after.head.slice(0, 7))}</code> ${esc(meta.after.subject)}<br>nene2-ui: ${meta.after['nene2-ui'] ?? '—'}</td></tr>
+  <tr><th>before</th><td><code>${esc(meta.before.head.slice(0, 7))}</code> ${esc(meta.before.subject)}${uncommittedNote(meta.before)}<br>nene2-ui: ${meta.before['nene2-ui'] ?? '未導入'}</td></tr>
+  <tr><th>after</th><td><code>${esc(meta.after.head.slice(0, 7))}</code> ${esc(meta.after.subject)}${uncommittedNote(meta.after)}<br>nene2-ui: ${meta.after['nene2-ui'] ?? '—'}</td></tr>
   <tr><th>本番</th><td>${esc(meta.production.note ?? 'clear.ayane.co.jp')}</td></tr>
   <tr><th>撮影</th><td>${esc(meta.captured_at ?? '—')} · ${meta.captured}/${meta.expected} 枚</td></tr>
  </table>

--- a/tests/e2e/capture-owner-review.mjs
+++ b/tests/e2e/capture-owner-review.mjs
@@ -1,0 +1,268 @@
+// Owner-review material for a kit-migration wave (#440).
+//
+// Renders the SAME thirteen screens from TWO builds — the wave's `before` commit
+// and the candidate — at two viewports, and writes a two-column page the owner
+// scrolls to answer one question per screen: does it work, and does it look put
+// together (ruling 2026-08-23). This is not a comparison tool and it decides
+// nothing: `docs/qa/owner-review/README.md` says what the columns mean and where
+// the verdict goes.
+//
+// Why two local builds and not "production vs local" (nene-vault's shape):
+// clear.ayane.co.jp answers every SPA path with 401 unless a real session is
+// seated, and there is no demo seat to borrow. Two local builds also make the
+// two columns carry IDENTICAL content — the API stand-in is shared — so a
+// difference in the picture is a difference in the chrome and nothing else.
+// The production build is recorded in `meta.json` instead, and the README says
+// how far it is from the `before` column.
+//
+// Run: see docs/qa/owner-review/README.md.
+import { chromium } from '@playwright/test'
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { dirname, resolve, join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { TOKEN, TOKEN_KEY, mockApi } from './review-fixtures.mjs'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = resolve(HERE, '../..')
+
+const BEFORE_URL = process.env.CLEAR_OWNER_REVIEW_BEFORE_URL ?? 'http://localhost:4181'
+const AFTER_URL = process.env.CLEAR_OWNER_REVIEW_AFTER_URL ?? 'http://localhost:4182'
+const BEFORE_REPO = process.env.CLEAR_OWNER_REVIEW_BEFORE_REPO ?? REPO
+const OUT = resolve(REPO, 'docs/qa/owner-review', process.env.CLEAR_OWNER_REVIEW_DIR ?? 'w1')
+
+const SIDES = [
+  { key: 'before', label: 'before（載せ替え前）', url: BEFORE_URL, repo: BEFORE_REPO },
+  { key: 'after', label: 'after（キット載せ替え後）', url: AFTER_URL, repo: REPO },
+]
+
+const VIEWPORTS = [
+  { key: 'pc', label: 'PC 1440×900', width: 1440, height: 900 },
+  { key: 'sp', label: 'SP 375×812', width: 375, height: 812 },
+]
+
+// The thirteen screens of the wave's tracking issue, in the order the owner
+// reads them there.
+//
+// The anchor is `.page` — the shell's content well — and NOT `.side-nav`: the
+// rail is `display:none` below the mobile breakpoint, and Playwright waits for
+// *visible*, so anchoring on the rail times out on every seated SP screen while
+// the screen itself renders perfectly (measured 2026-08-27: 22/52 cells lost).
+const SCREENS = [
+  { key: 'login', label: 'ログイン', route: '/login', seated: false, anchor: '.login-card' },
+  { key: 'accept-invite', label: '招待受諾', route: '/accept-invite?token=demo-invitation-token', seated: false, anchor: '.login-card, form, main' },
+  { key: 'dashboard', label: 'ダッシュボード', route: '/admin' },
+  { key: 'bank-import', label: '入金CSV取込', route: '/admin/bank-import' },
+  { key: 'bank-transactions', label: '入金明細', route: '/admin/bank-transactions' },
+  { key: 'reconciliation', label: '消込', route: '/admin/reconciliation' },
+  { key: 'client-credits', label: '預り金', route: '/admin/client-credits' },
+  { key: 'manual-receivables', label: '手動債権', route: '/admin/manual-receivables' },
+  { key: 'dunning', label: '督促', route: '/admin/dunning' },
+  { key: 'settings', label: '設定', route: '/admin/settings' },
+  { key: 'users', label: 'ユーザー管理', route: '/admin/users' },
+  { key: 'audit', label: '監査ログ', route: '/admin/audit-log' },
+  { key: 'help', label: 'ヘルプ', route: '/admin/help' },
+]
+
+const git = (repo, ...args) => execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' }).trim()
+const pkgVersion = (repo, name) => {
+  try {
+    return JSON.parse(readFileSync(join(repo, 'frontend/node_modules', name, 'package.json'), 'utf8')).version
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The `@source` guard, at run time (nene-vault #387, clear #440).
+ *
+ * `npm run source-probe` checks the build on disk; this checks the stylesheet
+ * the browser actually loaded, because the bundle is captured from a preview
+ * server that could be serving an older outDir than the one just built. Same
+ * sentinel, same positive control: the class exists only in the kit's `dist`,
+ * so its presence proves Tailwind scanned the kit.
+ *
+ * Only the `after` side is guarded — `before` predates the kit and is EXPECTED
+ * not to carry it, so running the guard there would fail an honest build.
+ */
+async function assertKitStyled(page, sentinel) {
+  const found = await page.evaluate((cls) => {
+    for (const sheet of document.styleSheets) {
+      try {
+        for (const rule of sheet.cssRules) if (rule.cssText.includes(`.${cls}`)) return true
+      } catch { /* cross-origin sheet (fonts) */ }
+    }
+    return false
+  }, sentinel)
+  if (!found) {
+    throw new Error(
+      `.${sentinel} is in no loaded stylesheet — the served build has no kit CSS.\n` +
+        '  Rebuild with the @source line present, then restart the preview server.',
+    )
+  }
+}
+
+rmSync(OUT, { recursive: true, force: true })
+mkdirSync(OUT, { recursive: true })
+
+// The kit lives in `frontend/node_modules`, not this workspace's, so it is
+// imported by path. Same single source of truth as `frontend/scripts/source-probe.mjs`:
+// the sentinel is never spelled out here.
+const kitDir = join(REPO, 'frontend/node_modules/@hideyukimori/nene2-ui')
+const kitMain = JSON.parse(readFileSync(join(kitDir, 'package.json'), 'utf8')).main
+const sentinel = (await import(pathToFileURL(resolve(kitDir, kitMain)).href)).SOURCE_PROBE_CLASS
+const browser = await chromium.launch()
+const notes = {} // `${side}-${screen}-${viewport}` -> reason it is not a picture
+let guarded = false
+let captured = 0
+
+for (const side of SIDES) {
+  for (const vp of VIEWPORTS) {
+    const context = await browser.newContext({ viewport: { width: vp.width, height: vp.height } })
+    for (const screen of SCREENS) {
+      const cell = `${side.key}-${screen.key}-${vp.key}`
+      const seated = screen.seated !== false
+      const page = await context.newPage()
+      if (seated) {
+        await page.addInitScript(([k, t]) => sessionStorage.setItem(k, t), [TOKEN_KEY, TOKEN])
+      }
+      await mockApi(page)
+      try {
+        await page.goto(side.url + screen.route, { waitUntil: 'domcontentloaded', timeout: 30000 })
+        await page.waitForSelector(screen.anchor ?? '.page', { timeout: 20000 })
+        // A seated screen that fell back to the login form is a captured
+        // *login page* wearing another screen's name (nene-deal §8-5).
+        if (seated && (await page.locator('.login-card').count()) > 0) {
+          throw new Error('fell back to the login screen — the session was not seated')
+        }
+        // `.page` exists while the shell is still showing its loading line, so
+        // wait that line out before the picture is taken.
+        await page
+          .waitForFunction(() => document.querySelector('.page > p.muted') === null, { timeout: 10000 })
+          .catch(() => {})
+        await page.waitForLoadState('networkidle').catch(() => {})
+        await page.waitForTimeout(700)
+        if (side.key === 'after' && !guarded) {
+          await assertKitStyled(page, sentinel)
+          guarded = true
+          console.log(`guard: .${sentinel} present in the served stylesheet`)
+        }
+        await page.screenshot({ path: `${OUT}/${cell}.png`, fullPage: true })
+        captured += 1
+        console.log(`✓ ${cell}`)
+      } catch (e) {
+        notes[cell] = e.message.split('\n')[0]
+        console.log(`✗ ${cell}: ${notes[cell]}`)
+      }
+      await page.close()
+    }
+    await context.close()
+  }
+}
+
+await browser.close()
+
+if (captured === 0) {
+  console.error('owner-review: nothing was captured on either side — are both preview servers up?')
+  process.exit(1)
+}
+if (!guarded) {
+  console.error('owner-review: the @source guard never ran (no `after` screen rendered).')
+  process.exit(1)
+}
+
+// ── provenance ───────────────────────────────────────────────────────────────
+const meta = {
+  captured_at: process.env.CLEAR_OWNER_REVIEW_AT ?? null,
+  wave: 'W1 — nene2-ui kit migration (#440)',
+  before: {
+    head: git(BEFORE_REPO, 'rev-parse', 'HEAD'),
+    subject: git(BEFORE_REPO, 'log', '-1', '--format=%s'),
+    'nene2-ui': pkgVersion(BEFORE_REPO, '@hideyukimori/nene2-ui'),
+    url: BEFORE_URL,
+  },
+  after: {
+    head: git(REPO, 'rev-parse', 'HEAD'),
+    subject: git(REPO, 'log', '-1', '--format=%s'),
+    'nene2-ui': pkgVersion(REPO, '@hideyukimori/nene2-ui'),
+    url: AFTER_URL,
+  },
+  production: {
+    host: 'clear.ayane.co.jp',
+    note: process.env.CLEAR_OWNER_REVIEW_PROD_NOTE ?? null,
+  },
+  screens: SCREENS.map((s) => s.key),
+  viewports: VIEWPORTS.map((v) => v.key),
+  captured,
+  expected: SIDES.length * VIEWPORTS.length * SCREENS.length,
+  not_captured: notes,
+}
+writeFileSync(`${OUT}/meta.json`, JSON.stringify(meta, null, 2) + '\n')
+
+// ── the page the owner reads ─────────────────────────────────────────────────
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+const cellHtml = (side, screen, vp) => {
+  const cell = `${side.key}-${screen.key}-${vp.key}`
+  if (notes[cell]) return `<div class="miss"><b>not captured</b><span>${esc(notes[cell])}</span></div>`
+  return `<a href="./${cell}.png" target="_blank"><img loading="lazy" src="./${cell}.png" alt="${esc(screen.label)} — ${esc(side.label)} — ${vp.label}"></a>`
+}
+
+const section = (screen) => `
+  <section id="${screen.key}">
+    <h2>${esc(screen.label)} <span class="route">${esc(screen.route)}</span></h2>
+    ${VIEWPORTS.map((vp) => `
+    <div class="vp">
+      <h3>${vp.label}</h3>
+      <div class="pair ${vp.key}">
+        ${SIDES.map((side) => `<figure><figcaption>${esc(side.label)}</figcaption>${cellHtml(side, screen, vp)}</figure>`).join('\n        ')}
+      </div>
+    </div>`).join('')}
+    <p class="verdict">判定: <b>GO</b> / <b>NG</b> — 追跡 issue #440 の表に記入</p>
+  </section>`
+
+const page = `<!doctype html>
+<html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NeNe Clear — W1 目視束</title>
+<style>
+ :root{ --ink:#1b2a3d; --muted:#5a6b80; --line:#dce3ec; --bg:#f4f6f9; }
+ *{ box-sizing:border-box } body{ margin:0; background:var(--bg); color:var(--ink);
+   font:14px/1.6 "Noto Sans JP",system-ui,sans-serif; padding:32px clamp(16px,3vw,48px); }
+ h1{ font-size:22px; margin:0 0 4px } .lede{ color:var(--muted); margin:0 0 20px; max-width:74ch }
+ table.meta{ border-collapse:collapse; margin:0 0 28px; background:#fff; border:1px solid var(--line) }
+ table.meta th,table.meta td{ border:1px solid var(--line); padding:6px 12px; text-align:left; font-size:12.5px }
+ table.meta th{ background:#eef2f7; font-weight:600; white-space:nowrap }
+ code{ font-family:ui-monospace,monospace; font-size:12px }
+ nav.toc{ display:flex; flex-wrap:wrap; gap:8px; margin:0 0 28px }
+ nav.toc a{ background:#fff; border:1px solid var(--line); padding:5px 11px; border-radius:999px;
+   text-decoration:none; color:inherit; font-size:12.5px }
+ section{ background:#fff; border:1px solid var(--line); border-radius:10px; padding:20px 22px; margin:0 0 22px }
+ section h2{ font-size:17px; margin:0 0 14px } .route{ color:var(--muted); font:12px ui-monospace,monospace; margin-left:8px }
+ .vp h3{ font-size:12px; letter-spacing:.06em; text-transform:uppercase; color:var(--muted); margin:16px 0 8px }
+ .pair{ display:grid; grid-template-columns:1fr 1fr; gap:16px; align-items:start }
+ .pair.sp{ grid-template-columns:375px 375px; justify-content:start }
+ figure{ margin:0 } figcaption{ font-size:12px; color:var(--muted); margin:0 0 6px }
+ img{ width:100%; display:block; border:1px solid var(--line); border-radius:6px; background:#fff }
+ .miss{ display:flex; flex-direction:column; gap:4px; padding:18px; border:1px dashed #c9432f;
+   border-radius:6px; color:#8c2c1e; font-size:12.5px; background:#fdf3f1 }
+ .verdict{ margin:18px 0 0; padding-top:12px; border-top:1px dashed var(--line); color:var(--muted); font-size:12.5px }
+ @media (max-width:900px){ .pair,.pair.sp{ grid-template-columns:1fr } }
+</style></head>
+<body>
+ <h1>NeNe Clear — W1 目視束（キット載せ替え）</h1>
+ <p class="lede">同じ13画面を、載せ替え<b>前</b>のビルドと<b>後</b>のビルドで撮っています。
+  中身のデータは両側とも同じ差し込みなので、<b>違いが出るのは部品の意匠だけ</b>です。
+  見るのはボタン・カード・バッジ・表・余白といった「器」で、行の中身ではありません。
+  判定は「同一かどうか」ではなく <b>動いていること／人が見て整っていること</b>（08-23 施主裁定）。</p>
+ <table class="meta">
+  <tr><th>before</th><td><code>${esc(meta.before.head.slice(0, 7))}</code> ${esc(meta.before.subject)}<br>nene2-ui: ${meta.before['nene2-ui'] ?? '未導入'}</td></tr>
+  <tr><th>after</th><td><code>${esc(meta.after.head.slice(0, 7))}</code> ${esc(meta.after.subject)}<br>nene2-ui: ${meta.after['nene2-ui'] ?? '—'}</td></tr>
+  <tr><th>本番</th><td>${esc(meta.production.note ?? 'clear.ayane.co.jp')}</td></tr>
+  <tr><th>撮影</th><td>${esc(meta.captured_at ?? '—')} · ${meta.captured}/${meta.expected} 枚</td></tr>
+ </table>
+ <nav class="toc">${SCREENS.map((s) => `<a href="#${s.key}">${esc(s.label)}</a>`).join('')}</nav>
+${SCREENS.map(section).join('\n')}
+</body></html>
+`
+writeFileSync(`${OUT}/index.html`, page)
+
+console.log(`\nowner-review: ${captured}/${meta.expected} → ${OUT}/index.html`)

--- a/tests/e2e/capture-screens.mjs
+++ b/tests/e2e/capture-screens.mjs
@@ -11,6 +11,7 @@ import { chromium } from '@playwright/test'
 import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
+import { TOKEN, TOKEN_KEY, mockApi } from './review-fixtures.mjs'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = resolve(HERE, '../..')
@@ -20,66 +21,9 @@ const OUT = '/tmp/nene-clear-screens'
 rmSync(OUT, { recursive: true, force: true })
 mkdirSync(OUT, { recursive: true })
 
-// ── admin JWT (decodable by the app's getUserRole / isAdmin; signature unused) ──
-const b64u = (o) => Buffer.from(JSON.stringify(o)).toString('base64url')
-const TOKEN = `${b64u({ alg: 'HS256', typ: 'JWT' })}.${b64u({ sub: 1, org: 7, role: 'superadmin', iat: 0, exp: 4102444800 })}.sig`
-
 // ── icon sprite (from index.html) so <use href="#i-..."> resolves standalone ──
 const indexHtml = readFileSync(resolve(REPO, 'frontend/index.html'), 'utf8')
 const sprite = indexHtml.match(/<svg width="0" height="0"[\s\S]*?<\/svg>/)?.[0] ?? ''
-
-// ── fixtures ─────────────────────────────────────────────────────────────────
-const list = (items, total) => ({ items, total: total ?? items.length, limit: 50, offset: 0 })
-const tx = (o) => ({ bank_transaction_id: 1, organization_id: 7, bank_import_batch_id: 1, bank_account_id: 1, value_date: '2026-04-20', amount_cents: 110000, counterparty_text: 'カ）アクメ', status: 'unmatched', ...o })
-const batch = (o) => ({ bank_import_batch_id: 1, organization_id: 7, bank_account_id: 1, file_hash: 'a1b2c3', source_filename: 'april.csv', row_count: 12, status: 'imported', imported_at: '2026-04-21 09:00:00', imported_by: 1, reversed_at: null, reversal_reason: null, ...o })
-const recon = (o) => ({ payment_reconciliation_id: 1, organization_id: 7, bank_transaction_id: 1, status: 'confirmed', reason_code: null, confirmed_by: 1, confirmed_at: '2026-04-21 10:00:00', reversed_at: null, reversal_reason: null, allocations: [{ invoice_id: 123, amount_cents: 110000, payment_id: 9 }], ...o })
-const credit = (o) => ({ client_credit_id: 1, organization_id: 7, client_id: 45, amount_cents: 50000, remaining_cents: 50000, status: 'open', source_bank_transaction_id: 3, reconciliation_id: 1, created_by: 1, created_at: '2026-04-21 10:00:00', ...o })
-const dunning = (o) => ({ dunning_notice_id: 1, organization_id: 7, invoice_id: 123, invoice_number: 'INV-2026-001', client_id: 45, recipient_email: 'accounts@acme.example', outstanding_at_send_cents: 110000, due_at: '2026-04-30', channel: 'log', sent_by: 1, sent_at: '2026-04-25 09:00:00', ...o })
-const invoice = (o) => ({ invoice_id: 123, invoice_number: 'INV-2026-009', client_id: 45, issued_at: '2026-03-31', due_at: '2026-04-30', total_cents: 110000, outstanding_cents: 110000, status: 'overdue', currency: 'JPY', ...o })
-const usr = (o) => ({ user_id: 1, organization_id: 7, email: 'member@acme.example', role: 'member', status: 'active', ...o })
-const settings = { organization_id: 7, upstream_base_url: 'https://invoice.example.com', upstream_token_ref: 'NENE_INVOICE_BEARER_TOKEN', dunning_min_interval_days: 7, bank_accounts: [{ bank_account_id: 1, bank_name: 'みずほ銀行', bank_branch: '本店', account_type: 'ordinary', account_number: '1234567' }] }
-const audit = (o) => ({ audit_event_id: 1, organization_id: 7, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1, actor_id: 1, occurred_at: '2026-04-21 10:00:00', before: { bank_transaction_status: 'unmatched' }, after: { bank_transaction_status: 'matched', total_allocated_cents: 110000 }, metadata: null, ...o })
-
-const txs = [
-  tx({ bank_transaction_id: 1, status: 'unmatched' }),
-  tx({ bank_transaction_id: 2, amount_cents: 50000, counterparty_text: 'カ）サクラ商事', value_date: '2026-04-21', status: 'matched' }),
-  tx({ bank_transaction_id: 3, amount_cents: 8000, counterparty_text: 'ヤマダタロウ', value_date: '2026-04-22', status: 'partially_matched' }),
-  tx({ bank_transaction_id: 4, amount_cents: 220000, counterparty_text: 'カ）ミドリ', value_date: '2026-04-23', status: 'unmatched' }),
-]
-const invoices = [
-  invoice({ invoice_id: 123, invoice_number: 'INV-2026-009', outstanding_cents: 110000, status: 'overdue' }),
-  invoice({ invoice_id: 124, invoice_number: 'INV-2026-010', outstanding_cents: 50000, status: 'issued', due_at: '2026-05-10' }),
-]
-const users = [
-  usr({ user_id: 1, email: 'admin@acme.example', role: 'admin', status: 'active' }),
-  usr({ user_id: 2, email: 'tanaka@acme.example', role: 'member', status: 'active' }),
-  usr({ user_id: 3, email: 'sato@acme.example', role: 'viewer', status: 'invited' }),
-]
-const audits = [
-  audit({ audit_event_id: 5, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1 }),
-  audit({ audit_event_id: 4, action: 'dunning_sent', entity_type: 'dunning_notice', entity_id: 7, before: null, after: { invoice_number: 'INV-2026-001', recipient_email: 'accounts@acme.example', channel: 'log' } }),
-  audit({ audit_event_id: 3, action: 'user_updated', entity_type: 'user', entity_id: 2, before: { role: 'viewer' }, after: { role: 'member' }, metadata: { user_id: 2, email: 'member@acme.example' } }),
-  audit({ audit_event_id: 2, action: 'clear_settings_updated', entity_type: 'clear_settings', entity_id: 7, before: { dunning_min_interval_days: 14 }, after: { dunning_min_interval_days: 7 } }),
-  audit({ audit_event_id: 1, action: 'login_succeeded', entity_type: 'user', entity_id: 1, before: null, after: { email: 'admin@acme.example' } }),
-]
-
-function payloadFor(pathname, method, empty) {
-  const E = (items) => list(empty ? [] : items)
-  if (pathname.endsWith('/auth/me')) return usr({ user_id: 1, email: 'admin@acme.example', role: 'superadmin' })
-  if (pathname.includes('/bank-transactions/unmatched')) return E(txs.filter((t) => t.status !== 'matched'))
-  if (pathname.includes('/bank-transactions')) return E(txs)
-  if (pathname.includes('/bank-import-batches')) return E([batch({ bank_import_batch_id: 1 }), batch({ bank_import_batch_id: 2, source_filename: 'march.csv', status: 'reversed', reversed_at: '2026-04-01 10:00:00', reversal_reason: '誤取込' })])
-  if (pathname.includes('/reconciliations/propose')) return { invoices }
-  if (pathname.includes('/reconciliations')) return E([recon({ payment_reconciliation_id: 1 }), recon({ payment_reconciliation_id: 2, status: 'reversed', reversed_at: '2026-04-22 09:00:00', reversal_reason: '入金取消' })])
-  if (pathname.includes('/client-credits')) return E([credit({ client_credit_id: 1 }), credit({ client_credit_id: 2, client_id: 88, amount_cents: 12000, remaining_cents: 4000, status: 'open' })])
-  if (pathname.includes('/upstream/invoices')) return { items: empty ? [] : invoices, total: empty ? 0 : invoices.length }
-  if (pathname.includes('/dunning-notices')) return E([dunning({ dunning_notice_id: 1 }), dunning({ dunning_notice_id: 2, invoice_number: 'INV-2026-002', recipient_email: 'ar@midori.example', channel: 'smtp' })])
-  if (pathname.includes('/dunning-pauses')) return E([{ dunning_pause_id: 1, organization_id: 7, invoice_id: 200, paused_by: 1, paused_at: '2026-04-20 09:00:00', paused_reason: '請求金額の確認中', unpaused_by: null, unpaused_at: null }])
-  if (pathname.includes('/audit-events')) return E(audits)
-  if (pathname.includes('/clear-settings')) return settings
-  if (pathname.includes('/users')) return E(users)
-  return {}
-}
 
 function htmlDoc(title, rootHtml) {
   return `<!doctype html>
@@ -129,17 +73,10 @@ const done = []
 for (const s of SCENARIOS) {
   const context = await browser.newContext({ viewport: { width: 1440, height: 960 } })
   if (s.token !== false) {
-    await context.addInitScript((t) => sessionStorage.setItem('nene_clear_token', t), TOKEN)
+    await context.addInitScript(([k, t]) => sessionStorage.setItem(k, t), [TOKEN_KEY, TOKEN])
   }
   const page = await context.newPage()
-  await page.route('**/admin/**', async (route) => {
-    const req = route.request()
-    if (req.resourceType() !== 'fetch' && req.resourceType() !== 'xhr') return route.continue()
-    const url = new URL(req.url())
-    const status = req.method() === 'DELETE' ? 204 : 200
-    const body = status === 204 ? '' : JSON.stringify(payloadFor(url.pathname, req.method(), s.empty))
-    return route.fulfill({ status, contentType: status === 204 ? 'text/plain' : 'application/json', body })
-  })
+  await mockApi(page, { empty: s.empty })
 
   try {
     await page.goto(BASE + s.route, { waitUntil: 'domcontentloaded', timeout: 20000 })

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -7,7 +7,8 @@
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "report": "playwright show-report playwright-report",
-    "screens": "node capture-screens.mjs"
+    "screens": "node capture-screens.mjs",
+    "owner-review": "node capture-owner-review.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0"

--- a/tests/e2e/review-fixtures.mjs
+++ b/tests/e2e/review-fixtures.mjs
@@ -1,0 +1,96 @@
+// Shared browser-side API stand-in for the two capture harnesses
+// (`capture-screens.mjs`, `capture-owner-review.mjs`).
+//
+// Both harnesses render the real built app and need the same thing from the
+// server: a seated admin and a plausible row of every list. Keeping one copy
+// means a screen added to either harness gets the same data, and a fixture fixed
+// for one is fixed for both — the owner-review bundle compares two builds, so a
+// fixture that drifts between harnesses would read as a design difference.
+//
+// Nothing here talks to PHP. `mockApi` fulfils every fetch/XHR the app makes, so
+// a capture run needs no backend and no database (#440).
+
+// ── admin JWT (decodable by the app's getUserRole / isAdmin; signature unused) ──
+const b64u = (o) => Buffer.from(JSON.stringify(o)).toString('base64url')
+export const TOKEN = `${b64u({ alg: 'HS256', typ: 'JWT' })}.${b64u({ sub: 1, org: 7, role: 'superadmin', iat: 0, exp: 4102444800 })}.sig`
+
+/** The session key the app reads (`shared/api/client`). */
+export const TOKEN_KEY = 'nene_clear_token'
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+const list = (items, total) => ({ items, total: total ?? items.length, limit: 50, offset: 0 })
+const tx = (o) => ({ bank_transaction_id: 1, organization_id: 7, bank_import_batch_id: 1, bank_account_id: 1, value_date: '2026-04-20', amount_cents: 110000, counterparty_text: 'カ）アクメ', status: 'unmatched', ...o })
+const batch = (o) => ({ bank_import_batch_id: 1, organization_id: 7, bank_account_id: 1, file_hash: 'a1b2c3', source_filename: 'april.csv', row_count: 12, status: 'imported', imported_at: '2026-04-21 09:00:00', imported_by: 1, reversed_at: null, reversal_reason: null, ...o })
+const recon = (o) => ({ payment_reconciliation_id: 1, organization_id: 7, bank_transaction_id: 1, status: 'confirmed', reason_code: null, confirmed_by: 1, confirmed_at: '2026-04-21 10:00:00', reversed_at: null, reversal_reason: null, allocations: [{ invoice_id: 123, amount_cents: 110000, payment_id: 9 }], ...o })
+const credit = (o) => ({ client_credit_id: 1, organization_id: 7, client_id: 45, amount_cents: 50000, remaining_cents: 50000, status: 'open', source_bank_transaction_id: 3, reconciliation_id: 1, created_by: 1, created_at: '2026-04-21 10:00:00', ...o })
+const dunning = (o) => ({ dunning_notice_id: 1, organization_id: 7, invoice_id: 123, invoice_number: 'INV-2026-001', client_id: 45, recipient_email: 'accounts@acme.example', outstanding_at_send_cents: 110000, due_at: '2026-04-30', channel: 'log', sent_by: 1, sent_at: '2026-04-25 09:00:00', ...o })
+const invoice = (o) => ({ invoice_id: 123, invoice_number: 'INV-2026-009', client_id: 45, issued_at: '2026-03-31', due_at: '2026-04-30', total_cents: 110000, outstanding_cents: 110000, status: 'overdue', currency: 'JPY', ...o })
+const usr = (o) => ({ user_id: 1, organization_id: 7, email: 'member@acme.example', role: 'member', status: 'active', ...o })
+const receivable = (o) => ({ manual_receivable_id: 1, organization_id: 7, source: 'manual', reference_number: 'MR-2026-004', client_name: '株式会社アクメ', recipient_email: 'ar@acme.example', total_cents: 132000, outstanding_cents: 132000, currency: 'JPY', issued_at: '2026-04-01', due_at: '2026-04-30', status: 'open', cancelled_at: null, created_by: 1, created_at: '2026-04-01 09:00:00', ...o })
+const settings = { organization_id: 7, upstream_base_url: 'https://invoice.example.com', upstream_token_ref: 'NENE_INVOICE_BEARER_TOKEN', dunning_min_interval_days: 7, bank_accounts: [{ bank_account_id: 1, bank_name: 'みずほ銀行', bank_branch: '本店', account_type: 'ordinary', account_number: '1234567' }] }
+const audit = (o) => ({ audit_event_id: 1, organization_id: 7, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1, actor_id: 1, occurred_at: '2026-04-21 10:00:00', before: { bank_transaction_status: 'unmatched' }, after: { bank_transaction_status: 'matched', total_allocated_cents: 110000 }, metadata: null, ...o })
+
+const txs = [
+  tx({ bank_transaction_id: 1, status: 'unmatched' }),
+  tx({ bank_transaction_id: 2, amount_cents: 50000, counterparty_text: 'カ）サクラ商事', value_date: '2026-04-21', status: 'matched' }),
+  tx({ bank_transaction_id: 3, amount_cents: 8000, counterparty_text: 'ヤマダタロウ', value_date: '2026-04-22', status: 'partially_matched' }),
+  tx({ bank_transaction_id: 4, amount_cents: 220000, counterparty_text: 'カ）ミドリ', value_date: '2026-04-23', status: 'unmatched' }),
+]
+const invoices = [
+  invoice({ invoice_id: 123, invoice_number: 'INV-2026-009', outstanding_cents: 110000, status: 'overdue' }),
+  invoice({ invoice_id: 124, invoice_number: 'INV-2026-010', outstanding_cents: 50000, status: 'issued', due_at: '2026-05-10' }),
+]
+const users = [
+  usr({ user_id: 1, email: 'admin@acme.example', role: 'admin', status: 'active' }),
+  usr({ user_id: 2, email: 'tanaka@acme.example', role: 'member', status: 'active' }),
+  usr({ user_id: 3, email: 'sato@acme.example', role: 'viewer', status: 'invited' }),
+]
+const receivables = [
+  receivable({ manual_receivable_id: 1, status: 'open' }),
+  receivable({ manual_receivable_id: 2, reference_number: 'MR-2026-005', client_name: 'サクラ商事', total_cents: 88000, outstanding_cents: 44000, status: 'partially_paid', due_at: '2026-05-15' }),
+  receivable({ manual_receivable_id: 3, reference_number: 'MR-2026-006', client_name: '緑川工業', total_cents: 45000, outstanding_cents: 0, status: 'paid', due_at: '2026-04-10' }),
+  receivable({ manual_receivable_id: 4, reference_number: 'MR-2026-007', client_name: 'ヤマダタロウ', recipient_email: null, total_cents: 12000, outstanding_cents: 12000, status: 'cancelled', due_at: null, cancelled_at: '2026-04-18 11:00:00' }),
+]
+const audits = [
+  audit({ audit_event_id: 5, action: 'reconciliation_confirmed', entity_type: 'payment_reconciliation', entity_id: 1 }),
+  audit({ audit_event_id: 4, action: 'dunning_sent', entity_type: 'dunning_notice', entity_id: 7, before: null, after: { invoice_number: 'INV-2026-001', recipient_email: 'accounts@acme.example', channel: 'log' } }),
+  audit({ audit_event_id: 3, action: 'user_updated', entity_type: 'user', entity_id: 2, before: { role: 'viewer' }, after: { role: 'member' }, metadata: { user_id: 2, email: 'member@acme.example' } }),
+  audit({ audit_event_id: 2, action: 'clear_settings_updated', entity_type: 'clear_settings', entity_id: 7, before: { dunning_min_interval_days: 14 }, after: { dunning_min_interval_days: 7 } }),
+  audit({ audit_event_id: 1, action: 'login_succeeded', entity_type: 'user', entity_id: 1, before: null, after: { email: 'admin@acme.example' } }),
+]
+
+export function payloadFor(pathname, method, empty) {
+  const E = (items) => list(empty ? [] : items)
+  // The invitee has no session, so this one is matched before /auth/me.
+  if (pathname.endsWith('/auth/invitation')) return { email: 'sato@acme.example' }
+  if (pathname.endsWith('/auth/me')) return usr({ user_id: 1, email: 'admin@acme.example', role: 'superadmin' })
+  if (pathname.includes('/bank-transactions/unmatched')) return E(txs.filter((t) => t.status !== 'matched'))
+  if (pathname.includes('/bank-transactions')) return E(txs)
+  if (pathname.includes('/bank-import-batches')) return E([batch({ bank_import_batch_id: 1 }), batch({ bank_import_batch_id: 2, source_filename: 'march.csv', status: 'reversed', reversed_at: '2026-04-01 10:00:00', reversal_reason: '誤取込' })])
+  if (pathname.includes('/reconciliations/propose')) return { invoices }
+  if (pathname.includes('/reconciliations')) return E([recon({ payment_reconciliation_id: 1 }), recon({ payment_reconciliation_id: 2, status: 'reversed', reversed_at: '2026-04-22 09:00:00', reversal_reason: '入金取消' })])
+  if (pathname.includes('/client-credits')) return E([credit({ client_credit_id: 1 }), credit({ client_credit_id: 2, client_id: 88, amount_cents: 12000, remaining_cents: 4000, status: 'open' })])
+  if (pathname.includes('/manual-receivables')) return E(receivables)
+  if (pathname.includes('/upstream/invoices')) return { items: empty ? [] : invoices, total: empty ? 0 : invoices.length }
+  if (pathname.includes('/dunning-notices')) return E([dunning({ dunning_notice_id: 1 }), dunning({ dunning_notice_id: 2, invoice_number: 'INV-2026-002', recipient_email: 'ar@midori.example', channel: 'smtp' })])
+  if (pathname.includes('/dunning-pauses')) return E([{ dunning_pause_id: 1, organization_id: 7, invoice_id: 200, paused_by: 1, paused_at: '2026-04-20 09:00:00', paused_reason: '請求金額の確認中', unpaused_by: null, unpaused_at: null }])
+  if (pathname.includes('/audit-events')) return E(audits)
+  if (pathname.includes('/clear-settings')) return settings
+  if (pathname.includes('/users')) return E(users)
+  return {}
+}
+
+/**
+ * Fulfil every API call the page makes. Document navigations still go to the
+ * preview server (they are not fetch/XHR), so the SPA boots normally.
+ */
+export async function mockApi(page, { empty = false } = {}) {
+  await page.route('**/admin/**', async (route) => {
+    const req = route.request()
+    if (req.resourceType() !== 'fetch' && req.resourceType() !== 'xhr') return route.continue()
+    const url = new URL(req.url())
+    const status = req.method() === 'DELETE' ? 204 : 200
+    const body = status === 204 ? '' : JSON.stringify(payloadFor(url.pathname, req.method(), empty))
+    return route.fulfill({ status, contentType: status === 204 ? 'text/plain' : 'application/json', body })
+  })
+}


### PR DESCRIPTION
受入ゲート⑤（**施主の目視・波1回**）の材料を作る便。あわせて、その束が出した退行を1件塞ぐ。

## 1. 目視束の生成器

`tests/e2e/capture-owner-review.mjs` ＋ 読み方 `docs/qa/owner-review/README.md`。
**13画面 × 2ビューポート（PC 1440×900 / SP 375×812） × 2側 = 52枚**。実測 52/52。

🔴 **vault の形（本番 vs 手元）は clear では成立しない。** `clear.ayane.co.jp` は
セッション無しだと SPA の全パスが 401 を返し、借りられるデモ席が無い（`/` は API の
JSON、SPA は `/assets/`）。代わりに **載せ替え前後の2ビルドを、同じ差し込みデータで**
並べた。両列の中身が一致するので、**絵に出る違いは器の違いだけ**になる（vault は各側が
別の使い捨て org なので行の中身も違う）。本番が何を配信していたかは `meta.json` に
記録する: 実配信は `index-CjD8vS40.js` / `index-DTUDTQtb.css` ＝ **before 列より古い
ビルド**（before までの frontend コミット 8本ぶんの差）。

**ガード2つ**:
- `@source` センチネル（vault #387）を **描画された stylesheet** で確認する。
  `npm run source-probe` はディスク上のビルドを見るが、束は preview server が配信して
  いるものを撮るので、直前にビルドしたのとは別の outDir でも起こりうる。**after 側だけ**
  掛ける — before はキット以前なので、陽性にならないのが正しい。
- **着席していない画面は絵にしない**（deal §8-5）。ログイン画面に落ちた画面は
  「not captured」として理由つきで報告する。これが無いと束が黙って
  「ログイン画面の写真13枚」になる。

差し込みデータは `tests/e2e/review-fixtures.mjs` に括り出し、既存の
`capture-screens.mjs` と共有した（束と収録が別のデータを見ると、fixture の差が意匠の差に見える）。

束の出力は **gitignore**。波ごとの使い捨てで、残すのは生成器と README、判定は #440。

⚠️ 最初の走りは **22/52 を落とした**。`.side-nav` を待っていたが、レールは
モバイル幅で `display:none` で、Playwright の既定は *visible* 待ち — SP の着席画面が
全滅した。画面自体は完全に描画されている。アンカーを `.page` に変えて 52/52。

## 2. 🔴 束が出した退行 — Button の nowrap（fleet #501）

キットの `Button` は `white-space` を持たない。clear の旧 `.btn` は持っていた
（`design.css:241` `cursor:pointer; white-space:nowrap; line-height:1;`）。

168ボタンを before(`3566eec`) / after(`08f3bc9`) で突合（`getBoundingClientRect().height`
＋ `getComputedStyle().whiteSpace`）:

| | before → after | |
| --- | --- | --- |
| sp・督促を送信 / 消込を確定 / 停止 | 26px → **70px** | 4行 |
| sp・ユーザーを招待 | 34px → 60px | |
| sp・CSV出力（4画面）/ 売掛を追加 | 34px → 46px | |
| sp・詳細 / 取消 / 適用 / 削除 | 24〜26px → 34px | |
| **PC 1440×900** | — | **0個** |

**SP で 15個・9画面／PC で 0個・縮んだものは 0個。** 日本語には単語境界が無いので
折り返すと「消込を / 確定」と語の途中で割れる。07-24 に下タブ＋ボトムシートを本番へ
出しているので、SP は捨てられない。

**Badge には 0.19.1 で nowrap が入っている**ので、同じ判断が Button に届いていない
だけと見て fleet **#501** を起票（実測つき）。入るまでの暫定を `kit-slots.css` に
**1規則だけ**置いた:

- `@layer components` なので、折り返させたい呼び出し側の `whitespace-normal` は勝つ。
- このファイルで**唯一スロットでなくキットのクラスを名指しする規則**なので、隔離して
  issue 番号を付け、剥がし方を書いた。代案は 69箇所の `className` で、それはキット自身の
  Button コメントが `inline-flex` について「艦が回避策を書く非対称」と呼んでいる形。

暫定投入後に再計測して**折り返し 0個**、他のボタンの寸法変化も 0。

## 検査

- `npm run check` EXIT=0（codegen:check / type-check / lint / 92 tests・14 files / knip / build / source-probe）
- 束 52/52・not captured 0

## 残（この PR ではやらない）

- 施主の目視判定（画面単位 GO/NG）→ #440 の表へ
- 切替便（配布物ができた状態で GO を1回・deal §8-11）
- fleet #501 が入ったら暫定を剥がす

Refs #440
