### PR TITLE
fix(ui): ソート中の列の背景を描画させる — 短いセレクタが特異度で負けていた（#439）

### DIFF
--- a/frontend/src/shared/ui/theme/design.css
+++ b/frontend/src/shared/ui/theme/design.css
@@ -601,7 +601,11 @@ table.tbl thead th.sortable:hover{ color:var(--navy-700); }
 th[aria-sort] .sort-ic{ opacity:1; color:var(--navy-600); }
 th[aria-sort="ascending"] .sort-ic::before{ content:"\2191"; }
 th[aria-sort="descending"] .sort-ic::before{ content:"\2193"; }
-[data-theme="a"] th[aria-sort]{ background:var(--navy-100); }
+/* The sorted column. The selector must carry `table.tbl thead` like its
+   neighbours do: `[data-theme="a"] table.tbl thead th` (0,2,3) sets every
+   header cell's background, so a short `[data-theme="a"] th[aria-sort]`
+   (0,2,1) loses on specificity and never paints (#439). */
+[data-theme="a"] table.tbl thead th[aria-sort]{ background:var(--navy-100); }
 
 /* date field (type-first) + calendar popover */
 .datefield{ position:relative; display:inline-flex; align-items:center; }

--- a/tests/e2e/specs/04-bank-transactions.spec.ts
+++ b/tests/e2e/specs/04-bank-transactions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import type { Locator } from '@playwright/test'
 import { apiRoute, json, list, bypassLogin, bankTransaction } from '../fixtures/helpers'
 
 test.beforeEach(async ({ page }) => {
@@ -79,5 +80,39 @@ test.describe('Bank transactions — list, filter, pagination boundaries', () =>
     await page.getByRole('button', { name: '検索' }).click()
 
     await expect.poll(() => lastUrl).toContain('status=matched')
+  })
+
+  // #439: the sorted column's background lost on specificity and never painted.
+  // Assert the painted colour, not the rule — a selector that loses is still in
+  // the stylesheet, so only the computed value can tell the two apart.
+  test('the sorted column header is painted differently from the unsorted ones', async ({ page }) => {
+    await apiRoute(page, '**/admin/bank-transactions?**', (route) =>
+      json(route, 200, list([bankTransaction()])),
+    )
+
+    await page.goto('/admin/bank-transactions')
+
+    // The page opens sorted by value_date, so exactly one header carries aria-sort.
+    const sorted = page.locator('table.tbl thead th[aria-sort]')
+    await expect(sorted).toHaveCount(1)
+
+    const bg = (l: Locator) => l.evaluate((el) => getComputedStyle(el).backgroundColor)
+    const sortedBg = await bg(sorted)
+    const plainBg = await bg(page.locator('table.tbl thead th.sortable:not([aria-sort])').first())
+
+    expect(sortedBg).not.toBe(plainBg)
+
+    // ...and that it is the colour the rule has always asked for. Resolve the
+    // token at run time rather than pasting its value, so a token change moves
+    // the expectation with it.
+    const navy100 = await sorted.evaluate((el) => {
+      const probe = document.createElement('div')
+      probe.style.backgroundColor = 'var(--navy-100)'
+      el.append(probe)
+      const c = getComputedStyle(probe).backgroundColor
+      probe.remove()
+      return c
+    })
+    expect(sortedBg).toBe(navy100)
   })
 })


### PR DESCRIPTION
Closes #439

## 何が起きていたか

`design.css` のこの1行が、**一度も描画されていなかった**:

```css
[data-theme="a"] th[aria-sort]{ background:var(--navy-100); }   /* (0,2,1) */
```

同じファイルの

```css
[data-theme="a"] table.tbl thead th{ background:var(--navy-50); … }   /* (0,2,3) */
```

に**型セレクタ3つ分で負ける**。後に書かれていても順序では覆らない。

🔑 隣の hover 規則は効いている:

```css
[data-theme="a"] table.tbl thead th.sortable:hover{ background:var(--navy-100); }   /* (0,4,3) */
```

⇒ **`table.tbl thead` の鎖を持たないのはこの1行だけ**だった。周りの書き方に揃え忘れた1行が、
「書いてあるのに存在しない」状態で残っていた。

## 直し方

鎖を揃えて **(0,3,3)** にした。`(0,2,3)` に勝ち、hover `(0,4,3)` には引き続き譲る（意図どおり）。
なぜ短く書くと負けるかを、その場にコメントで残した。

## 退行ガード（陰性対照つき）

E2E に1本足した。**規則の存在ではなく、描画された色を見る**——
負けているセレクタもスタイルシートには在るので、**computed 値でしか区別できない**。
トークンは実行時に解決させ、値をテストに写していない（トークンが変われば期待値も動く）。

| | ソート列 | 非ソート列 | 結果 |
|---|---|---|---|
| 修正あり | `rgb(229,236,245)`（`--navy-100`） | `rgb(238,242,248)` | ✅ 緑 |
| **修正なし** | `rgb(238,242,248)` | `rgb(238,242,248)` | ✅ **赤**（同色＝バグを再現） |

**陰性対照を実際に走らせて赤を確認した。** 通る側だけ見て緑を報告しない。

## 検査

`npm run check` 緑（codegen:check / type-check / lint / **test 92 passed** / knip / build / source-probe）。

## 経緯

W1 の1日目の測定（17画面を実ブラウザで描画し CDP `CSS.getMatchedStylesForNode` で
プロパティごとのカスケード勝者を取る）が検出した玉。`DataTable` はキットへ移らない
（ソートも状態行もキットに無い・板 L124）ので、clear のローカルで直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198YWHGnk4Dy9JTi5fzZSLo