### PR TITLE
chore(deps): nene2-ui 0.21.0 へ上げ、nowrap 暫定を剥がす（#450・fleet #501）

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource/inter": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@hideyukimori/nene2-client": "^1.1.0",
-        "@hideyukimori/nene2-ui": "^0.20.0",
+        "@hideyukimori/nene2-ui": "^0.21.0",
         "@tanstack/react-query": "^5.90.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -715,9 +715,9 @@
       }
     },
     "node_modules/@hideyukimori/nene2-ui": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.20.0.tgz",
-      "integrity": "sha512-gkPbpmz9zn0fF3wtIZCLdoX6Y0CWCUQmnsLNurnERw1lqcuCj6oSP/SnvZw9uwmsgnKgIlsbHlxQ4o175d8aBg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@hideyukimori/nene2-ui/-/nene2-ui-0.21.0.tgz",
+      "integrity": "sha512-VuzlBdb5oYCMUvtItFescFGJfq0r1ZTfCPJEkqgPEkk+lWsYZ+c/Z9FX0gQCulZpdckBRwdHYjgIrpcnPC0Egg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@fontsource/inter": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-ui": "^0.20.0",
+    "@hideyukimori/nene2-ui": "^0.21.0",
     "@tanstack/react-query": "^5.90.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/frontend/src/shared/ui/theme/kit-slots.css
+++ b/frontend/src/shared/ui/theme/kit-slots.css
@@ -94,36 +94,6 @@
  *    lighter `--color-warn` the kit had to use `--color-on-warn` (a dark brown)
  *    because white measured 3.48:1 there (fleet, #487).
  */
-/* ── Stopgap, NOT a slot — remove when the kit ships it (fleet #501) ────────
- *
- * The kit's `Button` sets no `white-space`, so its label wraps. Clear's `.btn`
- * carried `white-space: nowrap` (`design.css:241` before W1a), and dropping it
- * broke 15 buttons at SP 375×812 — measured across 168 buttons on 13 screens,
- * before (`3566eec`) vs after (`08f3bc9`): 「督促を送信」「消込を確定」「停止」
- * each go 26px → 70px (four lines), CSV出力 34px → 46px. PC 1440×900: zero.
- * Japanese has no word boundaries to break on, so a wrap splits mid-word
- * (「消込を / 確定」).
- *
- * This is the ONE rule in this file that names a kit class rather than a slot
- * the kit offers, and it is deliberately quarantined here so it is easy to
- * delete: `rounded-x-slot-button` is in `Button`'s `BASE_CLASS`, so it marks
- * every kit button and nothing else. The alternative was `className` on 69 call
- * sites — the same "the ship works around the kit" shape the kit's own Button
- * comment calls an asymmetry it fixed for `inline-flex`.
- *
- * `components`, not `utilities`, so `className="whitespace-normal"` still wins
- * at a call site that wants a wrapping label.
- *
- * 🔴 When nene2-ui ships nowrap on Button (fleet #501), delete this block —
- *    do not leave it "just in case". A stopgap nobody removes becomes the
- *    ship's own quiet fork of the kit.
- */
-@layer components {
-  .rounded-x-slot-button {
-    white-space: nowrap;
-  }
-}
-
 @theme {
   --radius-x-slot-button: var(--radius-x-none);
   --font-weight-x-slot-button: var(--font-weight-semibold);


### PR DESCRIPTION
Closes #450

W1 で入れた暫定ブロックには、その場に**「キットが出荷したら消せ・剥がし方はこう」**と書いてありました。
0.21.0 で条件が満たされたので、書いてあったとおりに剥がします。

## 中身

- 宣言 `^0.20.0` → **`^0.21.0`**（0.x の caret は minor を固定するので、宣言を変えないと入りません）
- `npm update` で lock を 0.21.0 へ。`npm ls` で実インストール版を確認
- `kit-slots.css` の暫定を削除:

```css
@layer components { .rounded-x-slot-button { white-space: nowrap; } }
```

0.21.0 の中身は3件で、**#486（InlineAlert の success）と #493（Modal の footer/description）は
clear が書いた PR**（fleet #507 / #508）。既定描画はどちらも不変で、**描画が変わりうるのは
#501（Button の `whitespace-nowrap`）だけ**です。

## 実測 — 「同一描画」を陽性対照つきで

12画面 × **4,875ノード**（22プロパティ＋ `white-space` / `overflow-wrap` / `word-break`）を
DOM パスで突合。**PC と SP の両方**で測りました。

| 比較 | 差分 |
|---|---|
| **陽性対照**: 暫定だけ外す（キットは 0.20.0＝nowrap 無し）SP 375×812 | **372**（`white-space: nowrap → normal`・ボタン高 +6px） |
| **0.20.0+暫定 → 0.21.0+暫定なし** SP 375×812 | **0** |
| 同 PC 1440×900 | **0** |

⇒ 暫定とキットの nowrap は**同じクラス（`rounded-x-slot-button`）に効いていて、入れ替えても
描画は1プロパティも動きません**。陽性対照が無ければ、この「0」は「測れていない」と区別できません。

**配布物の現物も読みました** — `dist/primitives/Button.js` に `whitespace-nowrap` が実在。
（**版が上がったことは、中身が出たことではない**ので。fleet が publish 側で `npm pack` を読んだのと対です。）

自艦での版の確認:

```
$ npm view @hideyukimori/nene2-ui version     → 0.21.0
$ npm view @hideyukimori/nene2-ui dist.shasum → 353024966a248e0eacea50ee878648872306117c
$ npm ls @hideyukimori/nene2-ui               → @hideyukimori/nene2-ui@0.21.0
```

## 横あふれ（fleet の申し送り）

> そちらが一番影響を受けます: SP の 15ボタンが折り返さなくなるので、横があふれる方向に効きます。

SP 375 の**全12画面で document の横あふれは 0px**。375 を超える要素は表の中にあり、
表は自前の横スクロール領域を持っています（`scrollWidth === clientWidth`）。

⚠️ `/admin/help` の `header.help-hero` だけ 14px 外に出ていますが、**この便より前から同値**
（before ビルドでも `right=389`）＝**退行ではありません**。別件として残します。

## 検査

`npm run check` 緑 ／ **E2E 58 passed**（`17-mobile-responsive` の
「sidebar collapses to a bottom-tab bar; **no horizontal overflow**」を含む）。

## 本番反映は別便

main までです。**配備は施主 GO**（W1 の切替と同じ手順）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198YWHGnk4Dy9JTi5fzZSLo